### PR TITLE
fix(nightly-sweep): chown /app to appuser so runtime can write .git

### DIFF
--- a/Dockerfile.nightly-sweep
+++ b/Dockerfile.nightly-sweep
@@ -66,7 +66,8 @@ USER root
 COPY --chown=appuser:appuser . .
 
 RUN mkdir -p /app/.claude/worktrees /app/.claude/sweep-digests \
-    && chown -R appuser:appuser /app/.claude
+    && chown -R appuser:appuser /app/.claude \
+    && chown appuser:appuser /app
 
 USER appuser
 


### PR DESCRIPTION
## Summary

Fourth startup blocker in the nightly-sweep activation chain (#86 build, #92 PATH, #93 git bootstrap, this one: filesystem perms). Latest failure:

```
/app/.git: Permission denied
❌ Your cronjob failed because of an error: Exited with status 1
```

`WORKDIR /app` creates `/app` owned by root. `COPY --chown=appuser:appuser . .` flips ownership of the files it copies but **not the destination directory itself**. Runner then tries `git init` at CWD=`/app` as appuser and can't write.

## Change

Extend the existing mkdir `RUN` (which already chowns `/app/.claude`) to also chown `/app`:

```diff
 RUN mkdir -p /app/.claude/worktrees /app/.claude/sweep-digests \
-    && chown -R appuser:appuser /app/.claude
+    && chown -R appuser:appuser /app/.claude \
+    && chown appuser:appuser /app
```

No `-R` on the new chown — files inside `/app` are already appuser-owned via the preceding `COPY --chown`.

## Blast radius

Only `Dockerfile.nightly-sweep`. Other Render services use the main `Dockerfile`, not this one.

## Test plan

- [ ] CI green
- [ ] Post-merge: `SWEEP_FORCE=1` manual trigger → runner should clear the bootstrap, reach the selector, and either run sweeps or cleanly report `Nothing to sweep tonight` / `abandoned` outcomes
- [ ] Reaching `Selector returned N picks` definitively clears all four startup blockers

Generated with [Claude Code](https://claude.com/claude-code)