### PR TITLE
feat(sweeper): add nightly autonomous KNOWN_ISSUES sweeper

### DIFF
--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -1,0 +1,43 @@
+# Nightly Sweep — Manual Invoke Skill
+
+**Purpose:** Run the KNOWN_ISSUES sweeper manually (same flow the Render cron runs nightly). Useful for ad-hoc backlog drains, testing changes to the selector, or verifying a classification change.
+
+**When to use:**
+- The user says "run the sweep", "drain the backlog", "sweep issue #N".
+- Local verification before landing a sweeper change.
+
+---
+
+## Steps
+
+1. **Pause-file check.** If `.claude/sweep.pause` exists, announce it and confirm with the user whether to proceed. If they say yes, do not delete the file — instead invoke the script with a `SWEEP_FORCE=1` environment override (documented in the runbook). The nightly cron stays paused.
+
+2. **Dry-run selector.** Run:
+   ```bash
+   python3 scripts/known_issues_selector.py --dry-run
+   ```
+   Show the user the picks. Confirm before continuing if `--max` should be different or `--include-review` should be on.
+
+3. **Pre-flight.** Confirm:
+   - `claude` CLI available (`command -v claude`)
+   - `gh` authenticated (`gh auth status`)
+   - On `main` with clean tree (`git status`, `git rev-parse --abbrev-ref HEAD`)
+   - `ANTHROPIC_API_KEY` set
+   If any fails, stop and report.
+
+4. **Invoke.** Run:
+   ```bash
+   bash scripts/run_nightly_sweep.sh
+   ```
+   Stream output to the user.
+
+5. **Report.** Summarise: N merged, N awaiting, N abandoned. Link each PR. Link the digest file.
+
+---
+
+## Rules
+
+- Never delete `.claude/sweep.pause` to run manually — use an env override instead.
+- Never pass `--no-pr-dedupe` to the orchestrator (only to `known_issues_selector.py --dry-run` when offline).
+- If the selector returns zero picks, do not run the orchestrator — report "nothing to sweep" and exit.
+- The manual run writes to the same `.claude/sweep-digests/` path as the cron; expect one digest file per date.

--- a/.claude/sweep-digests/.gitkeep
+++ b/.claude/sweep-digests/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder so the sweep-digests directory exists in git.
+# Nightly digests land here as YYYY-MM-DD.md via PR.
+# See docs/operations/nightly-sweep-runbook.md.

--- a/.claude/sweep.pause
+++ b/.claude/sweep.pause
@@ -1,0 +1,11 @@
+# Kill switch for the nightly KNOWN_ISSUES sweeper.
+#
+# When this file exists at repo root relative path .claude/sweep.pause, the
+# Render cron service (filings-nightly-sweep) refuses to run any sweep and
+# exits 0 with a log entry.
+#
+# To ACTIVATE the sweeper: delete this file, commit + merge.
+# To PAUSE the sweeper:    re-create this file, commit + merge.
+#
+# Intentionally committed so the sweeper ships disabled. First activation is
+# explicit and reviewable. See docs/operations/nightly-sweep-runbook.md.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Local guards (`.claude/settings.json`): `git push origin main`, `git push --forc
 
 See `docs/development/CONTRIBUTING.md` for the full flow.
 
