### PR TITLE
feat(known-issues): install pre-commit hook + CI drift-check (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src/review/ --strict
 
+      - name: Known-issues rollup is in sync with fragments
+        run: python3 scripts/regenerate_known_issues.py --check
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,24 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
         files: ^sql/.*\.sql$
+
+      # Pre-commit: validate and regenerate the KNOWN_ISSUES.md rollup whenever
+      # a fragment under docs/known-issues/ is staged.  Validate runs first so
+      # we never regenerate from invalid input.  The regenerator's --stage flag
+      # auto-adds the rollup to the commit, so developers don't need to stage it
+      # manually.  The rollup is byte-deterministic, so the hook never loops.
+      - id: known-issues-validate
+        name: Validate known-issue fragment frontmatter
+        entry: python3 scripts/validate_known_issues_fragments.py
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: '^docs/known-issues/.*\.md$'
+
+      - id: known-issues-rollup
+        name: Regenerate KNOWN_ISSUES.md rollup from fragments
+        entry: python3 scripts/regenerate_known_issues.py --stage
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: '^docs/known-issues/.*\.md$'

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -149,3 +149,24 @@ specific files by name.
 New issues surfaced during contribution go into `docs/KNOWN_ISSUES.md` with
 the next available number. See the existing entries for the expected shape
 (Status / Severity / Problem / Resolution or Next Steps).
+
+`docs/KNOWN_ISSUES.md` is auto-generated from fragment files under
+`docs/known-issues/`.  Edit the per-issue fragment, not the rollup directly.
+A pre-commit hook regenerates and re-stages the rollup automatically whenever
+you stage a fragment.
+
+### Merge conflicts on `docs/KNOWN_ISSUES.md`
+
+`docs/KNOWN_ISSUES.md` is auto-generated from `docs/known-issues/*.md`. When
+you hit a merge conflict on the rollup, don't resolve the conflict markers
+by hand — the file is fully deterministic given the fragment set, so:
+
+1. `git merge --abort` if the merge isn't otherwise useful, or just accept
+   either side for this file.
+2. `rm docs/KNOWN_ISSUES.md`
+3. `python3 scripts/regenerate_known_issues.py`
+4. `git add docs/KNOWN_ISSUES.md && git commit`
+
+If the conflict is *also* on `docs/known-issues/legacy-NNN-*.md` fragment
+files, resolve those conflicts normally first (they carry the real
+information) — then regenerate the rollup as above.


### PR DESCRIPTION
## Summary

Phase 2 of the fragment-known-issues migration. Installs the pre-commit hooks that keep `docs/KNOWN_ISSUES.md` in sync with `docs/known-issues/` fragments automatically, plus a CI safeguard for PRs that bypass the local hook.

Follows #115 (Phase 1a+1b).

## Changes

- **`.pre-commit-config.yaml`** — adds `known-issues-validate` (schema check on frontmatter) and `known-issues-rollup` (regenerate + auto-stage the rollup) to the existing `repo: local` block. Both fire only when a fragment under `docs/known-issues/` is staged (`files:` filter keeps commits on other paths fast). Validate runs first so we never regenerate from invalid input.
- **`.github/workflows/ci.yml`** — adds `python3 scripts/regenerate_known_issues.py --check` to the Lint job. Catches drift from PRs that edit fragments via the GitHub web UI or otherwise skip the local hook.
- **`docs/development/CONTRIBUTING.md`** — documents the rollup being auto-generated (edit fragments, not the rollup directly) + the merge-conflict resolution procedure (`rm` + regenerate + commit — the rollup is deterministic so conflicts are always resolvable this way).

## Auto-stage loop safety

The regenerator is byte-deterministic (enforced by `test_rollup_byte_deterministic` from #115). Feeding it the same fragment set twice produces identical output, so the `--stage` flag can safely re-run `git add docs/KNOWN_ISSUES.md` without triggering an infinite hook loop.

Smoke-tested: `pre-commit run known-issues-rollup --files docs/known-issues/legacy-074-*.md` passes cleanly, does not modify the staged fragment, does not loop.

## Test plan

- [x] `python3 scripts/regenerate_known_issues.py --check` — exit 0
- [x] Hook smoke test: single-fragment touch runs hook once, no loop
- [x] Phase 1 tests still pass (`pytest tests/unit/scripts/`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)