### PR TITLE
chore(ci): wire CI for merge queue + add concurrency groups

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -119,7 +119,7 @@
     - Otherwise: `gh pr create --fill` (auto-title from commit subject, auto-body from commit body + PR template). Capture the URL.
     - On `gh` failure (auth, rate-limit, etc.): report the exact error and stop. Do NOT fall back to any other form of merge.
 
-16. **Enable auto-merge.** `gh pr merge --auto --squash` (idempotent — no-op if already enabled). `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
+16. **Enable auto-merge.** `--auto` enqueues the PR into the GitHub merge queue; GitHub handles up-to-date-with-main automatically. `gh pr merge --auto --squash` (idempotent — no-op if already enabled). `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
 
 17. **Report.** Final one-line summary to the user:
     ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 ## Workflow
 
 **PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit` (project-local): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass.
+Merges go through GitHub's merge queue; do not manually rebase an in-flight PR unless the queue explicitly fails it for conflicts.
 
 **Worktree-first.** Run `/commit` (and any HEAD-moving git work) from a `ccw` worktree, not the primary tree — a PreToolUse guard denies `git checkout`/`switch`/`checkout -b` in the primary tree to protect concurrent sessions. Use `EnterWorktree` inside a session or `ccw [branch]` from the shell. See `docs/development/claude-sessions-and-worktrees.md`.
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 This document tracks known issues, limitations, and planned improvements identified during extraction system development.
 
-**Last Updated**: 2026-04-21, #61 resolved (integration coverage for `/ingest/preview`); added Nightly Sweeper Classification table (see below for the autonomous-merge / morning-review / skip tags used by `scripts/known_issues_selector.py`); #68 opened for macOS `timeout` incompatibility in the sweeper orchestrator; #69 opened for unpinned `claude`/`gh` installs in `Dockerfile.nightly-sweep`. #60 resolved (`detect_universe_gaps` now filters by SIC via `companies JOIN`); #67 resolved (cleanup-skill mode detection re-anchored to `git-common-dir`; companion session-hygiene safeguards for ccw + `/commit` also landed); #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
+**Last Updated**: 2026-04-21, #70 opened for Integration Tests job lacking a path filter (docs-only PRs still trigger full Postgres + migration run); #61 resolved (integration coverage for `/ingest/preview`); added Nightly Sweeper Classification table (see below for the autonomous-merge / morning-review / skip tags used by `scripts/known_issues_selector.py`); #68 opened for macOS `timeout` incompatibility in the sweeper orchestrator; #69 opened for unpinned `claude`/`gh` installs in `Dockerfile.nightly-sweep`. #60 resolved (`detect_universe_gaps` now filters by SIC via `companies JOIN`); #67 resolved (cleanup-skill mode detection re-anchored to `git-common-dir`; companion session-hygiene safeguards for ccw + `/commit` also landed); #66 opened for Render deploys skipping `apply_migrations.py`; #65 opened for secret-leak guard on mis-named env duplicates (Five-issue follow-up bundle landed in commit `7848605` — #42 `_download_missing_images` double-write collapsed; #50 new `tests/unit/web/test_api_unified_auth.py` covers blueprint-wide 401 path; #51 grep-the-source tests rewritten as behavioral mock-cursor assertions; #52 new `scripts/check_pg_client_version.py` pre-flight; #54 new `chart_metric_min_confidence` operator knob, default 0.60 to avoid Tier 1 regression. #64 opened — chart classifier Tier 1 boundary sensitivity (HOOD `cm_balance_by_cohort` scores 0.6024, 0.0024 above gate). Archive cleanup collapsed 29 resolved issues into Archive section; rewrote Summary table to foreground open items. Also landed (from `origin/main` Wave B/C/D batch-ingest-ui follow-ups): #58 for 8-K Exhibit 99.1 fetching; #59 for 8-K section classifier patterns; #60 for `detect_universe_gaps` SIC-blindness; #61 for `/ingest/preview` integration coverage; #62 for local-dev stuck-batch recovery runbook; #63 for cancel-during-populate integration test.)
 
 ---
 
@@ -41,6 +41,7 @@ _(none currently)_
 | Chart classifier Tier 1 boundary sensitivity (Issue #64) | Open | HOOD `cm_balance_by_cohort` scores 0.6024 — 0.0024 above the 0.6 gate; silent-regression risk |
 | Nightly sweeper uses GNU `timeout` — macOS incompatible (Issue #68) | Open | Local `/sweep` on Mac fails at the `timeout` call; Render (Linux) production is fine |
 | `Dockerfile.nightly-sweep` installs `claude` + `gh` unpinned (Issue #69) | Open | Version drift between builds could silently change sweeper behaviour |
+| Integration Tests job has no path filter (Issue #70) | Open | Docs-only / `.claude/`-only PRs still spin up Postgres + migrations; stacks extra wall-time under merge queue |
 
 ### Partially Resolved
 
@@ -108,6 +109,7 @@ Source of truth for `scripts/known_issues_selector.py` — the nightly autonomou
 | #66   | review   | S         | `render.yaml .claude/rules/infrastructure.md`                           | Wire apply_migrations into Render deploy; infra-change risk   |
 | #68   | safe     | XS        | `scripts/run_nightly_sweep.sh`                                          | Detect timeout vs gtimeout; fallback path for macOS           |
 | #69   | review   | S         | `Dockerfile.nightly-sweep`                                              | Pin claude + gh versions; needs validation step               |
+| #70   | safe     | XS        | `.github/workflows/ci.yml`                                              | Add path filter to integration-tests, mirroring ui-e2e        |
 
 ---
 
@@ -920,6 +922,24 @@ Discovered while implementing Issue #54: the issue's suggested default (`chart_m
 - Pin the `claude` installer to a specific version once the installer supports a version argument; otherwise cache a specific binary in the image.
 - Pin `gh` to a specific apt version (`gh=2.X.Y`) or switch to the GitHub Releases tarball.
 - Consider adding a build-time smoke test: `claude --version && gh --version` to fail the build on unexpected drift.
