### PR TITLE
chore(hooks): remind /simplify before /commit on 3+ file changes

### DIFF
--- a/.claude/hooks/precommit-simplify-check.sh
+++ b/.claude/hooks/precommit-simplify-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Reminds Claude to run /simplify before /commit when 3+ files are modified.
+# Wired as PreToolUse(Skill) hook in .claude/settings.json; filters for the
+# commit skill by parsing the tool-call JSON payload on stdin.
+
+INPUT=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  SKILL=$(echo "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null)
+else
+  SKILL=$(echo "$INPUT" | grep -oE '"skill"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+fi
+
+[ "${SKILL:-}" = "commit" ] || exit 0
+
+CHANGED=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "${CHANGED:-0}" -ge 3 ]; then
+  cat <<'EOF'
+
+REMINDER: 3+ files changed this session. Before proceeding with /commit,
+consider running /simplify to catch:
+  - Duplicate helpers or utilities
+  - Unnecessary abstractions / scope creep
+  - Dead imports, unused code, leftover comments
+
+If you've already simplified (or the changes are isolated / mechanical),
+proceed with /commit as usual.
+EOF
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/precommit-simplify-check.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ Metrics are classified into importance tiers based on analytical value. These ti
 5. **Image pipeline is active**: Do not delete image-processing code (`src/llm/vision_client.py`, `src/extraction_v2/` image/OCR stages, `src/web/routes/review_unified.py` + `api_unified.py` image endpoints, image scripts). The image review system is complete and in use.
 6. **Reviewed-filing guard**: Re-extraction of a filing with human review decisions requires explicit `force=True` / `--force-reextract`. Enforced in `V2PersistenceAdapter._persist_facts_in_tx`; raises `ReviewedFilingError` otherwise. Prevents silent CASCADE-destruction of reviewer work via `v2_review_decisions.fact_id ON DELETE CASCADE`.
 
+## Hooks
+
+A PreToolUse hook nudges `/simplify` when 3+ files are modified before `/commit` — see `.claude/hooks/precommit-simplify-check.sh`.
+
 ## Compact Instructions
 
 When compacting, preserve: modified file paths, current test/gold-standard validation status, extraction pipeline decisions made this session, and any active task checklist.


### PR DESCRIPTION
## Summary

- Adds a project-level `PreToolUse(Skill)` hook that nudges running `/simplify` when the commit skill starts with 3+ modified files in the working tree.
- Keeps scope discipline on small changes (no prompt below the 3-file threshold) while making simplification a natural step for larger ones.
- Hook script filters for the commit skill via the stdin JSON payload and always exits `0`, so it cannot block a commit if something goes wrong.

Threshold matches the existing Pre-Implementation Gate trigger in `CLAUDE.md`, so the workflow feels consistent.

## Files

- `.claude/hooks/precommit-simplify-check.sh` — new executable hook script
- `.claude/settings.json` — adds `PreToolUse` block with `matcher: "Skill"`
- `CLAUDE.md` — one-line `## Hooks` section pointing at the script

## Test plan

- [x] Standalone: non-commit skill payload → silent, exit 0
- [x] Standalone: commit skill with 4 dirty files → reminder printed, exit 0
- [x] Standalone: commit skill with 2 staged files in temp repo → silent, exit 0
- [x] Standalone: missing `skill` field in payload → silent, exit 0
- [x] `settings.json` validates as JSON
- [ ] Live: next `/commit` in a 3+ file session surfaces the reminder as additionalContext

🤖 Generated with [Claude Code](https://claude.com/claude-code)