### PR TITLE
refactor(persistence): unify chart_only SQL branches + dedup test helper

### DIFF
--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -831,21 +831,26 @@ class V2PersistenceAdapter:
         if not facts:
             return 0
 
+        # chart_only scopes the guard + DELETE to chart facts so text facts
+        # (and their reviewer decisions) survive the DELETE below, which
+        # would otherwise CASCADE through v2_review_decisions.fact_id.
+        params: dict[str, Any] = {"filing_id": filing_id}
+        where_scope = "doc_id = %(filing_id)s"
+        if chart_only:
+            params["source_type"] = SourceType.CHART.value
+            where_scope += " AND source_type = %(source_type)s"
+
         # Guard: refuse to wipe human review decisions without explicit opt-in.
-        # The DELETE below CASCADEs through v2_review_decisions.fact_id FK, so
-        # without this check any re-extraction silently destroys reviewer work.
-        # In chart_only mode, we only count decisions on chart facts — text
-        # facts are not touched, so decisions on them are irrelevant here.
-        guard_sql = """
+        cur.execute(
+            f"""
             SELECT COUNT(*) AS decision_count,
                    COUNT(DISTINCT rd.reviewer_id) AS reviewer_count
               FROM v2_metric_facts mf
               JOIN v2_review_decisions rd ON rd.fact_id = mf.fact_id
-             WHERE mf.doc_id = %(filing_id)s
-        """
-        if chart_only:
-            guard_sql += "               AND mf.source_type = 'chart'\n"
-        cur.execute(guard_sql, {"filing_id": filing_id})
+             WHERE mf.{where_scope}
+            """,
+            params,
+        )
         row = cur.fetchone()
         decision_count = int(row["decision_count"]) if row else 0
         reviewer_count = int(row["reviewer_count"]) if row else 0
@@ -865,20 +870,9 @@ class V2PersistenceAdapter:
                 chart_only,
             )
 
-        # Delete existing facts for this filing before inserting fresh results.
-        # This is idempotent and handles re-runs correctly without requiring a
-        # complex unique index across nullable expression columns. In
-        # chart_only mode the DELETE is scoped so text facts survive.
-        if chart_only:
-            cur.execute(
-                "DELETE FROM v2_metric_facts WHERE doc_id = %(filing_id)s AND source_type = 'chart'",
-                {"filing_id": filing_id},
-            )
-        else:
-            cur.execute(
-                "DELETE FROM v2_metric_facts WHERE doc_id = %(filing_id)s",
-                {"filing_id": filing_id},
-            )
+        # Delete-then-insert is idempotent and avoids a unique index across
+        # nullable expression columns.
+        cur.execute(f"DELETE FROM v2_metric_facts WHERE {where_scope}", params)
 
         sql = """
             INSERT INTO v2_metric_facts (

--- a/tests/integration/extraction_v2/test_persistence_guard.py
+++ b/tests/integration/extraction_v2/test_persistence_guard.py
@@ -126,26 +126,39 @@ def _make_fact(
     filing_id: int,
     value: float = 100.0,
     period_year: int = 2025,
+    source_type: SourceType = SourceType.TEXT,
 ) -> MetricFact:
     """Build a MetricFact with a unique identity tuple per ``period_year``.
 
     ``_persist_facts_in_tx`` dedupes by
     (metric, period, unit, scope, cohort), so tests that need multiple
     coexisting facts for the same filing must vary one of those fields.
