### PR TITLE
feat(ingest): accept company name OR industry; preserve form state on error

### DIFF
--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -204,26 +204,36 @@ JOIN companies c ON c.company_id = f.company_id
 LEFT JOIN v2_documents v ON v.filing_id = f.filing_id
 WHERE f.form_type = ANY(%(form_types)s)
   AND EXTRACT(YEAR FROM f.filing_date) BETWEEN %(year_min)s AND %(year_max)s
-  AND c.industry_code = ANY(%(sic_codes)s)
 """
+
+_INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
 
 _PHASE1_GATE = "  AND f.is_in_scope_phase1 = TRUE\n"
 
 _DISCOVERY_ORDER = "ORDER BY f.filing_date, c.company_name\n"
 
 # Exposed for tests and backward compatibility. Equivalent to the original
-# S-1/F-1-gated query (Phase-1 filter included).
-DISCOVERY_SQL = _DISCOVERY_SQL_BASE + _PHASE1_GATE + _DISCOVERY_ORDER
+# S-1/F-1-gated query (Phase-1 filter included, industry filter present).
+DISCOVERY_SQL = _DISCOVERY_SQL_BASE + _INDUSTRY_GATE + _PHASE1_GATE + _DISCOVERY_ORDER
 
 
-def _build_discovery_sql(form_types: list[str]) -> str:
+def _build_discovery_sql(form_types: list[str], sic_codes: list[str]) -> str:
     """Include the Phase-1 gate only when at least one S-1/F-1 form is requested.
 
     For 10-K-only (or other non-S-1/F-1) queries, Phase-1 filter doesn't apply:
     those filings intentionally land with is_in_scope_phase1=FALSE.
+
+    Include the industry (SIC-code) clause only when ``sic_codes`` is non-empty.
+    Empty SIC list means the caller is filtering by company name alone; emitting
+    ``= ANY(ARRAY[]::text[])`` would return zero rows.
     """
     include_phase1 = bool(S1F1_FORMS & set(form_types))
-    return _DISCOVERY_SQL_BASE + (_PHASE1_GATE if include_phase1 else "") + _DISCOVERY_ORDER
+    return (
+        _DISCOVERY_SQL_BASE
+        + (_INDUSTRY_GATE if sic_codes else "")
+        + (_PHASE1_GATE if include_phase1 else "")
+        + _DISCOVERY_ORDER
+    )
 
 
 def discover_candidates(
@@ -233,14 +243,16 @@ def discover_candidates(
     year_max: int,
     sic_codes: list[str],
 ) -> list[Candidate]:
+    params: dict[str, Any] = {
+        "form_types": form_types,
+        "year_min": year_min,
+        "year_max": year_max,
+    }
+    if sic_codes:
+        params["sic_codes"] = sic_codes
     rows = db.query(
-        _build_discovery_sql(form_types),
-        {
-            "form_types": form_types,
-            "year_min": year_min,
-            "year_max": year_max,
-            "sic_codes": sic_codes,
-        },
+        _build_discovery_sql(form_types, sic_codes),
+        params,
     )
     return [
         Candidate(
@@ -325,8 +337,9 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
     Raises
     ------
     ValueError
-        On unrecognised industry name, invalid SIC code, bad year string, or
-        empty resolved form-types list.
+        On unrecognised industry name, invalid SIC code, bad year string,
+        empty resolved form-types list, or when no narrowing criterion is
+        supplied (industry, SIC code, *and* company-name filter all empty).
     """
 
     # --- SIC codes from industry picker ---
@@ -345,8 +358,8 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
             raise ValueError(f"Invalid SIC code {code!r}: must be a 4-digit numeric string")
         sic_set.add(code)
 
-    if not sic_set:
-        raise ValueError("At least one industry or SIC code must be supplied in criteria")
+    if not sic_set and not (criteria.get("company_name_ilike") or "").strip():
+        raise ValueError("Provide at least one of: industry, SIC code, or company name filter")
 
     # --- Year range ---
     raw_year = criteria.get("year")

--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -112,26 +112,39 @@ def _volume_band_message(band: VolumeBand, total: int) -> str:
     return messages.get(band, f"{total} filings.")
 
 
