### PR TITLE
docs(known-issues): fix detail-section numbering drift (#67/#68 → #68/#69)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -889,7 +889,7 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 
 ---
 
-## 67. Nightly Sweeper Orchestrator Uses GNU `timeout` (Incompatible with macOS)
+## 68. Nightly Sweeper Orchestrator Uses GNU `timeout` (Incompatible with macOS)
 
 **Status**: Open
 **Severity**: Low
@@ -906,7 +906,7 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 
 ---
 
-## 68. `Dockerfile.nightly-sweep` Installs `claude` + `gh` Unpinned
+## 69. `Dockerfile.nightly-sweep` Installs `claude` + `gh` Unpinned
 
 **Status**: Open
 **Severity**: Low


### PR DESCRIPTION
## Summary

- Fixes numbering drift introduced by PR #64 (nightly autonomous sweeper) in `docs/KNOWN_ISSUES.md`
- Detail section `## 67.` renamed to `## 68.` (macOS `timeout` incompatibility)
- Detail section `## 68.` renamed to `## 69.` (`Dockerfile.nightly-sweep` unpinned installs)
- Summary table references to `#68` and `#69` were already correct — untouched
- `## 70.` and all Archive `### Issue #N:` entries — untouched

## Test plan

- [ ] Verify `## 68.` and `## 69.` detail headers now match the summary table rows
- [ ] Verify `## 70.` and Archive section are unchanged
- [ ] CI passes (docs-only change; lint/tests not triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)