### PR TITLE
feat(known-issues): rewrite selector to read fragments (Phase 3, fixes #79)

### DIFF
--- a/scripts/known_issues_selector.py
+++ b/scripts/known_issues_selector.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 """Known issues selector for the nightly autonomous sweeper.
 
-Parses the "Nightly Sweeper Classification" table in docs/KNOWN_ISSUES.md,
-filters for safe/review items, dedupes against open PRs (via `gh`), picks
-a non-colliding batch of up to N issues, and emits the picks as JSON.
+Reads YAML frontmatter from docs/known-issues/ fragment files, filters for
+safe/review items with open/partially-resolved status, dedupes against open
+PRs (via `gh`), picks a non-colliding batch of up to N issues, and emits the
+picks as JSON.
 
 Usage:
     python3 scripts/known_issues_selector.py [--max N] [--include-review]
-                                             [--known-issues PATH]
+                                             [--fragments-dir PATH]
                                              [--dry-run]
                                              [--no-pr-dedupe]
 
 Exit codes:
     0 — picks emitted (possibly empty array if nothing to do)
-    1 — parse error (malformed classification table)
+    1 — fragment parse error or fragments directory not found
     2 — `gh` call failed and --no-pr-dedupe was not set
 
 The orchestrator (scripts/run_nightly_sweep.sh) consumes the JSON output.
@@ -23,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import importlib.util
 import json
 import re
 import subprocess
@@ -31,8 +33,22 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_KNOWN_ISSUES = REPO_ROOT / "docs" / "KNOWN_ISSUES.md"
-TABLE_HEADING = "## Nightly Sweeper Classification"
+DEFAULT_FRAGMENTS_DIR = REPO_ROOT / "docs" / "known-issues"
+
+# Statuses that indicate a fragment is no longer actionable.
+_INACTIVE_STATUSES = frozenset({"resolved", "archived"})
+
+
+def _load_fragments_module():  # type: ignore[return]
+    """Load validate_known_issues_fragments as a module without requiring __init__.py."""
+    script_dir = Path(__file__).resolve().parent
+    module_path = script_dir / "validate_known_issues_fragments.py"
+    spec = importlib.util.spec_from_file_location("validate_known_issues_fragments", module_path)
+    assert spec is not None and spec.loader is not None, f"Could not load {module_path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["validate_known_issues_fragments"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
 
 
 @dataclass(frozen=True)
@@ -49,60 +65,46 @@ class IssueRecord:
         return d
 
 
-def parse_classification_table(md_content: str) -> list[IssueRecord]:
-    """Extract the Nightly Sweeper Classification table rows as IssueRecords.
+def parse_classification_from_fragments(fragments_dir: Path) -> list[IssueRecord]:
+    """Load IssueRecords from YAML frontmatter in docs/known-issues/ fragments.
 
-    Raises ValueError if the table heading is missing or no rows are parsed.
+    Skips fragments where:
+    - autonomy is 'n/a' (not eligible for sweep)
+    - status is 'resolved' or 'archived' (no longer actionable — fixes issue #79)
+
+    Raises FileNotFoundError if fragments_dir does not exist.
+    Raises ValueError on parse errors.
     """
-    heading_idx = md_content.find(TABLE_HEADING)
-    if heading_idx == -1:
-        raise ValueError(
-            f"Missing {TABLE_HEADING!r} heading in KNOWN_ISSUES.md — "
-            "sweeper cannot determine which issues to work."
-        )
-    # The table ends at the next top-level "## " heading after the heading.
-    tail = md_content[heading_idx + len(TABLE_HEADING) :]
-    next_heading = re.search(r"\n## ", tail)
-    table_block = tail[: next_heading.start()] if next_heading else tail
+    _frags = _load_fragments_module()
+    fragments = _frags.load_all_fragments(fragments_dir)
 
     records: list[IssueRecord] = []
-    for line in table_block.splitlines():
-        stripped = line.strip()
-        # Table rows look like "| #60 | safe | XS | glob glob | note |"
-        if not stripped.startswith("| #"):
+    for fragment in fragments:
+        fm = fragment.frontmatter
+        autonomy = str(fm.get("autonomy") or "")
+        status = str(fm.get("status") or "")
+
+        # Skip n/a autonomy (not eligible for sweep).
+        if autonomy == "n/a":
             continue
-        cells = [c.strip() for c in stripped.strip("|").split("|")]
-        if len(cells) < 5:
+
+        # Skip resolved/archived issues — they are no longer actionable.
+        if status in _INACTIVE_STATUSES:
             continue
-        issue_cell, autonomy, estimated, touches_cell, note = cells[:5]
-        m = re.match(r"#(\d+)", issue_cell)
-        if not m:
-            continue
-        issue_num = int(m.group(1))
-        if autonomy not in {"safe", "review", "skip"}:
-            raise ValueError(
-                f"Issue #{issue_num}: unknown Autonomy value {autonomy!r}. "
-                "Must be safe|review|skip."
-            )
-        touches_tuple: tuple[str, ...] = ()
-        if touches_cell and touches_cell not in {"—", "-"}:
-            # Strip backticks the table uses for inline code.
-            cleaned = touches_cell.replace("`", "")
-            touches_tuple = tuple(g for g in cleaned.split() if g)
+
+        touches_raw = fm.get("touches") or []
+        touches: tuple[str, ...] = tuple(touches_raw) if isinstance(touches_raw, list) else ()
+
         records.append(
             IssueRecord(
-                issue=issue_num,
+                issue=int(fm["id"]),
                 autonomy=autonomy,
-                estimated=estimated,
-                touches=touches_tuple,
-                note=note,
+                estimated=str(fm.get("estimated") or "—"),
+                touches=touches,
+                note=str(fm.get("note") or ""),
             )
         )
-    if not records:
-        raise ValueError(
-            "Nightly Sweeper Classification table parsed zero rows — "
-            "check the table format in docs/KNOWN_ISSUES.md."
-        )
+
     return records
 
 
@@ -199,10 +201,10 @@ def main() -> int:
         help="Include Autonomy=review issues in selection (default: safe-only).",
     )
     parser.add_argument(
-        "--known-issues",
+        "--fragments-dir",
         type=Path,
-        default=DEFAULT_KNOWN_ISSUES,
-        help="Path to KNOWN_ISSUES.md (default: docs/KNOWN_ISSUES.md).",
+        default=DEFAULT_FRAGMENTS_DIR,
+        help="Path to the known-issues fragment directory (default: docs/known-issues/).",
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Print a human-readable summary instead of JSON."
@@ -215,12 +217,10 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        md = args.known_issues.read_text()
-    except FileNotFoundError:
-        print(f"error: {args.known_issues} not found", file=sys.stderr)
+        records = parse_classification_from_fragments(args.fragments_dir)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
         return 1
-    try:
-        records = parse_classification_table(md)
     except ValueError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -168,12 +168,12 @@ sweep_issue() {
   # Prompt briefs Claude on the issue, restricts scope, calls /commit.
   local prompt
   prompt=$(cat <<EOF
-You are the nightly autonomous sweeper working issue #${issue} from docs/KNOWN_ISSUES.md.
+You are the nightly autonomous sweeper working issue #${issue}.
 
 Classification: Autonomy=${autonomy}. Note: "${note}".
 
 Rules (STRICT):
-1. Read the full issue body for #${issue} in docs/KNOWN_ISSUES.md. Do exactly what its "Next Steps" section asks, no more.
+1. Find the fragment file for issue #${issue} under docs/known-issues/ (filename prefix is either legacy- or gh-, e.g. legacy-${issue}-*.md or gh-${issue}-*.md) and read it in full. Do exactly what its "Next Steps" section asks, no more.
 2. If the issue requires schema migrations, infra edits, credential changes, or anything outside the "Touches" globs declared in the classification table: ABORT and explain.
 3. After implementing, invoke the /commit skill. The skill handles branch/tests/PR/auto-merge.
 4. If tests fail or you cannot complete the work cleanly, abort. Do NOT update baselines, do NOT skip tests, do NOT use --no-verify.

--- a/tests/unit/scripts/test_known_issues_selector.py
+++ b/tests/unit/scripts/test_known_issues_selector.py
@@ -6,6 +6,8 @@ Uses importlib.util.spec_from_file_location so that scripts/__init__.py is not r
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -13,6 +15,8 @@ from typing import Any
 import pytest
 
 _SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "known_issues_selector.py"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FRAGMENTS_DIR = _REPO_ROOT / "docs" / "known-issues"
 
 
 def _load_module() -> Any:
@@ -25,62 +29,57 @@ def _load_module() -> Any:
 
 
 _mod = _load_module()
-parse_classification_table = _mod.parse_classification_table
+parse_classification_from_fragments = _mod.parse_classification_from_fragments
 touches_collide = _mod.touches_collide
 select_picks = _mod.select_picks
 IssueRecord = _mod.IssueRecord
 
 
-TABLE_SNIPPET = """\
-# Known Issues
-
-## Nightly Sweeper Classification
-
-Preamble text.
-
-| Issue | Autonomy | Estimated | Touches                                              | Note                                |
-|-------|----------|-----------|------------------------------------------------------|-------------------------------------|
-| #1    | safe     | XS        | `src/a/mod_a.py`                                     | Alpha                               |
-| #2    | safe     | S         | `tests/integration/web/test_foo.py`                  | Bravo                               |
-| #3    | review   | M         | `src/b/mod_b.py tests/unit/b/*`                      | Charlie                             |
-| #4    | skip     | L         | —                                                    | Delta                               |
-| #5    | safe     | XS        | `src/a/mod_a.py`                                     | Echo — collides with #1             |
-
-## Next Section
-
-Unrelated content.
-"""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-class TestParseClassificationTable:
-    def test_parses_all_non_skip_and_skip_rows(self) -> None:
-        records = parse_classification_table(TABLE_SNIPPET)
-        issues = sorted(r.issue for r in records)
-        assert issues == [1, 2, 3, 4, 5]
+def _write_fragment(tmp_path: Path, filename: str, frontmatter: dict[str, Any]) -> Path:
+    """Write a minimal valid fragment file to tmp_path."""
+    import yaml
 
-    def test_parses_autonomy_values(self) -> None:
-        records = {r.issue: r for r in parse_classification_table(TABLE_SNIPPET)}
-        assert records[1].autonomy == "safe"
-        assert records[3].autonomy == "review"
-        assert records[4].autonomy == "skip"
+    fm_str = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True)
+    content = f"---\n{fm_str}---\n\nBody text.\n"
+    p = tmp_path / filename
+    p.write_text(content, encoding="utf-8")
+    return p
 
-    def test_parses_touches_globs(self) -> None:
-        records = {r.issue: r for r in parse_classification_table(TABLE_SNIPPET)}
-        assert records[3].touches == ("src/b/mod_b.py", "tests/unit/b/*")
-        assert records[4].touches == ()  # em-dash → empty
 
-    def test_raises_on_missing_heading(self) -> None:
-        with pytest.raises(ValueError, match="Missing"):
-            parse_classification_table("# Just a document\n\nNo table here.")
+def _base_fm(
+    id: int,
+    slug: str,
+    autonomy: str = "safe",
+    status: str = "open",
+    estimated: str = "XS",
+    touches: list[str] | None = None,
+    note: str = "",
+    source: str = "legacy",
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "source": source,
+        "slug": slug,
+        "title": f"Issue {id}",
+        "status": status,
+        "severity": "low",
+        "autonomy": autonomy,
+        "estimated": estimated,
+        "touches": touches if touches is not None else [f"src/mod_{id}.py"],
+        "discovered": "2026-01-01",
+        "updated": "2026-01-01",
+        "note": note,
+    }
 
-    def test_raises_on_bad_autonomy_value(self) -> None:
-        bad = TABLE_SNIPPET.replace("| safe     | XS", "| maybe    | XS", 1)
-        with pytest.raises(ValueError, match="unknown Autonomy"):
-            parse_classification_table(bad)
 
-    def test_stops_at_next_heading(self) -> None:
-        records = parse_classification_table(TABLE_SNIPPET)
-        assert all(r.issue <= 5 for r in records)
+# ---------------------------------------------------------------------------
+# TestTouchesCollide — unchanged function; keep tests
+# ---------------------------------------------------------------------------
 
 
 class TestTouchesCollide:
@@ -98,39 +97,72 @@ class TestTouchesCollide:
         assert not touches_collide(("src/a.py",), ())
 
 
-class TestSelectPicks:
-    def _records(self) -> list:
-        return parse_classification_table(TABLE_SNIPPET)
+# ---------------------------------------------------------------------------
+# TestSelectPicks — unchanged function; keep tests (uses inline IssueRecords)
+# ---------------------------------------------------------------------------
 
+
+def _make_records() -> list:
+    """Build a synthetic record list matching the original TABLE_SNIPPET shape."""
+    return [
+        IssueRecord(
+            issue=1, autonomy="safe", estimated="XS", touches=("src/a/mod_a.py",), note="Alpha"
+        ),
+        IssueRecord(
+            issue=2,
+            autonomy="safe",
+            estimated="S",
+            touches=("tests/integration/web/test_foo.py",),
+            note="Bravo",
+        ),
+        IssueRecord(
+            issue=3,
+            autonomy="review",
+            estimated="M",
+            touches=("src/b/mod_b.py", "tests/unit/b/*"),
+            note="Charlie",
+        ),
+        IssueRecord(issue=4, autonomy="skip", estimated="L", touches=(), note="Delta"),
+        IssueRecord(
+            issue=5,
+            autonomy="safe",
+            estimated="XS",
+            touches=("src/a/mod_a.py",),
+            note="Echo — collides with #1",
+        ),
+    ]
+
+
+class TestSelectPicks:
     def test_safe_only_by_default(self) -> None:
-        picks = select_picks(self._records(), max_n=5, include_review=False, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=5, include_review=False, open_pr_refs=set())
         assert [p.issue for p in picks] == [1, 2]  # #5 collides with #1
 
     def test_include_review_adds_review_picks(self) -> None:
-        picks = select_picks(self._records(), max_n=5, include_review=True, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=5, include_review=True, open_pr_refs=set())
         assert [p.issue for p in picks] == [1, 2, 3]
 
     def test_max_caps_results(self) -> None:
-        picks = select_picks(self._records(), max_n=1, include_review=False, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=1, include_review=False, open_pr_refs=set())
         assert [p.issue for p in picks] == [1]
 
     def test_open_pr_refs_exclude_issue(self) -> None:
-        picks = select_picks(self._records(), max_n=5, include_review=False, open_pr_refs={1})
+        picks = select_picks(_make_records(), max_n=5, include_review=False, open_pr_refs={1})
         # #1 excluded → #5 no longer collides → #5 takes its slot
         assert [p.issue for p in picks] == [2, 5]
 
     def test_skip_never_picked(self) -> None:
-        picks = select_picks(self._records(), max_n=10, include_review=True, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=10, include_review=True, open_pr_refs=set())
         assert 4 not in {p.issue for p in picks}
 
     def test_collision_drops_second_pick(self) -> None:
-        picks = select_picks(self._records(), max_n=10, include_review=False, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=10, include_review=False, open_pr_refs=set())
         issues = {p.issue for p in picks}
         # #1 and #5 both touch src/a/mod_a.py — only one should be in picks
         assert not ({1, 5}.issubset(issues))
 
     def test_safe_comes_before_review(self) -> None:
-        picks = select_picks(self._records(), max_n=10, include_review=True, open_pr_refs=set())
+        picks = select_picks(_make_records(), max_n=10, include_review=True, open_pr_refs=set())
         autonomies = [p.autonomy for p in picks]
         # safe entries must all appear before review entries
         last_safe = max((i for i, a in enumerate(autonomies) if a == "safe"), default=-1)
@@ -144,3 +176,201 @@ class TestSelectPicks:
         record = IssueRecord(issue=99, autonomy="safe", estimated="XS", touches=(), note="no globs")
         picks = select_picks([record], max_n=1, include_review=False, open_pr_refs=set())
         assert picks == []
+
+
+# ---------------------------------------------------------------------------
+# TestParseClassificationFromFragments
+# ---------------------------------------------------------------------------
+
+
+class TestParseClassificationFromFragments:
+    def test_skips_na_autonomy(self, tmp_path: Path) -> None:
+        _write_fragment(
+            tmp_path, "legacy-10-some-issue.md", _base_fm(10, "some-issue", autonomy="n/a")
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        assert records == []
+
+    def test_skips_resolved(self, tmp_path: Path) -> None:
+        """Regression test for issue #79: resolved fragments must not be picked."""
+        _write_fragment(
+            tmp_path,
+            "legacy-20-resolved-issue.md",
+            _base_fm(20, "resolved-issue", autonomy="safe", status="resolved"),
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        assert records == []
+
+    def test_skips_archived(self, tmp_path: Path) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-21-archived-issue.md",
+            _base_fm(21, "archived-issue", autonomy="safe", status="archived"),
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        assert records == []
+
+    def test_emits_open_and_partially_resolved(self, tmp_path: Path) -> None:
+        _write_fragment(
+            tmp_path, "legacy-30-open-issue.md", _base_fm(30, "open-issue", status="open")
+        )
+        _write_fragment(
+            tmp_path,
+            "legacy-31-partial-issue.md",
+            _base_fm(31, "partial-issue", status="partially-resolved"),
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        ids = {r.issue for r in records}
+        assert 30 in ids
+        assert 31 in ids
+
+    def test_preserves_issue_record_shape(self, tmp_path: Path) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-40-shaped-issue.md",
+            _base_fm(
+                40,
+                "shaped-issue",
+                autonomy="review",
+                estimated="M",
+                touches=["src/foo.py"],
+                note="my note",
+            ),
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        assert len(records) == 1
+        r = records[0]
+        assert r.issue == 40
+        assert r.autonomy == "review"
+        assert r.estimated == "M"
+        assert r.note == "my note"
+        assert isinstance(r.issue, int)
+        assert isinstance(r.autonomy, str)
+        assert isinstance(r.estimated, str)
+        assert isinstance(r.note, str)
+
+    def test_touches_tuple_not_list(self, tmp_path: Path) -> None:
+        """IssueRecord.touches must be a tuple (hashable, required for collision check)."""
+        _write_fragment(
+            tmp_path,
+            "legacy-50-tuple-issue.md",
+            _base_fm(50, "tuple-issue", touches=["src/a.py", "src/b.py"]),
+        )
+        records = parse_classification_from_fragments(tmp_path)
+        assert len(records) == 1
+        assert isinstance(records[0].touches, tuple)
+
+    def test_missing_fragments_dir_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "no-such-dir"
+        with pytest.raises(FileNotFoundError):
+            parse_classification_from_fragments(missing)
+
+
+# ---------------------------------------------------------------------------
+# TestFragmentParityWithMainBaseline
+# ---------------------------------------------------------------------------
+
+
+class TestFragmentParityWithMainBaseline:
+    """Real-repo structural parity test: run the selector against the live fragments
+    and verify the output has correct shape and no resolved/archived issues."""
+
+    def test_dry_run_produces_valid_output(self) -> None:
+        """Selector should run without errors against the real fragment directory."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--dry-run",
+                "--no-pr-dedupe",
+                "--fragments-dir",
+                str(_FRAGMENTS_DIR),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"selector failed:\n{result.stderr}"
+        assert "Classification totals:" in result.stdout
+        assert "Picks" in result.stdout
+
+    def test_json_output_is_valid_and_nonempty(self) -> None:
+        """JSON output must be parseable and contain at least one pick."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--no-pr-dedupe",
+                "--fragments-dir",
+                str(_FRAGMENTS_DIR),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"selector failed:\n{result.stderr}"
+        picks = json.loads(result.stdout)
+        assert isinstance(picks, list)
+        assert len(picks) > 0, "Expected at least one pick from the real fragment directory"
+
+    def test_json_output_schema_matches_contract(self) -> None:
+        """Each pick must have the fields run_nightly_sweep.sh expects."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--no-pr-dedupe",
+                "--fragments-dir",
+                str(_FRAGMENTS_DIR),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        picks = json.loads(result.stdout)
+        for pick in picks:
+            assert "issue" in pick and isinstance(pick["issue"], int)
+            assert "autonomy" in pick and isinstance(pick["autonomy"], str)
+            assert "estimated" in pick and isinstance(pick["estimated"], str)
+            assert "touches" in pick and isinstance(pick["touches"], list)
+            assert "note" in pick and isinstance(pick["note"], str)
+
+    def test_no_resolved_or_archived_in_picks(self) -> None:
+        """Core regression for #79: resolved/archived fragments must never appear in picks."""
+        import yaml
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--no-pr-dedupe",
+                "--max",
+                "10",
+                "--include-review",
+                "--fragments-dir",
+                str(_FRAGMENTS_DIR),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        picks = json.loads(result.stdout)
+        picked_ids = {p["issue"] for p in picks}
+
+        # Build a map from id → status from fragment files.
+        id_to_status: dict[int, str] = {}
+        for frag_path in _FRAGMENTS_DIR.glob("*.md"):
+            if frag_path.name == "CHANGELOG.md":
+                continue
+            text = frag_path.read_text(encoding="utf-8")
+            if not text.startswith("---\n"):
+                continue
+            fm_text = text[4 : text.find("\n---\n", 4)]
+            fm = yaml.safe_load(fm_text) or {}
+            if isinstance(fm, dict) and "id" in fm:
+                id_to_status[int(fm["id"])] = str(fm.get("status") or "")
+
+        for issue_id in picked_ids:
+            status = id_to_status.get(issue_id, "unknown")
+            assert status not in {"resolved", "archived"}, (
+                f"Issue #{issue_id} has status={status!r} but appeared in picks — "
+                "selector should filter out resolved/archived fragments (issue #79)"
+            )


### PR DESCRIPTION
## Summary

Phase 3 of the fragment-known-issues plan. Replaces the markdown-table parser in `scripts/known_issues_selector.py` with a YAML-frontmatter reader that sources from `docs/known-issues/` directly. Naturally resolves **#79** (selector picking resolved issues) by adding a status filter.

Follows #115 (Phase 1a+1b) and #116 (Phase 2 hook).

## Changes

- **`scripts/known_issues_selector.py`** — `parse_classification_table()` removed. Replaced with `parse_classification_from_fragments()` that reads via `validate_known_issues_fragments.load_all_fragments`, skips `autonomy == n/a` and `status in {resolved, archived}`. CLI arg `--known-issues PATH` replaced by `--fragments-dir PATH` (default `docs/known-issues/`). No compat shim — all callers are in-repo.
- **`scripts/run_nightly_sweep.sh`** — per-issue Claude prompt now directs the agent to find `docs/known-issues/legacy-${issue}-*.md` or `gh-${issue}-*.md` and read it. JSON-consumption loop (`while IFS=\$'\t' read`) is unchanged.
- **`tests/unit/scripts/test_known_issues_selector.py`** — removed `TestParseClassificationTable`. Refactored `TestSelectPicks` and `TestTouchesCollide` to build `IssueRecord`s inline (the `TABLE_SNIPPET` fixture went with the old parser). Added:
  - `TestParseClassificationFromFragments` — 7 tests including `test_skips_resolved` / `test_skips_archived` (the #79 regression).
  - `TestFragmentParityWithMainBaseline` — runs the real selector against the live fragment dir; asserts JSON schema matches the sweeper's contract and no resolved/archived issues appear in picks.

## External JSON contract preserved

The `IssueRecord` dataclass shape (`issue: int, autonomy: str, estimated: str, touches: tuple[str,...], note: str`) and `asdict()` output are byte-identical to the pre-Phase-3 selector, so `run_nightly_sweep.sh` keeps working without any change to its JSON parsing.

**Selector dry-run against current fragments:**
```
Classification totals: 5 safe, 8 review, 15 skip.
Picks (3/3 requested; include_review=False):
  #68 [safe/XS] touches=['scripts/run_nightly_sweep.sh']  — Detect timeout vs gtimeout...
  #71 [safe/XS] touches=['.github/workflows/ci.yml']  — Add path filter to integration-tests...
  #74 [safe/XS] touches=['.gitignore']  — One-line addition to root \`.gitignore\`
```

#60 was correctly filtered out (now `status: archived`). Note: #68 and #71 fragments still say `status: open` even though their fix-PRs merged — that's a data-curation issue (nobody updated the fragments post-merge), not a selector bug. Phase 4 can update the `/commit` skill to refresh fragment status on PR merge.

## Test plan

- [x] `pytest tests/unit/scripts/ -x -q` — 81 pass
- [x] `ruff check scripts/ tests/unit/scripts/` — clean
- [x] Live selector dry-run produces valid output
- [x] Parity test asserts no resolved/archived in picks
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)