### PR TITLE
fix(nightly-sweep): detect timeout vs gtimeout; fallback for macOS (Issue #68)

### DIFF
--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -69,6 +69,17 @@ require python3
 require claude
 require gh
 
+# Detect timeout command. GNU coreutils `timeout` is standard on Linux; macOS
+# ships without it. Install via `brew install coreutils` to get `gtimeout`.
+if command -v timeout >/dev/null 2>&1; then
+  _TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  _TIMEOUT_CMD="gtimeout"
+else
+  _TIMEOUT_CMD=""
+  log "WARNING: neither 'timeout' nor 'gtimeout' found — per-issue budget enforcement disabled (macOS: run 'brew install coreutils' to enable)"
+fi
+
 # Container images built from this repo strip .git via .dockerignore to keep
 # the web/extraction images lean. The sweeper orchestrator needs real git
 # history (fetch, checkout, worktree add, push), so bootstrap a minimal repo
@@ -183,7 +194,11 @@ EOF
   # of N. Reproduced locally with `(cat)` in place of claude.
   (
     cd "$worktree"
-    timeout "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
+    if [[ -n "$_TIMEOUT_CMD" ]]; then
+      "$_TIMEOUT_CMD" "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
+    else
+      claude -p "$prompt" > "$log_file" 2>&1
+    fi
   ) </dev/null || exit_code=$?
 
   local finished="$(date +%H:%M)"


### PR DESCRIPTION
## Summary

Opened on behalf of the nightly sweeper. On 2026-04-22 at 17:54 UTC, the inner `claude -p` session picked up Issue #68, produced a scoped single-file fix, committed (`3e82033`), and pushed to this branch — but could not call `gh pr create` because that tool is not in `.claude/settings.json`'s allow list. Code is the sweeper's; PR is opened manually to unblock the review.

Follow-up PR (separate) adds `--dangerously-skip-permissions` to the runner's `claude -p` invocation so future sweeper runs open their own PRs.

## Sweeper's commit message

> fix(nightly-sweep): detect timeout vs gtimeout; fallback for macOS (issue #68)
>
> Adds detection at script start: prefer GNU `timeout`, fall back to `gtimeout` (homebrew coreutils on macOS), or run without a timeout and emit a warning when neither is available. Fixes local /sweep failures on macOS where BSD userland omits `timeout`.

## Test plan

- [ ] CI green
- [ ] Manual local smoke: on macOS without `coreutils`, verify the warning path; with `brew install coreutils`, verify `gtimeout` fallback

Closes #68.

Co-Authored-By: Claude Sonnet 4.6 (via nightly sweeper) <noreply@anthropic.com>
