### PR TITLE
fix(nightly-sweep): pipe claude installer to bash (Render build fix)

### DIFF
--- a/Dockerfile.nightly-sweep
+++ b/Dockerfile.nightly-sweep
@@ -42,7 +42,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Claude Code CLI. Installs to /usr/local/bin/claude via the official installer.
 # The installer is idempotent and safe to run at build time.
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Non-privileged user (matches main Dockerfile pattern).
 ARG UID=10001


### PR DESCRIPTION
## Summary

- `Dockerfile.nightly-sweep:45` piped `https://claude.ai/install.sh` to `sh`. In `python:3.11-slim`, `/bin/sh` is dash, and the installer uses bash-only syntax on line 9 — every Render build since PR #64 (2026-04-21) has failed with `sh: 9: Syntax error: "(" unexpected (expecting "then")`.
- 5 consecutive `build_failed` deploys on cron `crn-d7jthh9o3t8c7398ss10` — the image layer has never succeeded, so no sweeper has ever run.
- One-line fix: `| sh` → `| bash`. Image already has bash (appuser login shell at :50, CMD at :65), and Anthropic's own install docs pipe to bash.

## Blast radius

- Affects only `filings-nightly-sweep`. `filings-reviewer`, `filings-onboarding-runner`, `filings-extraction`, and `filings_reviewer` use the main `Dockerfile`, not this one.
- `.claude/sweep.pause` remains in place — this PR only unblocks the image build, not autonomous sweeper behavior.
- Issue #69 (unpinned `claude` / `gh` versions) is adjacent and intentionally still open.

## Test plan

- [ ] CI green: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E
- [ ] Post-merge: confirm next Render deploy of `filings-nightly-sweep` no longer shows `build_failed` (via `mcp__render__list_deploys`)
- [ ] Confirm the four other Render services are unaffected (they share no layer with this file)

Generated with [Claude Code](https://claude.com/claude-code)