+_FORM_TYPES_AVAILABLE = [
+    {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)"},
+    {"key": "10k", "label": "10-K (Annual reports)"},
+    {"key": "8k", "label": "8-K (Current reports)"},
+]
+
+
+def _render_ingest_form(form_state: dict[str, Any] | None = None, status: int = 200):
+    """Render the criteria form. When *form_state* is given, the template
+    repopulates fields so a validation error doesn't wipe user input.
+    """
+    state = form_state or {}
+    reviewer_name = state.get("_reviewer_name") or request.cookies.get("ingest_reviewer", "")
+    return (
+        render_template(
+            "ingest_form.html",
+            reviewer_name=reviewer_name,
+            industries=_industry_options(),
+            form_types_available=_FORM_TYPES_AVAILABLE,
+            form_state=state,
+        ),
+        status,
+    )
+
+
 # ---------------------------------------------------------------------------
 # GET /ingest/
 # ---------------------------------------------------------------------------
 
 
 @ingest_bp.route("/", methods=["GET"])
-def ingest_form() -> str:
-    reviewer_name = request.cookies.get("ingest_reviewer", "")
-    industries = _industry_options()
-    form_types_available = [
-        {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)"},
-        {"key": "10k", "label": "10-K (Annual reports)"},
-        {"key": "8k", "label": "8-K (Current reports)"},
-    ]
-    return render_template(
-        "ingest_form.html",
-        reviewer_name=reviewer_name,
-        industries=industries,
-        form_types_available=form_types_available,
-    )
+def ingest_form():
+    return _render_ingest_form()
 
 
 # ---------------------------------------------------------------------------
@@ -142,13 +155,14 @@ def ingest_form() -> str:
 @ingest_bp.route("/preview", methods=["POST"])
 def ingest_preview():
     raw = _parse_form_criteria()
-    reviewer_name = raw.pop("_reviewer_name", "")
 
     try:
         query = resolve_criteria(raw)
     except ValueError as exc:
         flash(str(exc), "danger")
-        return redirect(url_for("ingest.ingest_form"))
+        return _render_ingest_form(form_state=raw, status=400)
+
+    reviewer_name = raw.pop("_reviewer_name", "")
 
     db = get_db()
 

--- a/src/web/templates/ingest_form.html
+++ b/src/web/templates/ingest_form.html
@@ -11,6 +11,9 @@
       After previewing the candidate list you can start a batch run.
     </p>
 
+    {% set state = form_state or {} %}
+    {% set selected_industries = state.get('industries') or [] %}
+    {% set selected_form_types = state.get('form_types') or ['s1f1'] %}
     <form method="POST" action="{{ url_for('ingest.ingest_preview') }}">
 
       <!-- Industry multi-select -->
@@ -18,10 +21,10 @@
         <label for="industries" class="form-label fw-semibold">Industries</label>
         <select id="industries" name="industries" class="form-select" multiple size="6">
           {% for ind in industries %}
-          <option value="{{ ind.key }}">{{ ind.label }}</option>
+          <option value="{{ ind.key }}" {% if ind.key in selected_industries %}selected{% endif %}>{{ ind.label }}</option>
           {% endfor %}
         </select>
-        <div class="form-text">Hold Ctrl / Cmd to select multiple industries.</div>
+        <div class="form-text">Hold Ctrl / Cmd to select multiple industries. Provide an industry, SIC code, or company name filter.</div>
       </div>
 
       <!-- Direct SIC codes -->
@@ -29,7 +32,7 @@
         <label for="sic_codes" class="form-label fw-semibold">Direct SIC Codes</label>
         <input type="text" id="sic_codes" name="sic_codes"
                class="form-control" placeholder="e.g. 7372, 5411"
-               value="">
+               value="{{ state.get('sic_codes') or '' }}">
         <div class="form-text">Comma-separated 4-digit SIC codes. Combined (union) with industry selection above.</div>
       </div>
 
@@ -41,7 +44,7 @@
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="checkbox"
                    id="ft_{{ ft.key }}" name="form_types" value="{{ ft.key }}"
-                   {% if ft.key == 's1f1' %}checked{% endif %}>
+                   {% if ft.key in selected_form_types %}checked{% endif %}>
             <label class="form-check-label" for="ft_{{ ft.key }}">{{ ft.label }}</label>
           </div>
           {% endfor %}
@@ -53,17 +56,18 @@
         <label for="year" class="form-label fw-semibold">Year or Year Range</label>
         <input type="text" id="year" name="year"
                class="form-control" placeholder="e.g. 2023 or 2020-2024"
