### PR TITLE
chore(render): pin all services to Ohio region

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -23,7 +23,13 @@ docker compose down    # Stop
 
 Cloud PostgreSQL format: `postgresql://user:password@host.neon.tech/dbname?sslmode=require`
 
-`render.yaml` defines: `filings-reviewer` web service + `filings-extraction` cron (daily 6am UTC, runs `batch_v2_extraction.py --status fetched --workers 2 --limit 50`).
+`render.yaml` defines 4 services, all pinned to Ohio region via `region: ohio`:
+- `filings-reviewer` — web service (URL: `filings-reviewer.onrender.com`)
+- `filings-extraction` — cron, daily 6am UTC (`batch_v2_extraction.py --status fetched --workers 2 --limit 50`)
+- `filings-onboarding-runner` — background worker (`src.universe.onboarding_runner --watch`)
+- `filings-nightly-sweep` — cron, daily 6am UTC (autonomous KNOWN_ISSUES sweeper; gated by `.claude/sweep.pause`)
+
+Region is pinned so blueprint re-deploys do not scatter services across regions. Render will ignore `region` changes on existing services — if you need to move a service to a different region you must delete and recreate it (env groups `filings-shared-secrets` and `filings-claude-secrets` persist across deletion, so secrets are inherited on recreate).
 
 ### pg_dump client version
 

--- a/docs/operations/cloud-deployment-runbook.md
+++ b/docs/operations/cloud-deployment-runbook.md
@@ -1,7 +1,7 @@
 # Cloud Deployment Runbook
 
-**Infrastructure:** Render (web service) + Neon (PostgreSQL)
-**Last updated:** 2026-04-18
+**Infrastructure:** Render (web service + worker + 2 crons, all Ohio region) + Neon (PostgreSQL)
+**Last updated:** 2026-04-22
 
 ---
 
@@ -12,6 +12,7 @@
 | Item | Detail |
 |------|--------|
 | Service URL | https://filings-reviewer.onrender.com |
+| Region | Ohio — pinned in `render.yaml` via `region: ohio` on every service |
 | Live since | 2026-04-08 |
 | Pre-cutover checklist | Complete |
 | DB | Production Neon — all 21 migrations applied; `html_content` and `image_cache` populated |

--- a/render.yaml
+++ b/render.yaml
@@ -27,6 +27,7 @@ envVarGroups:
 services:
   - type: web
     name: filings-reviewer
+    region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile
     envVars:
@@ -42,6 +43,7 @@ services:
 
   - type: cron
     name: filings-extraction
+    region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile
     dockerCommand: python3 scripts/batch_v2_extraction.py --status fetched --workers 2 --limit 50
@@ -51,6 +53,7 @@ services:
 
   - type: worker
     name: filings-onboarding-runner
+    region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile
     dockerCommand: python3 -m src.universe.onboarding_runner --watch --poll-interval 10
@@ -71,6 +74,7 @@ services:
   # Remove that file to activate the sweeper.
   - type: cron
     name: filings-nightly-sweep
+    region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile.nightly-sweep
     dockerCommand: bash scripts/run_nightly_sweep.sh


### PR DESCRIPTION
## Summary

- Add `region: ohio` to all 4 services in `render.yaml` (web, worker, extraction cron, nightly-sweep cron) so blueprint re-deploys don't scatter services across regions. The 2026-04-21 incident re-blueprinted the worker + crons into Oregon precisely because the blueprint was silent on region.
- Refresh `.claude/rules/infrastructure.md` — the `render.yaml defines:` summary previously listed only 2 of 4 services. Now lists all 4 and explains the region-pinning rationale (region immutable on existing services; env groups persist across deletion).
- Bump `docs/operations/cloud-deployment-runbook.md` "Last updated" to today and add a Region row to the Deployment Status table.

This PR alone does **not** move the 3 Oregon services — per Render docs, region changes on existing services are ignored. Consolidation happens separately (delete + blueprint re-create) after this merges, following the session plan at `~/.claude/plans/did-something-just-wipe-splendid-trinket.md`.

## Test plan

- [x] `render.yaml` parses as valid YAML
- [x] Pre-commit hooks pass (check-yaml, end-of-file, trailing-whitespace, secret detection, tier-1 regression guard)
- [x] Pre-push pytest unit tests pass
- [ ] Post-merge: manual Render blueprint sync with the Ohio web service renamed to match blueprint (phase 1 of plan)
- [ ] Post-merge: delete 4 Oregon services and let blueprint re-create the 3 non-web services in Ohio (phases 3-4 of plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)