+
+    Pass ``source_type=SourceType.CHART`` for chart-fact test cases — the
+    canonical_metric_id and source_locator shape switch accordingly so the
+    fact satisfies the chart-fact img_id invariant.
     """
+    if source_type is SourceType.CHART:
+        metric_id = "cm_revenue_by_cohort"
+        locator = SourceLocator(dom_locator=f"chart[{period_year}]", img_id=str(uuid.uuid4()))
+        snippet = f"<p>chart {value}</p>"
+    else:
+        metric_id = "cm_new_customers_acquired"
+        locator = SourceLocator(dom_locator=f"/p[{period_year}]")
+        snippet = f"<p>{value}</p>"
     return MetricFact(
         fact_id=str(uuid.uuid4()),
         doc_id=str(filing_id),
-        canonical_metric_id="cm_new_customers_acquired",
+        canonical_metric_id=metric_id,
         value=value,
         value_raw=str(value),
         unit=Unit.COUNT,
         period_type=PeriodType.ANNUAL,
         period_start=date(period_year, 1, 1),
         period_end=date(period_year, 12, 31),
-        source_type=SourceType.TEXT,
-        source_locator=SourceLocator(dom_locator=f"/p[{period_year}]"),
-        evidence_pack=EvidencePack(snippet_html=f"<p>{value}</p>"),
+        source_type=source_type,
+        source_locator=locator,
+        evidence_pack=EvidencePack(snippet_html=snippet),
         confidence=0.85,
         extraction_method=ExtractionMethod.EXACT_MATCH,
         review_status=ReviewStatus.PENDING_REVIEW,
@@ -534,33 +547,6 @@ def _make_pipeline_result_with_images(images: list[ImageAsset]) -> PipelineResul
     )
 
 
-def _make_chart_fact(
-    filing_id: int,
-    value: float = 500.0,
-    period_year: int = 2025,
-) -> MetricFact:
-    return MetricFact(
-        fact_id=str(uuid.uuid4()),
-        doc_id=str(filing_id),
-        canonical_metric_id="cm_revenue_by_cohort",
-        value=value,
-        value_raw=str(value),
-        unit=Unit.COUNT,
-        period_type=PeriodType.ANNUAL,
-        period_start=date(period_year, 1, 1),
-        period_end=date(period_year, 12, 31),
-        source_type=SourceType.CHART,
-        source_locator=SourceLocator(
-            dom_locator=f"chart[{period_year}]",
-            img_id=str(uuid.uuid4()),
-        ),
-        evidence_pack=EvidencePack(snippet_html=f"<p>chart {value}</p>"),
-        confidence=0.85,
-        extraction_method=ExtractionMethod.EXACT_MATCH,
-        review_status=ReviewStatus.PENDING_REVIEW,
-    )
-
-
 class TestChartOnlyMode:
     """Verify the `chart_only` persistence path preserves text facts + decisions."""
 
@@ -571,7 +557,9 @@ class TestChartOnlyMode:
         test_filing_id: int,
     ):
         text_fact = _make_fact(test_filing_id, value=100.0, period_year=2024)
-        chart_fact = _make_chart_fact(test_filing_id, value=500.0, period_year=2025)
+        chart_fact = _make_fact(
+            test_filing_id, value=500.0, period_year=2025, source_type=SourceType.CHART
+        )
 
         count = persistence_adapter.persist_facts(
             [text_fact, chart_fact], test_filing_id, chart_only=True
@@ -599,7 +587,7 @@ class TestChartOnlyMode:
         assert _decision_count(db_adapter, test_filing_id) == 1
 
         # Chart-only backfill: no force needed; text fact + decision must survive.
-        chart_fact = _make_chart_fact(test_filing_id, value=500.0)
+        chart_fact = _make_fact(test_filing_id, value=500.0, source_type=SourceType.CHART)
         count = persistence_adapter.persist_facts([chart_fact], test_filing_id, chart_only=True)
         assert count == 1
 
@@ -627,7 +615,7 @@ class TestChartOnlyMode:
         persistence_adapter.persist_facts([text_fact], test_filing_id)
         _insert_decision(db_adapter, text_fact.fact_id, reviewer_id="alice@example.com")
 
-        chart_fact = _make_chart_fact(test_filing_id, value=500.0)
+        chart_fact = _make_fact(test_filing_id, value=500.0, source_type=SourceType.CHART)
         # No force=True, no ReviewedFilingError expected.
         count = persistence_adapter.persist_facts([chart_fact], test_filing_id, chart_only=True)
         assert count == 1
@@ -640,11 +628,15 @@ class TestChartOnlyMode:
         test_filing_id: int,
     ):
         # Seed a reviewed chart fact — chart_only must raise without force.
-        chart_fact = _make_chart_fact(test_filing_id, value=500.0, period_year=2024)
+        chart_fact = _make_fact(
+            test_filing_id, value=500.0, period_year=2024, source_type=SourceType.CHART
+        )
         persistence_adapter.persist_facts([chart_fact], test_filing_id)
         _insert_decision(db_adapter, chart_fact.fact_id, reviewer_id="alice@example.com")
 
-        new_chart = _make_chart_fact(test_filing_id, value=600.0, period_year=2025)
+        new_chart = _make_fact(
+            test_filing_id, value=600.0, period_year=2025, source_type=SourceType.CHART
+        )
         with pytest.raises(ReviewedFilingError):
             persistence_adapter.persist_facts([new_chart], test_filing_id, chart_only=True)
         assert _decision_count(db_adapter, test_filing_id) == 1

--- a/tests/unit/extraction_v2/test_persistence_sql.py
+++ b/tests/unit/extraction_v2/test_persistence_sql.py
@@ -30,15 +30,18 @@ class TestFactUpsertSQL:
         )
 
     def test_delete_before_insert(self):
-        """DELETE FROM v2_metric_facts WHERE doc_id must precede INSERT (WP-12)."""
+        """DELETE FROM v2_metric_facts scoped by doc_id must precede INSERT (WP-12)."""
         source = self._get_persist_sql()
 
-        assert "DELETE FROM v2_metric_facts WHERE doc_id" in source, (
+        assert "DELETE FROM v2_metric_facts" in source, (
             "_persist_facts_in_tx must DELETE existing facts before inserting fresh results"
+        )
+        assert "doc_id = %(filing_id)s" in source, (
+            "_persist_facts_in_tx DELETE must be scoped by doc_id so cross-filing data is not wiped"
         )
 
         # DELETE should appear before INSERT in the source
-        delete_pos = source.index("DELETE FROM v2_metric_facts WHERE doc_id")
+        delete_pos = source.index("DELETE FROM v2_metric_facts")
         insert_pos = source.index("INSERT INTO v2_metric_facts")
         assert delete_pos < insert_pos, "DELETE must precede INSERT in _persist_facts_in_tx"
 


### PR DESCRIPTION
## Summary

Post-merge cleanup of PR #50 (chart_only persistence mode) surfaced by `/simplify`. No behavioral change — pure code-dedup against the merged feature.

- `_persist_facts_in_tx`: collapsed the two guard-SELECT and two DELETE branches into one parameterized form each, driven by a shared \`where_scope\` / \`params\` pair. Replaced the hardcoded \`'chart'\` SQL literal with \`SourceType.CHART.value\` so the enum remains the single source of truth.
- `test_persistence_guard.py`: folded `_make_chart_fact` into `_make_fact` via a `source_type=` kwarg; switches `canonical_metric_id` and `source_locator` shape accordingly to preserve the chart-fact \`img_id\` invariant (~25 LOC removed).
- `test_persistence_sql.py::test_delete_before_insert`: loosened the source-substring assertion (DELETE before INSERT, scoped by \`doc_id\`) so it survives the refactor. Underlying test brittleness still tracked by Issue #51.

## Test plan

- [x] `pytest -x -q` — 3630 passed, 0 failed
- [x] Full `tests/integration/extraction_v2/` run — 93 passed, 56 skipped (expected), 0 failed
- [x] Pre-commit gold-standard validation — F1 +0.2pp vs baseline (within noise; PASSED)
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)