### PR TITLE
fix(nightly-sweep): unattended perms + retag resolved #60 as skip

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -102,7 +102,7 @@ Source of truth for `scripts/known_issues_selector.py` — the nightly autonomou
 | #55   | skip     | S         | —                                                                       | Data cleanup; needs inspection of stuck filings               |
 | #58   | review   | S         | `src/filing_fetcher/*.py tests/unit/filing_fetcher/*.py`                | 8-K Exhibit 99.1 fetch; feature add, needs validator run      |
 | #59   | review   | S         | `src/extraction_v2/classifier*.py tests/unit/extraction_v2/*classifier*`| New classifier patterns; FP risk                              |
-| #60   | safe     | XS        | `src/universe/onboarding.py tests/unit/universe/test_onboarding.py`     | SIC-filter JOIN in detect_universe_gaps                       |
+| #60   | skip     | XS        | —                                                                       | Resolved 2026-04-21; retained in table as audit trail          |
 | #62   | review   | S         | `docs/operations/* src/universe/onboarding_runner.py`                   | Docs + optional admin flag; needs design call                 |
 | #63   | skip     | S         | —                                                                       | Monkey-patch integration test; mid-complexity                 |
 | #66   | review   | S         | `render.yaml .claude/rules/infrastructure.md`                           | Wire apply_migrations into Render deploy; infra-change risk   |

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -192,12 +192,21 @@ EOF
   # it) reads the remaining pick lines from the pipe on its first call,
   # which drains the iterator and makes the while-loop exit after pick 1
   # of N. Reproduced locally with `(cat)` in place of claude.
+  # --dangerously-skip-permissions: the sweeper runs unattended (no human to
+  # answer permission prompts), and the session is already scoped by the issue
+  # prompt's STRICT rules and by the Nightly Sweeper Classification "Touches"
+  # globs. Without this, `gh pr create` / `git push` get blocked by
+  # .claude/settings.json's default allow list and the session ends with a
+  # committed-but-unpushed branch (or pushed-but-no-PR), as observed on the
+  # 2026-04-22 17:50 UTC run where issues #68 and #71 were fixed correctly
+  # but their PRs had to be opened manually. The kill switch + classification
+  # table + prompt rules + CI checks remain the primary guardrails.
   (
     cd "$worktree"
     if [[ -n "$_TIMEOUT_CMD" ]]; then
-      "$_TIMEOUT_CMD" "$PER_ISSUE_BUDGET" claude -p "$prompt" > "$log_file" 2>&1
+      "$_TIMEOUT_CMD" "$PER_ISSUE_BUDGET" claude -p --dangerously-skip-permissions "$prompt" > "$log_file" 2>&1
     else
-      claude -p "$prompt" > "$log_file" 2>&1
+      claude -p --dangerously-skip-permissions "$prompt" > "$log_file" 2>&1
     fi
   ) </dev/null || exit_code=$?
 


### PR DESCRIPTION
## Summary

Two related cleanup items after the 2026-04-22 17:50 UTC end-to-end sweeper run exposed them:

1. **`scripts/run_nightly_sweep.sh`** — add `--dangerously-skip-permissions` to the per-issue `claude -p` invocation. On the 17:50 run, issues #68 and #71 produced scoped single-file fixes, committed, and pushed to origin — but the inner session could not call `gh pr create` because it inherits this repo's `.claude/settings.json` allow list (which rightly doesn't permit that for interactive human sessions). In an unattended cron there's no human to approve prompts, and the session is already scoped by the issue prompt's STRICT rules plus the Nightly Sweeper Classification `Touches` globs. Guardrails preserved: kill switch, classification table, prompt rules, required CI checks on every PR. User explicitly authorized this flag for the unattended nightly cron.
2. **`docs/KNOWN_ISSUES.md`** — retag #60 from `safe` to `skip`. #60 has been resolved since 2026-04-21 per the Last-Updated line, but the classification row still carried `safe`. The sweeper dutifully picked it up every run, wasted ~30s on "already resolved" abort, and burned one of three pick slots. `skip` keeps the audit row without eating a slot.

## Why `--dangerously-skip-permissions` is safe here

- **Kill switch:** `.claude/sweep.pause` committed in repo root; runner exits 0 when present.
- **Scope:** Sweeper only picks issues tagged `safe` (or `review` with opt-in), and only issues with `Touches` globs in the classification table. Anything outside globs → inner session aborts per prompt rule #2.
- **Prompt:** Explicitly forbids schema migrations, infra edits, credential changes, baseline updates, `--no-verify`, and anything the `Touches` glob doesn't cover.
- **Required CI checks:** Every sweeper-opened PR passes Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E, Docker Build & Smoke before auto-merge lands.
- **Blast radius of the flag:** only the `claude -p` child process inside a worktree the sweeper created. Does not grant the flag to any interactive human `claude` session in this repo.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `pytest -x -q` passes (3824 tests)
- [x] `bash -n scripts/run_nightly_sweep.sh` syntax clean
- [ ] CI green
- [ ] Post-merge: `SWEEP_FORCE=1` manual trigger should now produce PRs for any issue whose inner session completes `/commit`. With #60 retagged to `skip`, only #68 and #71 are safe picks — both already fixed (#107, #108 merged), so the next run should report "Nothing to sweep tonight" or pick up whatever new `safe` issues are classified.

Generated with [Claude Code](https://claude.com/claude-code)
