### PR TITLE
fix(review-ui): clear reviewer filter when unchecking all or using Clear

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -46,3 +46,5 @@ The unified review UI persists filter/sort/tab state client-side via localStorag
 | `cmasb:review:image_filter` | review page   | `{status}` JSON                     | `unified_review.html`    |
 
 **Pattern**: on page load, URL params win and are written to localStorage; if a param is absent and localStorage has a value, the page redirects once with the stored value applied. This pattern lets server routes stay stateless — do not add server-side session storage for view state. Do NOT rename `hideCompleted` → a `cmasb:` key; that would silently wipe existing users' saved preference.
+
+**Presence-based exception (`cmasb:filings:reviewers`)**: the reviewer filter uses URL *presence* (not value) as the signal, because HTML forms drop unchecked checkboxes — a cleared filter and a fresh visit would otherwise look identical. The reviewer form carries a hidden `<input name="reviewer_id" value="">` and the Clear link emits `?reviewer_id=` explicitly; an empty `reviewer_id=` in the URL means "explicitly cleared" and suppresses the localStorage restore.

--- a/src/web/templates/unified_filing_list.html
+++ b/src/web/templates/unified_filing_list.html
@@ -11,7 +11,8 @@
   {%- if dt and dt != 'all' %}{% set _ = kwargs.update({'document_type': dt}) %}{% endif -%}
   {%- if hide_completed %}{% set _ = kwargs.update({'hide_completed': 1}) %}{% endif -%}
   {%- if page_ %}{% set _ = kwargs.update({'page': page_, 'per_page': per_page}) %}{% endif -%}
-  {%- if include_reviewers and reviewers %}{% set _ = kwargs.update({'reviewer_id': reviewers}) %}{% endif -%}
+  {%- if include_reviewers and reviewers %}{% set _ = kwargs.update({'reviewer_id': reviewers}) %}
+  {%- elif not include_reviewers %}{% set _ = kwargs.update({'reviewer_id': ['']}) %}{% endif -%}
   {%- if extra %}{% for k, v in extra.items() %}{% set _ = kwargs.update({k: v}) %}{% endfor %}{% endif -%}
   {{ url_for('review_unified.filing_list', **kwargs) }}
 {%- endmacro -%}
@@ -57,6 +58,8 @@
             <input type="hidden" name="sort_by" value="{{ sort_by }}">
             <input type="hidden" name="sort_dir" value="{{ sort_dir }}">
             <input type="hidden" name="per_page" value="{{ per_page }}">
+            {# Sentinel: "this form was submitted". Distinguishes a cleared filter from a fresh visit in the JS read-back below. Backend strips empty values. #}
+            <input type="hidden" name="reviewer_id" value="">
             {% for r in all_reviewers %}
             <label class="d-block mb-1" style="font-size: 0.875rem;">
               <input type="checkbox" name="reviewer_id" value="{{ r }}"
@@ -336,9 +339,15 @@
   if (perPage && /^\d+$/.test(perPage)) {
     localStorage.setItem(KEYS.PER_PAGE, perPage);
   }
-  var reviewerIds = params.getAll('reviewer_id');
-  if (reviewerIds.length > 0) {
-    localStorage.setItem(KEYS.REVIEWERS, JSON.stringify(reviewerIds));
+  // Reviewer presence (even empty-string sentinel) signals "form was submitted".
+  // Filter out the sentinel before persisting; an explicit empty submission clears storage.
+  var reviewerIds = params.getAll('reviewer_id').filter(function (r) { return r; });
+  if (params.has('reviewer_id')) {
+    if (reviewerIds.length > 0) {
+      localStorage.setItem(KEYS.REVIEWERS, JSON.stringify(reviewerIds));
+    } else {
+      localStorage.removeItem(KEYS.REVIEWERS);
+    }
   }
   var hideParam = params.get('hide_completed');
   if (hideParam === '1') {
@@ -371,7 +380,10 @@
       dirty = true;
     }
   }
-  if (reviewerIds.length === 0) {
+  // Only restore from storage when the URL *completely omits* reviewer_id
+  // (fresh visit). An empty `reviewer_id=` param is the "explicitly cleared"
+  // sentinel and must not be overridden.
+  if (!params.has('reviewer_id')) {
     var savedReviewers = getJSON(KEYS.REVIEWERS);
     if (Array.isArray(savedReviewers) && savedReviewers.length > 0) {
       savedReviewers.forEach(function (r) { params.append('reviewer_id', r); });


### PR DESCRIPTION
## Summary

- Fixes a silent-restore bug in the \"Reviewed by\" dropdown: unchecking all reviewers + Apply, or clicking **Clear**, left the previous selection intact because the JS read-back block restored `cmasb:filings:reviewers` from localStorage whenever the URL had no `reviewer_id` params — which is indistinguishable between a fresh visit and a just-cleared submission (HTML forms drop unchecked checkboxes).
- Uses URL **presence** (not value) as the signal. The form now carries a hidden `<input name=\"reviewer_id\" value=\"\">` sentinel so every submission leaves `?reviewer_id=` in the URL. The `list_url` macro emits the same sentinel for the Clear link. JS read gate flips to `!params.has('reviewer_id')`; write side clears localStorage on empty submission so a subsequent fresh visit doesn't auto-restore.
- Backend (`src/web/routes/review_unified.py:143`) already strips empty `reviewer_id` values via `[r for r in ... if r]`, so no server changes needed. One sentence added to `.claude/rules/web.md` documenting the presence-based exception for future maintainers.

## Test plan

- [x] Rendered template with real Flask app — Clear link emits `?...&reviewer_id=`, hidden sentinel present, doc-type/sort/pagination links do **not** leak the sentinel.
- [x] Flask `url_for(reviewer_id=[''])` confirmed to emit `?reviewer_id=` (no Werkzeug fallback needed).
- [x] Full test suite: 3824 passed, 67 skipped, 0 failures (`pytest -x -q`).
- [x] Ruff clean on `src/` and `tests/`.
- [ ] **Manual browser verification on Render** (primary reason for this PR):
  - [ ] Apply alice → filter applied, localStorage has `[\"alice\"]`.
  - [ ] Uncheck alice + Apply → filter cleared, URL has empty `reviewer_id=`, localStorage absent.
  - [ ] Re-apply alice, then click **Clear** → filter cleared.
  - [ ] Fresh tab with no query string + saved localStorage → restore-from-storage still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)