### PR TITLE
chore(hooks): add cluster-DDL pre-commit guard for sql/ migrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,15 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+      # Pre-commit: flag migrations with cluster-scoped DDL (CREATE/ALTER/DROP
+      # on ROLE/USER/TABLESPACE/SUBSCRIPTION) that would race under parallel
+      # migration apply (pytest-xdist per-worker DBs). See Issue #78. Files
+      # containing the marker `-- cluster-ddl-ok: ...` are skipped.
+      - id: cluster-ddl-guard
+        name: cluster-scoped DDL guard (sql/ migrations)
+        entry: bash scripts/pre-commit-cluster-ddl-guard.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: ^sql/.*\.sql$

--- a/scripts/pre-commit-cluster-ddl-guard.sh
+++ b/scripts/pre-commit-cluster-ddl-guard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Pre-commit hook: flag migrations that add cluster-scoped DDL which races
+# under parallel apply.
+#
+# Why: CREATE/ALTER/DROP on ROLE/USER/TABLESPACE/SUBSCRIPTION modifies
+# cluster-wide catalogs (pg_authid, pg_tablespace, pg_subscription). When
+# pytest-xdist workers apply migrations to their per-worker DBs in parallel
+# (see tests/integration/conftest.py::_apply_migrations_to_test_db), these
+# statements contend on the same tuple across workers and fail with
+# "tuple concurrently updated". Migration 37 hit this; the advisory-lock
+# path in the test conftest now serialises apply, but any future migration
+# with the same pattern will re-break xdist unless the author is aware.
+#
+# Escape hatch: add a marker line `-- cluster-ddl-ok: <reason>` anywhere
+# in the migration to silence this check. Use this only after verifying
+# the serialisation path still covers the case.
+
+set -euo pipefail
+
+staged_sql=$(git diff --cached --name-only --diff-filter=ACMR \
+    | grep -E '^sql/.*\.sql$' || true)
+
+if [ -z "$staged_sql" ]; then
+    exit 0
+fi
+
+# Pattern: CREATE | ALTER | DROP followed by ROLE | USER | TABLESPACE | SUBSCRIPTION.
+# Case-insensitive. Word-boundary on the object type.
+pattern='(CREATE|ALTER|DROP)[[:space:]]+(ROLE|USER|TABLESPACE|SUBSCRIPTION)\b'
+
+flagged=()
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # Skip if the author has explicitly marked the migration as safe.
+    if grep -qE 'cluster-ddl-ok' "$file"; then
+        continue
+    fi
+    # Strip SQL line comments before matching so comment-only mentions
+    # don't trigger the guard.
+    if grep -ivE '^[[:space:]]*--' "$file" | grep -qEi "$pattern"; then
+        flagged+=("$file")
+    fi
+done <<< "$staged_sql"
+
+if [ ${#flagged[@]} -eq 0 ]; then
+    exit 0
+fi
+
+echo "ERROR: cluster-scoped DDL detected in migration(s):" >&2
+for f in "${flagged[@]}"; do
+    echo "  - $f" >&2
+done
+cat >&2 <<'EOF'
+
+Statements matching CREATE/ALTER/DROP on ROLE/USER/TABLESPACE/SUBSCRIPTION
+touch cluster-wide Postgres catalogs and race under parallel migration
+apply (e.g., pytest-xdist per-worker DBs hitting pg_authid as
+"tuple concurrently updated").
+
+Options:
+  1. Move the cluster-level statement out of per-DB migrations entirely —
+     create it once via ops tooling and keep only per-DB GRANTs/etc. in
+     migrations (guarded with `IF EXISTS (SELECT FROM pg_roles ...)`).
+
+  2. If it has to stay in a migration: confirm the serialisation path in
+     tests/integration/conftest.py::_apply_migrations_to_test_db still
+     covers your statement (Postgres advisory lock on the admin DB),
+     then add a marker comment to the migration file:
+
+         -- cluster-ddl-ok: <one-line reason pointing at the mitigation>
+
+     Any file containing `cluster-ddl-ok` skips this guard.
+EOF
+exit 1

--- a/sql/37_create_analytics_role.sql
+++ b/sql/37_create_analytics_role.sql
@@ -8,6 +8,11 @@
 -- Operator note: The password is NOT stored in this migration. Set it via:
 --     ALTER ROLE metabase_ro PASSWORD '<value from env METABASE_DB_PASSWORD>';
 -- immediately after applying. Rotate by repeating that ALTER.
+--
+-- cluster-ddl-ok: CREATE/ALTER ROLE hits cluster-scoped pg_authid; under
+-- pytest-xdist this serialises via the Postgres advisory lock in
+-- tests/integration/conftest.py::_apply_migrations_to_test_db. See also
+-- scripts/pre-commit-cluster-ddl-guard.sh.
 
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary

Follow-up to Issue #78 / PR #106. Adds a pre-commit hook that flags any new migration whose staged diff contains `CREATE/ALTER/DROP` on `ROLE`, `USER`, `TABLESPACE`, or `SUBSCRIPTION` — the cluster-scoped statements that race on shared Postgres catalogs under parallel migration apply (pytest-xdist).

PR #106 fixed the immediate problem for migration 37 via a Postgres advisory lock in `tests/integration/conftest.py::_apply_migrations_to_test_db`. This PR adds a guard so future migrations with the same pattern don't silently re-break xdist.

## Changes

- **`scripts/pre-commit-cluster-ddl-guard.sh`** (new): scans staged `sql/*.sql` files for the cluster-DDL pattern. Strips SQL line comments before matching (so docs-only mentions don't trigger). Fails with a clear remediation message.
- **`.pre-commit-config.yaml`**: wires the guard as a local pre-commit hook, scoped to `^sql/.*\.sql$`.
- **`sql/37_create_analytics_role.sql`**: adds the `-- cluster-ddl-ok: ...` escape-hatch marker with a pointer at the advisory-lock path, so the existing migration doesn't trip the guard on future edits.

## Escape hatch

A migration that has been verified to work under the existing advisory-lock path can add this marker anywhere in its file:

```sql
-- cluster-ddl-ok: <one-line reason>
```

Files containing `cluster-ddl-ok` bypass the guard entirely.

## Test plan

- [x] Guard passes against existing migrations (marker present on #37)
- [x] Guard fires when marker is stripped from #37: exit 1, actionable message
- [x] Guard skips non-`sql/` files — won't trip on unrelated commits
- [x] End-to-end: this PR's own commit ran the new hook (on staged #37 edit) and passed
- [x] Ruff clean, unit tests pass (3531 passed)

## Alternative considered

Refactoring migration 37 to move role creation into out-of-band ops tooling (keeping only per-DB `GRANT`s in migrations, guarded by `IF EXISTS (SELECT FROM pg_roles ...)`). Cleaner architecturally — roles are cluster infrastructure, not per-DB schema — but touches production too: Neon/Render would need the bootstrap run once, and `38_create_analytics_views.sql`'s `GRANT SELECT TO metabase_ro` would need matching treatment. The advisory lock already solves the test problem, so the guard covers the risk with much less surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)