### PR TITLE
fix(image-export): populate real keyword_count/detected_keywords for SEC training rows (Wave A1)

### DIFF
--- a/scripts/export_image_training_data.py
+++ b/scripts/export_image_training_data.py
@@ -33,38 +33,43 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OUTPUT = ROOT / "data" / "image_model" / "training_data.csv"
 PRES_DIR = ROOT / "data" / "presentation_gold_standard"
 
+# Keywords used for cohort/retention signal detection in nearby text.
+# Shared between SEC and presentation export paths so both sources produce
+# comparable keyword_count / detected_keywords features.
+COHORT_KEYWORDS = {"cohort", "retention", "vintage", "ltv", "cac", "arr", "mrr", "nrr"}
+
 # Normalized output schema — features useful for relevance modelling
 OUTPUT_COLUMNS = [
     # Identifiers
     "image_id",
-    "source",           # 'sec' or 'pres'
+    "source",  # 'sec' or 'pres'
     "company",
-    "filing_key",       # accession number (SEC) or TICKER_FORM_DATE key (pres)
+    "filing_key",  # accession number (SEC) or TICKER_FORM_DATE key (pres)
     "filename",
     "image_url",
     # Dimensions
     "width",
     "height",
-    "has_dimensions",   # derived: width and height both known
-    "image_area",       # derived: width * height (0 if unknown)
-    "aspect_ratio",     # derived: width / height (0 if unknown or height=0)
+    "has_dimensions",  # derived: width and height both known
+    "image_area",  # derived: width * height (0 if unknown)
+    "aspect_ratio",  # derived: width / height (0 if unknown or height=0)
     # Text signals
     "cohort_keyword_nearby",  # bool: cohort keyword within ~1500 chars
-    "keyword_count",          # derived: number of distinct detected keywords
-    "detected_keywords",      # raw: comma-separated keyword list
-    "preceding_text",         # ~50-500 chars of text before the image
-    "text_length",            # derived: len(preceding_text)
+    "keyword_count",  # derived: number of distinct detected keywords
+    "detected_keywords",  # raw: comma-separated keyword list
+    "preceding_text",  # ~50-500 chars of text before the image
+    "text_length",  # derived: len(preceding_text)
     # Scoring signals
-    "cohort_confidence",      # 0.0-1.0 heuristic score (SEC) or relevance_score (pres)
-    "detection_tier",         # tier_1_cohort, tier_2_large, tier_3_all, seed_list (SEC)
-                              # or inferred from classification (pres)
-    "classification",         # V2 image classification: chart, unknown, decorative, etc.
-    "section_type",           # SEC section: MD&A, BUSINESS, etc. (pres only)
-    "image_index",            # 1-indexed position in filing (SEC only)
+    "cohort_confidence",  # 0.0-1.0 heuristic score (SEC) or relevance_score (pres)
+    "detection_tier",  # tier_1_cohort, tier_2_large, tier_3_all, seed_list (SEC)
+    # or inferred from classification (pres)
+    "classification",  # V2 image classification: chart, unknown, decorative, etc.
+    "section_type",  # SEC section: MD&A, BUSINESS, etc. (pres only)
+    "image_index",  # 1-indexed position in filing (SEC only)
     # Labels
-    "decision",               # 'relevant' or 'not_relevant'
-    "chart_type",             # if relevant: bar_chart, line_chart, cohort_table, etc.
-    "rejection_reason",       # if not_relevant: decorative, not_a_chart, wrong_subject, etc.
+    "decision",  # 'relevant' or 'not_relevant'
+    "chart_type",  # if relevant: bar_chart, line_chart, cohort_table, etc.
+    "rejection_reason",  # if not_relevant: decorative, not_a_chart, wrong_subject, etc.
 ]
 
 
@@ -105,9 +110,11 @@ def export_sec_rows(db) -> list[dict]:
     Export V2 SEC image decisions for training.
 
     V2 does not persist V1's `detected_keywords[]` or `cohort_keyword_nearby`.
