### PR TITLE
docs: slash commands table sweep + issue #68 (stale CONTRIBUTING.md /commit wording)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21, #60 resolved (`detect_universe_gaps` now filters by SIC via `companies JOIN`); #67 resolved (cleanup-skill mode detection re-anchored to `git-common-dir`; companion session-hygiene safeguards for ccw + `/commit` also landed); #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, #68 opened for stale CONTRIBUTING.md `/commit` step 1 wording post-worktree-hook (doc-only; functional behavior correct); PR #71 merged `/supervise-prs` + orchestration section to worktree guide; #60 resolved (`detect_universe_gaps` now filters by SIC via `companies JOIN`); #67 resolved (cleanup-skill mode detection re-anchored to `git-common-dir`; companion session-hygiene safeguards for ccw + `/commit` also landed); #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -40,6 +40,7 @@ _(none currently)_
 | Local-dev stuck-batch recovery is manual (Issue #62) | Open | No watcher runs locally; subprocess death leaves `status='running'` forever |
 | Cancel-during-populate not integration-tested (Issue #63) | Open | Conditional `_BATCH_COMPLETE_SQL` unit-tested; no end-to-end race-condition test |
 | Chart classifier Tier 1 boundary sensitivity (Issue #64) | Open | HOOD `cm_balance_by_cohort` scores 0.6024 — 0.0024 above the 0.6 gate; silent-regression risk |
+| CONTRIBUTING.md `/commit` step 1 wording stale post-worktree-hook (Issue #68) | Open | Step 1 implies `/commit` can run from primary tree on `main`; hook now blocks that path |
 
 ### Partially Resolved
 
@@ -853,6 +854,36 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 - `scripts/apply_migrations.py` — migration runner (idempotent via `schema_migrations` ledger)
 - `sql/39_v2_ingest_batches.sql` — the migration that triggered this discovery
 - `render.yaml` — pre-deploy hook would attach to the web service entry
+
+---
+
+## 68. CONTRIBUTING.md `/commit` Step 1 Wording Is Stale Post-Worktree-Hook
+
+**Status**: Open
+**Severity**: Low — documentation only; functional behavior is correct
+**Discovered**: 2026-04-21 (during PR #71 planning — CLAUDE.md + worktree-rule documentation sweep)
+
+### Problem
+
+`docs/development/CONTRIBUTING.md` § "Committing via `/commit`" step 1 currently reads:
+
+> "If on `main`, auto-creates `claude/<type>-<slug>` and switches to it. Otherwise stays on the current branch."
+
+This implies `/commit` can be invoked from the primary worktree while on `main`. In practice, `~/.claude/hooks/guard-destructive-git.sh` (the PreToolUse hook) now denies `git checkout -b` in the primary tree, so running `/commit` from there will fail with a hook block. The step 1 description does not reflect the worktree-required model that is actually enforced.
+
+The functional behavior is correct — the hook fires and blocks the operation as intended. Only the documentation lags behind.
+
+### Next Steps
+
+- Rewrite step 1 to state that `/commit` must be invoked from a `ccw` worktree (or via an `Agent` call with `isolation: "worktree"`), and that invoking it from the primary tree will be refused by the PreToolUse hook.
+- Cross-link `docs/development/claude-sessions-and-worktrees.md` § Orchestration pattern for the recommended workflow.
+
+### Cross-References
+
+- `docs/development/CONTRIBUTING.md` — § "Committing via `/commit`", step 1
+- `docs/development/claude-sessions-and-worktrees.md` — § Orchestration pattern
+- `~/.claude/hooks/guard-destructive-git.sh` — the hook that blocks `git checkout -b` in the primary tree
+- PR #71 — added `/supervise-prs` and orchestration guidance to the worktree guide
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 **Project:** SEC Filings Customer Metrics Extraction System
 **Version:** 2.6
 **Status:** Production Ready
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-21
 
 ---
 
@@ -349,13 +349,17 @@ Workflow commands for common tasks:
 
 | Command | Purpose |
 |---------|---------|
-| `/metric-lifecycle` | Guidance for adding, deprecating, or removing metrics |
+| `/cleanup` | Project-local: prune merged branches, stale remote-tracking refs, and dead Claude worktrees. Safe to re-run. |
 | `/commit` | Project-local: auto-branch off main, commit, push, open PR, enable auto-merge. See [CONTRIBUTING.md](development/CONTRIBUTING.md#committing-via-commit-claude-code). |
-| `/plan-review` | Review and critique a plan before execution |
 | `/doc-audit` | Run documentation freshness audit (reports staleness, does not auto-fix) |
+| `/metric-lifecycle` | Guidance for adding, deprecating, or removing metrics |
 | `/project-tutorial [lesson]` | Interactive project lessons with live codebase walkthroughs (10 topics) |
+| `/supervise-prs` | Project-local: single-shot PR-cohort status check; compose with `/loop <interval> /supervise-prs <prs>` to poll merges, dispatch `/ci-fix` on required-check failures, and hand off to `/cleanup`. |
+| `/ci-fix` | Global/plugin: iterate ruff / mypy / pytest to green on a red PR, then defer to `/commit`. |
+| `/merge-check` | Global/plugin: pre-merge sanity sweep (CI status, migrations, import integrity, tests, type check, branch freshness). |
+| `/plan-review` | Global/plugin: review and critique a plan before execution. |
 
-> **Note:** `/commit`, `/doc-audit`, `/metric-lifecycle`, and `/project-tutorial` are project-local command files under `.claude/commands/`. `/plan-review` is delivered via Claude Code skills/plugins rather than a project-local file.
+> **Note:** `/cleanup`, `/commit`, `/doc-audit`, `/metric-lifecycle`, `/project-tutorial`, and `/supervise-prs` are project-local command files under `.claude/commands/`. `/ci-fix`, `/merge-check`, and `/plan-review` are delivered via Claude Code skills/plugins rather than project-local files.
 
 ### Sub-Agents (`.claude/agents/`)
 


### PR DESCRIPTION
## Summary

- **`docs/README.md`**: Add four missing slash command rows to the Slash Commands table (`/cleanup`, `/supervise-prs`, `/ci-fix`, `/merge-check`); reorder alphabetically within project-local commands, then global/plugin; rewrite the trailing Note to accurately list all project-local vs. plugin-delivered commands; bump Last Updated to 2026-04-21. Follow-up to PR #71 which added `/supervise-prs` but didn't update the README table.
- **`docs/KNOWN_ISSUES.md`**: Open issue #68 — `CONTRIBUTING.md` `/commit` step 1 wording is stale post-worktree-hook (doc-only; functional behavior is correct — the hook fires and blocks). Add summary table row and body entry. Update Last Updated header.

## Test plan

- [ ] Docs-only change — no code, tests, or config touched; lint and test suite not required per CLAUDE.md testing standards
- [ ] Pre-commit hooks passed (end-of-file, trailing whitespace, large files, private-key scan, docs-folder guard)
- [ ] Pre-push unit tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)