### PR TITLE
chore(workflow): enforce PR-required flow via /commit + local guards

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,144 @@
+# Safe Commit + PR Skill (project-local)
+
+**Purpose:** Gate code quality before commit (lint, tests, doc-freshness, known-issues triage), then branch + commit + push + open a PR + enable auto-merge. `main` is protected server-side; this skill matches the local flow to the remote contract.
+
+**When to use:** Any time the user asks to commit changes.
+
+---
+
+## Steps
+
+1. **Branch preflight.** Run `git branch --show-current`.
+   - **If on `main` or `master`:** derive a new branch name from the staged diff.
+     - Type: conventional-commit type inferred from the diff (`feat`/`fix`/`refactor`/`chore`/`docs`/`test`).
+     - Slug: 3–6 word kebab-case summary of the change (e.g., `pr-workflow-enforcement`).
+     - Branch: `claude/<type>-<slug>` (fall back to `claude/$(date +%Y%m%d)-$(git rev-parse --short HEAD)` if inference is uncertain).
+     - Run `git checkout -b <branch>` and announce the branch name in one line.
+   - **Otherwise:** stay on the current branch and continue.
+
+2. **Pre-commit framework check.** Run `test -x .git/hooks/pre-commit` (the `pre-commit` framework installs an executable there). If missing, run `make hooks-install` and announce. Never symlink `scripts/pre-commit-extraction-guard.sh` into `.git/hooks/pre-commit` directly — it would clobber ruff / ruff-format. The guard is registered as a `local` hook in `.pre-commit-config.yaml` (id `extraction-guard`).
+
+3. **Doc update check.** Review session changes and determine whether docs need updating. Skip if session changes are narrow. Otherwise apply targeted checks:
+
+   | If the session touched... | Check and update... |
+   |---|---|
+   | New script or CLI command | `CLAUDE.md` commands section, `docs/README.md` |
+   | New or renamed `src/` module | Architecture docs (`docs/architecture/`) |
+   | New or changed API route | `docs/HUMAN_REVIEW_SYSTEM.md` or relevant route doc |
+   | New env var | `.env.template` reference in `CLAUDE.md` |
+   | New DB migration or schema change | `CLAUDE.md` database section, `docs/architecture/` |
+   | Changed workflow or pipeline stage | `CLAUDE.md` pipeline description, relevant `docs/` file |
+
+   For each implicated doc: read, compare against current code, update only what is factually wrong or missing. Flag editorial judgment calls to the user.
+
+4. **Preserve pre-existing staging.** Run `git diff --cached --name-only`; capture already-staged files. Unstage with `git restore --staged <files>`. After the commit (step 12), re-stage them to restore index state.
+
+5. **Stage files** — three-tier logic:
+   - **Session files exist:** Identify all files edited/created by Claude this conversation (via Edit/Write tool calls), including any doc files updated in step 3. Cross-reference with `git status --porcelain` to confirm uncommitted. Auto-stage with `git add <files>` — no user confirmation. Do NOT auto-stage files with uncommitted changes that were not touched in this session.
+   - **No session files, but pre-existing changes exist:** Run `git status --short`, show it to the user, ask which to stage, wait for explicit confirmation.
+   - **Nothing to commit:** Report "No changes to commit" and stop.
+
+6. **Lint check.** Check staged files (`git diff --cached --name-only`). If no code files are staged (`src/`, `tests/`, `scripts/`, `config/`, `sql/`, `pyproject.toml`, `requirements.txt`), skip with a note. Otherwise `ruff check src/ tests/` and fix any errors.
+
+7. **Full test suite.** If no code files staged, skip with a note. Otherwise `pytest -x -q`. All must pass. Diagnose root cause on failures, fix, re-run until green in a single run.
+
+8. **Doc freshness.** After pytest passes:
+   - If pytest output shows a coverage percentage different from `CLAUDE.md` (currently "87%"), update and stage.
+   - If `docs/KNOWN_ISSUES.md` is staged, update its "Last Updated" date to today and re-stage.
+   - If `docs/PROJECT_TASK_INVENTORY.md` "Last Verified" date is >30 days old, warn and suggest `/doc-audit`.
+   - Stage any fixes made here.
+
+9. **Out-of-scope issue triage.** Review the session for issues that surfaced but were NOT addressed by this commit, and recommend which merit filing to `docs/KNOWN_ISSUES.md`.
+
+   **9a. Pre-flight guard.** If `docs/KNOWN_ISSUES.md` already has pre-existing uncommitted edits (staged or unstaged), stop and tell the user to commit those separately first.
+
+   **9b. Enumerate candidates.** Consider every issue that surfaced but was not fixed:
+   - Bugs/incorrect behavior observed but deliberately not fixed
+   - Missing test coverage noticed and deferred
+   - Code smells, dead code, tech debt flagged during exploration
+   - Brittle patterns or fragile tests encountered
+   - Follow-up work explicitly deferred ("let's handle X later", "out of scope")
+   - Unexpected behavior in adjacent code paths surfaced while debugging
+
+   Filter out:
+   - Already tracked in `docs/KNOWN_ISSUES.md`
+   - Items the user told you to forget or decline to track
+   - Ephemeral observations (test timing variance, comment typos)
+   - Style preferences with no behavioral impact
+
+   **9c. Classify.** Assign `FILE` or `SKIP` with a one-line rationale per item. Propose severity (Critical/High/Medium/Low) for `FILE` items.
+
+   **9d. Present recommendations.** Default action is to file every `FILE`-recommended item. If no candidates, state "No out-of-scope issues surfaced this session" and proceed. Otherwise output:
+
+   ```
+   Out-of-scope issues surfaced this session. My recommendations:
+
+   TO FILE:
+   1. [Title] — Severity: [level]. Rationale: [why]
+   2. ...
+
+   TO SKIP:
+   A. [Title]. Rationale: [why]
+   B. ...
+
+   Proceeding with filing items 1–[N] unless you say otherwise. Reply "approve" / "all" to accept, "none" to skip all, or list changes.
+   ```
+
+   **9e. Act.** "approve"/"all"/silent → file all `TO FILE`. "none"/"skip" → file nothing. Anything else → apply user edits, confirm revised list, file.
+
+   **9f. Write entries.** For each item:
+   - Read `docs/KNOWN_ISSUES.md`, scan `## N.` headings, pick max + 1.
+   - Format: `## [N]. [Title]`, then `**Status**: Open`, `**Severity**: [level]`, `**Discovered**: [today's date]`, then `### Problem` (1–3 sentences) and `### Next Steps` (1–3 bullets). 5–15 lines each.
+   - Append below last existing issue, above the summary table.
+   - Update `**Last Updated**` to today, append `, #N opened for [descriptor]`.
+   - Add a row per issue to the summary table.
+   - Do NOT stage `docs/KNOWN_ISSUES.md` yet — it's a separate follow-up commit (step 13).
+
+10. **Show staged diff.** Run `git diff --cached --stat`.
+
+11. **Generate commit message and commit.** From `git diff --cached` + staged files:
+    - Conventional commit: `type: concise description` (subject ≤72 chars)
+    - Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
+    - If a ticket/issue reference is apparent, include it in parens: `feat: add X (GR-16)`
+    - Add a body (blank line + detail) only when the diff spans multiple distinct concerns
+    - Use the generated message directly — no confirmation. Run `git commit` via heredoc for multi-line messages.
+
+12. **Restore pre-existing staging.** Re-stage files that were unstaged in step 4.
+
+13. **Known-issues follow-up commit.** Only if step 9 produced changes to `docs/KNOWN_ISSUES.md`:
+    - `git add docs/KNOWN_ISSUES.md` (only that file).
+    - Commit: `docs(known-issues): log issue(s) #N[, #M] — [descriptor]` (matches commits `87b54f7`, `e96b6fb`).
+    - Do NOT push yet — step 14 pushes both commits together.
+
+14. **Push the branch.** `git push -u origin "$(git branch --show-current)"`. If the push fails (e.g., pre-push hook rejects because of a test failure): report the error verbatim and stop. Do NOT retry silently, do NOT use `--no-verify`, do NOT push to any other branch.
+
+15. **Open or reuse PR.**
+    - `gh pr view --json number,state,url 2>/dev/null` — capture the JSON.
+    - If `state == OPEN`: skip create; reuse the existing PR. Report the URL.
+    - Otherwise: `gh pr create --fill` (auto-title from commit subject, auto-body from commit body + PR template). Capture the URL.
+    - On `gh` failure (auth, rate-limit, etc.): report the exact error and stop. Do NOT fall back to any other form of merge.
+
+16. **Enable auto-merge.** `gh pr merge --auto --squash` (idempotent — no-op if already enabled). `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
+
+17. **Report.** Final one-line summary to the user:
+    ```
+    PR #<n> opened/updated: <url>. Auto-merge enabled (squash). Waits on: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright). Run /ci-fix if checks go red.
+    ```
+
+---
+
+## Rules
+
+- Never commit with failing tests.
+- Never commit with ruff errors (warnings are acceptable).
+- Never amend an existing commit unless the user explicitly asks.
+- Auto-stage session files; never auto-stage files not touched this session (always ask first for pre-existing changes).
+- Never use `git add -A` or `git add .` — always stage specific files by name.
+- Auto-commit using the generated message — no confirmation.
+- **Never push directly to `main`.** Step 1 branches off main; if for any reason the branch is still `main` when step 14 runs, stop and report.
+- **Never `--force` push. Never `--no-verify`. Never `gh pr merge --admin`.**
+- If a PR already exists for the branch, reuse it — do not open a duplicate.
+- Doc auto-fixes are limited to deterministic values (coverage percentage, dates) and factual corrections (wrong command name, renamed module). Editorial-judgment changes must be flagged to the user.
+- Out-of-scope triage (step 9) is mandatory — never skip it silently.
+- Known-issues entries are always a separate follow-up commit (step 13).
+- If any `gh` or `git push` command fails, report verbatim and stop. No silent retries.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,10 +25,27 @@
       "Bash(rm -rf /)*",
       "Bash(sudo*)",
       "Bash(curl*|*bash)",
-      "Bash(*> /etc/*)"
+      "Bash(*> /etc/*)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push -u origin main)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(gh pr merge*--admin*)"
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cmd=\"${CLAUDE_TOOL_INPUT_command:-$1}\"; case \"$cmd\" in *\"git commit\"*) br=$(git -C \"$CLAUDE_PROJECT_DIR\" branch --show-current 2>/dev/null); if [ \"$br\" = \"main\" ] || [ \"$br\" = \"master\" ]; then echo \"BLOCKED: refusing to commit on $br. Use /commit (auto-branches) or git checkout -b <branch> first.\" >&2; exit 2; fi ;; esac' _ \"$CLAUDE_TOOL_INPUT_command\""
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,49 +8,28 @@
 
 
 ## Test Plan
-<!-- How was this tested? -->
-- [ ] Unit tests pass (`pytest tests/unit/`)
-- [ ] Integration tests pass (if applicable)
-- [ ] Manual testing completed
 
+- [ ] Unit tests pass (`pytest tests/unit/ -x -q`)
+- [ ] Integration tests pass (if applicable)
+- [ ] Manual/UI testing completed for user-facing changes
 
 ---
 
 ## Extraction Code Checklist
 
 <!--
-If this PR modifies extraction code, please review the checklist below.
-Check items that apply, or mark N/A if this PR doesn't touch extraction.
+Complete this section if the PR modifies `src/extraction_v2/**` or `config/metric_keywords.yaml`.
+Mark items N/A otherwise.
 -->
 
-**Does this PR modify any of these paths?**
-- `src/extraction_v2/**`
-- `config/metric_keywords.yaml`
-
-If **yes**, please complete this checklist:
-
-- [ ] **Decision Log**: Does this change warrant an entry in `docs/architecture/extraction-decisions.md`?
-  - *Add an entry if: changing extraction logic, adding/removing metrics, modifying classification thresholds, or fixing a bug that reveals a design decision*
-
-- [ ] **Gold Standard Validation**: Did you run `python3 -m src.gold_standard.v2_validator`?
-  - *Required for extraction changes to ensure no regression in extraction quality*
-
-- [ ] **Keyword Config**: If modifying `metric_keywords.yaml`, did you follow the `/metric-lifecycle` guide?
+- [ ] **Gold standard validation passed locally OR N/A** — `python3 -m src.gold_standard.v2_validator --fail-on-regression` exits clean (the pre-commit hook enforces this, but confirm explicitly in the PR description if you skipped via `--no-verify`).
+- [ ] **Decision log** — Added an entry in `docs/architecture/extraction-decisions.md` if this change alters extraction logic, adds/removes metrics, modifies classification thresholds, or fixes a bug that reveals a design decision. N/A otherwise.
+- [ ] **Keyword config** — Followed `/metric-lifecycle` guidance for any `metric_keywords.yaml` edits. N/A otherwise.
 
 ### Decision Log Entry (if applicable)
 
 <!--
-If adding a decision log entry, paste a brief summary here:
-
 **Decision:** [What was decided]
 **Rationale:** [Why this approach]
 **Date:** [YYYY-MM-DD]
--->
-
-
----
-
-<!--
-Note: This template serves as a gentle reminder for extraction changes.
-Not all checkboxes need to be checked - use judgment based on the scope of changes.
 -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,13 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+
+      # Pre-commit: block Tier-1 gold-standard regressions and unapproved
+      # docs/ folders before they land in a PR. Script inspects staged files
+      # itself, so pass_filenames is false.
+      - id: extraction-guard
+        name: extraction/docs guard (Tier-1 regression + docs folder allowlist)
+        entry: bash scripts/pre-commit-extraction-guard.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,16 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 
 **Analytics surface:** `v_analytics_*` Postgres views (sql/38) are the canonical shape for BI/reporting queries. Add new reporting views as `sql/NN_*.sql` migrations rather than aggregation code in `src/`. See `docs/operations/analytics-ui-runbook.md`.
 
+## Workflow
+
+**PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit` (project-local): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass.
+
+Required status checks: **Lint**, **Unit Tests**, **Vulnerability Scan**, **Integration Tests**, **UI E2E (Playwright)**. Use `/ci-fix` when checks fail; `/merge-check` for a manual pre-merge sweep.
+
+Local guards (`.claude/settings.json`): `git push origin main`, `git push --force*`, and `gh pr merge --admin*` are denied. A PreToolUse hook refuses `git commit` on `main`. Pre-commit framework (`make hooks-install`) runs ruff + the Tier-1 regression / docs-folder guard on every commit.
+
+See `docs/development/CONTRIBUTING.md` for the full flow.
+
 ## Key Commands
 
 ```bash
@@ -51,8 +61,8 @@ Metrics are classified into importance tiers based on analytical value. These ti
 - All other `cm_*` metrics (customer counts, MAU/DAU, ARPU, AOV, etc.)
 
 **Rules:**
-- Tier 1 regression in gold standard validation = blocker, must fix before commit
-- Tier 2 regression = acceptable trade-off if Tier 1 improves; note in commit message
+- Tier 1 regression in gold standard validation = blocker, must fix before the PR can merge (enforced locally by the pre-commit hook, again in CI on the PR)
+- Tier 2 regression = acceptable trade-off if Tier 1 improves; note in PR description
 - Extraction improvements (keywords, FP rules, value binding) should prioritize Tier 1 recall gaps first
 - Gold standard coverage expansion should target Tier 1 metrics with low coverage
 - Tier definitions live in `config/metric_keywords.yaml` (authoritative) and `src/gold_standard/v2_validator.py` (runtime)

--- a/docs/README.md
+++ b/docs/README.md
@@ -350,12 +350,12 @@ Workflow commands for common tasks:
 | Command | Purpose |
 |---------|---------|
 | `/metric-lifecycle` | Guidance for adding, deprecating, or removing metrics |
-| `/commit` | Safe commit: runs ruff + pytest before committing |
+| `/commit` | Project-local: auto-branch off main, commit, push, open PR, enable auto-merge. See [CONTRIBUTING.md](development/CONTRIBUTING.md#committing-via-commit-claude-code). |
 | `/plan-review` | Review and critique a plan before execution |
 | `/doc-audit` | Run documentation freshness audit (reports staleness, does not auto-fix) |
 | `/project-tutorial [lesson]` | Interactive project lessons with live codebase walkthroughs (10 topics) |
 
-> **Note:** Only `/doc-audit`, `/metric-lifecycle`, and `/project-tutorial` are project-local command files in `.claude/commands/`. `/commit` and `/plan-review` are delivered via Claude Code skills/plugins rather than project-local files, so they won't appear under `.claude/commands/`.
+> **Note:** `/commit`, `/doc-audit`, `/metric-lifecycle`, and `/project-tutorial` are project-local command files under `.claude/commands/`. `/plan-review` is delivered via Claude Code skills/plugins rather than a project-local file.
 
 ### Sub-Agents (`.claude/agents/`)
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -30,6 +30,51 @@ feature branch → PR against main → CI green → squash-merge
 [`docs/operations/ci-branch-protection.md`](../operations/ci-branch-protection.md)).
 Direct pushes are refused; a red CI blocks the merge button.
 
+### Committing via `/commit` (Claude Code)
+
+The project-local `/commit` skill (`.claude/commands/commit.md`) handles the
+full flow in one invocation:
+
+1. **Branch preflight.** If on `main`, auto-creates `claude/<type>-<slug>` and
+   switches to it. Otherwise stays on the current branch.
+2. **Pre-commit framework check.** Verifies `.git/hooks/pre-commit` is
+   installed; if missing, runs `make hooks-install`.
+3. **Lint + tests + doc-freshness + known-issues triage** (unchanged).
+4. **Commit** (primary) + optional `docs(known-issues): ...` follow-up commit.
+5. **Push** the branch: `git push -u origin <branch>`.
+6. **PR.** If no open PR exists for the branch: `gh pr create --fill`. If
+   one already exists: reuse it (new commits are appended).
+7. **Auto-merge.** `gh pr merge --auto --squash`. GitHub merges the PR once
+   all required checks pass (Lint / Unit Tests / Vulnerability Scan /
+   Integration Tests / UI E2E).
+
+Local safety rails in `.claude/settings.json`:
+
+- `git push origin main`, `git push --force*`, and `gh pr merge*--admin*` are
+  denied before the Bash tool fires them.
+- A PreToolUse hook refuses `git commit` while on `main` (belt-and-suspenders
+  if you bypass `/commit`).
+
+### When checks fail
+
+- **Red CI on a PR:** invoke `/ci-fix` — it iterates ruff/mypy/pytest to
+  green, then defers to `/commit` to push the fix. Auto-merge stays armed and
+  completes when the next run is green.
+- **Pre-merge sanity:** `/merge-check` runs the full local gauntlet (CI
+  status, migrations, import integrity, tests, type check, branch freshness)
+  and reports blockers without taking any action.
+- **Disable auto-merge on a specific PR:** `gh pr merge --disable-auto <num>`.
+
+### Escape hatches
+
+- `git push --no-verify` skips only the **pre-push** unit-test hook. CI still
+  runs the full suite and must pass for the merge button to enable.
+- The PreToolUse hook's `BLOCKED: refusing to commit on main` message is
+  recoverable: `git checkout -b <branch>` and retry the commit.
+- Do **not** use `gh pr merge --admin` — it's denied in settings and bypasses
+  required status checks. `enforce_admins: true` on the branch protection
+  rule would reject it server-side anyway.
+
 ## What runs on commit
 
 `.pre-commit-config.yaml` runs on every `git commit`:

--- a/scripts/pre-commit-extraction-guard.sh
+++ b/scripts/pre-commit-extraction-guard.sh
@@ -3,11 +3,10 @@
 #   1. Extraction guard — blocks commits that regress gold standard metrics
 #   2. Docs structure guard — blocks commits that create unapproved docs folders
 #
-# Install:
-#   ln -sf ../../scripts/pre-commit-extraction-guard.sh .git/hooks/pre-commit
-#
-# Or add to an existing pre-commit hook:
-#   source scripts/pre-commit-extraction-guard.sh
+# Registration: this script is invoked by the `pre-commit` framework via an
+# entry in `.pre-commit-config.yaml` (hook id: extraction-guard). Install the
+# framework's git hook with `make hooks-install` — do NOT symlink this file
+# into `.git/hooks/pre-commit` (that would clobber ruff + ruff-format).
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

`main` is protected server-side (`enforce_admins: true`, 5 required status checks). Local tooling now matches the remote contract: `/commit` auto-branches off main, commits, pushes, opens a PR, and sets `gh pr merge --auto --squash`. Direct commits/pushes to `main` are refused by local guards before they reach the remote.

## Changes

- **New project-local `/commit`** (`.claude/commands/commit.md`) — overrides the global skill; adds branch preflight, `make hooks-install` check, and steps 14–17 (push + `gh pr create` + auto-merge).
- **`.claude/settings.json`** — deny `git push origin main`, `git push --force*`, `gh pr merge*--admin*`; PreToolUse hook refuses `git commit` while on main.
- **`.pre-commit-config.yaml`** — register `extraction-guard` as a local pre-commit hook (was previously an optional standalone symlink).
- **`scripts/pre-commit-extraction-guard.sh`** — header comment updated; no longer symlinked manually.
- **`CLAUDE.md`** — new "Workflow" section; Tier-1 regression wording reworded from "before commit" to "before merge".
- **`.github/pull_request_template.md`** — tightened: Test Plan first, gold-standard checkbox strengthened, "gentle reminder" footer dropped.
- **`docs/development/CONTRIBUTING.md`** — "Committing via `/commit`" section with local safety rails and failure recovery.
- **`docs/README.md`** — `/commit` entry updated (it's project-local now).
- **Remote (one-time):** `allow_auto_merge=true`, `delete_branch_on_merge=true` enabled on `RGMjr/filings_reviewer`.

## Test Plan

- [x] `jq -e . .claude/settings.json` — valid JSON
- [x] `.pre-commit-config.yaml` parses + contains `extraction-guard` hook id
- [x] `ruff check src/ tests/` — clean
- [x] `gh api repos/RGMjr/filings_reviewer --jq '.allow_auto_merge'` → `true`
- [x] Pre-commit hooks fire on commit (`check yaml`, `fix end of files`, `trim trailing whitespace`, `check for added large files`, `detect private key`, `extraction/docs guard` all pass)
- [x] Pre-push hook runs `pytest tests/unit/` (passed)

## Extraction Code Checklist

- [x] N/A — no extraction code, keyword config, or gold-standard logic modified.