-               required>
+               value="{{ state.get('year') or '' }}" required>
         <div class="form-text">Single year (2023) or inclusive range (2020-2024).</div>
       </div>
 
       <!-- Company name filter -->
       <div class="mb-3">
         <label for="company_name_ilike" class="form-label fw-semibold">
-          Company Name Filter <span class="text-muted fw-normal">(optional)</span>
+          Company Name Filter <span class="text-muted fw-normal">(optional if an industry or SIC code is supplied)</span>
         </label>
         <input type="text" id="company_name_ilike" name="company_name_ilike"
-               class="form-control" placeholder="e.g. Chewy">
+               class="form-control" placeholder="e.g. Chewy"
+               value="{{ state.get('company_name_ilike') or '' }}">
         <div class="form-text">Case-insensitive substring match on company name.</div>
       </div>
 

--- a/tests/integration/universe/test_discover_candidates_integration.py
+++ b/tests/integration/universe/test_discover_candidates_integration.py
@@ -1,0 +1,83 @@
+"""Integration coverage for the conditional industry filter in discover_candidates.
+
+The discovery SQL omits the ``AND c.industry_code = ANY(...)`` clause when
+``sic_codes`` is empty so that company-name-only discovery returns rows. This
+test seeds two companies with different SIC codes and asserts an empty-SIC
+search sees both, while a constrained search still narrows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.universe.onboarding import discover_candidates
+
+
+def _seed(db, *, cik: str, name: str, sic: str, accession: str, form_type: str = "S-1"):
+    company_id = db.upsert_company(
+        cik=cik,
+        company_name=name,
+        ticker=None,
+        industry_code=sic,
+    )
+    db.upsert_filing(
+        company_id=company_id,
+        cik=cik,
+        accession_number=accession,
+        form_type=form_type,
+        filing_date="2015-06-01",
+        sec_html_url=f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/"
+        f"{accession.replace('-', '')}/primary.htm",
+        is_in_scope_phase1=True,
+        is_first_time_issuer=True,
+        is_spac=False,
+        is_post_combination=False,
+        is_investment_vehicle=False,
+        is_resource_extraction=False,
+    )
+
+
+@pytest.mark.integration
+def test_discover_candidates_empty_sic_returns_all_matching_form_types(clean_db):
+    """Empty sic_codes list → industry filter is omitted; both rows return."""
+    _seed(
+        clean_db, cik="0000999101", name="Software Co", sic="7372", accession="0000999101-15-000001"
+    )
+    _seed(
+        clean_db, cik="0000999102", name="Grocery Co", sic="5411", accession="0000999102-15-000001"
+    )
+
+    results = discover_candidates(
+        clean_db,
+        form_types=["S-1"],
+        year_min=2015,
+        year_max=2015,
+        sic_codes=[],
+    )
+
+    names = {c.company_name for c in results}
+    assert "Software Co" in names
+    assert "Grocery Co" in names
+
+
+@pytest.mark.integration
+def test_discover_candidates_nonempty_sic_still_filters(clean_db):
+    """Non-empty sic_codes retains the industry filter (regression)."""
+    _seed(
+        clean_db, cik="0000999201", name="Software Co", sic="7372", accession="0000999201-15-000001"
+    )
+    _seed(
+        clean_db, cik="0000999202", name="Grocery Co", sic="5411", accession="0000999202-15-000001"
+    )
+
+    results = discover_candidates(
+        clean_db,
+        form_types=["S-1"],
+        year_min=2015,
+        year_max=2015,
+        sic_codes=["7372"],
+    )
+
+    names = {c.company_name for c in results}
+    assert "Software Co" in names
+    assert "Grocery Co" not in names

--- a/tests/unit/test_onboard_tickers.py
+++ b/tests/unit/test_onboard_tickers.py
@@ -342,8 +342,16 @@ def test_exclude_amendments_filters_slash_a_forms(cli):
     """With --exclude-amendments, s1f1 bundle narrows to S-1 + F-1 only."""
     parser = cli.build_parser()
     args = parser.parse_args(
-        ["discover", "--industry", "software", "--year", "2015",
-         "--form-type", "s1f1", "--exclude-amendments"]
+        [
+            "discover",
+            "--industry",
+            "software",
+            "--year",
+            "2015",
+            "--form-type",
+            "s1f1",
+            "--exclude-amendments",
+        ]
     )
     assert args.exclude_amendments is True
 
@@ -355,9 +363,7 @@ def test_exclude_amendments_filters_slash_a_forms(cli):
 
 def test_exclude_amendments_default_false(cli):
     parser = cli.build_parser()
-    args = parser.parse_args(
-        ["discover", "--industry", "software", "--year", "2015"]
-    )
+    args = parser.parse_args(["discover", "--industry", "software", "--year", "2015"])
     assert args.exclude_amendments is False
 
 
@@ -388,13 +394,13 @@ def test_populate_default_form_type_s1f1(cli):
 
 def test_build_discovery_sql_includes_phase1_for_s1f1(cli):
     """S-1/F-1 requests retain the is_in_scope_phase1 = TRUE filter."""
-    sql = cli._build_discovery_sql(["S-1", "S-1/A", "F-1", "F-1/A"])
+    sql = cli._build_discovery_sql(["S-1", "S-1/A", "F-1", "F-1/A"], ["7372"])
     assert "is_in_scope_phase1 = TRUE" in sql
 
 
 def test_build_discovery_sql_drops_phase1_for_10k(cli):
     """10-K requests omit the Phase-1 gate (10-K is not Phase 1 by design)."""
-    sql = cli._build_discovery_sql(["10-K", "10-K/A"])
+    sql = cli._build_discovery_sql(["10-K", "10-K/A"], ["7372"])
     assert "is_in_scope_phase1" not in sql
 
 
@@ -404,8 +410,24 @@ def test_build_discovery_sql_keeps_phase1_for_mixed_bundle(cli):
     Rationale: the filter is conservative — only drop it when the operator
     is explicitly asking for non-Phase-1 forms only.
     """