+**Nightly autonomous sweeper:** `filings-nightly-sweep` cron runs 06:00 UTC daily, picks up to 3 issues tagged `Autonomy: safe` from the **Nightly Sweeper Classification** table in `docs/KNOWN_ISSUES.md`, auto-merges on green CI, and writes a morning-review digest to `.claude/sweep-digests/`. Ships paused via `.claude/sweep.pause`. See `docs/operations/nightly-sweep-runbook.md` and the `/sweep` skill for manual runs.
+
 ## Key Commands
 
 ```bash

--- a/Dockerfile.nightly-sweep
+++ b/Dockerfile.nightly-sweep
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+#
+# Dockerfile.nightly-sweep — image for the autonomous KNOWN_ISSUES sweeper.
+#
+# Differences vs. the main Dockerfile:
+#   - Adds the Claude Code CLI (`claude`) and GitHub CLI (`gh`)
+#   - Installs git (the base `python:slim` image lacks it)
+#   - Keeps the same Python + pip layer so /commit's `pytest -x -q` can run
+#     inside worktrees.
+#
+# Entrypoint is the orchestrator shell script; the Render cron service
+# overrides with its own command if needed.
+
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /app
+
+# System deps: git (for worktrees + push), curl (to fetch CLIs), build deps
+# for psycopg/cffi wheels that the repo pulls in via requirements.lock.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh). Official install via keyring + apt.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI. Installs to /usr/local/bin/claude via the official installer.
+# The installer is idempotent and safe to run at build time.
+RUN curl -fsSL https://claude.ai/install.sh | sh
+
+# Non-privileged user (matches main Dockerfile pattern).
+ARG UID=10001
+RUN adduser --disabled-password --gecos "" \
+        --home "/home/appuser" --shell "/bin/bash" --uid "${UID}" appuser
+
+# Python dependencies — same lockfile as the main image so pytest works inside
+# sweep worktrees without a separate install step.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.lock,target=requirements.lock \
+    python -m pip install -r requirements.lock
+
+COPY --chown=appuser:appuser . .
+
+RUN mkdir -p /app/.claude/worktrees /app/.claude/sweep-digests \
+    && chown -R appuser:appuser /app/.claude
+
+USER appuser
+
+CMD ["bash", "scripts/run_nightly_sweep.sh"]

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21, #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, added Nightly Sweeper Classification table (see below for the autonomous-merge / morning-review / skip tags used by `scripts/known_issues_selector.py`); #67 opened for macOS `timeout` incompatibility in the sweeper orchestrator; #68 opened for unpinned `claude`/`gh` installs in `Dockerfile.nightly-sweep`. #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -41,6 +41,8 @@ _(none currently)_
 | Local-dev stuck-batch recovery is manual (Issue #62) | Open | No watcher runs locally; subprocess death leaves `status='running'` forever |
 | Cancel-during-populate not integration-tested (Issue #63) | Open | Conditional `_BATCH_COMPLETE_SQL` unit-tested; no end-to-end race-condition test |
 | Chart classifier Tier 1 boundary sensitivity (Issue #64) | Open | HOOD `cm_balance_by_cohort` scores 0.6024 — 0.0024 above the 0.6 gate; silent-regression risk |
+| Nightly sweeper uses GNU `timeout` — macOS incompatible (Issue #67) | Open | Local `/sweep` on Mac fails at the `timeout` call; Render (Linux) production is fine |
+| `Dockerfile.nightly-sweep` installs `claude` + `gh` unpinned (Issue #68) | Open | Version drift between builds could silently change sweeper behaviour |
 
 ### Partially Resolved
 
@@ -62,6 +64,53 @@ _(none currently)_
 | Issue | Notes |
 |-------|-------|
 | Image cache / R2 backend (Issue #34) | Cross-referenced by #24, #35, #42; body retained until those close |
+
+---
+
+## Nightly Sweeper Classification
+
+Source of truth for `scripts/known_issues_selector.py` — the nightly autonomous sweeper reads this table to decide which issues it may work on, and whether to auto-merge or hold for morning review. See `docs/operations/nightly-sweep-runbook.md` for the full flow.
+
+**Autonomy values:**
+- `safe` — sweeper may open a PR and auto-merge on green CI (branch protection's 5 required checks are the real gate).
+- `review` — sweeper may open a draft PR, but it holds for your morning approval. Use for judgment calls, cross-module edits, new feature logic.
+- `skip` — sweeper never touches. Use for stakeholder decisions, data-driven tuning, investigations, or anything requiring human reasoning.
+
+**Default for new issues:** `skip`. Reclassify after triage. The `/commit` skill's known-issues-filing step appends a row here with `skip` / `?` / `—` defaults.
+
+**Touches** column holds space-separated file globs. The selector uses these to pick non-colliding batches — if two issues touch overlapping files, only one is picked per night.
+
+| Issue | Autonomy | Estimated | Touches                                                                 | Note                                                          |
+|-------|----------|-----------|-------------------------------------------------------------------------|---------------------------------------------------------------|
+| #2    | skip     | L         | —                                                                       | Umbrella for Farfetch recall; sub-issues, stakeholder tuning  |
+| #4    | skip     | —         | —                                                                       | Known limitation; not actionable                              |
+| #5    | skip     | —         | —                                                                       | Working as designed                                           |
+| #9    | skip     | M         | —                                                                       | Needs re-ingestion of real Snap filing; not a code fix        |
+| #11   | skip     | XS        | —                                                                       | Tied to archived Issue #10; defer                             |
+| #16   | skip     | M         | —                                                                       | Precision tuning; data-driven, needs judgment                 |
+| #24   | skip     | M         | —                                                                       | Data audit + FK migration; needs cleanup decision             |
+| #27   | skip     | S         | —                                                                       | Stale assertions — needs judgment on test rewrite             |
+| #28   | skip     | L         | —                                                                       | Root architecture issue; no single-file fix                   |
+| #34   | skip     | —         | —                                                                       | Cross-referenced only; closes when dependents close           |
+| #35   | skip     | L         | —                                                                       | Backfill; needs coordination with #53/#54                     |
+| #38   | review   | M         | `sql/*.sql src/*/*.py src/web/routes/*.py tests/**/*.py`                | Column rename + callsite sweep; needs callsite audit          |
+| #39   | skip     | M         | —                                                                       | Column rename; needs migration ordering decision              |
+| #40   | skip     | —         | —                                                                       | Stakeholder decision (supersession semantics)                 |
+| #43   | skip     | —         | —                                                                       | Latent; no action needed until re-extraction                  |
+| #49   | skip     | M         | —                                                                       | Flaky test investigation; risk of masking real bug            |
+| #53   | skip     | M         | —                                                                       | Chart call limit; needs data-driven tuning                    |
+| #55   | skip     | S         | —                                                                       | Data cleanup; needs inspection of stuck filings               |
+| #58   | review   | S         | `src/filing_fetcher/*.py tests/unit/filing_fetcher/*.py`                | 8-K Exhibit 99.1 fetch; feature add, needs validator run      |
+| #59   | review   | S         | `src/extraction_v2/classifier*.py tests/unit/extraction_v2/*classifier*`| New classifier patterns; FP risk                              |
+| #60   | safe     | XS        | `src/universe/onboarding.py tests/unit/universe/test_onboarding.py`     | SIC-filter JOIN in detect_universe_gaps                       |
+| #61   | safe     | S         | `tests/integration/web/test_ingest_flow.py`                             | New integration test; isolated file                           |
+| #62   | review   | S         | `docs/operations/* src/universe/onboarding_runner.py`                   | Docs + optional admin flag; needs design call                 |
+| #63   | skip     | S         | —                                                                       | Monkey-patch integration test; mid-complexity                 |
+| #64   | skip     | S         | —                                                                       | Classifier margin investigation; data-driven                  |
+| #65   | review   | S         | `.gitignore .pre-commit-config.yaml`                                    | Regex patterns for secret detection; needs judgment           |
+| #66   | review   | S         | `render.yaml .claude/rules/infrastructure.md`                           | Wire apply_migrations into Render deploy; infra-change risk   |
+| #67   | safe     | XS        | `scripts/run_nightly_sweep.sh`                                          | Detect timeout vs gtimeout; fallback path for macOS           |
+| #68   | review   | S         | `Dockerfile.nightly-sweep`                                              | Pin claude + gh versions; needs validation step               |
 
 ---
 
@@ -872,6 +921,41 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 - `scripts/apply_migrations.py` — migration runner (idempotent via `schema_migrations` ledger)
 - `sql/39_v2_ingest_batches.sql` — the migration that triggered this discovery
 - `render.yaml` — pre-deploy hook would attach to the web service entry
+
+---
+
+## 67. Nightly Sweeper Orchestrator Uses GNU `timeout` (Incompatible with macOS)
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-04-21 (during nightly sweeper implementation)
+
+### Problem
+
+`scripts/run_nightly_sweep.sh` invokes `timeout "$PER_ISSUE_BUDGET" claude -p "$prompt"` to enforce per-issue wall-clock budgets. `timeout` is GNU coreutils; macOS ships BSD utilities and does not include it by default. Local `/sweep` skill invocations on macOS fail at the `timeout` call. Render's container image is Linux so production is fine.
+
+### Next Steps
+
+- Detect `timeout` vs `gtimeout` vs neither at script start; fall back to `gtimeout` on macOS (via `brew install coreutils`) or to a no-timeout code path with a warning log.
+- Alternatively, install `coreutils` as part of the local-dev setup docs for the `/sweep` skill.
+
+---
+
+## 68. `Dockerfile.nightly-sweep` Installs `claude` + `gh` Unpinned
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-04-21 (during nightly sweeper implementation)
+
+### Problem
+
+`Dockerfile.nightly-sweep` installs the Claude Code CLI via `curl -fsSL https://claude.ai/install.sh | sh` and the GitHub CLI via the package repo without a version pin. Each Render build pulls whatever is current, so a tool update between builds could silently change sweeper behaviour (e.g., `claude -p` flag semantics, `gh pr merge` auto-squash wiring).
+
+### Next Steps
+
+- Pin the `claude` installer to a specific version once the installer supports a version argument; otherwise cache a specific binary in the image.
+- Pin `gh` to a specific apt version (`gh=2.X.Y`) or switch to the GitHub Releases tarball.
+- Consider adding a build-time smoke test: `claude --version && gh --version` to fail the build on unexpected drift.
 
 ---
 

--- a/docs/operations/nightly-sweep-runbook.md
+++ b/docs/operations/nightly-sweep-runbook.md
@@ -1,0 +1,114 @@
+# Nightly KNOWN_ISSUES Sweeper — Runbook
+
+## What it does
+
+Every night at 02:00 EDT (06:00 UTC), the `filings-nightly-sweep` Render cron service:
+
+1. Parses the **Nightly Sweeper Classification** table in `docs/KNOWN_ISSUES.md`.
+2. Picks up to 3 non-colliding issues tagged `Autonomy: safe` (default) or `review` (opt-in).
+3. For each pick, creates an isolated git worktree and runs a Claude Code session that:
+   - Reads the issue body.
+   - Implements exactly what the "Next Steps" section asks.
+   - Runs the `/commit` skill — which gates lint/tests/doc-freshness, opens a PR, enables auto-merge.
+4. Writes `.claude/sweep-digests/YYYY-MM-DD.md` summarising:
+   - **Auto-merged** — safe-tier PRs already in flight to main (CI gates still enforced).
+   - **Awaiting your approval** — review-tier draft PRs with one-line approve/discard commands.
+   - **Abandoned** — issues the sweeper tried but gave up on, with the reason.
+5. Opens a PR for the digest file.
+
+The source of truth for which issues the sweeper may touch is the classification table in `docs/KNOWN_ISSUES.md`.
+
+## Activate / pause
+
+The sweeper ships **paused**. To activate:
+
+```bash
+rm .claude/sweep.pause
+# commit via /commit; land the PR
+```
+
+To pause again any time:
+
+```bash
+touch .claude/sweep.pause
+git add .claude/sweep.pause
+# commit via /commit; land the PR
+```
+
+The cron still fires on schedule — it just exits `0` with a log line on the Render service page.
+
+## Morning review workflow
+
+1. Open `.claude/sweep-digests/<today>.md` (it's in the repo; check the latest PR from `claude/sweep-digest/<date>`).
+2. **Auto-merged** section: for awareness. The PRs have already been squash-merged if CI went green; any red-CI PRs stay open and show up in `gh pr list`.
+3. **Awaiting your approval** section: for each entry, either run the "To merge" command or the "To discard" command.
+4. **Abandoned** section: decide whether to retry (the sweeper will re-select the same issue tomorrow unless tagged `skip`) or reclassify the issue.
+
+## Classifying issues
+
+When you open a new issue via `/commit`'s step 9, the filing defaults to `Autonomy: skip`. Reclassify it by editing the row in `docs/KNOWN_ISSUES.md` → **Nightly Sweeper Classification**:
+
+- `safe` — single file or disjoint files; no schema/migration; no infra/credential change; existing test coverage. Sweeper auto-merges on green CI.
+- `review` — cross-module edits, judgment calls, new feature logic. Sweeper opens draft PR for morning approval.
+- `skip` — stakeholder decision, data-driven tuning, investigation. Sweeper never touches.
+
+Always fill in the **Touches** column with space-separated file globs. An issue without globs is skipped regardless of tag — the sweeper cannot scope its work otherwise.
+
+## Local dry-run / debugging
+
+```bash
+# See what the sweeper would pick tonight
+python3 scripts/known_issues_selector.py --dry-run --no-pr-dedupe
+
+# Run the full orchestrator locally (requires claude + gh + ANTHROPIC_API_KEY + GH_TOKEN)
+bash scripts/run_nightly_sweep.sh
+```
+
+Unit tests:
+
+```bash
+pytest tests/unit/scripts/test_known_issues_selector.py \
+       tests/unit/scripts/test_write_sweep_digest.py -v --no-cov
+```
+
+## Budgets
+
+Configurable via Render env vars on the `filings-nightly-sweep` service (defaults in `scripts/run_nightly_sweep.sh`):
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `SWEEP_MAX` | `3` | Max issues per run |
+| `SWEEP_INCLUDE_REVIEW` | `0` | If `1`, include `review` issues in selection |
+| `SWEEP_WALL_BUDGET` | `2700` s | Total wall-clock cap for a run (45 min) |
+| `SWEEP_PER_ISSUE` | `900` s | Per-issue wall-clock cap (15 min) |
+
+## Guardrails
+
+- Branch protection on `main` (`enforce_admins: true`) rejects any direct push, including the sweeper's.
+- Five CI checks (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E) gate every sweeper PR.
+- Local `.claude/settings.json` hooks deny `git push origin main`, `--force`, `gh pr merge --admin`.
+- The sweeper's prompt explicitly forbids: schema migrations, infra/credential changes, work outside declared `Touches` globs, baseline updates to silence tests, `--no-verify`.
+- Worktree isolation — the sweeper cannot collide with a concurrent human session.
+- Credential scope — the sweeper's env group (`ANTHROPIC_API_KEY`, `GH_TOKEN`) deliberately excludes DB and R2 creds.
+
+## When things go wrong
+
+**Sweeper abandons every issue with "tests failed"**: a pre-existing test failure on `main` is blocking `/commit`. Run `pytest -x -q` locally, fix or triage, commit. The sweeper will retry tomorrow.
+
+**Sweeper can't authenticate to GitHub**: `GH_TOKEN` is missing or expired in the Render env group. Update it in the Render dashboard.
+
+**A `safe`-tagged issue gets merged but introduced a regression**: the CI gates should have caught it. If they didn't, downgrade the offending issue class to `review` (or `skip`) and file an issue on the CI gap.
+
+**An issue was misclassified and the sweeper worked on something risky**: pause with `.claude/sweep.pause`, revert the bad PR via `gh pr revert`, reclassify the issue to `skip`, unpause.
+
+**Render cron is not firing**: check the Render service dashboard — the cron may be disabled, suspended, or failing at Docker build. Logs are on the service page.
+
+## References
+
+- Selector: `scripts/known_issues_selector.py` (unit tests: `tests/unit/scripts/test_known_issues_selector.py`)
+- Digest writer: `scripts/write_sweep_digest.py` (unit tests: `tests/unit/scripts/test_write_sweep_digest.py`)
+- Orchestrator: `scripts/run_nightly_sweep.sh`
+- Image: `Dockerfile.nightly-sweep`
+- Cron wiring: `render.yaml` (service `filings-nightly-sweep`)
+- Classification table: `docs/KNOWN_ISSUES.md` → **Nightly Sweeper Classification**
+- Manual invocation: `/sweep` (see `.claude/skills/sweep/SKILL.md`)

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,16 @@ envVarGroups:
       - key: R2_ENDPOINT_URL
         sync: false
 
+  - name: filings-claude-secrets
+    envVars:
+      # Used only by the autonomous sweeper (filings-nightly-sweep cron). Kept
+      # separate from filings-shared-secrets — no DB or R2 creds need to leak
+      # into the sweeper's container.
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: GH_TOKEN
+        sync: false
+
 services:
   - type: web
     name: filings-reviewer
@@ -50,3 +60,29 @@ services:
         sync: false
       - key: OPENAI_API_KEY
         sync: false
+
+  # Autonomous nightly sweeper for docs/KNOWN_ISSUES.md. Parses the
+  # "Nightly Sweeper Classification" table, picks up to 3 non-colliding
+  # safe/review issues, and attempts to work each in an isolated worktree.
+  # Safe issues auto-merge on green CI; review issues open draft PRs for
+  # the morning review. See docs/operations/nightly-sweep-runbook.md.
+  #
+  # SAFETY: .claude/sweep.pause (committed) halts all sweeps until deleted.
+  # Remove that file to activate the sweeper.
+  - type: cron
+    name: filings-nightly-sweep
+    runtime: docker
+    dockerfilePath: ./Dockerfile.nightly-sweep
+    dockerCommand: bash scripts/run_nightly_sweep.sh
+    schedule: "0 6 * * *"  # Daily at 06:00 UTC (02:00 EDT / 02:00 EST)
+    envVars:
+      - fromGroup: filings-claude-secrets
+      # Sweeper budgets (override defaults from run_nightly_sweep.sh).
+      - key: SWEEP_MAX
+        value: "3"
+      - key: SWEEP_INCLUDE_REVIEW
+        value: "0"  # safe-only by default; flip to 1 to allow review-tier holds
+      - key: SWEEP_WALL_BUDGET
+        value: "2700"  # 45 minutes total
+      - key: SWEEP_PER_ISSUE
+        value: "900"   # 15 minutes per issue

--- a/scripts/known_issues_selector.py
+++ b/scripts/known_issues_selector.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Known issues selector for the nightly autonomous sweeper.
+
+Parses the "Nightly Sweeper Classification" table in docs/KNOWN_ISSUES.md,
+filters for safe/review items, dedupes against open PRs (via `gh`), picks
+a non-colliding batch of up to N issues, and emits the picks as JSON.
+
+Usage:
+    python3 scripts/known_issues_selector.py [--max N] [--include-review]
+                                             [--known-issues PATH]
+                                             [--dry-run]
+                                             [--no-pr-dedupe]
+
+Exit codes:
+    0 — picks emitted (possibly empty array if nothing to do)
+    1 — parse error (malformed classification table)
+    2 — `gh` call failed and --no-pr-dedupe was not set
+
+The orchestrator (scripts/run_nightly_sweep.sh) consumes the JSON output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_KNOWN_ISSUES = REPO_ROOT / "docs" / "KNOWN_ISSUES.md"
+TABLE_HEADING = "## Nightly Sweeper Classification"
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    issue: int
+    autonomy: str  # "safe" | "review" | "skip"
+    estimated: str  # "XS" | "S" | "M" | "L" | "—"
+    touches: tuple[str, ...]  # file globs; empty tuple for skip rows
+    note: str
+
+    def asdict(self) -> dict:
+        d = asdict(self)
+        d["touches"] = list(self.touches)
+        return d
+
+
+def parse_classification_table(md_content: str) -> list[IssueRecord]:
+    """Extract the Nightly Sweeper Classification table rows as IssueRecords.
+
+    Raises ValueError if the table heading is missing or no rows are parsed.
+    """
+    heading_idx = md_content.find(TABLE_HEADING)
+    if heading_idx == -1:
+        raise ValueError(
+            f"Missing {TABLE_HEADING!r} heading in KNOWN_ISSUES.md — "
+            "sweeper cannot determine which issues to work."
+        )
+    # The table ends at the next top-level "## " heading after the heading.
+    tail = md_content[heading_idx + len(TABLE_HEADING) :]
+    next_heading = re.search(r"\n## ", tail)
+    table_block = tail[: next_heading.start()] if next_heading else tail
+
+    records: list[IssueRecord] = []
+    for line in table_block.splitlines():
+        stripped = line.strip()
+        # Table rows look like "| #60 | safe | XS | glob glob | note |"
+        if not stripped.startswith("| #"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        issue_cell, autonomy, estimated, touches_cell, note = cells[:5]
+        m = re.match(r"#(\d+)", issue_cell)
+        if not m:
+            continue
+        issue_num = int(m.group(1))
+        if autonomy not in {"safe", "review", "skip"}:
+            raise ValueError(
+                f"Issue #{issue_num}: unknown Autonomy value {autonomy!r}. "
+                "Must be safe|review|skip."
+            )
+        touches_tuple: tuple[str, ...] = ()
+        if touches_cell and touches_cell not in {"—", "-"}:
+            # Strip backticks the table uses for inline code.
+            cleaned = touches_cell.replace("`", "")
+            touches_tuple = tuple(g for g in cleaned.split() if g)
+        records.append(
+            IssueRecord(
+                issue=issue_num,
+                autonomy=autonomy,
+                estimated=estimated,
+                touches=touches_tuple,
+                note=note,
+            )
+        )
+    if not records:
+        raise ValueError(
+            "Nightly Sweeper Classification table parsed zero rows — "
+            "check the table format in docs/KNOWN_ISSUES.md."
+        )
+    return records
+
+
+def fetch_open_pr_issue_refs() -> set[int]:
+    """Return the set of issue numbers referenced by any open PR title or body.
+
+    Uses `gh pr list --state open --json title,body`. Raises CalledProcessError
+    if `gh` is unavailable or unauthenticated.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "title,body"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    prs = json.loads(result.stdout)
+    refs: set[int] = set()
+    pattern = re.compile(r"#(\d+)")
+    for pr in prs:
+        for field in ("title", "body"):
+            text = pr.get(field) or ""
+            for m in pattern.finditer(text):
+                refs.add(int(m.group(1)))
+    return refs
+
+
+def _glob_matches_any(g: str, others: list[str]) -> bool:
+    # Treat each glob as a pattern; we call two globs "colliding" if either
+    # matches a concrete path the other could also match. Without a file list,
+    # approximate by: if either pattern matches against the other pattern
+    # literally or their directory prefixes overlap.
+    for o in others:
+        if fnmatch.fnmatch(o, g) or fnmatch.fnmatch(g, o):
+            return True
+        # Prefix overlap: directory before first glob char.
+        g_prefix = re.split(r"[*?\[]", g, maxsplit=1)[0]
+        o_prefix = re.split(r"[*?\[]", o, maxsplit=1)[0]
+        if (
+            g_prefix
+            and o_prefix
+            and (g_prefix.startswith(o_prefix) or o_prefix.startswith(g_prefix))
+        ):
+            return True
+    return False
+
+
+def touches_collide(a: tuple[str, ...], b: tuple[str, ...]) -> bool:
+    """Heuristic: two issues collide if any pair of globs overlap by prefix or fnmatch."""
+    if not a or not b:
+        return False
+    for g in a:
+        if _glob_matches_any(g, list(b)):
+            return True
+    return False
+
+
+def select_picks(
+    records: list[IssueRecord],
+    max_n: int,
+    include_review: bool,
+    open_pr_refs: set[int],
+) -> list[IssueRecord]:
+    """Greedy selection: safe-first, then review (if allowed), lowest-issue-first,
+    skipping any record that collides with already-picked records or appears in
+    an open PR."""
+    autonomy_rank = {"safe": 0, "review": 1}
+    candidates = [
+        r
+        for r in records
+        if r.autonomy in autonomy_rank
+        and (include_review or r.autonomy == "safe")
+        and r.issue not in open_pr_refs
+        and r.touches  # skip records without Touches globs; sweeper can't scope them
+    ]
+    candidates.sort(key=lambda r: (autonomy_rank[r.autonomy], r.issue))
+    picks: list[IssueRecord] = []
+    for r in candidates:
+        if any(touches_collide(r.touches, p.touches) for p in picks):
+            continue
+        picks.append(r)
+        if len(picks) >= max_n:
+            break
+    return picks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max", type=int, default=3, help="Maximum number of picks to return (default: 3)."
+    )
+    parser.add_argument(
+        "--include-review",
+        action="store_true",
+        help="Include Autonomy=review issues in selection (default: safe-only).",
+    )
+    parser.add_argument(
+        "--known-issues",
+        type=Path,
+        default=DEFAULT_KNOWN_ISSUES,
+        help="Path to KNOWN_ISSUES.md (default: docs/KNOWN_ISSUES.md).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print a human-readable summary instead of JSON."
+    )
+    parser.add_argument(
+        "--no-pr-dedupe",
+        action="store_true",
+        help="Skip the `gh pr list` dedupe step (for offline runs and tests).",
+    )
+    args = parser.parse_args()
+
+    try:
+        md = args.known_issues.read_text()
+    except FileNotFoundError:
+        print(f"error: {args.known_issues} not found", file=sys.stderr)
+        return 1
+    try:
+        records = parse_classification_table(md)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    open_pr_refs: set[int] = set()
+    if not args.no_pr_dedupe:
+        try:
+            open_pr_refs = fetch_open_pr_issue_refs()
+        except subprocess.CalledProcessError as e:
+            print(
+                f"error: `gh pr list` failed ({e.returncode}). Use --no-pr-dedupe to skip.",
+                file=sys.stderr,
+            )
+            return 2
+        except FileNotFoundError:
+            print("error: `gh` CLI not found. Install or use --no-pr-dedupe.", file=sys.stderr)
+            return 2
+
+    picks = select_picks(records, args.max, args.include_review, open_pr_refs)
+
+    if args.dry_run:
+        total_safe = sum(1 for r in records if r.autonomy == "safe")
+        total_review = sum(1 for r in records if r.autonomy == "review")
+        total_skip = sum(1 for r in records if r.autonomy == "skip")
+        print(
+            f"Classification totals: {total_safe} safe, {total_review} review, {total_skip} skip."
+        )
+        print(f"Open-PR refs excluded: {sorted(open_pr_refs)}")
+        print(f"Picks ({len(picks)}/{args.max} requested; include_review={args.include_review}):")
+        for p in picks:
+            print(
+                f"  #{p.issue} [{p.autonomy}/{p.estimated}] touches={list(p.touches)}  — {p.note}"
+            )
+        return 0
+
+    print(json.dumps([p.asdict() for p in picks], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# run_nightly_sweep.sh — orchestrator for the nightly KNOWN_ISSUES sweeper.
+#
+# Flow:
+#   1. Honor .claude/sweep.pause kill switch.
+#   2. Fetch latest main, check out.
+#   3. Call scripts/known_issues_selector.py for up to N picks.
+#   4. For each pick: create a worktree, invoke `claude -p` with an issue-scoped
+#      prompt that runs /commit, capture outcome, classify.
+#   5. Emit run-outcomes JSON, invoke scripts/write_sweep_digest.py.
+#   6. Open a PR for the digest (docs-only, not via /commit).
+#   7. Clean up worktrees that produced no commits; delete stale branches.
+#
+# Environment:
+#   SWEEP_MAX            max picks per run (default: 3)
+#   SWEEP_INCLUDE_REVIEW if set to 1, include Autonomy=review (default: 0)
+#   SWEEP_WALL_BUDGET    total wall-clock budget in seconds (default: 2700 = 45m)
+#   SWEEP_PER_ISSUE      per-issue budget in seconds (default: 900 = 15m)
+#   ANTHROPIC_API_KEY    required by `claude`
+#   GH_TOKEN             required by `gh` (or prior `gh auth login`)
+#
+# Exits:
+#   0 — ran to completion (including empty picks / paused)
+#   1 — fatal prerequisite missing (git, claude, gh, or selector failure)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MAX_PICKS="${SWEEP_MAX:-3}"
+INCLUDE_REVIEW="${SWEEP_INCLUDE_REVIEW:-0}"
+WALL_BUDGET="${SWEEP_WALL_BUDGET:-2700}"
+PER_ISSUE_BUDGET="${SWEEP_PER_ISSUE:-900}"
+DATE="$(date +%Y-%m-%d)"
+RUN_START_EPOCH="$(date +%s)"
+RUN_START_HHMM="$(date +%H:%M)"
+
+PAUSE_FILE="$REPO_ROOT/.claude/sweep.pause"
+WORKTREE_ROOT="$REPO_ROOT/.claude/worktrees"
+DIGEST_DIR="$REPO_ROOT/.claude/sweep-digests"
+OUTCOMES_FILE="$(mktemp -t sweep-outcomes.XXXXXX.json)"
+echo "[]" > "$OUTCOMES_FILE"
+
+log() { printf '[sweep %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { log "FATAL: $1 not installed"; exit 1; }
+}
+
+cleanup() {
+  rm -f "$OUTCOMES_FILE"
+}
+trap cleanup EXIT
+
+# --- 1. Kill switch ---
+if [[ -f "$PAUSE_FILE" ]]; then
+  if [[ "${SWEEP_FORCE:-0}" == "1" ]]; then
+    log "Kill switch active but SWEEP_FORCE=1 — proceeding anyway."
+  else
+    log "Kill switch active ($PAUSE_FILE exists). Exiting."
+    exit 0
+  fi
+fi
+
+# --- 2. Prereqs + fresh main ---
+require git
+require python3
+require claude
+require gh
+
+log "Fetching origin/main..."
+git fetch origin main --quiet
+git checkout main --quiet 2>/dev/null || git checkout -B main origin/main --quiet
+git reset --hard origin/main --quiet
+
+# --- 3. Selector ---
+INCLUDE_REVIEW_FLAG=""
+[[ "$INCLUDE_REVIEW" == "1" ]] && INCLUDE_REVIEW_FLAG="--include-review"
+
+log "Running selector (max=$MAX_PICKS, include_review=$INCLUDE_REVIEW)..."
+PICKS_JSON="$(python3 scripts/known_issues_selector.py \
+    --max "$MAX_PICKS" $INCLUDE_REVIEW_FLAG)"
+NUM_PICKS="$(echo "$PICKS_JSON" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+log "Selector returned $NUM_PICKS picks."
+
+if [[ "$NUM_PICKS" == "0" ]]; then
+  log "Nothing to sweep tonight."
+  echo "[]" > "$OUTCOMES_FILE"
+fi
+
+# --- 4. Per-issue sweep loop ---
+append_outcome() {
+  # $1: JSON object for one outcome
+  python3 - "$OUTCOMES_FILE" "$1" <<'PY'
+import json, sys
+path, new = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data.append(json.loads(new))
+with open(path, "w") as f:
+    json.dump(data, f)
+PY
+}
+
+sweep_issue() {
+  local issue="$1" autonomy="$2" note="$3"
+  local branch="claude/sweep/issue-${issue}-${DATE}"
+  local worktree="$WORKTREE_ROOT/sweep-${DATE}-issue-${issue}"
+  local started="$(date +%H:%M)"
+
+  log "Issue #$issue [$autonomy] — creating worktree $worktree"
+
+  if ! git worktree add -b "$branch" "$worktree" origin/main --quiet 2>/dev/null; then
+    append_outcome "$(python3 -c "import json; print(json.dumps({'issue': $issue, 'autonomy': '$autonomy', 'outcome': 'abandoned', 'reason': 'worktree create failed (branch may already exist)'}))")"
+    return
+  fi
+
+  # Prompt briefs Claude on the issue, restricts scope, calls /commit.
+  local prompt
+  prompt=$(cat <<EOF
+You are the nightly autonomous sweeper working issue #${issue} from docs/KNOWN_ISSUES.md.
+
+Classification: Autonomy=${autonomy}. Note: "${note}".
+
+Rules (STRICT):
+1. Read the full issue body for #${issue} in docs/KNOWN_ISSUES.md. Do exactly what its "Next Steps" section asks, no more.
+2. If the issue requires schema migrations, infra edits, credential changes, or anything outside the "Touches" globs declared in the classification table: ABORT and explain.
+3. After implementing, invoke the /commit skill. The skill handles branch/tests/PR/auto-merge.
+4. If tests fail or you cannot complete the work cleanly, abort. Do NOT update baselines, do NOT skip tests, do NOT use --no-verify.
+5. On successful /commit, report the PR URL on stdout as: "PR_URL=<url>".
+6. On abort, report the reason on stdout as: "ABORT_REASON=<short reason>".
+
+Begin.
+EOF
+)
+
+  local log_file="$worktree/.sweep.log"
+  local exit_code=0
+  (
+    cd "$worktree"
+    timeout "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
+  ) || exit_code=$?
+
+  local finished="$(date +%H:%M)"
+  local pr_url="" pr_number="" abort_reason=""
+  if grep -qE '^PR_URL=' "$log_file" 2>/dev/null; then
+    pr_url="$(grep -E '^PR_URL=' "$log_file" | tail -1 | sed 's/^PR_URL=//')"
+    pr_number="$(echo "$pr_url" | grep -oE '[0-9]+$' || true)"
+  fi
+  if grep -qE '^ABORT_REASON=' "$log_file" 2>/dev/null; then
+    abort_reason="$(grep -E '^ABORT_REASON=' "$log_file" | tail -1 | sed 's/^ABORT_REASON=//')"
+  fi
+
+  local outcome_json
+  if [[ -n "$pr_url" && "$autonomy" == "safe" ]]; then
+    outcome_json=$(python3 -c "import json; print(json.dumps({'issue': $issue, 'autonomy': '$autonomy', 'outcome': 'merged', 'pr_number': int('$pr_number' or 0), 'pr_url': '$pr_url', 'branch': '$branch', 'started_at': '$started', 'finished_at': '$finished'}))")
+  elif [[ -n "$pr_url" && "$autonomy" == "review" ]]; then
+    outcome_json=$(python3 -c "import json; print(json.dumps({'issue': $issue, 'autonomy': '$autonomy', 'outcome': 'awaiting_review', 'pr_number': int('$pr_number' or 0), 'pr_url': '$pr_url', 'branch': '$branch', 'started_at': '$started', 'finished_at': '$finished', 'reason': 'Autonomy=review — manual approval required'}))")
+  else
+    local reason="${abort_reason:-claude session exited $exit_code without a PR}"
+    outcome_json=$(python3 -c "import json; print(json.dumps({'issue': $issue, 'autonomy': '$autonomy', 'outcome': 'abandoned', 'reason': '$reason', 'started_at': '$started', 'finished_at': '$finished'}))")
+  fi
+  append_outcome "$outcome_json"
+
+  # Cleanup worktree + branch if no PR was opened.
+  if [[ -z "$pr_url" ]]; then
+    log "Issue #$issue produced no PR — cleaning up worktree and branch."
+    git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+    git branch -D "$branch" >/dev/null 2>&1 || true
+  else
+    # Worktree served its purpose; branch is on origin now. Remove worktree dir,
+    # keep the local branch reference (PR is the source of truth).
+    git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  fi
+}
+
+if [[ "$NUM_PICKS" != "0" ]]; then
+  echo "$PICKS_JSON" | python3 -c '
+import json, sys
+picks = json.load(sys.stdin)
+for p in picks:
+    issue = p["issue"]
+    autonomy = p["autonomy"]
+    note = (p.get("note") or "").replace("\x27", " ")
+    print(f"{issue}\t{autonomy}\t{note}")
+' | while IFS=$'\t' read -r issue autonomy note; do
+    elapsed=$(($(date +%s) - RUN_START_EPOCH))
+    if [[ $elapsed -gt $WALL_BUDGET ]]; then
+      log "Wall budget ($WALL_BUDGET s) exceeded — stopping before issue #$issue."
+      append_outcome "$(python3 -c "import json; print(json.dumps({'issue': $issue, 'autonomy': '$autonomy', 'outcome': 'abandoned', 'reason': 'wall budget exceeded before start'}))")"
+      continue
+    fi
+    sweep_issue "$issue" "$autonomy" "$note"
+  done
+fi
+
+# --- 5. Digest ---
+FINISHED_EPOCH="$(date +%s)"
+DURATION_SEC=$((FINISHED_EPOCH - RUN_START_EPOCH))
+DURATION_MIN=$((DURATION_SEC / 60))
+log "Writing digest for $DATE ($DURATION_MIN m)."
+
+python3 scripts/write_sweep_digest.py \
+  --date "$DATE" \
+  --input "$OUTCOMES_FILE" \
+  --run-start "$RUN_START_HHMM" \
+  --run-duration "${DURATION_MIN}m"
+
+# --- 6. PR the digest (docs-only, minimal flow) ---
+DIGEST_PATH="$DIGEST_DIR/$DATE.md"
+if [[ -f "$DIGEST_PATH" ]]; then
+  DIGEST_BRANCH="claude/sweep-digest/$DATE"
+  if git checkout -b "$DIGEST_BRANCH" --quiet 2>/dev/null; then
+    git add "$DIGEST_PATH"
+    git commit -m "docs(sweep-digest): nightly digest for $DATE" --quiet || true
+    if git push -u origin "$DIGEST_BRANCH" --quiet; then
+      gh pr create --fill >/dev/null || log "digest PR create failed (may already exist)"
+      gh pr merge --auto --squash >/dev/null || log "digest auto-merge enable failed"
+    else
+      log "digest push failed — leaving branch local"
+    fi
+  else
+    log "digest branch $DIGEST_BRANCH already exists — skipping PR"
+  fi
+fi
+
+log "Sweep complete. Outcomes: $(python3 -c 'import json, sys; d=json.load(open(sys.argv[1])); print(len([o for o in d if o["outcome"]=="merged"])) , " merged,", len([o for o in d if o["outcome"]=="awaiting_review"]), "awaiting,", len([o for o in d if o["outcome"]=="abandoned"]), "abandoned"' "$OUTCOMES_FILE")"

--- a/scripts/write_sweep_digest.py
+++ b/scripts/write_sweep_digest.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Writes the nightly sweep digest markdown file.
+
+Reads a JSON run-outcomes payload on stdin (or --input PATH) and emits a
+markdown digest to .claude/sweep-digests/YYYY-MM-DD.md. The digest is the
+morning-review surface: auto-merged PRs, PRs awaiting approval, and
+abandoned attempts with failure reasons.
+
+Payload shape (list of per-issue outcomes):
+    [
+      {
+        "issue": 60,
+        "autonomy": "safe",
+        "outcome": "merged" | "awaiting_review" | "abandoned",
+        "pr_number": 78,          // omitted when outcome == "abandoned"
+        "pr_url": "https://...",  // omitted when outcome == "abandoned"
+        "branch": "claude/...",   // omitted when outcome == "merged"
+        "reason": "tests failed", // required when outcome == "abandoned"
+        "started_at": "02:03",
+        "finished_at": "02:17"
+      },
+      ...
+    ]
+
+Usage:
+    python3 scripts/write_sweep_digest.py --date 2026-04-22 [--input PATH] [--run-start 02:03] [--run-duration 14m]
+
+Exit 0 on success. Exit 1 on malformed payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIGEST_DIR = REPO_ROOT / ".claude" / "sweep-digests"
+
+
+def render_digest(
+    outcomes: list[dict],
+    date: str,
+    run_start: str | None = None,
+    run_duration: str | None = None,
+) -> str:
+    merged = [o for o in outcomes if o.get("outcome") == "merged"]
+    awaiting = [o for o in outcomes if o.get("outcome") == "awaiting_review"]
+    abandoned = [o for o in outcomes if o.get("outcome") == "abandoned"]
+
+    header = f"# Nightly sweep — {date}"
+    if run_start and run_duration:
+        header += f" (ran {run_start}, took {run_duration})"
+    elif run_start:
+        header += f" (ran {run_start})"
+
+    lines: list[str] = [header, ""]
+
+    lines.append(f"## Auto-merged ({len(merged)})")
+    if not merged:
+        lines.append("- _(none)_")
+    else:
+        for o in merged:
+            ts = f" at {o['finished_at']}" if o.get("finished_at") else ""
+            lines.append(
+                f"- #{o['issue']} — PR [#{o['pr_number']}]({o.get('pr_url', '')}) merged{ts}"
+            )
+    lines.append("")
+
+    lines.append(f"## Awaiting your approval ({len(awaiting)})")
+    if not awaiting:
+        lines.append("- _(none)_")
+    else:
+        for o in awaiting:
+            pr_num = o.get("pr_number", "?")
+            pr_url = o.get("pr_url", "")
+            branch = o.get("branch", "?")
+            reason = o.get("reason", f"Autonomy tier = {o.get('autonomy')}")
+            lines.append(f"- #{o['issue']} — PR [#{pr_num}]({pr_url})")
+            lines.append(f"  - Why held: {reason}")
+            lines.append(
+                f"  - To merge: "
+                f"`gh pr review --approve {pr_num} && "
+                f"gh pr merge --auto --squash {pr_num}`"
+            )
+            lines.append(
+                f"  - To discard: `gh pr close {pr_num} && git push origin --delete {branch}`"
+            )
+    lines.append("")
+
+    lines.append(f"## Abandoned ({len(abandoned)})")
+    if not abandoned:
+        lines.append("- _(none)_")
+    else:
+        for o in abandoned:
+            reason = o.get("reason", "unknown reason")
+            lines.append(f"- #{o['issue']} — abandoned: {reason}")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def validate_outcome(o: dict) -> None:
+    required = {"issue", "autonomy", "outcome"}
+    missing = required - set(o)
+    if missing:
+        raise ValueError(f"Outcome {o!r} missing required fields: {sorted(missing)}")
+    valid_outcomes = {"merged", "awaiting_review", "abandoned"}
+    if o["outcome"] not in valid_outcomes:
+        raise ValueError(
+            f"Outcome {o['outcome']!r} not in {sorted(valid_outcomes)} for issue #{o['issue']}"
+        )
+    if o["outcome"] == "merged" and "pr_number" not in o:
+        raise ValueError(f"Issue #{o['issue']} merged outcome missing pr_number")
+    if o["outcome"] == "awaiting_review" and "pr_number" not in o:
+        raise ValueError(f"Issue #{o['issue']} awaiting_review outcome missing pr_number")
+    if o["outcome"] == "abandoned" and "reason" not in o:
+        raise ValueError(f"Issue #{o['issue']} abandoned outcome missing reason")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--date",
+        default=dt.date.today().isoformat(),
+        help="ISO date for the digest (default: today).",
+    )
+    parser.add_argument(
+        "--input", type=Path, help="Path to JSON outcomes payload. Reads stdin if omitted."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DIGEST_DIR,
+        help="Directory for the digest markdown file.",
+    )
+    parser.add_argument("--run-start", help="Start time for the header (e.g. '02:03').")
+    parser.add_argument("--run-duration", help="Run duration for the header (e.g. '14m').")
+    parser.add_argument(
+        "--stdout", action="store_true", help="Print digest to stdout instead of writing a file."
+    )
+    args = parser.parse_args()
+
+    raw = args.input.read_text() if args.input else sys.stdin.read()
+    try:
+        outcomes = json.loads(raw) if raw.strip() else []
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON payload: {e}", file=sys.stderr)
+        return 1
+    if not isinstance(outcomes, list):
+        print("error: payload must be a JSON array of outcome objects", file=sys.stderr)
+        return 1
+    for o in outcomes:
+        try:
+            validate_outcome(o)
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+
+    digest = render_digest(outcomes, args.date, args.run_start, args.run_duration)
+
+    if args.stdout:
+        print(digest)
+        return 0
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.output_dir / f"{args.date}.md"
+    out_path.write_text(digest + "\n")
+    print(f"Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_known_issues_selector.py
+++ b/tests/unit/scripts/test_known_issues_selector.py
@@ -1,0 +1,146 @@
+"""Unit tests for scripts/known_issues_selector.py.
+
+Uses importlib.util.spec_from_file_location so that scripts/__init__.py is not required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "known_issues_selector.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("known_issues_selector", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["known_issues_selector"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_mod = _load_module()
+parse_classification_table = _mod.parse_classification_table
+touches_collide = _mod.touches_collide
+select_picks = _mod.select_picks
+IssueRecord = _mod.IssueRecord
+
+
+TABLE_SNIPPET = """\
+# Known Issues
+
+## Nightly Sweeper Classification
+
+Preamble text.
+
+| Issue | Autonomy | Estimated | Touches                                              | Note                                |
+|-------|----------|-----------|------------------------------------------------------|-------------------------------------|
+| #1    | safe     | XS        | `src/a/mod_a.py`                                     | Alpha                               |
+| #2    | safe     | S         | `tests/integration/web/test_foo.py`                  | Bravo                               |
+| #3    | review   | M         | `src/b/mod_b.py tests/unit/b/*`                      | Charlie                             |
+| #4    | skip     | L         | —                                                    | Delta                               |
+| #5    | safe     | XS        | `src/a/mod_a.py`                                     | Echo — collides with #1             |
+
+## Next Section
+
+Unrelated content.
+"""
+
+
+class TestParseClassificationTable:
+    def test_parses_all_non_skip_and_skip_rows(self) -> None:
+        records = parse_classification_table(TABLE_SNIPPET)
+        issues = sorted(r.issue for r in records)
+        assert issues == [1, 2, 3, 4, 5]
+
+    def test_parses_autonomy_values(self) -> None:
+        records = {r.issue: r for r in parse_classification_table(TABLE_SNIPPET)}
+        assert records[1].autonomy == "safe"
+        assert records[3].autonomy == "review"
+        assert records[4].autonomy == "skip"
+
+    def test_parses_touches_globs(self) -> None:
+        records = {r.issue: r for r in parse_classification_table(TABLE_SNIPPET)}
+        assert records[3].touches == ("src/b/mod_b.py", "tests/unit/b/*")
+        assert records[4].touches == ()  # em-dash → empty
+
+    def test_raises_on_missing_heading(self) -> None:
+        with pytest.raises(ValueError, match="Missing"):
+            parse_classification_table("# Just a document\n\nNo table here.")
+
+    def test_raises_on_bad_autonomy_value(self) -> None:
+        bad = TABLE_SNIPPET.replace("| safe     | XS", "| maybe    | XS", 1)
+        with pytest.raises(ValueError, match="unknown Autonomy"):
+            parse_classification_table(bad)
+
+    def test_stops_at_next_heading(self) -> None:
+        records = parse_classification_table(TABLE_SNIPPET)
+        assert all(r.issue <= 5 for r in records)
+
+
+class TestTouchesCollide:
+    def test_same_file_collides(self) -> None:
+        assert touches_collide(("src/a.py",), ("src/a.py",))
+
+    def test_disjoint_dirs_do_not_collide(self) -> None:
+        assert not touches_collide(("src/a/*",), ("src/b/*",))
+
+    def test_prefix_overlap_collides(self) -> None:
+        assert touches_collide(("src/a/foo.py",), ("src/a/*",))
+
+    def test_empty_touches_does_not_collide(self) -> None:
+        assert not touches_collide((), ("src/a.py",))
+        assert not touches_collide(("src/a.py",), ())
+
+
+class TestSelectPicks:
+    def _records(self) -> list:
+        return parse_classification_table(TABLE_SNIPPET)
+
+    def test_safe_only_by_default(self) -> None:
+        picks = select_picks(self._records(), max_n=5, include_review=False, open_pr_refs=set())
+        assert [p.issue for p in picks] == [1, 2]  # #5 collides with #1
+
+    def test_include_review_adds_review_picks(self) -> None:
+        picks = select_picks(self._records(), max_n=5, include_review=True, open_pr_refs=set())
+        assert [p.issue for p in picks] == [1, 2, 3]
+
+    def test_max_caps_results(self) -> None:
+        picks = select_picks(self._records(), max_n=1, include_review=False, open_pr_refs=set())
+        assert [p.issue for p in picks] == [1]
+
+    def test_open_pr_refs_exclude_issue(self) -> None:
+        picks = select_picks(self._records(), max_n=5, include_review=False, open_pr_refs={1})
+        # #1 excluded → #5 no longer collides → #5 takes its slot
+        assert [p.issue for p in picks] == [2, 5]
+
+    def test_skip_never_picked(self) -> None:
+        picks = select_picks(self._records(), max_n=10, include_review=True, open_pr_refs=set())
+        assert 4 not in {p.issue for p in picks}
+
+    def test_collision_drops_second_pick(self) -> None:
+        picks = select_picks(self._records(), max_n=10, include_review=False, open_pr_refs=set())
+        issues = {p.issue for p in picks}
+        # #1 and #5 both touch src/a/mod_a.py — only one should be in picks
+        assert not ({1, 5}.issubset(issues))
+
+    def test_safe_comes_before_review(self) -> None:
+        picks = select_picks(self._records(), max_n=10, include_review=True, open_pr_refs=set())
+        autonomies = [p.autonomy for p in picks]
+        # safe entries must all appear before review entries
+        last_safe = max((i for i, a in enumerate(autonomies) if a == "safe"), default=-1)
+        first_review = min(
+            (i for i, a in enumerate(autonomies) if a == "review"), default=len(autonomies)
+        )
+        assert last_safe < first_review
+
+    def test_records_without_touches_are_excluded(self) -> None:
+        # A safe record with no Touches cannot be scoped by the sweeper → skip.
+        record = IssueRecord(issue=99, autonomy="safe", estimated="XS", touches=(), note="no globs")
+        picks = select_picks([record], max_n=1, include_review=False, open_pr_refs=set())
+        assert picks == []

--- a/tests/unit/scripts/test_write_sweep_digest.py
+++ b/tests/unit/scripts/test_write_sweep_digest.py
@@ -1,0 +1,122 @@
+"""Unit tests for scripts/write_sweep_digest.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "write_sweep_digest.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("write_sweep_digest", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["write_sweep_digest"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_mod = _load_module()
+render_digest = _mod.render_digest
+validate_outcome = _mod.validate_outcome
+
+
+class TestRenderDigest:
+    def test_empty_outcomes_produces_all_none_sections(self) -> None:
+        out = render_digest([], "2026-04-22")
+        assert "## Auto-merged (0)" in out
+        assert "## Awaiting your approval (0)" in out
+        assert "## Abandoned (0)" in out
+        assert "_(none)_" in out
+
+    def test_merged_outcome_renders_pr_link(self) -> None:
+        out = render_digest(
+            [
+                {
+                    "issue": 60,
+                    "autonomy": "safe",
+                    "outcome": "merged",
+                    "pr_number": 78,
+                    "pr_url": "https://gh.example/78",
+                    "finished_at": "02:17",
+                }
+            ],
+            "2026-04-22",
+        )
+        assert "#60" in out
+        assert "[#78](https://gh.example/78)" in out
+        assert "merged at 02:17" in out
+
+    def test_awaiting_review_renders_approve_command(self) -> None:
+        out = render_digest(
+            [
+                {
+                    "issue": 38,
+                    "autonomy": "review",
+                    "outcome": "awaiting_review",
+                    "pr_number": 80,
+                    "pr_url": "https://gh.example/80",
+                    "branch": "claude/sweep/issue-38",
+                }
+            ],
+            "2026-04-22",
+        )
+        assert "gh pr review --approve 80" in out
+        assert "gh pr merge --auto --squash 80" in out
+        assert "gh pr close 80" in out
+        assert "git push origin --delete claude/sweep/issue-38" in out
+
+    def test_abandoned_requires_reason(self) -> None:
+        out = render_digest(
+            [
+                {
+                    "issue": 66,
+                    "autonomy": "safe",
+                    "outcome": "abandoned",
+                    "reason": "gh pr create rate limit",
+                }
+            ],
+            "2026-04-22",
+        )
+        assert "abandoned: gh pr create rate limit" in out
+
+    def test_header_includes_run_start_and_duration(self) -> None:
+        out = render_digest([], "2026-04-22", run_start="02:03", run_duration="14m")
+        assert out.splitlines()[0] == "# Nightly sweep — 2026-04-22 (ran 02:03, took 14m)"
+
+
+class TestValidateOutcome:
+    def test_accepts_valid_merged(self) -> None:
+        validate_outcome(
+            {
+                "issue": 60,
+                "autonomy": "safe",
+                "outcome": "merged",
+                "pr_number": 78,
+            }
+        )
+
+    def test_rejects_missing_required_field(self) -> None:
+        with pytest.raises(ValueError, match="missing required fields"):
+            validate_outcome({"issue": 60, "autonomy": "safe"})
+
+    def test_rejects_unknown_outcome(self) -> None:
+        with pytest.raises(ValueError, match="not in"):
+            validate_outcome({"issue": 60, "autonomy": "safe", "outcome": "skipped"})
+
+    def test_merged_without_pr_number_rejected(self) -> None:
+        with pytest.raises(ValueError, match="merged outcome missing pr_number"):
+            validate_outcome({"issue": 60, "autonomy": "safe", "outcome": "merged"})
+
+    def test_awaiting_review_without_pr_number_rejected(self) -> None:
+        with pytest.raises(ValueError, match="awaiting_review outcome missing pr_number"):
+            validate_outcome({"issue": 60, "autonomy": "review", "outcome": "awaiting_review"})
+
+    def test_abandoned_without_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match="abandoned outcome missing reason"):
+            validate_outcome({"issue": 60, "autonomy": "safe", "outcome": "abandoned"})


### PR DESCRIPTION
## Summary
- Render cron service `filings-nightly-sweep` (06:00 UTC daily) that picks up to 3 non-colliding issues tagged \`Autonomy: safe\` in a new Nightly Sweeper Classification table in \`docs/KNOWN_ISSUES.md\`, works each in an isolated worktree via \`claude -p\` + \`/commit\`, and auto-merges on green CI.
- Review-tier issues open draft PRs held for a morning digest at \`.claude/sweep-digests/YYYY-MM-DD.md\` with one-line approve/discard commands.
- Ships **paused** via a committed \`.claude/sweep.pause\` kill switch — first activation is a deliberate \`rm\` + PR.

## Why
Formalises the ad-hoc pattern from commit \`8cd3b4d\` (five-issue bundle PR #55) into a recurring passive-yield loop. Backlog items get closed overnight; the user wakes up to either merged PRs or a short review queue.

## Components
- \`scripts/known_issues_selector.py\` + 18 unit tests — parses classification table, dedupes against open PRs.
- \`scripts/write_sweep_digest.py\` + 11 unit tests — renders morning-review markdown.
- \`scripts/run_nightly_sweep.sh\` — orchestrator with wall-clock (45m) + per-issue (15m) budgets, \`SWEEP_FORCE=1\` override, abandoned-worktree cleanup.
- \`Dockerfile.nightly-sweep\` — base image with \`claude\` CLI + \`gh\` + \`requirements.lock\`.
- \`render.yaml\` — new cron service scoped to a new \`filings-claude-secrets\` env group (ANTHROPIC_API_KEY + GH_TOKEN only; no DB/R2 creds).
- \`/sweep\` skill for manual runs; \`docs/operations/nightly-sweep-runbook.md\` for operator docs.

## Guardrails
- Branch protection (\`enforce_admins: true\`) and 5 required CI checks are the real merge gate; sweeper can't bypass them.
- Credential scope deliberately excludes DB and R2 from the sweeper container.
- Worktree isolation + hard 3-issue/run budget bound blast radius.
- \`/commit\` step 9f defaults new issues to \`Autonomy: skip\`; reclassification is a conscious human action.

## Classification after this PR
3 safe (#60, #61, #67), 7 review (#38, #58, #59, #62, #65, #66, #68), 19 skip. Selector dry-run picks #60, #61, #67 with disjoint Touches globs.

## Triage entries filed this session
- #67 — Orchestrator uses GNU \`timeout\` (macOS-incompatible; Render fine).
- #68 — \`Dockerfile.nightly-sweep\` installs \`claude\`/\`gh\` unpinned.

## Test plan
- [x] 29 new unit tests pass
- [x] Full unit suite pre-rebase: 3803 pass, 67 skipped
- [x] Selector dry-run on live backlog returns expected picks
- [x] ruff clean, bash syntax clean, render.yaml parses
- [ ] Required CI checks (Lint / Unit / Vuln / Integration / UI E2E) after push
- [ ] Render build succeeds for \`Dockerfile.nightly-sweep\` once PR is merged and auto-deploy fires
- [ ] After merge: set \`ANTHROPIC_API_KEY\` and \`GH_TOKEN\` in Render dashboard env group

## Activation
After merge, when ready: \`rm .claude/sweep.pause\` + \`/commit\`. First live run next 02:00 EDT.

Supersedes #62 (same branch content, rebased onto latest main).