### PR TITLE
test(ui): cut Playwright flake rate — retries + race fix + traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: tests/ui/playwright-report/
+          path: |
+            tests/ui/playwright-report/
+            tests/ui/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
   vulnerability-scan:
     name: Vulnerability Scan

--- a/tests/ui/playwright.config.js
+++ b/tests/ui/playwright.config.js
@@ -8,10 +8,14 @@ module.exports = defineConfig({
   testDir: '.',
   testMatch: '*.spec.js',
   timeout: 30000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
     baseURL: 'http://localhost:5200',
     headless: true,
     channel: 'chrome',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
   webServer: {
     command: 'python3 test_server.py',

--- a/tests/ui/review.spec.js
+++ b/tests/ui/review.spec.js
@@ -560,18 +560,19 @@ test.describe('Correct Form', () => {
   });
 
   test('Enter in correct notes submits the correction', async ({ page }) => {
-    let submitted = false;
-    await page.route('/api/v2/decisions', async route => {
-      submitted = true;
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'success' }) });
-    });
+    await page.route('/api/v2/decisions', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'success' }) })
+    );
     await page.goto('/');
     await page.keyboard.press('c');
     await page.keyboard.press('Enter');
     await page.keyboard.press('Enter');
     await page.locator('#correct-notes').fill('test note');
+    const decisionPost = page.waitForRequest(
+      req => req.url().endsWith('/api/v2/decisions') && req.method() === 'POST'
+    );
     await page.keyboard.press('Enter');
-    expect(submitted).toBe(true);
+    await decisionPost;
   });
 });
 


### PR DESCRIPTION
## Summary

Three small changes to stop UI E2E flakes from dominating failed CI runs (Phase 1 of the approved plan — Phase 3 is in parallel as PR #75):

- **Retries in CI** — \`playwright.config.js\` gets \`retries: 2\` (CI only), HTML reporter, \`trace: 'on-first-retry'\`, \`screenshot: 'only-on-failure'\`. Retried tests are reported as \`flaky\` (distinct from \`passed\`) so regressions stay visible; single-test flakes stop reddening the whole job.
- **One confirmed race fix** — \`review.spec.js:562-575\` (\`Correct Form › Enter in correct notes submits the correction\`) had \`expect(submitted).toBe(true)\` firing before the \`/api/v2/decisions\` POST handler ran. Swapped to \`page.waitForRequest\` — deterministic, no sleeps.
- **Artifact path widened** — \`ci.yml\` upload now includes \`tests/ui/test-results/\` (where traces land) in addition to \`playwright-report/\`. Adds \`if-no-files-found: ignore\` so the step is a no-op on green runs.

Evidence for the flake pattern: run [24701946165](https://github.com/RGMjr/filings_reviewer/actions/runs/24701946165) had 7 failed / 142 passed in 1.4m — all \`Timeout: 5000ms, element(s) not found\`, all different tests. Exactly the signature retries fix.

## What this does NOT do

- Replace the other 7 \`waitForTimeout(500)\` anti-patterns (lines 440, 783, 812, 842, 874, 903, 936) — that is Phase 2, deliberately separate.
- Investigate the 6 non-race DOM-assertion flakes (lines 66, 71, 229, 253, 1094, 1099) — \`retries: 2\` should mask them; Phase 4 is investigate-only, deferred until we have post-merge data.

## Test plan

- [x] Config \`--list\` clean, no parse errors
- [x] \`npx playwright test -g \"Enter in correct notes submits the correction\"\` — 3/3 local reps green (793ms / 558ms / 526ms)
- [x] Full Playwright suite: 149 passed / 2 skipped / 0 failed
- [x] \`uv run pytest -x -q --no-cov\` — 3774 passed / 67 skipped
- [x] \`ruff check src/ tests/\` clean
- [x] YAML parse of ci.yml clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)