### PR TITLE
fix(nightly-sweep): redirect claude -p stdin from /dev/null

### DIFF
--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -175,10 +175,16 @@ EOF
 
   local log_file="$worktree/.sweep.log"
   local exit_code=0
+  # </dev/null is load-bearing: this function is called from inside a
+  # `picks | while read` pipeline, so the subshell inherits the pick stream
+  # on stdin. Without the redirect, `claude -p` (or `timeout` forwarding to
+  # it) reads the remaining pick lines from the pipe on its first call,
+  # which drains the iterator and makes the while-loop exit after pick 1
+  # of N. Reproduced locally with `(cat)` in place of claude.
   (
     cd "$worktree"
     timeout "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
-  ) || exit_code=$?
+  ) </dev/null || exit_code=$?
 
   local finished="$(date +%H:%M)"
   local pr_url="" pr_number="" abort_reason=""


### PR DESCRIPTION
## Summary

Sixth nightly-sweep bug — first post-activation one. After the full activation chain (#86, #92, #93, #94, #97) let the orchestrator complete end-to-end on 2026-04-22 at 17:24 UTC, the digest showed only issue #60 processed despite the selector returning 3 picks. Issues #68 and #71 were silently dropped.

## Root cause

The per-issue loop is `picks | while read ...; do sweep_issue; done`. `sweep_issue` spawns a subshell `( timeout "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1 )`. The subshell inherits stdin from the pipe, which still has the unread pick lines for #68 and #71. `claude -p` (or `timeout` forwarding stdin) reads those lines on its first call, draining the pipe. The next `read` in the while loop gets EOF → loop exits cleanly → bug is silent.

Reproduced locally:

```bash
printf "1\n2\n3\n" | while read -r line; do
  (cat > /tmp/slurp.txt)    # substitute for claude -p
done
# Output: only line 1 is read. /tmp/slurp.txt contains "2\n3\n".
```

## Fix

Add `</dev/null` at the subshell level:

```diff
   (
     cd "$worktree"
     timeout "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
-  ) || exit_code=$?
+  ) </dev/null || exit_code=$?
```

Subshell-level redirect is more defensive than `claude -p ... </dev/null` inside — also guards against any other command inside the subshell that might read stdin.

## Blast radius

One file. Local `/sweep` runs had the same latent bug (would also cap at 1 pick per run), now fixed. No behavior change to other Render services.

## Test plan

- [x] `bash -n scripts/run_nightly_sweep.sh` — syntax clean
- [x] `pytest -x -q` — 3824 passed
- [x] Local stdin-leak reproduction confirms the bug pattern, and confirms `</dev/null` fixes it
- [ ] CI green
- [ ] Post-merge on Render: next `SWEEP_FORCE=1` trigger should process up to 3 picks, not 1. Digest should show 3 outcomes (all abandoned unless a safe issue actually has work to do)

## Note on the digest summary

Unrelated but visible in this run: the final `Sweep complete. Outcomes: 0` log line comes from a subtle bug in the inline python — `print(X) , " merged", …` is parsed as `print(X)` plus a tuple that's discarded, so only the merged count prints. Worth a follow-up (not in this PR).

Generated with [Claude Code](https://claude.com/claude-code)