+
+---
+
+## 70. Integration Tests Job Has No Path Filter
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-04-21 (during merge-queue rollout planning)
+
+### Problem
+
+`.github/workflows/ci.yml` runs the `integration-tests` job on every PR regardless of touched paths. UI E2E already has a conservative path filter (`ci.yml:49-69`) that skips the job when every changed path is under `docs/`, `.claude/`, `CLAUDE.md`, `README.md`, `.gitignore`, or `.github/CODEOWNERS`. Integration Tests has no equivalent, so docs-only and `.claude/`-only PRs still spin up Postgres 15, apply migrations, and run the full integration suite (~3–6 min). After the merge queue is enabled, this wall-time adds directly to queue latency per batch, slowing unrelated PRs.
+
+### Next Steps
+
+- Mirror the UI E2E filter structure (`ci.yml:49-69`) on the `integration-tests` job. Same allowlist (`docs/`, `.claude/`, `CLAUDE.md`, `README.md`, `.gitignore`, `.github/CODEOWNERS`) — err on the side of running when in doubt.
+- Verify by opening a docs-only PR and confirming `Integration Tests` reports `skipped` in Actions.
+- Do NOT remove Integration Tests from required status checks — a skipped job still counts as passing for branch protection, so the gate stays intact.
 
 ---
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -23,12 +23,12 @@ covered in [`docs/operations/setup-guide.md`](../operations/setup-guide.md).
 ## Workflow
 
 ```
-feature branch → PR against main → CI green → squash-merge
+feature branch → PR against main → auto-enqueue → merge_group CI green → squash-merged
 ```
 
 `main` is protected (see
 [`docs/operations/ci-branch-protection.md`](../operations/ci-branch-protection.md)).
-Direct pushes are refused; a red CI blocks the merge button.
+Direct pushes are refused; a red CI blocks the merge button. Merges flow through GitHub's merge queue — the queue runs required checks on a synthetic `merge_group` ref atop current `main`, so stale-branch manual rebases are no longer needed.
 
 Run `/commit` from a `ccw` worktree. HEAD-moving git commands in the primary tree are blocked by a PreToolUse hook — see `docs/development/claude-sessions-and-worktrees.md`.
 
@@ -46,9 +46,10 @@ full flow in one invocation:
 5. **Push** the branch: `git push -u origin <branch>`.
 6. **PR.** If no open PR exists for the branch: `gh pr create --fill`. If
    one already exists: reuse it (new commits are appended).
-7. **Auto-merge.** `gh pr merge --auto --squash`. GitHub merges the PR once
-   all required checks pass (Lint / Unit Tests / Vulnerability Scan /
-   Integration Tests / UI E2E).
+7. **Auto-merge.** `gh pr merge --auto --squash` enqueues the PR in the merge
+   queue. GitHub runs required checks (Lint / Unit Tests / Vulnerability Scan /
+   Integration Tests / UI E2E) on the queue's `merge_group` ref and
+   squash-merges the PR when they pass.
 
 Local safety rails in `.claude/settings.json`:
 
