### PR TITLE
docs: align CLAUDE.md + tooling docs with planning-session-orchestrates workflow model

### DIFF
--- a/.claude/commands/supervise-prs.md
+++ b/.claude/commands/supervise-prs.md
@@ -1,0 +1,32 @@
+# Supervise PRs Skill (project-local)
+
+**Purpose:** Single-shot PR-cohort status check. After a planning session dispatches N parallel implementation subagents, invoke via `/loop <interval> /supervise-prs <prs>` to periodically check status, dispatch `/ci-fix` when a required check fails, and hand off to `/cleanup` once every PR reaches a terminal state.
+
+**Usage:** `/supervise-prs <pr_num>[,<pr_num>...]`
+
+This skill does not loop internally. Repetition is provided by `/loop`.
+
+## Steps (per iteration)
+
+1. **Parse** the comma-separated PR list. Validate each with `gh pr view <num> --json number,state,mergeable,statusCheckRollup`.
+2. **Classify** each PR:
+   - `MERGED` → mark done (record in skill state file at `/tmp/supervise-prs-<session>.json` or echo in output for the next iteration to read).
+   - `CLOSED` (not merged) → mark failed.
+   - `OPEN` with `statusCheckRollup` showing any required check at `FAILURE` → invoke `/ci-fix <pr_num>` as a subagent: `Agent` with `isolation: "worktree"` and a prompt that reuses the PR's branch. Cap total `/ci-fix` attempts per PR at 2; if exceeded, escalate (report to user and mark the PR as blocked).
+   - `OPEN` with checks pending/running → keep in active set.
+3. **Report** current state: `merged=<list>`, `failed=<list>`, `ci_fix_in_progress=<list>`, `active=<list>`.
+4. **Termination signal.** When the active set is empty:
+   - Print a clearly parseable completion line: `SUPERVISE_PRS_DONE merged=<n> failed=<n>`.
+   - Invoke `/cleanup` to sweep merged branches + worktrees.
+   - The surrounding `/loop` should stop on detecting this line (or the user stops it manually).
+
+## Safety
+
+- Never call `gh pr merge --admin`.
+- Never invoke `/ci-fix` more than 2 times for the same PR — report and stop.
+- If a PR's branch is deleted mid-supervision (branch ref gone), log and drop from active set; do not try to recover.
+- Do not duplicate `/cleanup` logic; always hand off.
+
+## Why single-shot
+
+Skills cannot call `ScheduleWakeup` directly (that tool is only available inside `/loop` dynamic mode). Keeping this skill single-shot means it composes cleanly with `/loop <interval>` and is trivial to invoke ad-hoc as a one-off status check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 
 **PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit` (project-local): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass.
 
+**Worktree-first.** Run `/commit` (and any HEAD-moving git work) from a `ccw` worktree, not the primary tree — a PreToolUse guard denies `git checkout`/`switch`/`checkout -b` in the primary tree to protect concurrent sessions. Use `EnterWorktree` inside a session or `ccw [branch]` from the shell. See `docs/development/claude-sessions-and-worktrees.md`.
+
+**Planning rule.** For any plan touching 3+ files or new deps / config, make worktree setup (`EnterWorktree` or `ccw <branch>`) the first step. The `/commit` skill assumes you're in one.
+
 Required status checks: **Lint**, **Unit Tests**, **Vulnerability Scan**, **Integration Tests**, **UI E2E (Playwright)**. Use `/ci-fix` when checks fail; `/merge-check` for a manual pre-merge sweep.
 
 Local guards (`.claude/settings.json`): `git push origin main`, `git push --force*`, and `gh pr merge --admin*` are denied. A PreToolUse hook refuses `git commit` on `main`. Pre-commit framework (`make hooks-install`) runs ruff + the Tier-1 regression / docs-folder guard on every commit.

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -30,6 +30,8 @@ feature branch → PR against main → CI green → squash-merge
 [`docs/operations/ci-branch-protection.md`](../operations/ci-branch-protection.md)).
 Direct pushes are refused; a red CI blocks the merge button.
 
+Run `/commit` from a `ccw` worktree. HEAD-moving git commands in the primary tree are blocked by a PreToolUse hook — see `docs/development/claude-sessions-and-worktrees.md`.
+
 ### Committing via `/commit` (Claude Code)
 
 The project-local `/commit` skill (`.claude/commands/commit.md`) handles the

--- a/docs/development/claude-sessions-and-worktrees.md
+++ b/docs/development/claude-sessions-and-worktrees.md
@@ -114,3 +114,41 @@ only remove paths under `~/.claude-worktrees/`.
 **Orphaned worktrees.** If you delete a worktree directory manually
 (outside `git worktree remove`), run `git worktree prune` in the repo
 to clean up git's internal bookkeeping.
+
+## Orchestration pattern (planning session → parallel subagents)
+
+The primary working tree is where planning sessions run. They are read-only by design — `guard-destructive-git.sh` denies HEAD-moving commands, so `/commit` cannot run from the primary tree.
+
+For multi-fix plans, the planning session orchestrates:
+
+1. **Plan** — develop the plan in the primary tree and write it to `~/.claude/plans/<name>.md` with discrete phases.
+2. **Dispatch** — call `Agent` in parallel, one per phase, each with `isolation: "worktree"`. Each subagent prompt points at the plan file and specifies the single phase to execute. Subagent runs `/commit` inside its own worktree, opens a PR, enables `--auto --squash`, and returns the PR URL.
+3. **Supervise** — invoke via `/loop 90s /supervise-prs <pr_nums>`. Each iteration checks status, dispatches `/ci-fix` as a subagent when required checks fail, and prints a completion line once every PR is terminal.
+4. **Cleanup** — the final iteration of `/supervise-prs` hands off to `/cleanup` automatically. Merged branches and worktrees are removed; dirty or in-use worktrees are preserved.
+
+### Subagent prompt template
+
+Every dispatched subagent should receive:
+
+```
+You are implementing Phase {N} of the plan at {plan_file_path}.
+
+Pre-flight:
+1. Read the plan file in full.
+2. Confirm pwd is under a worktree (not the primary tree). You were launched with isolation: "worktree", so this should already be true.
+3. Run `uv pip install -r requirements.txt` if `.venv/` is absent (fresh worktree).
+
+Execution:
+- Implement only Phase {N}'s tasks. Do not touch other phases.
+- Complete the project's Pre-Implementation Gate before coding (CLAUDE.md).
+- Run tests relevant to the phase.
+
+Commit:
+- Invoke `/commit`. It will auto-branch, push, open a PR, and enable auto-merge.
+
+Return:
+- Final line of your response must be the PR URL (format: https://github.com/.../pull/NNN).
+- If anything blocks, report the blocker instead — do NOT invent a URL.
+```
+
+This keeps dispatch to a one-line Agent call per phase.


### PR DESCRIPTION
## Summary

- Adds **Worktree-first** and **Planning rule** paragraphs to project `CLAUDE.md` Workflow section so planning agents see the worktree prerequisite where they read project rules
- Adds a one-sentence pointer to `docs/development/CONTRIBUTING.md` directing readers to run `/commit` from a `ccw` worktree and referencing the canonical worktree guide
- Extends `docs/development/claude-sessions-and-worktrees.md` with a new **Orchestration pattern** section covering plan → parallel-subagent dispatch → supervise → cleanup, plus a reusable subagent prompt template
- Adds new project-local skill `.claude/commands/supervise-prs.md` for single-shot PR-cohort status checking, designed to compose with `/loop <interval>` for periodic polling and handoff to `/cleanup` on completion

## Test plan

- [ ] Doc-only change — no code, tests, or migrations affected
- [ ] Pre-commit hooks passed (yaml, whitespace, docs-folder guard)
- [ ] Pre-push unit tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)