-    sql = cli._build_discovery_sql(["S-1", "10-K"])
+    sql = cli._build_discovery_sql(["S-1", "10-K"], ["7372"])
     assert "is_in_scope_phase1 = TRUE" in sql
+
+
+def test_build_discovery_sql_omits_industry_gate_when_sic_codes_empty(cli):
+    """Empty sic_codes → the industry filter clause is not emitted.
+
+    Enables company-name-only discovery: ``= ANY(ARRAY[]::text[])`` would
+    match zero rows, so the clause must be dropped entirely when the caller
+    is filtering by company name alone.
+    """
+    sql = cli._build_discovery_sql(["S-1"], [])
+    assert "c.industry_code = ANY" not in sql
+
+
+def test_build_discovery_sql_includes_industry_gate_when_sic_codes_present(cli):
+    sql = cli._build_discovery_sql(["S-1"], ["7372"])
+    assert "c.industry_code = ANY(%(sic_codes)s)" in sql
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/universe/test_onboarding.py
+++ b/tests/unit/universe/test_onboarding.py
@@ -139,9 +139,22 @@ def test_resolve_criteria_missing_year_raises() -> None:
         resolve_criteria({"industries": ["software"]})
 
 
-def test_resolve_criteria_empty_sic_and_industries_raises() -> None:
-    with pytest.raises(ValueError, match="At least one industry or SIC code"):
+def test_resolve_criteria_empty_sic_industries_and_company_raises() -> None:
+    with pytest.raises(ValueError, match="industry, SIC code, or company name"):
         resolve_criteria({"year": "2020"})
+
+
+def test_resolve_criteria_company_name_only_allowed() -> None:
+    """Company-name filter alone satisfies the narrowing requirement."""
+    q = resolve_criteria({"year": "2020", "company_name_ilike": "Chewy"})
+    assert q.sic_codes == []
+    assert q.company_name_ilike == "Chewy"
+
+
+def test_resolve_criteria_blank_company_name_does_not_satisfy() -> None:
+    """Whitespace-only company_name_ilike does not satisfy the narrowing rule."""
+    with pytest.raises(ValueError, match="industry, SIC code, or company name"):
+        resolve_criteria({"year": "2020", "company_name_ilike": "   "})
 
 
 def test_resolve_criteria_exclude_amendments() -> None:

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -129,6 +129,91 @@ def test_parse_form_criteria_multi_industry(app):
 
 
 # ---------------------------------------------------------------------------