@@ -122,6 +123,8 @@ the required jobs. At time of writing:
 
 Coverage threshold (`fail_under`) and the suite's expectations are in
 `pyproject.toml` under `[tool.coverage.report]` and `[tool.pytest.ini_options]`.
+
+Checks run both on PR pushes and on the merge queue's `merge_group` ref. A PR must pass the latter to merge.
 
 ## Commit style
 

--- a/docs/development/claude-sessions-and-worktrees.md
+++ b/docs/development/claude-sessions-and-worktrees.md
@@ -94,9 +94,12 @@ Two sessions stepping into the same ccw worktree would share one HEAD, one index
   worktree starts without them. Copy or symlink `.env` from the primary
   tree if the session needs it.
 - **Starting ref.** `ccw <new-branch>` branches off the primary tree's
-  **current** HEAD. If that's stale, run `git -C <primary> fetch && git
-  -C <primary> checkout main && git -C <primary> pull` before calling
-  `ccw`, or pass an explicit ref via `git worktree add` directly.
+  **current** HEAD. Rarely needed now that merges go through GitHub's
+  merge queue — the queue keeps `main` advancing predictably, so
+  primary-tree HEAD shouldn't drift far. But if you haven't fetched in a
+  while and see "branch out of date" on a PR, run
+  `git -C <primary> fetch && git -C <primary> pull` before calling `ccw`
+  to branch off a current main.
 - **One checkout per branch.** Git refuses to check out the same branch
   in two worktrees at once. If you get "branch is already checked out",
   use a different branch name or `ccw-rm` the stale worktree.

--- a/docs/operations/ci-branch-protection.md
+++ b/docs/operations/ci-branch-protection.md
@@ -34,54 +34,40 @@ Five jobs from `.github/workflows/ci.yml` are consistent enough to gate on:
 - `Gold Standard Validation` — requires `OPENAI_API_KEY`; runs on a schedule
   rather than per-PR.
 
-### Path A — GitHub Web UI
+### GitHub Web UI — enabling Merge Queue
 
 1. Go to `https://github.com/RGMjr/filings_reviewer/settings/branches`.
-2. Click **Add branch ruleset** (or **Add classic branch protection rule**, which is simpler for a single repo).
+2. Click the edit pencil next to the `main` branch protection rule (or **Add classic branch protection rule** if starting fresh).
 3. Branch name pattern: `main`.
 4. Enable:
    - **Require a pull request before merging**
      - Required approvals: `0` for solo work, `1` if reviewing across a team.
      - Dismiss stale pull request approvals when new commits are pushed: `off` for solo, `on` for team.
+   - **Require merge queue**
+     - Merge method: **Squash**.
+     - Starter tunables: min group size `1`, max group size `5`, min wait `0` min, max wait `5` min, grace period `5` min. These are adjustable; start here and tune based on observed throughput.
    - **Require status checks to pass before merging**
-     - Require branches to be up to date before merging: `on`.
+     - **Require branches to be up to date before merging**: uncheck this. The merge queue subsumes it — leaving it on is harmless but redundant.
      - Status checks required: add each of the five listed above by name. They must have run at least once on a branch for GitHub to recognise them.
    - **Require conversation resolution before merging**: `on`.
-   - **Do not allow bypassing the above settings**: `off` initially (lets admin push directly for emergencies). Flip to `on` once the workflow is stable.
+   - **Do not allow bypassing the above settings** (`enforce_admins: true`), `allow_force_pushes: false`, `allow_deletions: false`: keep these as-is.
 5. Save.
 
-### Path B — `gh` CLI (idempotent)
+### Why no `gh` CLI path
 
-```bash
-gh api --method PUT /repos/RGMjr/filings_reviewer/branches/main/protection \
-  --input - <<'EOF'
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": [
-      "Lint",
-      "Unit Tests",
-      "Vulnerability Scan",
-      "Integration Tests",
-      "UI E2E (Playwright)"
-    ]
-  },
-  "enforce_admins": false,
-  "required_pull_request_reviews": {
-    "required_approving_review_count": 0,
-    "dismiss_stale_reviews": false
-  },
-  "restrictions": null,
-  "allow_force_pushes": false,
-  "allow_deletions": false,
-  "required_conversation_resolution": true
-}
-EOF
-```
+The classic `branches/:branch/protection` REST API does not expose the merge-queue toggle — merge-queue configuration lives in the newer GitHub Rulesets API, which this repo has not audited. Use the UI; it's reliable and reversible in under two minutes.
 
