### PR TITLE
chore(render): shared secrets env group + KNOWN_ISSUES #66 (rebased)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21, #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -18,6 +18,7 @@ _(none currently)_
 |-------|--------|-------|
 | Low Farfetch Recall (Issue #2) | Re-diagnosed umbrella | P=50% R=37% F1=42% on 2026-04-18; superseded by sub-issues #14–#19 |
 | Secret-leak guard on mis-named env duplicates (Issue #65) | Open | `.gitignore` only matches `.env` exactly; a file named `" "` containing full env was untracked but not ignore-protected |
+| Migrations not auto-applied on Render deploy (Issue #66) | Open | PR #48 merged `sql/39` but Render didn't run `apply_migrations.py`; worker crashed with `UndefinedTable` until manual apply |
 
 ### Open — Low Severity
 
@@ -882,6 +883,30 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 
 - `.gitignore` line 2 (current `.env` entry)
 - `.pre-commit-config.yaml` (hook location)
+
+---
+
+## 66. Migrations Not Auto-Applied on Render Deploy
+
+**Status**: Open
+**Severity**: Medium
+**Discovered**: 2026-04-21 (during `filings-onboarding-runner` recovery)
+
+### Problem
+
+`scripts/apply_migrations.py` is idempotent (via the `schema_migrations` ledger) and keeps a registered list through `sql/39_v2_ingest_batches.sql`, but Render's blueprint-driven deploys do not invoke it. When PR #48 merged with `sql/39_v2_ingest_batches.sql`, Render auto-deployed `filings-onboarding-runner` without running the migration, and the worker then crashed every ~5 minutes with `psycopg.errors.UndefinedTable: relation "v2_ingest_batches" does not exist` until an operator manually ran `python3 scripts/apply_migrations.py` against Neon. Every future schema-change PR has the same failure mode.
+
+### Next Steps
+
+- Add a Render pre-deploy command on `filings-reviewer` (the web service with the longest deploy budget) that runs `python3 scripts/apply_migrations.py` before the container starts. The ledger makes it safe on every deploy.
+- Alternative: a dedicated one-shot Render Job that runs the migration runner on every merge to main, blocking service redeploys until it exits 0.
+- Document the chosen path in `.claude/rules/infrastructure.md` so future schema-change PRs don't repeat this.
+
+### Cross-References
+
+- `scripts/apply_migrations.py` — migration runner (idempotent via `schema_migrations` ledger)
+- `sql/39_v2_ingest_batches.sql` — the migration that triggered this discovery
+- `render.yaml` — pre-deploy hook would attach to the web service entry
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,26 @@
+envVarGroups:
+  - name: filings-shared-secrets
+    envVars:
+      # Values set manually in the Render dashboard. Linked to every service
+      # that needs Postgres + R2 image-cache access.
+      - key: DATABASE_URL
+        sync: false
+      - key: R2_BUCKET
+        sync: false
+      - key: R2_ACCESS_KEY_ID
+        sync: false
+      - key: R2_SECRET_ACCESS_KEY
+        sync: false
+      - key: R2_ENDPOINT_URL
+        sync: false
+
 services:
   - type: web
     name: filings-reviewer
     runtime: docker
     dockerfilePath: ./Dockerfile
     envVars:
-      - key: DATABASE_URL
-        sync: false  # set manually — works with Neon or Render Postgres
+      - fromGroup: filings-shared-secrets
       - key: SECRET_KEY
         generateValue: true
       - key: APP_ENV
@@ -14,15 +29,6 @@ services:
         sync: false
       - key: INGEST_SPAWN_SUBPROCESS
         value: "false"  # production drains via filings-onboarding-runner worker
-      # Cloudflare R2 image cache (src/infra/image_storage.py). Values set via Render dashboard.
-      - key: R2_BUCKET
-        sync: false
-      - key: R2_ACCESS_KEY_ID
-        sync: false
-      - key: R2_SECRET_ACCESS_KEY
-        sync: false
-      - key: R2_ENDPOINT_URL
-        sync: false
 
   - type: cron
     name: filings-extraction
@@ -31,17 +37,7 @@ services:
     dockerCommand: python3 scripts/batch_v2_extraction.py --status fetched --workers 2 --limit 50
     schedule: "0 6 * * *"  # Daily at 6am UTC
     envVars:
-      - key: DATABASE_URL
-        sync: false
-      # Cron writes images to R2 — must share the same bucket credentials as the web service.
-      - key: R2_BUCKET
-        sync: false
-      - key: R2_ACCESS_KEY_ID
-        sync: false
-      - key: R2_SECRET_ACCESS_KEY
-        sync: false
-      - key: R2_ENDPOINT_URL
-        sync: false
+      - fromGroup: filings-shared-secrets
 
   - type: worker
     name: filings-onboarding-runner
@@ -49,18 +45,8 @@ services:
     dockerfilePath: ./Dockerfile
     dockerCommand: python3 -m src.universe.onboarding_runner --watch --poll-interval 10
     envVars:
-      - key: DATABASE_URL
-        sync: false
+      - fromGroup: filings-shared-secrets
       - key: SEC_USER_AGENT
         sync: false
       - key: OPENAI_API_KEY
-        sync: false
-      # Worker runs V2Pipeline for onboard batches — image OCR writes to R2.
-      - key: R2_BUCKET
-        sync: false
-      - key: R2_ACCESS_KEY_ID
-        sync: false
-      - key: R2_SECRET_ACCESS_KEY
-        sync: false
-      - key: R2_ENDPOINT_URL
         sync: false


### PR DESCRIPTION
Supersedes #57 (closed — needed rebase on main after PR #56 landed #65; force-push blocked by local guards, so re-opening from a fresh branch).

## Summary

- Consolidates five secrets shared by all three Render services (`DATABASE_URL`, four `R2_*`) into a `filings-shared-secrets` env group in `render.yaml`.
- Logs KNOWN_ISSUES #66 for a related gap surfaced during recovery: Render deploys don't run `apply_migrations.py`, so PRs with new `sql/NN` files ship broken services until someone manually applies.

## Context

`filings-onboarding-runner` (auto-created by blueprint sync when PR #48 merged earlier today) went live without `DATABASE_URL` pasted — `sync: false` secrets must be set per-service manually, and that step was missed on the auto-provisioned worker. The runner loop logged `DATABASE_URL environment variable is not set` every ~5 min for hours.

Rather than just paste the secrets, we consolidated shared secrets into an env group: any future blueprint-auto-created service that declares `fromGroup: filings-shared-secrets` inherits the values at first boot.

## Deployment ordering (already done)

Dashboard state was established first so the blueprint change is a runtime no-op:

1. Created `filings-shared-secrets` env group in dashboard.
2. Pasted five values (also fixed a literal-quote paste bug on `DATABASE_URL`).
3. Linked the group to all three services.
4. Pasted worker-only secrets (`SEC_USER_AGENT`, `OPENAI_API_KEY`) on the worker.
5. Ran `apply_migrations.py` against Neon to create `v2_ingest_batches` (sql/39).

## Test plan

- [x] Pre-commit + pre-push hooks green (yaml, private-key scan, docs guard, ruff, pytest unit)
- [x] Worker verified green after Phase 1: DB connection + sql/39 tables both confirmed via logs
- [x] Rebased cleanly on top of origin/main (which now includes #65)
- [ ] After merge: confirm Render blueprint sync removes no env vars from the three services
- [ ] After merge: tail logs on all three services, confirm no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)