+# POST /ingest/preview — validation error re-renders form with preserved state
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_preview_no_criteria_returns_400_with_preserved_state(client):
+    """Missing industry/SIC/company → 400, form re-rendered with typed values preserved."""
+    resp = client.post(
+        "/ingest/preview",
+        data={
+            "year": "2023",
+            "reviewer_name": "Rob",
+            # No industries / SIC / company — triggers the validation error.
+            # Keep a non-default form_types checkbox to prove checkbox state
+            # survives the round-trip.
+            "form_types": ["10k"],
+        },
+    )
+    assert resp.status_code == 400
+    body = resp.get_data(as_text=True)
+    # Flash message rendered
+    assert "industry, SIC code, or company name" in body
+    # Year field repopulated
+    assert 'value="2023"' in body
+    # Reviewer name repopulated
+    assert 'value="Rob"' in body
+
+    # The 10-K checkbox is checked; the default s1f1 is not. The template
+    # renders <input ... id="ft_X" ... {% if ... %}checked{% endif %}>; split
+    # the HTML on `<input` so each chunk is a single input tag.
+    def _input_block(html: str, input_id: str) -> str:
+        for chunk in html.split("<input"):
+            if f'id="{input_id}"' in chunk:
+                return chunk.split(">", 1)[0]
+        raise AssertionError(f"no <input id={input_id!r}> in response body")
+
+    assert "checked" in _input_block(body, "ft_10k")
+    assert "checked" not in _input_block(body, "ft_s1f1")
+
+
+def test_ingest_preview_preserves_sic_and_company_on_error(client):
+    """Typed-but-invalid SIC triggers ValueError; other fields still round-trip."""
+    resp = client.post(
+        "/ingest/preview",
+        data={
+            "year": "2023",
+            "reviewer_name": "Rob",
+            "sic_codes": "73AB",  # invalid → ValueError from resolve_criteria
+            "company_name_ilike": "Chewy",
+        },
+    )
+    assert resp.status_code == 400
+    body = resp.get_data(as_text=True)
+    # Typed SIC preserved verbatim so the user can fix the typo
+    assert 'value="73AB"' in body
+    # Company name preserved
+    assert 'value="Chewy"' in body
+
+
+def test_ingest_preview_company_only_passes_validation(client):
+    """Company name alone (no industry/SIC) satisfies validation and reaches discover()."""
+    from src.universe.onboarding import DiscoveryResult
+
+    mock_db = MagicMock()
+
+    with (
+        patch("src.web.routes.ingest.get_db", return_value=mock_db),
+        patch(
+            "src.web.routes.ingest.discover",
+            return_value=DiscoveryResult(new=[], already_extracted=[], gaps=[]),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/preview",
+            data={
+                "year": "2023",
+                "reviewer_name": "Rob",
+                "company_name_ilike": "Chewy",
+            },
+        )
+    # Success renders the preview template — confirm we didn't get the form
+    # re-render 400.
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
 # Volume band enforcement
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Validation**: \`resolve_criteria\` now accepts a company-name filter as an alternative to industry/SIC. At least one of \`industries\`, \`sic_codes\`, or \`company_name_ilike\` must be supplied.
- **SQL**: discovery query drops the \`c.industry_code = ANY(...)\` clause when \`sic_codes\` is empty (mirrors the existing \`_PHASE1_GATE\` pattern). Public \`DISCOVERY_SQL\` constant is preserved byte-identical for backward compatibility.
- **Form UX**: on validation error, \`/ingest/preview\` re-renders the form with HTTP 400 and repopulates user input (industries, SIC text, form-type checkboxes, year, company-name filter) instead of redirecting to a blank form.

## Scope

Intentionally narrow:
- Only \`ingest_preview()\` — \`ingest_start()\` redirect branches (post-preview errors, rare) are out of scope.
- No client-side OR-validation JS — server enforces the rule.
- No doc updates needed: no existing docs describe the "industry required" rule.

## Test plan

- [x] \`pytest tests/unit/ -x -q\` — 3639 passed, 11 skipped
- [x] \`ruff check src/ tests/\` — clean
- [x] Manual smoke via Flask test client: company-only POST → 200 preview; no-criteria POST → 400 with preserved \`year\`/\`reviewer_name\`/\`form_types\` checkbox state and a visible flash message
- [x] Unit tests added: \`resolve_criteria\` (company-only allowed, blank-only rejected), \`ingest_preview\` (400 re-render preserves checkboxes + SIC + company values), \`_build_discovery_sql\` (industry gate conditional)
- [x] Integration test added (\`tests/integration/universe/test_discover_candidates_integration.py\`): empty \`sic_codes\` returns all matching form types; non-empty still filters. *Note:* local run was blocked by a pre-existing migration-checksum mismatch on \`sql/37_create_analytics_role.sql\` that affects all integration tests on this workstation — CI will exercise the new test against a fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)