-- `enforce_admins: false` keeps the admin escape hatch for emergency pushes. Set to `true` once the workflow is stable.
-- `required_approving_review_count: 0` works for solo development; bump to `1` when reviewing across a team.
-- `strict: true` = "require branches to be up to date" — prevents merging a PR that hasn't rebased on the latest failing commit.
+### Diagnosing a stuck queue
+
+**Symptom:** a PR sits in the queue for minutes without being merged or dequeued.
+
+- **First check:** open Actions and filter by event `merge_group`. If no `merge_group` runs exist, the CI workflow is missing the `merge_group:` trigger. It should appear in the `on:` block of `.github/workflows/ci.yml`. Add it if absent and push to the PR branch.
+- **Second check:** if `merge_group` runs exist but failed, GitHub automatically dequeues the offending PR and continues with the rest of the queue. Inspect the failing run to identify which PR in the group caused it.
+- **Third check:** if the queue is completely unresponsive (no activity at all), toggle **Require merge queue** off and back on again in the branch protection rule to reset it.
+
+### Temporarily disable the queue
+
+In the branch protection rule, uncheck **Require merge queue** and save. All currently-queued PRs fall back to per-PR auto-merge (still honoring the existing `--auto --squash` setting from `/commit`). Reversible in under 2 minutes. No data loss.
 
 ### Verify
 
@@ -89,24 +75,22 @@ EOF
 # Should reject with "protected branch hook declined" or similar.
 git push origin main
 
-# Should show the protection config.
+# Should show the required status check contexts.
 gh api /repos/RGMjr/filings_reviewer/branches/main/protection | jq '.required_status_checks.contexts'
 ```
 
+Additionally: queue a trivial PR via `/commit` and confirm a `merge_group` event appears in the Actions run list, running all 5 required checks before the PR merges.
+
 ### Rollback (emergency)
 
-If the protection blocks a legitimate hotfix:
+If the protection blocks a legitimate hotfix, use the UI:
 
-```bash
-# Temporarily disable, push the fix, re-enable.
-gh api --method DELETE /repos/RGMjr/filings_reviewer/branches/main/protection
-git push origin main
-# Re-apply the `gh api --method PUT` block above.
-```
+1. Go to `https://github.com/RGMjr/filings_reviewer/settings/branches`.
+2. Edit the `main` rule.
+3. Uncheck **Require merge queue** (and, if needed, **Require status checks to pass**).
+4. Save. The change takes effect immediately.
 
-Prefer "admin bypass" (flip `enforce_admins` to `false` if it isn't already)
-over deleting the rule — the rule stays visible and you only skip it for one
-push.
+This is reversible in under 2 minutes — re-enable the same checkboxes once the hotfix is in.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase A of the merge-queue rollout (see `/Users/rgmarkey/.claude/plans/we-have-a-problem-vivid-breeze.md`). Prepares CI so GitHub's native merge queue can validate required checks on queued refs once it's enabled via the repo UI.

- Adds `merge_group:` trigger to `ci.yml` → required checks will run on queue refs.
- Adds `concurrency:` block → superseded PR runs cancel (push/main and merge_group runs preserved).
- Updates docs (branch-protection runbook, CONTRIBUTING, sessions-and-worktrees, CLAUDE.md, `/commit` step 16) to reflect the queue model.
- Triaged #70 (Integration Tests job lacks path filter) as an orthogonal follow-up.

## Why

Concurrent Claude sessions were starving on `strict: true` + 4–8 min CI: PR-A waits on CI → PR-B merges → PR-A is stale → rebase → rerun CI → repeat. Direct evidence: PR #59 `(rebased)`, PR #60 re-opened as #68 after base-branch conflict.

Merge queue serializes and batches merges atomically — no more manual rebase treadmill.

## What this PR does NOT do

This PR only wires the CI side. The merge queue itself is enabled via **GitHub web UI** (Settings → Branches → `main` → check **Require merge queue**). That's Phase C and must be done manually — the classic branch-protection API doesn't expose the queue toggle, and the newer Rulesets API hasn't been audited. Runbook in `docs/operations/ci-branch-protection.md`.

## Test plan

- [ ] CI green on this PR (this validates concurrency groups and confirms `merge_group:` trigger is a no-op until Phase C).
- [ ] After merge: enable **Require merge queue** in branch protection UI (Phase C).
- [ ] Queue a trivial follow-up PR via `/commit` → confirm `merge_group` event fires in Actions with all 5 required checks passing.
- [ ] Stress test: open 2–3 small PRs concurrently from different worktrees → confirm no "branch out of date" stalls.
- [ ] Rollback drill: temporarily uncheck **Require merge queue** to confirm < 2 min recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)