### PR TITLE
fix(ci): add path filter to integration-tests, mirroring ui-e2e (Issue #71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,26 +161,56 @@ jobs:
       TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/filings_analysis_test
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for integration-relevant changes
+        id: filter
+        # Skip Postgres + migrations when EVERY changed path is in the docs/skills/meta
+        # allowlist. Any src/, tests/, config/, sql/, requirements*, pyproject,
+        # uv.lock, or .github/workflows change still runs the full suite.
+        # Conservative — err toward running when in doubt.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            base="origin/${{ github.base_ref }}"
+          else
+            base="HEAD^"
+          fi
+          if git diff --name-only "$base"...HEAD \
+              | grep -vE '^(docs/|\.claude/|CLAUDE\.md|README\.md|\.gitignore|\.github/CODEOWNERS)' \
+              | grep -q .; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Integration Tests skipped::No integration-relevant paths changed."
+          fi
 
       - uses: astral-sh/setup-uv@v7
+        if: steps.filter.outputs.run == 'true'
 
       - name: Install dependencies
+        if: steps.filter.outputs.run == 'true'
         run: uv sync --extra dev
 
       - name: Apply migrations
+        if: steps.filter.outputs.run == 'true'
         run: uv run python3 scripts/apply_migrations.py --test
 
       - name: Link-integrity check
+        if: steps.filter.outputs.run == 'true'
         env:
           DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
         run: uv run python3 scripts/validate_database_urls.py --fail-on-errors
 
       - name: Chart-image referential integrity
+        if: steps.filter.outputs.run == 'true'
         env:
           DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
         run: uv run python3 scripts/check_image_referential_integrity.py
 
       - name: Run integration tests
+        if: steps.filter.outputs.run == 'true'
         run: >-
           uv run pytest tests/integration/ -x -q --tb=short --no-cov
           --ignore=tests/integration/test_gold_standard_regression.py


### PR DESCRIPTION
## Summary

Opened on behalf of the nightly sweeper. On 2026-04-22 at 17:57 UTC, the inner `claude -p` session picked up Issue #71, produced a scoped single-file fix, committed (`5d6611a`), and pushed to this branch — but could not call `gh pr create` because that tool is not in `.claude/settings.json`'s allow list. Code is the sweeper's; PR is opened manually to unblock the review.

Follow-up PR (separate) adds `--dangerously-skip-permissions` to the runner's `claude -p` invocation so future sweeper runs open their own PRs.

## Sweeper's commit message

> fix(ci): add path filter to integration-tests, mirroring ui-e2e (Issue #71)
>
> Docs-only / .claude-only PRs now skip Postgres + migrations (~3-6 min wall-time save). Same allowlist as ui-e2e: docs/, .claude/, CLAUDE.md, README.md, .gitignore, .github/CODEOWNERS. All other paths still run the full suite. Skipped job still satisfies branch-protection (required status check counts skipped as passing).

## Test plan

- [ ] CI green (note: the path filter itself is the change — docs-only PRs after this merges should skip Integration Tests while still showing it as a required check pass)
- [ ] Sanity check: after merge, open a docs-only PR and confirm Integration Tests is skipped but branch protection doesn't hold the merge

Closes #71.

Co-Authored-By: Claude Sonnet 4.6 (via nightly sweeper) <noreply@anthropic.com>
