### PR TITLE
fix(nightly-sweep): bootstrap .git + git identity at runtime

### DIFF
--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -69,6 +69,30 @@ require python3
 require claude
 require gh
 
+# Container images built from this repo strip .git via .dockerignore to keep
+# the web/extraction images lean. The sweeper orchestrator needs real git
+# history (fetch, checkout, worktree add, push), so bootstrap a minimal repo
+# from origin when running inside a stripped image. Local /sweep invocations
+# already have .git and skip this branch.
+if [[ ! -d .git ]]; then
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    log "FATAL: GH_TOKEN required to bootstrap .git from origin"
+    exit 1
+  fi
+  log "No .git found — initializing repo from origin..."
+  git init --quiet
+  git remote add origin "https://github.com/RGMjr/filings_reviewer.git"
+fi
+
+# Let gh front github.com auth for git so tokens stay out of .git/config.
+# Idempotent; safe to run on every invocation.
+gh auth setup-git 2>/dev/null || { log "FATAL: gh auth setup-git failed (GH_TOKEN invalid?)"; exit 1; }
+
+# Commit author identity is required downstream — the per-issue Claude session
+# runs /commit, which calls `git commit`, which aborts without user.email/name.
+git config --global user.email "${GIT_AUTHOR_EMAIL:-sweeper@users.noreply.github.com}"
+git config --global user.name  "${GIT_AUTHOR_NAME:-Nightly Sweeper}"
+
 log "Fetching origin/main..."
 git fetch origin main --quiet
 git checkout main --quiet 2>/dev/null || git checkout -B main origin/main --quiet


### PR DESCRIPTION
## Summary

Continuation of the nightly-sweep activation work (#86 fixed the build, #92 put `claude` on appuser's PATH). Latest manual-trigger failure:

```
[sweep 15:34:26] Fetching origin/main...
fatal: not a git repository (or any of the parent directories): .git
❌ Your cronjob failed because of an error: Exited with status 128
```

`.dockerignore:11` excludes `**/.git` (rightly — keeps the web/extraction images lean), so the container has the file snapshot but not the repo history. The orchestrator needs real git for `fetch`/`worktree add`/`push`.

## Change

`scripts/run_nightly_sweep.sh`, after the prereq checks:

- Detect missing `.git` → `git init` + `git remote add origin <https url>`. Aborts with FATAL if `GH_TOKEN` is unset (we'd need it for fetch/push regardless).
- `gh auth setup-git` once per run so git uses gh's credential helper for github.com — keeps the token out of `.git/config`. Idempotent.
- `git config --global user.email/user.name` so the per-issue Claude session's `/commit` step has commit author identity. Honors `GIT_AUTHOR_EMAIL` / `GIT_AUTHOR_NAME` env vars when set; falls back to `Nightly Sweeper <sweeper@users.noreply.github.com>`.

## Blast radius

- One file. Local `/sweep` from a real worktree skips the bootstrap branch (`.git` already present) — existing behavior preserved.
- `.claude/sweep.pause` still gates autonomous execution.
- No Dockerfile or `.dockerignore` change — main image stays lean.

## Test plan

- [x] `bash -n scripts/run_nightly_sweep.sh` — syntax clean
- [x] `pytest -x -q` — 3824 passed locally
- [ ] CI green: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E, Docker Build & Smoke
- [ ] Post-merge: `SWEEP_FORCE=1` manual trigger on Render — runner should clear the bootstrap, fetch origin/main, reach the selector step
- [ ] If the runner reaches "Selector returned N picks" we know all four startup blockers (build / PATH / git / identity) are fixed

Generated with [Claude Code](https://claude.com/claude-code)