### PR TITLE
fix(nightly-sweep): clean untracked tree before checkout in bootstrap path

### DIFF
--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -74,6 +74,7 @@ require gh
 # history (fetch, checkout, worktree add, push), so bootstrap a minimal repo
 # from origin when running inside a stripped image. Local /sweep invocations
 # already have .git and skip this branch.
+_BOOTSTRAPPED=0
 if [[ ! -d .git ]]; then
   if [[ -z "${GH_TOKEN:-}" ]]; then
     log "FATAL: GH_TOKEN required to bootstrap .git from origin"
@@ -82,6 +83,7 @@ if [[ ! -d .git ]]; then
   log "No .git found — initializing repo from origin..."
   git init --quiet
   git remote add origin "https://github.com/RGMjr/filings_reviewer.git"
+  _BOOTSTRAPPED=1
 fi
 
 # Let gh front github.com auth for git so tokens stay out of .git/config.
@@ -95,8 +97,20 @@ git config --global user.name  "${GIT_AUTHOR_NAME:-Nightly Sweeper}"
 
 log "Fetching origin/main..."
 git fetch origin main --quiet
-git checkout main --quiet 2>/dev/null || git checkout -B main origin/main --quiet
-git reset --hard origin/main --quiet
+
+if [[ "$_BOOTSTRAPPED" == "1" ]]; then
+  # After a fresh `git init`, every file in /app (populated by the Dockerfile's
+  # `COPY . .`) is untracked. `git checkout main` would refuse to overwrite
+  # those paths. Wipe the untracked tree first, then materialize origin/main.
+  # The running bash process keeps executing from its in-memory script copy
+  # even after `scripts/run_nightly_sweep.sh` is removed and recreated.
+  log "Reconciling COPY'd tree with origin/main..."
+  git clean -fdx --quiet
+  git checkout -B main origin/main --quiet
+else
+  git checkout main --quiet 2>/dev/null || git checkout -B main origin/main --quiet
+  git reset --hard origin/main --quiet
+fi
 
 # --- 3. Selector ---
 INCLUDE_REVIEW_FLAG=""


### PR DESCRIPTION
## Summary

Fifth startup blocker in the nightly-sweep activation chain (#86 build, #92 PATH, #93 git bootstrap, #94 /app perms, this one: untracked-tree reconciliation). Latest failure after PR #94 let the runner create `/app/.git`:

```
error: The following untracked working tree files would be overwritten by checkout:
    .claude/agent-memory/extraction-implementer/MEMORY.md
    .claude/agents/dev-implementer.md
    ... (30+ files)
```

The bootstrap sequence is `git init` → `git fetch origin main` → `git checkout main`. Since the Dockerfile's `COPY . .` already populated `/app` with the image-build snapshot, those files are entirely untracked by the fresh `.git`. Git refuses to overwrite untracked paths on checkout, so the bootstrap stalls with HEAD still unborn.

## Change

In the bootstrap branch only, `git clean -fdx --quiet` to wipe the untracked tree before `git checkout -B main origin/main`. Local `/sweep` invocations skip this — they already have `.git` and keep the existing `checkout + reset --hard` flow so uncommitted work in a user's tree is never silently nuked.

## Safety note

`git clean -fdx` removes `scripts/run_nightly_sweep.sh` (the executing script) as part of the sweep. The running bash process continues from its in-memory copy — Linux preserves the inode for any open fd after `rm`, and bash slurps small scripts before executing. The checkout that follows recreates the file, so later `python3 scripts/known_issues_selector.py` invocations find it on disk again.

## Blast radius

One file. Local `/sweep` runs unaffected (`_BOOTSTRAPPED` flag defaults to 0). No Dockerfile, `.dockerignore`, or Python changes.

## Test plan

- [x] `bash -n scripts/run_nightly_sweep.sh` — syntax clean
- [x] `pytest -x -q` — 3824 passed locally
- [ ] CI green
- [ ] Post-merge: `SWEEP_FORCE=1` manual trigger → runner should clear the bootstrap + clean + checkout cycle and reach the selector step
- [ ] If the runner logs `Selector returned N picks` or `Nothing to sweep tonight`, all five startup blockers are resolved and we're into real sweeper behavior

Generated with [Claude Code](https://claude.com/claude-code)
