### PR TITLE
docs: session-hygiene safeguards (closes #67)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -10,7 +10,18 @@
 
 ## Steps
 
-1. **Detect execution context.** Run `test -d .claude/worktrees && echo local || echo remote`. Remote runs skip step 5. Report the mode in the opening line.
+1. **Detect execution context.** Run the following expression; it anchors to the primary repo's git dir so the check works from any linked worktree (agent-isolation or ccw) — not just the primary tree.
+
+   ```bash
+   if test -d "$(git rev-parse --git-common-dir 2>/dev/null)/.claude/worktrees" \
+      || test -d "$HOME/.claude-worktrees"; then
+     echo local
+   else
+     echo remote
+   fi
+   ```
+
+   Remote runs skip step 5. Report the mode in the opening line.
 
 2. **Sync remote state.** Run `git fetch --prune origin`. This deletes remote-tracking refs whose upstream branch is gone.
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -13,6 +13,7 @@
      - Type: conventional-commit type inferred from the diff (`feat`/`fix`/`refactor`/`chore`/`docs`/`test`).
      - Slug: 3–6 word kebab-case summary of the change (e.g., `pr-workflow-enforcement`).
      - Branch: `claude/<type>-<slug>` (fall back to `claude/$(date +%Y%m%d)-$(git rev-parse --short HEAD)` if inference is uncertain).
+     - **Collision check:** if `git show-ref --verify --quiet "refs/heads/<branch>"` returns true, append `-HHMM` (current-minute timestamp) so the rename is obviously collision-avoidance and survives multi-collision per day. If the suffixed name also collides (vanishingly rare), fail fast with a clear message.
      - Run `git checkout -b <branch>` and announce the branch name in one line.
    - **Otherwise:** stay on the current branch and continue.
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21, #67 opened for `/cleanup` skill step-1 mode-detection returning false `remote` from ccw worktrees; #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, #67 resolved (cleanup-skill mode detection re-anchored to `git-common-dir`; companion session-hygiene safeguards for ccw + `/commit` also landed); #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -41,7 +41,6 @@ _(none currently)_
 | Local-dev stuck-batch recovery is manual (Issue #62) | Open | No watcher runs locally; subprocess death leaves `status='running'` forever |
 | Cancel-during-populate not integration-tested (Issue #63) | Open | Conditional `_BATCH_COMPLETE_SQL` unit-tested; no end-to-end race-condition test |
 | Chart classifier Tier 1 boundary sensitivity (Issue #64) | Open | HOOD `cm_balance_by_cohort` scores 0.6024 — 0.0024 above the 0.6 gate; silent-regression risk |
-| `/cleanup` skill mode-detection false-remote from ccw worktrees (Issue #67) | Open | Step 1's CWD-relative check returns `remote` when run from a ccw worktree; silently skips worktree sweep |
 
 ### Partially Resolved
 
@@ -876,28 +875,6 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 
 ---
 
-## 67. `/cleanup` Skill Mode-Detection Returns False `remote` From ccw Worktrees
-
-**Status**: Open
-**Severity**: Low
-**Discovered**: 2026-04-21
-
-### Problem
-
-`.claude/commands/cleanup.md` step 1 decides local vs. remote execution with `test -d .claude/worktrees && echo local || echo remote`. The check is relative to the current working directory, but agent-isolation worktrees live at `.claude/worktrees/` **inside the primary repo** (e.g. `<repo>.git/.claude/worktrees/`), not inside a ccw worktree checkout like `$HOME/.claude-worktrees/filings_reviewer/<branch>`. Running `/cleanup` from a ccw worktree therefore reports `mode=remote` on a local machine and silently skips step 5 (worktree sweep), leaving dead agent worktrees and merged ccw worktrees to accumulate until the user notices and re-runs with an explicit override.
-
-### Next Steps
-
-- Replace the CWD-relative heuristic with one anchored to the primary repo — e.g. `test -d "$(git rev-parse --git-common-dir)/.claude/worktrees"`, or test for the ccw convention path `$HOME/.claude-worktrees/` on the host.
-- Alternatively: infer local mode by inspecting `git worktree list --porcelain` for any `.claude/worktrees/agent-*` or `$HOME/.claude-worktrees/` entries.
-- Simplest fallback: accept an explicit `--local` / `--remote` arg and keep the current heuristic as the default.
-
-### Cross-References
-
-- `.claude/commands/cleanup.md` — step 1 mode detection
-
----
-
 ## Archive (Resolved Issues)
 
 ### Issue #1: Metric ID Mismatch Between Gold Standard and System
@@ -1139,6 +1116,12 @@ New `scripts/check_pg_client_version.py` pre-flight that compares `pg_dump` majo
 
 New `PipelineConfig.chart_metric_min_confidence` knob (Guard 6 on `ChartFactBridgeStage`). Default 0.60 matches the existing classification gate — no default behavior change — because Tier 1 `cm_balance_by_cohort` classifies at ~0.6024 and a 0.70 default would regress Tier 1 recall. Operators can tighten the knob during backfills to suppress weak top-match binds. 5 unit tests added as `TestGuard6MetricConfidenceFloor`. See commit `7848605` and companion Issue #64 for the boundary sensitivity follow-up.
 
+### Issue #67: `/cleanup` Skill Mode-Detection Returns False `remote` From ccw Worktrees
+
+**Status**: Resolved (2026-04-21)
+
+`.claude/commands/cleanup.md` step 1 replaced the CWD-relative `test -d .claude/worktrees` check with an `if`-expression anchored to the primary repo's git dir via `git rev-parse --git-common-dir`, with `$HOME/.claude-worktrees` as a fallback. Works from any linked worktree (agent-isolation or ccw) as well as the primary tree. Companion `ccw` PID-lockfile + `ccw-rm` merged-branch cleanup (both `~/.zshrc`) close the same accumulation vector from the session-creation side. `/commit` skill step 1 now appends `-HHMM` timestamp on branch-name collision.
+
 ---
 
 ## Change Log
@@ -1216,3 +1199,4 @@ New `PipelineConfig.chart_metric_min_confidence` knob (Guard 6 on `ChartFactBrid
 - **2026-04-21**: Five-issue follow-up bundle landed in commit `7848605` — resolved #42 (double image-write collapsed via public `SECClient.get_image_cache_path`), #50 (new `tests/unit/web/test_api_unified_auth.py`), #51 (behavioral mock-cursor rewrite; `# fmt: skip` removed), #52 (new `scripts/check_pg_client_version.py` pre-flight + infrastructure.md doc section), #54 (new `chart_metric_min_confidence` knob with default 0.60 to avoid Tier 1 regression). Archive entries added. #64 opened — chart classifier Tier 1 boundary sensitivity: HOOD `cm_balance_by_cohort` scores 0.6024 (0.0024 above gate); surfaced while forcing #54's default down from the originally-proposed 0.70. (Renumbered from an earlier working #58 after merge from origin/main revealed issues #58–#63 had been claimed by the Wave B/C/D batch-ingest-ui follow-ups.)
 - **2026-04-21**: Issue #11 archived — resolved-by-deletion. Remaining "1/12" test was in `tests/integration/test_gold_standard_coverage.py`, deleted in commit `03a8a20` during V1 retirement.
 - **2026-04-21**: Added Issue #67 — `/cleanup` skill step-1 mode-detection (`test -d .claude/worktrees`) is CWD-relative and returns `remote` when invoked from a ccw worktree, silently skipping the step-5 worktree sweep on local machines. Companion to the step-5 `-f -f` fix in commit for `.claude/commands/cleanup.md`.
+- **2026-04-21**: Issue #67 resolved — session-hygiene bundle: (a) `cleanup.md` step 1 re-anchored to `git rev-parse --git-common-dir` so local mode detects from any linked worktree; (b) `ccw` in `~/.zshrc` now writes a PID lockfile on entry and refuses silent second-session occupancy (self-healing via `kill -0`); (c) `ccw-rm` auto-deletes merged branches via `gh pr list --state merged` (offline-safe fallback); (d) `/commit` step 1 appends `-HHMM` timestamp on branch-name collision. Docs updated in `docs/development/claude-sessions-and-worktrees.md`. Summary row removed. Note: `~/.zshrc` edits (b, c) apply manually — patch in PR description.

--- a/docs/development/claude-sessions-and-worktrees.md
+++ b/docs/development/claude-sessions-and-worktrees.md
@@ -68,6 +68,20 @@ Session A cannot run `git checkout feat/foo` — the hook denies it and
 points at `ccw`. Sessions B and C do their work in parallel, never
 visible to each other.
 
+## Concurrent sessions (safeguards)
+
+Two sessions stepping into the same ccw worktree would share one HEAD, one index, and one set of files — a silent hazard. `ccw` protects against this with a PID lockfile:
+
+- On entry, `ccw` writes `$wt_dir/.ccw-session` with the shell's PID and registers an EXIT trap to remove it.
+- On re-entry, if the lockfile exists and the recorded PID is alive (`kill -0`), `ccw` refuses and points at `ccw --reuse` or `ccw-rm`. Stale lockfiles (PID gone) self-heal.
+- `.ccw-session` is listed in `~/.config/git/ignore` so it never leaks into a commit.
+
+**`ccw --reuse <branch>`** — intentionally share a worktree. Use when you want a second Claude session to observe the first (read-only tailing, for instance). Accept that file edits race.
+
+**`ccw-rm` behavior on merged branches.** After removing the worktree, `ccw-rm` checks via `gh` whether the branch has a merged PR. If so, it also runs `git branch -D <branch>`. On any `gh` failure (offline, rate-limit, auth), the branch is preserved. Pass `--keep-branch` to skip the deletion unconditionally.
+
+**`/commit` branch-name collisions.** When invoked from `main`, `/commit` derives `claude/<type>-<slug>`. If that branch already exists locally, `/commit` appends `-HHMM` (current-minute timestamp) before calling `checkout -b`, so two sessions starting similar work don't stomp each other's branch.
+
 ## Caveats
 
 - **First worktree checkout is slow.** A new worktree re-materializes


### PR DESCRIPTION
## Summary

Closes Issue #67 and companions. Three coordinated changes to prevent Claude sessions from silently clobbering each other's worktrees/branches, plus a pair of `~/.zshrc` changes that must be applied manually (see below).

- **`/cleanup` mode detection** now anchors on `git rev-parse --git-common-dir` so it correctly returns `local` when invoked from a ccw worktree.
- **`/commit` step 1** appends `-HHMM` timestamp on branch-name collision — no more raw git errors mid-flow.
- **`docs/development/claude-sessions-and-worktrees.md`** gains a "Concurrent sessions" section documenting the `.ccw-session` lockfile contract, `--reuse`, `ccw-rm`'s new merged-branch cleanup, and `/commit`'s collision-rename.
- **`docs/KNOWN_ISSUES.md`** — Issue #67 archived.

## Manual follow-up (my edits to `~/.zshrc` were denied — apply yourself)

**1.** Replace the existing `ccw` and `ccw-rm` bodies in `~/.zshrc` with:

```zsh
ccw() {
  local repo_root
  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
    echo "ccw: not inside a git repo" >&2; return 1
  }
  local primary
  primary=$(git -C "$repo_root" worktree list --porcelain \
            | awk 'NR==1 && $1=="worktree" {print $2; exit}')
  local repo_name
  repo_name=$(basename "${primary:-$repo_root}")
  repo_name="${repo_name%.git}"

  local existing=0 reuse=0
  while [[ "$1" == --* ]]; do
    case "$1" in
      --existing) existing=1; shift ;;
      --reuse)    reuse=1;    shift ;;
      *) echo "ccw: unknown flag $1" >&2; return 1 ;;
    esac
  done

  local branch="${1:-scratch/$(date +%Y%m%d-%H%M%S)}"
  local wt_dir="$HOME/.claude-worktrees/$repo_name/${branch//\//_}"

  if [[ ! -d "$wt_dir" ]]; then
    if (( existing )); then
      git -C "$repo_root" worktree add "$wt_dir" "$branch" || return 1
    else
      git -C "$repo_root" worktree add "$wt_dir" -b "$branch" || return 1
    fi
  fi

  # Prevent silent double-occupancy. Stale locks self-heal via kill -0.
  local lockfile="$wt_dir/.ccw-session"
  if [[ -f "$lockfile" ]] && (( ! reuse )); then
    local existing_pid
    existing_pid=$(awk 'NR==1 {print $1}' "$lockfile" 2>/dev/null)
    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
      echo "ccw: $wt_dir already in use by pid $existing_pid" >&2
      echo "     use 'ccw --reuse $branch' to share, or 'ccw-rm $branch' if stale" >&2
      return 1
    fi
    rm -f "$lockfile"
  fi

  (
    cd "$wt_dir" || return 1
    echo "$$ $(date +%Y-%m-%dT%H:%M:%S)" > "$lockfile"
    trap 'rm -f "$lockfile"' EXIT
    claude
  )
}

ccw-rm() {
  local repo_root
  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
  local primary
  primary=$(git -C "$repo_root" worktree list --porcelain \
            | awk 'NR==1 && $1=="worktree" {print $2; exit}')
  local repo_name
  repo_name=$(basename "${primary:-$repo_root}")
  repo_name="${repo_name%.git}"

  local keep_branch=0
  if [[ "$1" == "--keep-branch" ]]; then keep_branch=1; shift; fi

  local branch="$1"
  if [[ -z "$branch" ]]; then
    echo "usage: ccw-rm [--keep-branch] <branch>" >&2; return 1
  fi
  local wt_dir="$HOME/.claude-worktrees/$repo_name/${branch//\//_}"

  git -C "$repo_root" worktree remove "$wt_dir" || return 1

  if (( ! keep_branch )) && command -v gh >/dev/null 2>&1; then
    local merged
    merged=$(gh pr list --head "$branch" --state merged --json number --limit 1 2>/dev/null)
    if [[ -n "$merged" && "$merged" != "[]" ]]; then
      git -C "$repo_root" branch -D "$branch" \
        && echo "ccw-rm: deleted merged branch $branch"
    fi
  fi
}
```

Then `source ~/.zshrc`.

**2.** Add `.ccw-session` to the global git ignore:

```bash
echo '.ccw-session' >> ~/.config/git/ignore
```

### Latent bug fixed in the new ccw-rm

The existing `ccw-rm` uses `basename "$repo_root"` (not `"${primary:-$repo_root}"`). From inside a linked worktree, `$repo_root` is the linked tree path; the derived `repo_name` then points at the wrong `~/.claude-worktrees/` subdir. The new `ccw-rm` uses the primary-worktree derivation from `ccw` — same as `ccw` has always done.

## Test plan

- [ ] Checkout this branch; from a ccw worktree run `test -d "$(git rev-parse --git-common-dir 2>/dev/null)/.claude/worktrees" || test -d "$HOME/.claude-worktrees" && echo local` → prints `local`.
- [ ] From the primary repo, same expression → prints `local`.
- [ ] Apply the `~/.zshrc` patch + source. In terminal A, `ccw feat/test-lock` → enters worktree, lockfile created. In terminal B, `ccw feat/test-lock` → refuses with the occupying PID. Close A → B can now enter.
- [ ] `ccw --reuse feat/test-lock` while A is active → two sessions share the worktree intentionally.
- [ ] `echo 9999999 > $wt_dir/.ccw-session` (stale lock) → next `ccw` self-heals.
- [ ] After merging a PR with a ccw worktree, `ccw-rm <branch>` → worktree removed and branch deleted (prints confirmation).
- [ ] `gh auth logout`, then `ccw-rm <merged-branch>` → branch preserved (offline fallback). Re-auth and retry → deleted.
- [ ] On main with similar staged diff, run `/commit` twice within a minute → second run produces `claude/<type>-<slug>-HHMM` instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
