### PR TITLE
chore(gitignore): ignore .claude/*.lock runtime files (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ htmlcov/
 # But keep project-specific Claude settings
 !.claude/settings.json
 
+# Claude Code runtime locks (created by the scheduled-tasks system)
+.claude/*.lock
+
 # Python tool caches
 .mypy_cache/
 .pytest_cache/

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -44,7 +44,6 @@ This document tracks known issues, limitations, and planned improvements identif
 | CONTRIBUTING.md `/commit` step 1 wording stale post-worktree-hook (Issue #70) | Open | Step 1 implies `/commit` can run from primary tree on `main`; hook now blocks that path |
 | Integration Tests job has no path filter (Issue #71) | Open | Docs-only / `.claude/`-only PRs still spin up Postgres + migrations (~3–6 min); wall-time save |
 | `.github` PR template case collision (Issue #73) | Open | Duplicate `PULL_REQUEST_TEMPLATE.md` + `pull_request_template.md` (identical blobs) trigger fresh-clone warnings on macOS/Windows |
-| `.claude/scheduled_tasks.lock` not gitignored (Issue #74) | Open | Runtime lockfile shows up as untracked in every `git status`; not covered by any `.gitignore` rule |
 
 ### Partially Resolved
 
@@ -112,7 +111,6 @@ Source of truth for `scripts/known_issues_selector.py` — the nightly autonomou
 | #71   | safe     | XS        | `.github/workflows/ci.yml`                                              | Add path filter to integration-tests, mirroring ui-e2e        |
 | #72   | review   | S         | `pyproject.toml uv.lock`                                                | Boto3 fix unblocks ingestion (stage 1); R2 image-bytes layer still needs separate fix before baseline refresh |
 | #73   | safe     | XS        | `.github/PULL_REQUEST_TEMPLATE.md .github/pull_request_template.md`     | Delete one of the duplicate templates; pick lowercase per GH convention |
-| #74   | safe     | XS        | `.gitignore`                                                            | One-line addition to root `.gitignore`                        |
 | #75   | skip     | S         | `tests/ui/*.spec.js tests/ui/test_server.py`                            | Playwright E2E gap — cross-filing auto-advance; needs stub-server extension |
 | #76   | safe     | S         | `tests/integration/test_db_filings_reviewers.py`                        | New integration test for filings-list reviewer aggregate; isolated file |
 | #77   | skip     | M         | —                                                                       | Second layer of #72 — R2 chart-image bytes missing/mis-keyed for HOOD S-1; needs R2 head-object check + migration or re-ingest |
@@ -1005,6 +1003,12 @@ Cross-references: #34 (R2 migration, Phases 1+3), #72 (overall regression tracki
 ---
 
 ## Archive (Resolved Issues)
+
+### Issue #74: `.claude/scheduled_tasks.lock` Not Gitignored
+
+**Status**: Resolved (2026-04-22)
+
+Added `.claude/*.lock` glob to root `.gitignore`. `.claude/settings.json` remains un-ignored (different extension, un-ignore rule at `.gitignore:97` still matches first). Audit of `.claude/` found no other runtime files needing to be added.
 
 ### Issue #60: `detect_universe_gaps` Ignores SIC Filter
 


### PR DESCRIPTION
`.claude/scheduled_tasks.lock` (and any other runtime lock files the
scheduled-tasks system may create) was showing up as untracked in every
`git status`. Glob-ignore keeps status output clean and guards against
accidental staging via `git add -A`. Archives KNOWN_ISSUES #74.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