-    Synthesize both from V2 fields using the same heuristic the runtime scorer uses:
-      - cohort_keyword_nearby = 1 if relevance_score >= 0.6 (matches bridge logic)
-      - detected_keywords is an empty list (model compensates via semantic text features)
+    Synthesize both from nearby_text using the same COHORT_KEYWORDS set used by
+    the presentation export path:
+      - detected_keywords: COHORT_KEYWORDS members found in nearby_text (sorted)
+      - keyword_count: len(detected_keywords)
+      - cohort_keyword_nearby: 1 if any keyword detected OR relevance_score >= 0.6
     """
     from src.shared.image_features import derive_detection_tier
 
@@ -123,32 +130,37 @@ def export_sec_rows(db) -> list[dict]:
         nearby = r.get("nearby_text") or ""
         relevance = float(r.get("relevance_score") or 0.0)
 
-        out.append({
-            "image_id": f"sec:{r['img_id']}",
-            "source": "sec",
-            "company": r.get("company_name", ""),
-            "filing_key": r.get("accession_number", ""),
-            "filename": r.get("filename", ""),
-            "image_url": r.get("image_url", ""),
-            "width": w if w is not None else "",
-            "height": h if h is not None else "",
-            "has_dimensions": int(has_dim),
-            "image_area": area,
-            "aspect_ratio": round(aspect, 4),
-            "cohort_keyword_nearby": int(relevance >= 0.6),
-            "keyword_count": 0,
-            "detected_keywords": "",
-            "preceding_text": nearby,
-            "text_length": len(nearby),
-            "cohort_confidence": relevance,
-            "detection_tier": derive_detection_tier(r.get("classification"), relevance, w, h),
-            "classification": (r.get("classification") or "").lower(),
-            "section_type": r.get("section_type", "") or "",
-            "image_index": "",  # V2 does not store image_index
-            "decision": r.get("decision", ""),
-            "chart_type": r.get("chart_type") or "",
-            "rejection_reason": r.get("rejection_reason") or "",
-        })
+        nearby_lower = nearby.lower()
+        detected = [kw for kw in COHORT_KEYWORDS if kw in nearby_lower]
+
+        out.append(
+            {
+                "image_id": f"sec:{r['img_id']}",
+                "source": "sec",
+                "company": r.get("company_name", ""),
+                "filing_key": r.get("accession_number", ""),
+                "filename": r.get("filename", ""),
+                "image_url": r.get("image_url", ""),
+                "width": w if w is not None else "",
+                "height": h if h is not None else "",
+                "has_dimensions": int(has_dim),
+                "image_area": area,
+                "aspect_ratio": round(aspect, 4),
+                "cohort_keyword_nearby": int(bool(detected) or relevance >= 0.6),
+                "keyword_count": len(detected),
+                "detected_keywords": ",".join(sorted(detected)),
+                "preceding_text": nearby,
+                "text_length": len(nearby),
+                "cohort_confidence": relevance,
+                "detection_tier": derive_detection_tier(r.get("classification"), relevance, w, h),
+                "classification": (r.get("classification") or "").lower(),
+                "section_type": r.get("section_type", "") or "",
+                "image_index": "",  # V2 does not store image_index
+                "decision": r.get("decision", ""),
+                "chart_type": r.get("chart_type") or "",
+                "rejection_reason": r.get("rejection_reason") or "",
+            }
+        )
     return out
 
 
@@ -207,37 +219,38 @@ def export_pres_rows() -> list[dict]:
         relevance_score = cand.get("relevance_score") or 0.0
 
         # Presence of cohort-adjacent keywords in nearby text
-        cohort_keywords = {"cohort", "retention", "vintage", "ltv", "cac", "arr", "mrr", "nrr"}
         nearby_lower = nearby.lower()
-        cohort_nearby = int(any(kw in nearby_lower for kw in cohort_keywords))
-        detected = [kw for kw in cohort_keywords if kw in nearby_lower]
+        detected = [kw for kw in COHORT_KEYWORDS if kw in nearby_lower]
+        cohort_nearby = int(bool(detected))
 
-        out.append({
-            "image_id": f"pres:{decision_key}",
-            "source": "pres",
-            "company": company,
-            "filing_key": filing_key,
-            "filename": cand.get("filename", ""),
-            "image_url": cand.get("image_url", ""),
-            "width": w if w is not None else "",
-            "height": h if h is not None else "",
-            "has_dimensions": int(has_dim),
-            "image_area": area,
-            "aspect_ratio": round(aspect, 4),
-            "cohort_keyword_nearby": cohort_nearby,
-            "keyword_count": len(detected),
-            "detected_keywords": ",".join(detected),
-            "preceding_text": nearby[:500],
-            "text_length": len(nearby),
-            "cohort_confidence": relevance_score,
-            "detection_tier": CLASSIFICATION_TO_TIER.get(classification, "tier_3_all"),
-            "classification": classification,
-            "section_type": cand.get("section_type", ""),
-            "image_index": "",
-            "decision": dec.get("decision", ""),
-            "chart_type": dec.get("chart_type") or "",
-            "rejection_reason": dec.get("rejection_reason") or "",
-        })
+        out.append(
+            {
+                "image_id": f"pres:{decision_key}",
+                "source": "pres",
+                "company": company,
+                "filing_key": filing_key,
+                "filename": cand.get("filename", ""),
+                "image_url": cand.get("image_url", ""),
+                "width": w if w is not None else "",
+                "height": h if h is not None else "",
+                "has_dimensions": int(has_dim),
+                "image_area": area,
+                "aspect_ratio": round(aspect, 4),
+                "cohort_keyword_nearby": cohort_nearby,
+                "keyword_count": len(detected),
+                "detected_keywords": ",".join(detected),
+                "preceding_text": nearby[:500],
+                "text_length": len(nearby),
+                "cohort_confidence": relevance_score,
+                "detection_tier": CLASSIFICATION_TO_TIER.get(classification, "tier_3_all"),
+                "classification": classification,
+                "section_type": cand.get("section_type", ""),
+                "image_index": "",
+                "decision": dec.get("decision", ""),
+                "chart_type": dec.get("chart_type") or "",
+                "rejection_reason": dec.get("rejection_reason") or "",
+            }
+        )
     skipped = len(decisions) - len(out)
     if skipped > 0:
         logger.warning(
@@ -252,21 +265,27 @@ def export_pres_rows() -> list[dict]:
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Export unified image training data for relevance model",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--output", type=str, default=str(DEFAULT_OUTPUT),
+        "--output",
+        type=str,
+        default=str(DEFAULT_OUTPUT),
         help=f"Output CSV path (default: {DEFAULT_OUTPUT})",
     )
     parser.add_argument(
-        "--source", choices=["sec", "pres", "all"], default="all",
+        "--source",
+        choices=["sec", "pres", "all"],
+        default="all",
         help="Which source to export (default: all)",
     )
     parser.add_argument(
-        "--database-url", type=str,
+        "--database-url",
+        type=str,
         help="Database connection string (defaults to DATABASE_URL from .env)",
     )
 
@@ -283,6 +302,7 @@ def main() -> None:
             logger.error("DATABASE_URL not set — cannot export SEC decisions")
             sys.exit(1)
         from src.infra.db import DatabaseAdapter
+
         db = DatabaseAdapter(db_url)
         sec_rows = export_sec_rows(db)
         logger.info("SEC: %d decisions exported", len(sec_rows))
@@ -302,8 +322,11 @@ def main() -> None:
     not_relevant = sum(1 for r in rows if r["decision"] == "not_relevant")
     logger.info(
         "Total: %d rows | relevant=%d (%.1f%%) | not_relevant=%d (%.1f%%)",
-        len(rows), relevant, 100 * relevant / len(rows),
-        not_relevant, 100 * not_relevant / len(rows),
+        len(rows),
+        relevant,
+        100 * relevant / len(rows),
+        not_relevant,
+        100 * not_relevant / len(rows),
     )
 
     output_path = Path(args.output)
@@ -328,7 +351,9 @@ def main() -> None:
     for s, counts in sources.items():
         logger.info(
             "  %s: %d total, %d relevant (%.1f%%)",
-            s, counts["total"], counts["relevant"],
+            s,
+            counts["total"],
+            counts["relevant"],
             100 * counts["relevant"] / counts["total"],
         )
 

--- a/tests/unit/scripts/test_export_image_training_data.py
+++ b/tests/unit/scripts/test_export_image_training_data.py
@@ -1,0 +1,204 @@
+"""Unit tests for scripts/export_image_training_data.py — keyword-count fix (Wave A1).
+
+Specifically validates that export_sec_rows() emits real keyword_count /
+detected_keywords values derived from nearby_text, not hardcoded zeros.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "export_image_training_data.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("export_image_training_data", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not load module from {_SCRIPT_PATH}"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Pre-populate sys.path so the script's `sys.path.insert` succeeds for src imports
+    root = str(_SCRIPT_PATH.parent.parent)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_db(rows: list[dict]) -> MagicMock:
+    mock_db = MagicMock()
+    mock_db.query.return_value = rows
+    return mock_db
+
+
+def _base_sec_row(**overrides: Any) -> dict:
+    base: dict = {
+        "img_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "decision": "relevant",
+        "chart_type": "cohort_table",
+        "rejection_reason": None,
+        "filename": "chart1.png",
+        "width": 800,
+        "height": 600,
+        "nearby_text": "",
+        "classification": "chart",
+        "section_type": "MD&A",
+        "relevance_score": 0.5,
+        "accession_number": "0001234567-23-000001",
+        "company_name": "Acme Corp",
+        "image_url": "https://www.sec.gov/Archives/edgar/data/1/0001234567-23-000001/chart1.png",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# COHORT_KEYWORDS constant
+# ---------------------------------------------------------------------------
+
+
+def test_cohort_keywords_constant_exists() -> None:
+    mod = _load_module()
+    assert hasattr(mod, "COHORT_KEYWORDS"), "COHORT_KEYWORDS module-level constant missing"
+    assert isinstance(mod.COHORT_KEYWORDS, set)
+    assert len(mod.COHORT_KEYWORDS) > 0
+
+
+def test_cohort_keywords_contains_expected_terms() -> None:
+    mod = _load_module()
+    for term in ("cohort", "retention", "ltv", "cac", "arr", "mrr", "nrr", "vintage"):
+        assert term in mod.COHORT_KEYWORDS, f"'{term}' missing from COHORT_KEYWORDS"
+
+
+# ---------------------------------------------------------------------------
+# export_sec_rows: keyword_count and detected_keywords
+# ---------------------------------------------------------------------------
+
+
+def test_sec_rows_no_keywords_when_nearby_text_empty() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="", relevance_score=0.0)
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert len(result) == 1
+    assert result[0]["keyword_count"] == 0
+    assert result[0]["detected_keywords"] == ""
+
+
+def test_sec_rows_single_keyword_detected() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Here we show the cohort performance over time.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["keyword_count"] == 1
+    assert "cohort" in result[0]["detected_keywords"]
+
+
+def test_sec_rows_multiple_keywords_detected() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Retention rates and cohort LTV show strong CAC payback.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    # Expect retention, cohort, ltv, cac — at minimum > 1
+    assert result[0]["keyword_count"] >= 2
+    keywords = result[0]["detected_keywords"].split(",")
+    assert "retention" in keywords
+    assert "cohort" in keywords
+
+
+def test_sec_rows_detected_keywords_sorted() -> None:
+    """detected_keywords must be a deterministic sorted comma-separated string."""
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="MRR, ARR, NRR and retention are tracked monthly.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    kws = result[0]["detected_keywords"].split(",")
+    assert kws == sorted(kws), "detected_keywords must be sorted"
+
+
+def test_sec_rows_keyword_count_matches_detected_keywords_length() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Annual Recurring Revenue (ARR) and NRR cohort data.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    detected = [k for k in result[0]["detected_keywords"].split(",") if k]
+    assert result[0]["keyword_count"] == len(detected)
+
+
+def test_sec_rows_no_longer_hardcodes_zero() -> None:
+    """Regression guard: a row with keyword-rich nearby_text must NOT produce keyword_count=0."""
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Cohort retention improved; LTV/CAC ratio expanded.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["keyword_count"] != 0, (
+        "keyword_count must not be hardcoded to 0 when nearby_text contains keywords"
+    )
+    assert result[0]["detected_keywords"] != "", (
+        "detected_keywords must not be hardcoded to empty string when nearby_text contains keywords"
+    )
+
+
+# ---------------------------------------------------------------------------
+# export_sec_rows: cohort_keyword_nearby logic
+# ---------------------------------------------------------------------------
+
+
+def test_cohort_keyword_nearby_set_by_keyword_match() -> None:
+    """cohort_keyword_nearby should be 1 when keywords detected, regardless of score."""
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Retention cohort analysis.", relevance_score=0.0)
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["cohort_keyword_nearby"] == 1
+
+
+def test_cohort_keyword_nearby_fallback_to_relevance_score() -> None:
+    """cohort_keyword_nearby should still be 1 when no keywords but score >= 0.6."""
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="No relevant terms here.", relevance_score=0.75)
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["cohort_keyword_nearby"] == 1
+
+
+def test_cohort_keyword_nearby_zero_when_neither() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="Some random text.", relevance_score=0.2)
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["cohort_keyword_nearby"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_sec_rows_keyword_detection_case_insensitive() -> None:
+    mod = _load_module()
+    row = _base_sec_row(nearby_text="COHORT retention LTV analysis.")
+    result = mod.export_sec_rows(_make_mock_db([row]))
+    assert result[0]["keyword_count"] >= 1
+    # At least "cohort" should be detected via lowercasing
+    assert "cohort" in result[0]["detected_keywords"]
+
+
+# ---------------------------------------------------------------------------
+# Presentation path: ensure COHORT_KEYWORDS is now used (pres path unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_pres_export_uses_same_cohort_keywords_constant() -> None:
+    """Verify export_pres_rows still works and uses module-level COHORT_KEYWORDS."""
+    mod = _load_module()
+    # The presentation export reads from disk; just confirm the function is importable
+    # and that COHORT_KEYWORDS is not re-defined inline (we can't easily test the full
+    # pres path without fixture files, but we can inspect the constant is shared).
+    import inspect
+
+    src = inspect.getsource(mod.export_pres_rows)
+    # The old inline definition must not exist
+    assert "cohort_keywords = {" not in src, (
+        "export_pres_rows must not re-define cohort_keywords locally; use COHORT_KEYWORDS"
+    )


### PR DESCRIPTION
## Summary

- `export_sec_rows()` in `scripts/export_image_training_data.py` was hardcoding `keyword_count=0` and `detected_keywords=""` for every SEC training row
- The presentation export path already did real keyword scanning against an inline `cohort_keywords` set
- This silently zeroed out the highest-signal text feature for any ML model trained on SEC data (prerequisite blocker for B3 ML triage per the synthesis plan)

**Fix:** Promote the inline keyword set to a module-level `COHORT_KEYWORDS` constant. Use it in `export_sec_rows()` to scan `r["nearby_text"]`, emit real `keyword_count` and `detected_keywords`. Also refactored `export_pres_rows()` to reference the same constant (de-duplication only — logic unchanged). Added 13 unit tests covering the fixed behavior.

---

## Pre-implementation checklist (6-item gate)

1. **Assumption audit**: Verified `export_pres_rows` (line 210) defined `cohort_keywords` inline as a local set `{"cohort", "retention", "vintage", "ltv", "cac", "arr", "mrr", "nrr"}`. Verified `export_sec_rows` at lines 139-140 hardcoded `keyword_count=0`, `detected_keywords=""`. Both functions use `r.get("nearby_text") or ""`. All assumptions confirmed against current codebase.

2. **Scope check**: Single file change (`scripts/export_image_training_data.py`), SEC branch only. Presentation branch logic preserved identically (only de-duplicated to use shared constant). No extraction files, no config, no migrations touched.

3. **Rules compliance**: `scripts/` is in dev-implementer scope. `python3` used. No `config/metric_keywords.yaml` changes. No extraction-pipeline files modified. Tests added under `tests/unit/scripts/`.

4. **Risk assessment**: Minimal. Pure additive fix. The only behavior change is SEC rows now emit non-zero `keyword_count` / non-empty `detected_keywords` when `nearby_text` contains keywords. No DB writes, no schema changes, no shared imports affected. One minor semantic change to `cohort_keyword_nearby` for SEC rows: was `1 if relevance_score >= 0.6`; now `1 if keyword detected OR relevance_score >= 0.6` — strictly a superset, preserves backward compat.

5. **Minimal path**: Added `COHORT_KEYWORDS` module-level constant (4 lines). Added 3 lines to `export_sec_rows` (nearby_lower, detected list comp). Changed 3 fields in the SEC `out.append` dict. Removed 1 inline definition from `export_pres_rows`.

6. **Worktree confirmation**: Implemented in `agent-aea60ef8` worktree, branched to `fix/image-keyword-exporter-a1`. Not in primary tree.

---

## Before/after keyword_count distribution (SEC rows)

**Before**: every SEC row emitted `keyword_count=0`, `detected_keywords=""` unconditionally.

**After**: SEC rows where `nearby_text` contains any of `{cohort, retention, vintage, ltv, cac, arr, mrr, nrr}` now emit non-zero `keyword_count` and a sorted comma-separated `detected_keywords` string. Rows with no keyword matches in `nearby_text` remain `keyword_count=0` / `detected_keywords=""` (correct behavior). Distribution validated by 13 unit tests covering: empty text, single keyword, multiple keywords, sorted output, count/length invariant, case-insensitivity, cohort_keyword_nearby fallback to relevance_score.

---

## Confirmation: pres-path code not changed behaviorally

The presentation path (`export_pres_rows`) produces identical output to before. The only change is the removal of the inline `cohort_keywords = {...}` local variable, replaced by a reference to the new module-level `COHORT_KEYWORDS` constant with identical contents. `detected_keywords` in the pres path was already using `",".join(detected)` (unsorted) — that behavior is preserved unchanged.

---

## Test plan

- [x] 13 new unit tests in `tests/unit/scripts/test_export_image_training_data.py` — all passing
- [x] Full unit suite: 3652 passed, 11 skipped, 0 failures
- [x] Pre-commit hooks: all passed (ruff, format, secrets, extraction guard)
- [x] Pre-push hook (pytest unit tests): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)