### PR TITLE
fix(nightly-sweep): install claude as appuser so it's on runtime PATH

### DIFF
--- a/Dockerfile.nightly-sweep
+++ b/Dockerfile.nightly-sweep
@@ -40,20 +40,28 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Code CLI. Installs to /usr/local/bin/claude via the official installer.
-# The installer is idempotent and safe to run at build time.
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Non-privileged user (matches main Dockerfile pattern).
+# Non-privileged user (matches main Dockerfile pattern). Created before the
+# Claude install so the installer drops the binary into appuser's $HOME.
 ARG UID=10001
 RUN adduser --disabled-password --gecos "" \
         --home "/home/appuser" --shell "/bin/bash" --uid "${UID}" appuser
 
 # Python dependencies — same lockfile as the main image so pytest works inside
-# sweep worktrees without a separate install step.
+# sweep worktrees without a separate install step. Installed as root into the
+# system site-packages so both root and appuser can import them.
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.lock,target=requirements.lock \
     python -m pip install -r requirements.lock
+
+# Claude Code CLI. The official installer drops a native binary into
+# $HOME/.local/bin and explicitly warns it does not touch PATH. Installing
+# as appuser lands it at /home/appuser/.local/bin/claude; we prepend that
+# dir to the image PATH so `scripts/run_nightly_sweep.sh` (runs as appuser)
+# can resolve `claude` via `command -v`.
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+USER appuser
+RUN curl -fsSL https://claude.ai/install.sh | bash
+USER root
 
 COPY --chown=appuser:appuser . .
 


### PR DESCRIPTION
## Summary

- PR #86 unblocked the Docker build but the orchestrator still aborts at startup with `FATAL: claude not installed`.
- Render build log makes the cause obvious: `Claude Code successfully installed! Location: ~/.local/bin/claude • Native installation exists but ~/.local/bin is not in your PATH.` The installer ran as root → binary landed at `/root/.local/bin/claude`, but the container runs as `appuser` (whose PATH never had that dir and who can't traverse `/root`).
- Fix: reorder the Dockerfile so `appuser` exists before the Claude install, run the installer under `USER appuser` so the binary lands in `/home/appuser/.local/bin/`, and prepend that dir to the image's `ENV PATH`. Python deps still install as root into system site-packages.

## Blast radius

- Only `Dockerfile.nightly-sweep`. Affects `filings-nightly-sweep` only; the other three Render services use a different Dockerfile.
- `.claude/sweep.pause` remains committed — autonomous sweeper is still gated.

## Test plan

- [ ] CI green: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E, Docker Build & Smoke
- [ ] Post-merge: manual "Trigger Run" on Render with `SWEEP_FORCE=1` env var → runner should no longer exit with `FATAL: claude not installed` at the prereq check
- [ ] If the runner now reaches the selector step, ensure the subsequent behavior is also clean (selector output, worktree creation, etc.)

Generated with [Claude Code](https://claude.com/claude-code)