### PR TITLE
chore(commands): add /cleanup skill + open #65 secret-leak guard

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -1,0 +1,59 @@
+# Cleanup Skill (project-local)
+
+**Purpose:** Prune merged branches, stale remote-tracking refs, and dead Claude worktrees. Safe to re-run.
+
+**When to use:**
+- Scheduled daily at 2:00am (remote run) — handles branches + remote-tracking refs only.
+- On demand when the user says "clean up", "prune branches", or "clear stale worktrees" — also sweeps local worktrees.
+
+---
+
+## Steps
+
+1. **Detect execution context.** Run `test -d .claude/worktrees && echo local || echo remote`. Remote runs skip step 5. Report the mode in the opening line.
+
+2. **Sync remote state.** Run `git fetch --prune origin`. This deletes remote-tracking refs whose upstream branch is gone.
+
+3. **Find merged PRs.** Run:
+   ```bash
+   gh pr list --state merged --author @me \
+     --json number,headRefName,mergedAt \
+     --limit 100
+   ```
+   Keep branches from the last 90 days; older ones are likely already cleaned.
+
+4. **Delete merged local branches.** For each `headRefName` from step 3:
+   - Skip `main` and the currently checked-out branch (`git branch --show-current`).
+   - If local ref exists (`git show-ref --verify --quiet refs/heads/<branch>`): run `git branch -D <branch>`. Safe because the PR is verified merged via GitHub API. Squash-merges produce different commit hashes, so `-d` often refuses even on cleanly merged branches — that's why `-D` after the gh-state check.
+   - Record deletions for the summary.
+
+5. **Local-only: sweep dead worktrees.** Skip entirely if step 1 reported `remote`.
+   - Run `git worktree list --porcelain`.
+   - For each worktree whose path matches `.claude/worktrees/agent-*`:
+     - Parse the `locked` line to extract the pid (format: `locked claude agent <name> (pid <N>)`).
+     - Check liveness: `ps -p <pid> -o pid= 2>/dev/null`. If the pid is alive, **skip** (active Claude session).
+     - If dead: `git worktree remove --force <path>` then `git branch -D <branch>` for the matching `worktree-agent-*` branch.
+   - Worktrees without a `locked` line (unexpected): report and skip — do not auto-remove.
+
+6. **Report.** Output a concise summary:
+   ```
+   cleanup: mode=<local|remote>
+     pruned remote-tracking refs: N
+     deleted local branches: <list or "none">
+     removed stale worktrees: <list or "none">
+     skipped active worktrees: N (live pids)
+   ```
+
+## Safety rules
+
+- Never touch `main` or the currently checked-out branch.
+- Never delete a local branch unless GitHub confirms its PR is merged (step 3 is the source of truth; do not infer from `git branch --merged`).
+- Never force-remove a worktree whose lock pid is live. A live lock means an active session owns it.
+- Never modify uncommitted changes in any worktree — `git worktree remove --force` aborts on dirty trees; if that happens, report and skip.
+- Do not prune branches matching `worktree-agent-*` via step 4 — those are managed by step 5.
+
+## Out of scope
+
+- Remote branch deletion — handled by GitHub's "delete branch on merge" setting. Step 2's prune catches anything that slipped through.
+- Closed-but-not-merged PRs — their branches may still hold unmerged work. Require manual review.
+- Repo-wide `gc` / `repack` — run `git gc --auto` separately if disk matters.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21 (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -17,6 +17,7 @@ _(none currently)_
 | Issue | Status | Notes |
 |-------|--------|-------|
 | Low Farfetch Recall (Issue #2) | Re-diagnosed umbrella | P=50% R=37% F1=42% on 2026-04-18; superseded by sub-issues #14–#19 |
+| Secret-leak guard on mis-named env duplicates (Issue #65) | Open | `.gitignore` only matches `.env` exactly; a file named `" "` containing full env was untracked but not ignore-protected |
 
 ### Open — Low Severity
 
@@ -857,6 +858,30 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 - Issue #54 — landed `chart_metric_min_confidence` knob; forced to default 0.60 by this sensitivity.
 - `src/extraction_v2/chart/metric_classifier.py::ChartMetricClassifier.classify`
 - `tests/extraction_v2/chart/test_chart_fact_bridge_stage.py::test_emits_facts_for_classified_chart`
+
+---
+
+## 65. Secret-Leak Guard for Mis-Named Env File Duplicates
+
+**Status**: Open
+**Severity**: Medium
+**Discovered**: 2026-04-21 (surfaced during branch-cleanup session)
+
+### Problem
+
+`.gitignore` matches `.env` by exact name only. During cleanup today a file literally named `" "` (single space) was found in the repo root — a 19-line subset of `.env` containing real production secrets (OpenAI key, Neon DB URL with creds, GitHub PAT, Brave/Gemini keys, `SECRET_KEY`, `FILINGS_API_KEY`). The file was untracked and never committed, but **`git check-ignore` confirms `.gitignore` does NOT protect it** — a `git add .` or `git add -A` would have caught it. Likely origin: a shell redirect typo like `cp .env " "`. No pre-commit hook scans staged blobs for secret patterns either.
+
+### Next Steps
+
+- Broaden `.gitignore` to cover env-variant filenames: add `.env*` and consider `!.env.template` / `!.env.example` allowlists.
+- Add a `detect-private-key`-style pre-commit hook that scans staged content for known secret patterns: `sk-proj-*`, `github_pat_*`, `postgresql://*neon.tech`, `OPENAI_API_KEY=`, `SECRET_KEY=`, `FILINGS_API_KEY=`, R2 endpoint URLs.
+- Evaluate `gitleaks` or `detect-secrets` as a belt-and-suspenders scan at commit-time and in CI.
+- Audit `git log --all -S 'OPENAI_API_KEY='` / `sk-proj-` / `github_pat_` to confirm no secret was ever committed historically.
+
+### Cross-References
+
+- `.gitignore` line 2 (current `.env` entry)
+- `.pre-commit-config.yaml` (hook location)
 
 ---
 


### PR DESCRIPTION
## Summary

- New `.claude/commands/cleanup.md` skill: prunes merged local branches (gh-verified) and sweeps dead-pid `.claude/worktrees/agent-*` dirs. Context-aware — detects remote vs local and skips worktree sweep when running remotely.
- Companion to the `daily-branch-cleanup` remote trigger (trig_01C9V1d6GHox3EzkpViMq4PM, fires at 7 6 * * * UTC = 2:07 AM EDT). Trigger prompt is self-contained so it does not depend on this file being on main.
- Opens KNOWN_ISSUES #65 for a secret-leak guard on mis-named env duplicates, surfaced during the same cleanup session when a file literally named `" "` was found containing a full `.env` copy (untracked, never committed, but `.gitignore` did not cover it).

## Test plan

- [x] Pre-commit framework hooks pass (ruff skipped — no code files; extraction/docs guard passed)
- [x] Pre-push pytest-unit hook passes
- [ ] Required CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)
- [ ] Manually invoke `/cleanup` locally after merge to confirm worktree-sweep path

🤖 Generated with [Claude Code](https://claude.com/claude-code)