### PR TITLE
feat(llm): vision provider abstraction — OpenAI + Gemini + Anthropic (Wave B2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "sentry-sdk>=1.0.0",
     "boto3>=1.34.0",
     "google-genai>=1.0.0",
-    "anthropic>=0.30.0",
+    "anthropic>=0.87.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     "datasets>=2.0.0",
     "sentry-sdk>=1.0.0",
     "boto3>=1.34.0",
+    "google-genai>=1.0.0",
+    "anthropic>=0.30.0",
 ]
 
 [project.optional-dependencies]
@@ -61,9 +63,6 @@ dev = [
     "types-PyYAML>=6.0",
     "pip-audit>=2.7.0",
     "pre-commit>=3.7.0",
-]
-annotation = [
-    "anthropic>=0.30.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,15 @@ scikit-learn>=1.4.0
 # OpenAI API - For metric extraction and quality scoring
 openai>=1.0.0
 
+# Google Gemini vision API - used via VisionProvider abstraction (Wave B2).
+# Imported as `from google import genai`. No Vertex/GCP project — uses
+# GOOGLE_API_KEY env var for auth.
+google-genai>=1.0.0
+
+# Anthropic Claude vision API - used via VisionProvider abstraction (Wave B2).
+# Pinned >=0.87.0 for CVE-2026-34450 and CVE-2026-34452 (fixed in 0.87.0).
+anthropic>=0.87.0
+
 # Token counting - For cost tracking and context management
 tiktoken>=0.5.0
 

--- a/scripts/check_docs_sync.py
+++ b/scripts/check_docs_sync.py
@@ -84,6 +84,7 @@ class DocsChecker:
             "dateutil": "boto3",  # python-dateutil ships transitively via boto3 → botocore
             "botocore": "boto3",  # botocore is a direct boto3 dependency
             "PIL": "pillow",  # Pillow package exposes the PIL module (case-sensitive import)
+            "google": "google_genai",  # google-genai SDK is imported as `from google import genai`
         }
 
         # Find all imports in src/

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -5,11 +5,11 @@ This module provides LLM API integration for metric extraction from SEC filings.
 Supports OpenAI (default), Gemini, and Anthropic vision providers via VISION_PROVIDER env var.
 """
 
-from .cache import CacheConfig, CachedResponse, LLMCache
-from .openai_client import OpenAIClient
-from .prompts import PromptTemplates
-from .providers import VisionProvider
-from .vision_client import VisionClient, VisionResponse
+from src.llm.cache import CacheConfig, CachedResponse, LLMCache
+from src.llm.openai_client import OpenAIClient
+from src.llm.prompts import PromptTemplates
+from src.llm.providers import VisionProvider
+from src.llm.vision_client import VisionClient, VisionResponse
 
 __all__ = [
     "CacheConfig",

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,12 +1,14 @@
 """
 LLM Integration Module
 
-This module provides OpenAI API integration for metric extraction from SEC filings.
+This module provides LLM API integration for metric extraction from SEC filings.
+Supports OpenAI (default), Gemini, and Anthropic vision providers via VISION_PROVIDER env var.
 """
 
 from .cache import CacheConfig, CachedResponse, LLMCache
 from .openai_client import OpenAIClient
 from .prompts import PromptTemplates
+from .providers import VisionProvider
 from .vision_client import VisionClient, VisionResponse
 
 __all__ = [
@@ -16,5 +18,6 @@ __all__ = [
     "OpenAIClient",
     "PromptTemplates",
     "VisionClient",
+    "VisionProvider",
     "VisionResponse",
 ]

--- a/src/llm/cache.py
+++ b/src/llm/cache.py
@@ -26,15 +26,10 @@ class CacheConfig:
     """Configuration for LLM response cache."""
 
     enabled: bool = field(
-        default_factory=lambda: os.environ.get("LLM_CACHE_ENABLED", "true").lower()
-        == "true"
+        default_factory=lambda: os.environ.get("LLM_CACHE_ENABLED", "true").lower() == "true"
     )
-    connection_string: str = field(
-        default_factory=lambda: os.environ.get("DATABASE_URL", "")
-    )
-    cache_version: str = field(
-        default_factory=lambda: os.environ.get("LLM_CACHE_VERSION", "v1")
-    )
+    connection_string: str = field(default_factory=lambda: os.environ.get("DATABASE_URL", ""))
+    cache_version: str = field(default_factory=lambda: os.environ.get("LLM_CACHE_VERSION", "v2"))
     max_age_days: int = 30
 
 

--- a/src/llm/providers/__init__.py
+++ b/src/llm/providers/__init__.py
@@ -1,0 +1,9 @@
+"""Vision provider adapters.
+
+Each adapter implements the VisionProvider interface defined in base.py.
+Provider selection is controlled by the VISION_PROVIDER environment variable.
+"""
+
+from .base import VisionProvider
+
+__all__ = ["VisionProvider"]

--- a/src/llm/providers/anthropic.py
+++ b/src/llm/providers/anthropic.py
@@ -1,0 +1,182 @@
+"""Anthropic vision provider adapter.
+
+Uses the ``anthropic`` SDK with ``ANTHROPIC_API_KEY`` environment variable
+authentication.
+
+Default model: ``claude-sonnet-4-6`` (matches the bake-off target in the plan).
+
+The ``VISION_MODEL_OCR`` / ``VISION_MODEL_CHART`` env vars override the model
+via the dispatcher in ``VisionClient``.
+
+Retry-eligible exceptions (``anthropic.RateLimitError``,
+``anthropic.APIConnectionError``, ``anthropic.APIStatusError`` with 5xx) are
+translated to provider-neutral shims so ``VisionClient``'s single retry loop
+handles all providers uniformly.
+
+``response_format={"type": "json_object"}`` is handled by appending a JSON
+instruction to the prompt (Anthropic does not have a native ``response_format``
+parameter equivalent to OpenAI's ``json_object`` mode).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import time
+
+from src.llm.vision_client import VisionResponse
+
+from .base import VisionProvider
+from .retry_shim import ProviderRateLimitError, ProviderServerError
+
+logger = logging.getLogger(__name__)
+
+# Pricing (as of 2025-Q1)
+# Claude Sonnet 4.6 / claude-sonnet-4-5: $3.00/1M input, $15.00/1M output
+# Claude Haiku 3.5: $0.80/1M input, $4.00/1M output
+_MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-sonnet-4-5": (3.00, 15.00),
+    "claude-3-5-sonnet-20241022": (3.00, 15.00),
+    "claude-3-5-haiku-20241022": (0.80, 4.00),
+    "claude-3-opus-20240229": (15.00, 75.00),
+    "claude-3-haiku-20240307": (0.25, 1.25),
+}
+_DEFAULT_PRICING = (3.00, 15.00)  # conservative fallback
+
+
+class AnthropicVisionProvider(VisionProvider):
+    """Vision provider backed by Anthropic Claude (anthropic SDK).
+
+    Authentication: set ``ANTHROPIC_API_KEY`` in the environment.
+    """
+
+    def __init__(self, model: str = "claude-sonnet-4-6") -> None:
+        """Initialize the Anthropic vision provider.
+
+        Args:
+            model: Anthropic model identifier. Defaults to
+                ``claude-sonnet-4-6`` which is the planned B5 bake-off target.
+        """
+        self.model = model
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY is not set; Anthropic calls will fail at runtime.")
+        # Lazy import: anthropic may be installed as optional dep
+        try:
+            import anthropic as anthropic_sdk  # type: ignore[import-untyped]
+
+            self._sdk = anthropic_sdk
+            self._client = anthropic_sdk.Anthropic(api_key=api_key or "MISSING")
+        except ImportError as exc:
+            raise ImportError(
+                "anthropic is required for the Anthropic provider. "
+                "Install it with: pip install anthropic"
+            ) from exc
+
+        pricing = _MODEL_PRICING.get(model, _DEFAULT_PRICING)
+        self._cost_in, self._cost_out = pricing
+
+    def call_api(
+        self,
+        image_bytes: bytes,
+        mime_type: str,
+        prompt: str,
+        *,
+        detail: str = "high",  # noqa: ARG002 — Anthropic does not expose detail level
+        max_tokens: int = 2000,
+        response_format: dict[str, str] | None = None,
+    ) -> VisionResponse:
+        """Call the Anthropic Messages API with an image payload.
+
+        ``detail`` is accepted for interface compatibility but has no effect
+        (Anthropic does not expose a per-request image-quality parameter).
+
+        ``response_format={"type": "json_object"}`` is handled by appending
+        a JSON instruction to the prompt, since the Anthropic API does not
+        have a native JSON mode parameter.
+        """
+        b64_data = base64.standard_b64encode(image_bytes).decode("utf-8")
+
+        effective_prompt = prompt
+        if response_format and response_format.get("type") == "json_object":
+            if "JSON" not in prompt:
+                effective_prompt = prompt + "\n\nReturn ONLY valid JSON."
+
+        # Validate mime_type for Anthropic (only JPEG, PNG, GIF, WebP supported)
+        supported_mime = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+        if mime_type not in supported_mime:
+            # Fall back to PNG if unrecognized
+            logger.warning(
+                "Anthropic does not support mime_type=%r; falling back to image/png",
+                mime_type,
+            )
+            mime_type = "image/png"
+
+        message_content = [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": mime_type,
+                    "data": b64_data,
+                },
+            },
+            {"type": "text", "text": effective_prompt},
+        ]
+
+        start_ms = int(time.time() * 1000)
+        try:
+            response = self._client.messages.create(
+                model=self.model,
+                max_tokens=max_tokens,
+                messages=[{"role": "user", "content": message_content}],
+            )
+        except Exception as exc:
+            _translate_anthropic_exception(exc, self._sdk)
+            raise  # unreachable; _translate raises
+        latency_ms = int(time.time() * 1000) - start_ms
+
+        content = ""
+        if response.content and len(response.content) > 0:
+            first_block = response.content[0]
+            if hasattr(first_block, "text"):
+                content = first_block.text or ""
+
+        usage = response.usage
+        prompt_tokens = getattr(usage, "input_tokens", 0) or 0
+        completion_tokens = getattr(usage, "output_tokens", 0) or 0
+
+        cost_usd = (prompt_tokens / 1_000_000) * self._cost_in + (
+            completion_tokens / 1_000_000
+        ) * self._cost_out
+
+        return VisionResponse(
+            content=content,
+            model=self.model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost_usd,
+            latency_ms=latency_ms,
+        )
+
+
+def _translate_anthropic_exception(exc: Exception, sdk: object) -> None:
+    """Convert anthropic SDK exceptions to provider-neutral shims.
+
+    Raises the appropriate shim exception so ``VisionClient``'s retry
+    loop handles it correctly.
+    """
+    try:
+        import anthropic as anthropic_sdk  # type: ignore[import-untyped]
+    except ImportError:
+        return
+
+    if isinstance(exc, anthropic_sdk.RateLimitError):
+        raise ProviderRateLimitError(str(exc)) from exc
+    if isinstance(exc, anthropic_sdk.APIConnectionError):
+        raise ProviderRateLimitError(str(exc)) from exc
+    if isinstance(exc, anthropic_sdk.APIStatusError):
+        if exc.status_code and 500 <= exc.status_code < 600:
+            raise ProviderServerError(str(exc)) from exc

--- a/src/llm/providers/base.py
+++ b/src/llm/providers/base.py
@@ -1,0 +1,57 @@
+"""Abstract base for vision provider adapters.
+
+Every provider adapter must implement ``call_api``, which performs the raw
+network call and returns a ``VisionResponse``. The retry + cache wrapping
+is handled once in ``VisionClient.analyze_image`` — adapters only deal with
+the network boundary.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from src.llm.vision_client import VisionResponse
+
+
+class VisionProvider(ABC):
+    """Abstract vision provider.
+
+    Adapters implement ``call_api`` which maps the common call contract to
+    the underlying SDK.  Retry logic and LLMCache integration live in
+    ``VisionClient``; providers are responsible only for the single
+    network call and cost accounting.
+    """
+
+    @abstractmethod
+    def call_api(
+        self,
+        image_bytes: bytes,
+        mime_type: str,
+        prompt: str,
+        *,
+        detail: str = "high",
+        max_tokens: int = 2000,
+        response_format: dict[str, str] | None = None,
+    ) -> VisionResponse:
+        """Perform a single (non-retried) vision API call.
+
+        Args:
+            image_bytes: Raw image bytes (already validated non-empty by caller).
+            mime_type: MIME type string, e.g. ``"image/png"``.
+            prompt: User prompt (already validated non-empty by caller).
+            detail: Provider-specific detail hint (``"high"`` / ``"low"``).
+            max_tokens: Maximum response tokens.
+            response_format: Optional structured-output hint.  Providers that
+                do not support this parameter should ignore it gracefully.
+
+        Returns:
+            ``VisionResponse`` with ``content``, ``model``, ``prompt_tokens``,
+            ``completion_tokens``, ``cost_usd``, and ``latency_ms`` populated.
+
+        Raises:
+            Any provider-specific exception on unrecoverable error.  Retryable
+            errors (rate-limit, transient 5xx, connection) should bubble up as
+            their native exception types so ``VisionClient``'s retry logic can
+            handle them uniformly.
+        """
+        ...

--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -1,0 +1,194 @@
+"""Gemini vision provider adapter.
+
+Uses the ``google-genai`` SDK (``google.genai``) with ``GOOGLE_API_KEY``
+environment variable authentication.  No GCP project or Vertex AI dependency.
+
+Default models:
+  OCR  : ``gemini-2.0-flash`` (fast, cheap)
+  Chart: ``gemini-2.5-pro-preview-05-06`` (high-quality reasoning)
+
+The ``VISION_MODEL_OCR`` / ``VISION_MODEL_CHART`` env vars override these
+via the dispatcher in ``VisionClient``.  This adapter is model-agnostic;
+pass the desired model string to ``__init__``.
+
+Retry-eligible exceptions re-raised as-is so ``VisionClient``'s retry loop
+can catch them.  The ``google.genai`` SDK raises:
+  - ``google.api_core.exceptions.ResourceExhausted`` — maps to rate-limit
+  - ``google.api_core.exceptions.ServiceUnavailable`` — maps to 5xx
+  - ``google.api_core.exceptions.GoogleAPICallError`` — general API error
+
+Since ``VisionClient`` retries on ``RateLimitError`` / ``APIConnectionError``
+/ ``APIError``, and those are OpenAI types, the Gemini adapter converts the
+Gemini exceptions to a parallel hierarchy using the shim at the bottom of
+this module.  This keeps retry logic in one place.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import time
+from typing import Any
+
+from src.llm.vision_client import VisionResponse
+
+from .base import VisionProvider
+from .retry_shim import ProviderRateLimitError, ProviderServerError
+
+logger = logging.getLogger(__name__)
+
+# Pricing (as of 2025-Q1 preview pricing — update when GA pricing is announced)
+# Gemini 2.5 Pro: $1.25/1M input (<=200K tokens), $10.00/1M output
+# Gemini 2.0 Flash: $0.10/1M input, $0.40/1M output
+_MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "gemini-2.5-pro-preview-05-06": (1.25, 10.00),
+    "gemini-2.5-pro": (1.25, 10.00),
+    "gemini-2.0-flash": (0.10, 0.40),
+    "gemini-2.0-flash-lite": (0.075, 0.30),
+    "gemini-1.5-pro": (1.25, 5.00),
+    "gemini-1.5-flash": (0.075, 0.30),
+}
+_DEFAULT_PRICING = (1.25, 10.00)  # conservative fallback
+
+
+class GeminiVisionProvider(VisionProvider):
+    """Vision provider backed by Google Gemini (google-genai SDK).
+
+    Authentication: set ``GOOGLE_API_KEY`` in the environment.
+    No GCP project / Application Default Credentials required.
+    """
+
+    def __init__(self, model: str = "gemini-2.0-flash") -> None:
+        """Initialize the Gemini vision provider.
+
+        Args:
+            model: Gemini model identifier. Defaults to ``gemini-2.0-flash``
+                for cost-effective OCR work.
+        """
+        self.model = model
+        api_key = os.environ.get("GOOGLE_API_KEY", "")
+        if not api_key:
+            logger.warning("GOOGLE_API_KEY is not set; Gemini calls will fail at runtime.")
+        # Lazy import: google-genai is an optional dependency
+        try:
+            import google.genai as genai  # type: ignore[import-untyped]
+
+            self._genai = genai
+            self._client = genai.Client(api_key=api_key or "MISSING")
+        except ImportError as exc:
+            raise ImportError(
+                "google-genai is required for the Gemini provider. "
+                "Install it with: pip install google-genai"
+            ) from exc
+
+        pricing = _MODEL_PRICING.get(model, _DEFAULT_PRICING)
+        self._cost_in, self._cost_out = pricing
+
+    def call_api(
+        self,
+        image_bytes: bytes,
+        mime_type: str,
+        prompt: str,
+        *,
+        detail: str = "high",  # noqa: ARG002 — not used by Gemini
+        max_tokens: int = 2000,
+        response_format: dict[str, str] | None = None,
+    ) -> VisionResponse:
+        """Call the Gemini GenerateContent API with an image payload.
+
+        ``detail`` is accepted for interface compatibility but has no effect
+        (Gemini does not expose a per-request image-quality parameter).
+
+        ``response_format={"type": "json_object"}`` is handled by appending
+        ``"Return ONLY valid JSON."`` to the prompt when the caller requests
+        JSON mode, matching the OpenAI behavior at the prompt level.
+        """
+        # Build the image Part
+        b64_data = base64.standard_b64encode(image_bytes).decode("utf-8")
+
+        effective_prompt = prompt
+        if response_format and response_format.get("type") == "json_object":
+            if "JSON" not in prompt:
+                effective_prompt = prompt + "\n\nReturn ONLY valid JSON."
+
+        try:
+            import google.genai.types as genai_types  # type: ignore[import-untyped]
+
+            image_part = genai_types.Part.from_bytes(
+                data=base64.standard_b64decode(b64_data),
+                mime_type=mime_type,
+            )
+            contents = [image_part, effective_prompt]
+
+            generation_config = genai_types.GenerateContentConfig(
+                max_output_tokens=max_tokens,
+                temperature=0.0,
+            )
+        except ImportError:
+            # Older google-genai API (pre-1.0) uses dict-based parts
+            contents = _build_legacy_contents(b64_data, mime_type, effective_prompt)
+            generation_config = {"maxOutputTokens": max_tokens, "temperature": 0.0}
+
+        start_ms = int(time.time() * 1000)
+        try:
+            response = self._client.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=generation_config,
+            )
+        except Exception as exc:
+            _translate_gemini_exception(exc)
+            raise  # unreachable; _translate raises
+        latency_ms = int(time.time() * 1000) - start_ms
+
+        content = ""
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        if response.text:
+            content = response.text
+        if response.usage_metadata:
+            prompt_tokens = getattr(response.usage_metadata, "prompt_token_count", 0) or 0
+            completion_tokens = getattr(response.usage_metadata, "candidates_token_count", 0) or 0
+
+        cost_usd = (prompt_tokens / 1_000_000) * self._cost_in + (
+            completion_tokens / 1_000_000
+        ) * self._cost_out
+
+        return VisionResponse(
+            content=content,
+            model=self.model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost_usd,
+            latency_ms=latency_ms,
+        )
+
+
+def _build_legacy_contents(b64_data: str, mime_type: str, prompt: str) -> list[Any]:
+    """Build contents list for older google-genai SDK versions."""
+    return [
+        {
+            "parts": [
+                {"inline_data": {"mime_type": mime_type, "data": b64_data}},
+                {"text": prompt},
+            ]
+        }
+    ]
+
+
+def _translate_gemini_exception(exc: Exception) -> None:
+    """Convert google-api-core exceptions to provider-neutral shims.
+
+    Raises the appropriate shim exception so ``VisionClient``'s retry
+    loop handles it correctly.
+    """
+    exc_type_name = type(exc).__name__
+    exc_module = getattr(type(exc), "__module__", "")
+
+    if "google" in exc_module:
+        if exc_type_name == "ResourceExhausted":
+            raise ProviderRateLimitError(str(exc)) from exc
+        if exc_type_name in ("ServiceUnavailable", "InternalServerError", "DeadlineExceeded"):
+            raise ProviderServerError(str(exc)) from exc

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -1,0 +1,112 @@
+"""OpenAI vision provider adapter.
+
+Wraps the ``openai`` SDK.  This is the default provider (``VISION_PROVIDER=openai``)
+and is behaviorally identical to the original ``VisionClient`` implementation.
+
+Retry logic (RateLimitError, APIConnectionError, 5xx APIError) is handled by
+``VisionClient.analyze_image``; this adapter only performs a single call.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+
+from openai import OpenAI
+from openai.types.chat import ChatCompletionUserMessageParam
+
+from src.llm.vision_client import VisionResponse
+
+from .base import VisionProvider
+
+
+class OpenAIVisionProvider(VisionProvider):
+    """Vision provider backed by OpenAI's Chat Completions API.
+
+    Pricing defaults match GPT-4o as of 2025-01.  Pass a different
+    ``model`` and cost constants when using other OpenAI vision models.
+    """
+
+    # GPT-4o pricing per 1M tokens (as of 2025-01)
+    COST_PER_1M_INPUT_TOKENS: float = 2.50
+    COST_PER_1M_OUTPUT_TOKENS: float = 10.00
+
+    def __init__(
+        self,
+        model: str = "gpt-4o",
+        cost_per_1m_input: float | None = None,
+        cost_per_1m_output: float | None = None,
+    ) -> None:
+        """Initialize the OpenAI vision provider.
+
+        Args:
+            model: OpenAI model identifier.
+            cost_per_1m_input: Override input token cost ($/1M). Defaults to
+                ``COST_PER_1M_INPUT_TOKENS``.
+            cost_per_1m_output: Override output token cost ($/1M). Defaults to
+                ``COST_PER_1M_OUTPUT_TOKENS``.
+        """
+        self.model = model
+        self._cost_in = (
+            cost_per_1m_input if cost_per_1m_input is not None else self.COST_PER_1M_INPUT_TOKENS
+        )
+        self._cost_out = (
+            cost_per_1m_output if cost_per_1m_output is not None else self.COST_PER_1M_OUTPUT_TOKENS
+        )
+        self._client = OpenAI()  # uses OPENAI_API_KEY from env
+
+    def call_api(
+        self,
+        image_bytes: bytes,
+        mime_type: str,
+        prompt: str,
+        *,
+        detail: str = "high",
+        max_tokens: int = 2000,
+        response_format: dict[str, str] | None = None,
+    ) -> VisionResponse:
+        """Call the OpenAI Chat Completions API with an image payload."""
+        b64_image = base64.standard_b64encode(image_bytes).decode("utf-8")
+
+        user_message: ChatCompletionUserMessageParam = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:{mime_type};base64,{b64_image}",
+                        "detail": detail,  # type: ignore[typeddict-item]
+                    },
+                },
+            ],
+        }
+
+        create_kwargs: dict = {
+            "model": self.model,
+            "messages": [user_message],
+            "max_tokens": max_tokens,
+        }
+        if response_format is not None:
+            create_kwargs["response_format"] = response_format
+
+        start_ms = int(time.time() * 1000)
+        response = self._client.chat.completions.create(**create_kwargs)
+        latency_ms = int(time.time() * 1000) - start_ms
+
+        usage = response.usage
+        prompt_tokens = usage.prompt_tokens if usage else 0
+        completion_tokens = usage.completion_tokens if usage else 0
+
+        cost_usd = (prompt_tokens / 1_000_000) * self._cost_in + (
+            completion_tokens / 1_000_000
+        ) * self._cost_out
+
+        return VisionResponse(
+            content=response.choices[0].message.content or "",
+            model=response.model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost_usd,
+            latency_ms=latency_ms,
+        )

--- a/src/llm/providers/retry_shim.py
+++ b/src/llm/providers/retry_shim.py
@@ -1,0 +1,28 @@
+"""Provider-neutral exception shims for the retry layer in VisionClient.
+
+VisionClient's retry loop was originally written against OpenAI exception
+types (``RateLimitError``, ``APIConnectionError``, ``APIError``).  Rather
+than adding provider-specific exception handling to the core retry loop,
+non-OpenAI adapters translate their SDK exceptions into these lightweight
+shims at the adapter boundary.
+
+``VisionClient`` catches ``ProviderRateLimitError``, ``ProviderServerError``,
+and ``ProviderConnectionError`` in addition to the original OpenAI types.
+"""
+
+
+class ProviderRateLimitError(Exception):
+    """Rate limit exceeded — should be retried with exponential backoff."""
+
+
+class ProviderServerError(Exception):
+    """Transient 5xx server error — should be retried with exponential backoff."""
+
+    # Mirror the OpenAI APIError interface so retry code can read status_code
+    def __init__(self, message: str, status_code: int = 503) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ProviderConnectionError(Exception):
+    """Network connection error — should be retried with exponential backoff."""

--- a/src/llm/vision_client.py
+++ b/src/llm/vision_client.py
@@ -1,37 +1,50 @@
-"""LLM Vision API client for chart image analysis.
+"""LLM Vision API client — provider-agnostic dispatcher.
 
-This module provides a client for the OpenAI GPT-4o Vision API, designed
-specifically for extracting structured data from chart images in SEC filings.
+``VisionClient`` is the single public entry point for all vision calls.
+It handles:
+  - Input validation
+  - LLMCache integration (lookup before call, write after)
+  - Retry + exponential backoff (RateLimitError, connection errors, 5xx)
+  - Provider dispatch (OpenAI by default; Gemini / Anthropic via env var)
 
-Design: OpenAI-only for now. Can be extended to support Claude Vision
-in the future via subclassing or protocol pattern.
+Provider selection is controlled by:
+  ``VISION_PROVIDER``      — ``openai`` (default) | ``gemini`` | ``anthropic``
+  ``VISION_MODEL_OCR``     — override per-provider default model for OCR calls
+  ``VISION_MODEL_CHART``   — override per-provider default model for chart calls
+  ``VISION_ROUTING_MODE``  — ``legacy`` (default) | ``two_stage`` (Wave B4)
 
-Future Improvements:
-    1. Timing precision: Consider using time.perf_counter() instead of time.time()
-       for latency_ms measurement. time.perf_counter() provides monotonic,
-       high-resolution timing better suited for measuring elapsed time.
+Default behavior (all env vars unset) is **identical** to the pre-refactor
+implementation — the OpenAI adapter executes the same code path.
 
-    2. Pipeline integration: This client is standalone. To integrate with the
-       extraction pipeline, orchestrate as:
-       - CohortChartDetector.detect_charts_in_filing() -> list of image candidates
-       - SECClient.fetch_image() -> download each image
-       - ChartValueExtractor.extract() -> extract values from each image
-       See VIS-2a for planned caching to avoid repeated SEC downloads.
+Design notes:
+  1. Timing: uses ``time.time()`` for consistency with the original (see
+     docstring in the original for the perf_counter improvement note).
+  2. Prompts are unchanged — adapters receive exactly the prompt string
+     that callers pass.  Any prompt modifications live in the adapters
+     (e.g. appending JSON mode hints for Gemini/Anthropic).
+  3. Cache key includes ``model`` as a top-level field via ``LLMCache._compute_key``.
+     ``LLM_CACHE_VERSION`` is bumped to ``v2`` in this PR to prevent old GPT-4o
+     cached responses from appearing as hits under a new provider default.
 """
 
 from __future__ import annotations
 
-import base64
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass
 
-from openai import APIConnectionError, APIError, OpenAI, RateLimitError
+from openai import APIConnectionError, APIError, RateLimitError
 
 from src.llm.cache import CacheConfig, LLMCache
+from src.llm.providers.retry_shim import (
+    ProviderConnectionError,
+    ProviderRateLimitError,
+    ProviderServerError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +85,7 @@ def detect_mime_type(image_bytes: bytes) -> str:
     ):
         return "image/webp"
 
-    # Default to PNG for unknown formats (OpenAI will reject if invalid)
+    # Default to PNG for unknown formats
     return "image/png"
 
 
@@ -144,25 +157,90 @@ Do not include any commentary outside the JSON."""
 
 _VALID_CHART_HINTS = frozenset({"bar", "line", "pie", "area", "stacked_bar", "scatter", "none"})
 
+# Per-provider default models
+_PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
+    "openai": {"ocr": "gpt-4o", "chart": "gpt-4o"},
+    "gemini": {"ocr": "gemini-2.0-flash", "chart": "gemini-2.5-pro-preview-05-06"},
+    "anthropic": {"ocr": "claude-sonnet-4-6", "chart": "claude-sonnet-4-6"},
+}
+
+
+def _get_provider_and_model(
+    model: str | None,
+) -> tuple[str, str]:
+    """Resolve provider name and model string from env vars + argument.
+
+    Priority (highest to lowest):
+      1. ``model`` argument passed directly to ``VisionClient.__init__``
+         (when non-None, uses ``openai`` provider regardless of VISION_PROVIDER)
+      2. ``VISION_PROVIDER`` env var + ``VISION_MODEL_OCR`` / ``VISION_MODEL_CHART``
+      3. Provider defaults from ``_PROVIDER_DEFAULT_MODELS``
+
+    Returns:
+        (provider_name, model_string)
+    """
+    provider = os.environ.get("VISION_PROVIDER", "openai").lower().strip()
+    if provider not in _PROVIDER_DEFAULT_MODELS:
+        logger.warning("Unknown VISION_PROVIDER=%r; falling back to 'openai'", provider)
+        provider = "openai"
+
+    if model is not None:
+        # Explicit model passed → force openai provider (back-compat with
+        # call sites that do VisionClient(model="gpt-4o-mini"))
+        return "openai", model
+
+    # Use VISION_MODEL_OCR as the default model for the client.  Callers that
+    # need chart-specific models will be handled in Wave B4.
+    env_model = os.environ.get("VISION_MODEL_OCR", "").strip()
+    if env_model:
+        return provider, env_model
+
+    return provider, _PROVIDER_DEFAULT_MODELS[provider]["ocr"]
+
+
+def _build_provider(provider_name: str, model: str) -> object:
+    """Instantiate the appropriate provider adapter.
+
+    Returns an instance of ``VisionProvider`` for the given provider name.
+    """
+    if provider_name == "openai":
+        from src.llm.providers.openai import OpenAIVisionProvider
+
+        return OpenAIVisionProvider(model=model)
+    elif provider_name == "gemini":
+        from src.llm.providers.gemini import GeminiVisionProvider
+
+        return GeminiVisionProvider(model=model)
+    elif provider_name == "anthropic":
+        from src.llm.providers.anthropic import AnthropicVisionProvider
+
+        return AnthropicVisionProvider(model=model)
+    else:
+        raise ValueError(f"Unknown provider: {provider_name!r}")
+
 
 class VisionClient:
-    """Client for OpenAI GPT-4o Vision API.
+    """Provider-agnostic vision client.
 
-    Provides a simple interface for sending images to GPT-4o Vision
-    and receiving structured responses. Includes cost tracking,
-    MIME type detection, and retry logic with exponential backoff.
+    Routes image analysis calls to the configured provider (default: OpenAI
+    GPT-4o).  Provider is selected via ``VISION_PROVIDER`` env var.  When
+    ``VISION_PROVIDER`` is unset or ``"openai"``, behavior is **identical** to
+    the pre-refactor implementation.
 
-    Example:
+    Public interface is unchanged from the original:
         client = VisionClient()
         response = client.analyze_image(
             image_bytes=open("chart.jpg", "rb").read(),
             prompt="Extract data from this chart...",
         )
         print(response.content)
+
+    Cache, retry, and cost-tracking semantics are preserved across all
+    providers.
     """
 
-    # GPT-4o pricing per 1M tokens (as of 2025-01)
-    # Source: https://openai.com/pricing
+    # GPT-4o pricing per 1M tokens (as of 2025-01) — kept as class attrs for
+    # test back-compat (tests reference VisionClient.COST_PER_1M_INPUT_TOKENS).
     COST_PER_1M_INPUT_TOKENS: float = 2.50  # $2.50/1M input
     COST_PER_1M_OUTPUT_TOKENS: float = 10.00  # $10.00/1M output
 
@@ -170,16 +248,23 @@ class VisionClient:
     DEFAULT_MAX_RETRIES: int = 3
     BASE_BACKOFF_SECONDS: float = 1.0
 
-    def __init__(self, model: str = "gpt-4o", cache_config: CacheConfig | None = None) -> None:
+    def __init__(self, model: str | None = None, cache_config: CacheConfig | None = None) -> None:
         """Initialize VisionClient.
 
         Args:
-            model: OpenAI model to use (default: gpt-4o)
-            cache_config: Optional cache configuration. If None, uses defaults from
-                environment. Cache is disabled automatically when DATABASE_URL is unset.
+            model: Optional model override. When set, forces the OpenAI
+                provider with the specified model (back-compat). When None,
+                provider and model are resolved from env vars.
+            cache_config: Optional cache configuration. If None, uses defaults
+                from environment. Cache is disabled automatically when
+                DATABASE_URL is unset.
         """
-        self.model = model
-        self._client = OpenAI()  # Uses OPENAI_API_KEY from env
+        # Accept model="gpt-4o" for back-compat (original signature)
+        _model_arg: str | None = model if model is not None else None
+
+        provider_name, resolved_model = _get_provider_and_model(_model_arg)
+        self.model = resolved_model
+        self._provider = _build_provider(provider_name, resolved_model)
         self._cache = LLMCache(cache_config)
 
     def analyze_image(
@@ -195,21 +280,23 @@ class VisionClient:
         """Send image to Vision LLM for analysis.
 
         Args:
-            image_bytes: Raw image bytes (JPEG, PNG, or GIF)
+            image_bytes: Raw image bytes (JPEG, PNG, GIF, or WebP)
             prompt: Text prompt describing what to extract
             detail: Image detail level ("high" for accuracy, "low" for speed/cost)
             max_tokens: Maximum response tokens
             max_retries: Maximum retry attempts (default: 3)
-            response_format: Optional OpenAI response_format, e.g.
+            response_format: Optional response_format, e.g.
                 ``{"type": "json_object"}`` to force valid JSON output. Requires
-                the word "JSON" to appear in the prompt. Included in the cache key.
+                the word "JSON" to appear in the prompt (OpenAI requirement;
+                other providers use a prompt injection instead). Included in
+                the cache key.
 
         Returns:
             VisionResponse with content and metadata
 
         Raises:
             ValueError: On invalid inputs (empty image or prompt)
-            openai.APIError: On API failures (after retries exhausted)
+            Exception: Provider-specific API error after retries exhausted
         """
         # Input validation - fail fast before API call
         if not image_bytes:
@@ -221,18 +308,17 @@ class VisionClient:
             max_retries = self.DEFAULT_MAX_RETRIES
 
         # Compute SHA-256 of image bytes once; used as part of the cache key
-        # so that different images with identical prompts produce distinct keys.
         image_sha256 = hashlib.sha256(image_bytes).hexdigest()
 
-        # Serialize response_format for cache key (None and json_object must produce distinct keys)
+        # Serialize response_format for cache key
         response_format_key = response_format.get("type", "none") if response_format else "none"
 
-        # Cache lookup — returns immediately with zero cost if entry exists
+        # Cache lookup
         cached = self._cache.get(
             model=self.model,
             system_message="",
             prompt=prompt,
-            temperature=0.0,  # placeholder for key stability; not passed to API
+            temperature=0.0,
             max_tokens=max_tokens,
             image_sha256=image_sha256,
             detail=detail,
@@ -248,84 +334,41 @@ class VisionClient:
                 latency_ms=0,
             )
 
-        # Encode image as base64
-        b64_image = base64.standard_b64encode(image_bytes).decode("utf-8")
-
-        # Detect MIME type from magic bytes
+        # Detect MIME type from magic bytes (done here, not in adapter,
+        # so it's part of the common path and available for logging)
         mime_type = detect_mime_type(image_bytes)
-
-        # Build message content for Vision API
-        # Type assertion needed for OpenAI SDK's strict typing
-        from openai.types.chat import ChatCompletionUserMessageParam
-
-        user_message: ChatCompletionUserMessageParam = {
-            "role": "user",
-            "content": [
-                {"type": "text", "text": prompt},
-                {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{mime_type};base64,{b64_image}",
-                        "detail": detail,  # type: ignore[typeddict-item]
-                    },
-                },
-            ],
-        }
 
         # Retry loop with exponential backoff
         last_exception: Exception | None = None
         for attempt in range(max_retries + 1):
             try:
-                start_ms = int(time.time() * 1000)
+                response = self._provider.call_api(  # type: ignore[attr-defined]
+                    image_bytes=image_bytes,
+                    mime_type=mime_type,
+                    prompt=prompt,
+                    detail=detail,
+                    max_tokens=max_tokens,
+                    response_format=response_format,
+                )
 
-                create_kwargs: dict = {
-                    "model": self.model,
-                    "messages": [user_message],
-                    "max_tokens": max_tokens,
-                }
-                if response_format is not None:
-                    create_kwargs["response_format"] = response_format
-
-                response = self._client.chat.completions.create(**create_kwargs)
-
-                latency_ms = int(time.time() * 1000) - start_ms
-
-                # Extract usage stats
-                usage = response.usage
-                prompt_tokens = usage.prompt_tokens if usage else 0
-                completion_tokens = usage.completion_tokens if usage else 0
-
-                # Calculate cost (per 1M tokens)
-                cost_usd = (prompt_tokens / 1_000_000) * self.COST_PER_1M_INPUT_TOKENS + (
-                    completion_tokens / 1_000_000
-                ) * self.COST_PER_1M_OUTPUT_TOKENS
-
-                # Store result in cache for future calls on same image/prompt
+                # Store result in cache
                 self._cache.set(
                     model=self.model,
                     system_message="",
                     prompt=prompt,
-                    temperature=0.0,  # placeholder for key stability; not passed to API
+                    temperature=0.0,
                     max_tokens=max_tokens,
-                    response_content=response.choices[0].message.content or "",
-                    input_tokens=prompt_tokens,
-                    output_tokens=completion_tokens,
+                    response_content=response.content,
+                    input_tokens=response.prompt_tokens,
+                    output_tokens=response.completion_tokens,
                     image_sha256=image_sha256,
                     detail=detail,
                     response_format=response_format_key,
                 )
 
-                return VisionResponse(
-                    content=response.choices[0].message.content or "",
-                    model=response.model,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    cost_usd=cost_usd,
-                    latency_ms=latency_ms,
-                )
+                return response
 
-            except RateLimitError as e:
-                # Rate limit - always retry with backoff
+            except (RateLimitError, ProviderRateLimitError) as e:
                 last_exception = e
                 if attempt < max_retries:
                     backoff = self.BASE_BACKOFF_SECONDS * (2**attempt)
@@ -337,8 +380,7 @@ class VisionClient:
                 else:
                     logger.error(f"Rate limit exceeded after {max_retries} retries")
 
-            except APIConnectionError as e:
-                # Connection error - retry with backoff
+            except (APIConnectionError, ProviderConnectionError) as e:
                 last_exception = e
                 if attempt < max_retries:
                     backoff = self.BASE_BACKOFF_SECONDS * (2**attempt)
@@ -350,8 +392,22 @@ class VisionClient:
                 else:
                     logger.error(f"Connection failed after {max_retries} retries: {e}")
 
+            except ProviderServerError as e:
+                # Provider-neutral 5xx shim
+                last_exception = e
+                if attempt < max_retries:
+                    backoff = self.BASE_BACKOFF_SECONDS * (2**attempt)
+                    logger.warning(
+                        f"Server error {e.status_code}, retrying in {backoff}s "
+                        f"(attempt {attempt + 1}/{max_retries + 1})"
+                    )
+                    time.sleep(backoff)
+                else:
+                    logger.error(f"Server error after {max_retries} retries: {e}")
+                    raise
+
             except APIError as e:
-                # Server error (5xx) - retry; client error (4xx) - don't retry
+                # OpenAI server error (5xx) - retry; client error (4xx) - don't retry
                 last_exception = e
                 status_code = getattr(e, "status_code", None)
                 if status_code and 500 <= status_code < 600 and attempt < max_retries:
@@ -362,7 +418,6 @@ class VisionClient:
                     )
                     time.sleep(backoff)
                 else:
-                    # Client error or max retries exceeded - raise immediately
                     logger.error(f"API error (status={status_code}): {e}")
                     raise
 
@@ -395,8 +450,8 @@ class VisionClient:
 
         Notes:
             - Uses ``response_format={"type": "json_object"}`` to force valid
-              JSON out of gpt-4o. ``_parse_text_ocr_json`` repairs the rare
-              truncated response (mirrors ``OCRExtractionStage._parse_chart_json``).
+              JSON where the provider supports it; other providers receive a
+              prompt injection.
             - Cache key includes the prompt, so this call never collides with
               cached chart/table responses.
         """
@@ -428,8 +483,6 @@ class VisionClient:
         chart_hint_raw = str(parsed.get("chart_hint", "none") or "none").lower()
         chart_hint = chart_hint_raw if chart_hint_raw in _VALID_CHART_HINTS else "none"
 
-        # If the model said no chart, normalize the hint so callers don't see
-        # stale hints from a flipped-flag response.
         if not contains_chart:
             chart_hint = "none"
 

--- a/tests/unit/llm/test_cache.py
+++ b/tests/unit/llm/test_cache.py
@@ -21,7 +21,10 @@ class TestCacheConfig:
 
             assert config.enabled is True
             assert config.connection_string == ""
-            assert config.cache_version == "v1"
+            # Bumped to v2 in Wave B2 (provider abstraction) to invalidate
+            # single-provider GPT-4o cached responses under the new multi-
+            # provider dispatch.
+            assert config.cache_version == "v2"
             assert config.max_age_days == 30
 
     def test_config_from_environment(self):
@@ -29,13 +32,13 @@ class TestCacheConfig:
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv("LLM_CACHE_ENABLED", "false")
             mp.setenv("DATABASE_URL", "postgresql://user:pass@localhost/testdb")
-            mp.setenv("LLM_CACHE_VERSION", "v2")
+            mp.setenv("LLM_CACHE_VERSION", "v3")
 
             config = CacheConfig()
 
             assert config.enabled is False
             assert config.connection_string == "postgresql://user:pass@localhost/testdb"
-            assert config.cache_version == "v2"
+            assert config.cache_version == "v3"
 
     def test_config_explicit_values(self):
         """Test explicit configuration values override defaults."""
@@ -167,17 +170,12 @@ class TestLLMCache:
         )
         assert success is True
         # Verify an INSERT ... ON CONFLICT call was made
-        insert_calls = [
-            call for call in mock_conn.execute.call_args_list
-            if "INSERT" in str(call)
-        ]
+        insert_calls = [call for call in mock_conn.execute.call_args_list if "INSERT" in str(call)]
         assert len(insert_calls) >= 1
 
     def test_get_hit_returns_cached_response(self, cache, mock_conn):
         """get() returns CachedResponse when the DB row is found."""
-        mock_conn.execute.return_value = MagicMock(
-            fetchone=MagicMock(return_value=("4", 15, 1))
-        )
+        mock_conn.execute.return_value = MagicMock(fetchone=MagicMock(return_value=("4", 15, 1)))
         result = cache.get(
             model="gpt-4o-mini",
             system_message="You are helpful",
@@ -193,9 +191,7 @@ class TestLLMCache:
 
     def test_get_miss_returns_none(self, cache, mock_conn):
         """get() returns None when the DB row is not found."""
-        mock_conn.execute.return_value = MagicMock(
-            fetchone=MagicMock(return_value=None)
-        )
+        mock_conn.execute.return_value = MagicMock(fetchone=MagicMock(return_value=None))
         result = cache.get(
             model="gpt-4o-mini",
             system_message="",
@@ -225,10 +221,7 @@ class TestLLMCache:
         mock_conn.execute.return_value = mock_cursor
         deleted = cache.cleanup_expired()
         assert deleted == 2
-        delete_calls = [
-            call for call in mock_conn.execute.call_args_list
-            if "DELETE" in str(call)
-        ]
+        delete_calls = [call for call in mock_conn.execute.call_args_list if "DELETE" in str(call)]
         assert len(delete_calls) >= 1
 
     def test_session_hit_miss_counters(self, cache, mock_conn):
@@ -240,9 +233,7 @@ class TestLLMCache:
         assert cache._hits == 0
 
         # Hit
-        mock_conn.execute.return_value = MagicMock(
-            fetchone=MagicMock(return_value=("resp", 5, 3))
-        )
+        mock_conn.execute.return_value = MagicMock(fetchone=MagicMock(return_value=("resp", 5, 3)))
         cache.get(model="m", system_message="", prompt="p", temperature=0.0, max_tokens=10)
         assert cache._hits == 1
 

--- a/tests/unit/llm/test_vision_client.py
+++ b/tests/unit/llm/test_vision_client.py
@@ -205,19 +205,19 @@ class TestVisionClientCostCalculation:
 class TestVisionClientInit:
     """Test suite for VisionClient initialization."""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_default_model(self, mock_openai):
         """Test that default model is gpt-4o."""
         client = VisionClient()
         assert client.model == "gpt-4o"
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_custom_model(self, mock_openai):
         """Test initialization with custom model."""
         client = VisionClient(model="gpt-4o-mini")
         assert client.model == "gpt-4o-mini"
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_creates_openai_client(self, mock_openai):
         """Test that OpenAI client is created on init."""
         VisionClient()
@@ -227,7 +227,7 @@ class TestVisionClientInit:
 class TestVisionClientAnalyzeImage:
     """Test suite for analyze_image method."""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_success(self, mock_openai):
         """Test successful image analysis."""
         # Set up mock response
@@ -262,7 +262,7 @@ class TestVisionClientAnalyzeImage:
         assert result.prompt_tokens == 1000
         assert result.completion_tokens == 500
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_uses_correct_mime_type(self, mock_openai):
         """Test that correct MIME type is detected and used."""
         mock_usage = MagicMock()
@@ -296,7 +296,7 @@ class TestVisionClientAnalyzeImage:
         image_content = messages[0]["content"][1]["image_url"]["url"]
         assert "data:image/png;base64," in image_content
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_detail_parameter(self, mock_openai):
         """Test that detail parameter is passed correctly."""
         mock_usage = MagicMock()
@@ -331,7 +331,7 @@ class TestVisionClientAnalyzeImage:
         image_content = messages[0]["content"][1]["image_url"]
         assert image_content["detail"] == "low"
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_max_tokens_parameter(self, mock_openai):
         """Test that max_tokens parameter is passed correctly."""
         mock_usage = MagicMock()
@@ -364,7 +364,7 @@ class TestVisionClientAnalyzeImage:
         call_args = mock_client_instance.chat.completions.create.call_args
         assert call_args.kwargs["max_tokens"] == 1000
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_handles_none_content(self, mock_openai):
         """Test handling of None content from API."""
         mock_usage = MagicMock()
@@ -395,7 +395,7 @@ class TestVisionClientAnalyzeImage:
         # Should handle None gracefully
         assert result.content == ""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_handles_none_usage(self, mock_openai):
         """Test handling of None usage stats from API."""
         mock_message = MagicMock()
@@ -424,7 +424,7 @@ class TestVisionClientAnalyzeImage:
         assert result.completion_tokens == 0
         assert result.cost_usd == 0.0
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_latency_tracking(self, mock_openai):
         """Test that latency is tracked."""
         mock_usage = MagicMock()
@@ -455,7 +455,7 @@ class TestVisionClientAnalyzeImage:
         # Latency should be non-negative
         assert result.latency_ms >= 0
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_analyze_image_api_error_propagates(self, mock_openai):
         """Test that API errors propagate."""
         from openai import APIError
@@ -484,7 +484,7 @@ class TestVisionClientAnalyzeImage:
 class TestInputValidation:
     """Test suite for input validation."""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_empty_image_bytes_raises_error(self, mock_openai):
         """Test that empty image bytes raise ValueError."""
         client = VisionClient()
@@ -492,7 +492,7 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="image_bytes cannot be empty"):
             client.analyze_image(image_bytes=b"", prompt="test")
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_empty_prompt_raises_error(self, mock_openai):
         """Test that empty prompt raises ValueError."""
         client = VisionClient()
@@ -500,7 +500,7 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="prompt cannot be empty"):
             client.analyze_image(image_bytes=b"\xff\xd8\xff\xe0test", prompt="")
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_whitespace_only_prompt_raises_error(self, mock_openai):
         """Test that whitespace-only prompt raises ValueError."""
         client = VisionClient()
@@ -508,7 +508,7 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="prompt cannot be empty"):
             client.analyze_image(image_bytes=b"\xff\xd8\xff\xe0test", prompt="   ")
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_validation_before_api_call(self, mock_openai):
         """Test that validation happens before API call is made."""
         mock_client_instance = MagicMock()
@@ -527,7 +527,7 @@ class TestInputValidation:
 class TestRetryLogic:
     """Test suite for retry logic with exponential backoff."""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     @patch("src.llm.vision_client.time.sleep")
     def test_rate_limit_retries_with_backoff(self, mock_sleep, mock_openai):
         """Test that rate limit errors trigger retries with backoff."""
@@ -577,7 +577,7 @@ class TestRetryLogic:
         mock_sleep.assert_any_call(1.0)
         mock_sleep.assert_any_call(2.0)
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     @patch("src.llm.vision_client.time.sleep")
     def test_connection_error_retries(self, mock_sleep, mock_openai):
         """Test that connection errors trigger retries."""
@@ -617,7 +617,7 @@ class TestRetryLogic:
         assert result.content == "result"
         assert mock_sleep.call_count == 1
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     @patch("src.llm.vision_client.time.sleep")
     def test_server_error_retries(self, mock_sleep, mock_openai):
         """Test that 5xx server errors trigger retries."""
@@ -662,7 +662,7 @@ class TestRetryLogic:
         assert result.content == "result"
         assert mock_sleep.call_count == 1
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_client_error_no_retry(self, mock_openai):
         """Test that 4xx client errors don't trigger retries."""
         from openai import APIError
@@ -689,7 +689,7 @@ class TestRetryLogic:
         # Should only call once (no retries)
         assert mock_client_instance.chat.completions.create.call_count == 1
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     @patch("src.llm.vision_client.time.sleep")
     def test_max_retries_exhausted(self, mock_sleep, mock_openai):
         """Test that error is raised after max retries exhausted."""
@@ -718,7 +718,7 @@ class TestRetryLogic:
         # Should have slept twice
         assert mock_sleep.call_count == 2
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_default_max_retries(self, mock_openai):
         """Test that default max_retries value is used."""
         mock_usage = MagicMock()
@@ -748,7 +748,7 @@ class TestRetryLogic:
 class TestBase64Encoding:
     """Test suite for base64 encoding functionality."""
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_base64_encoding_applied(self, mock_openai):
         """Test that image bytes are base64 encoded."""
         import base64
@@ -817,7 +817,7 @@ class TestVisionClientCaching:
         mock_response.model = model
         return mock_response
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_cache_hit_skips_api_call(self, mock_openai):
         """Cache HIT: analyze_image returns cached data without calling the API."""
         from src.llm.cache import CacheConfig, CachedResponse, LLMCache
@@ -852,7 +852,7 @@ class TestVisionClientCaching:
         assert result.cost_usd == 0.0
         assert result.latency_ms == 0
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_cache_miss_calls_api_and_writes_cache(self, mock_openai):
         """Cache MISS: analyze_image calls the API then writes to cache with correct fields."""
         import hashlib
@@ -898,7 +898,7 @@ class TestVisionClientCaching:
         assert set_kwargs["input_tokens"] == 120
         assert set_kwargs["output_tokens"] == 60
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_different_image_bytes_produce_different_sha256(self, mock_openai):
         """Different image_bytes lead to distinct image_sha256 cache keys."""
         import hashlib
@@ -935,7 +935,7 @@ class TestVisionClientCaching:
         assert sha_values[1] == sha_b
         assert sha_values[0] != sha_values[1]
 
-    @patch("src.llm.vision_client.OpenAI")
+    @patch("src.llm.providers.openai.OpenAI")
     def test_cache_disabled_does_not_call_cache_get(self, mock_openai):
         """CacheConfig(enabled=False): analyze_image hits the API without touching the cache."""
         from src.llm.cache import CacheConfig, LLMCache
@@ -996,7 +996,7 @@ def _mock_vision_client(monkeypatch, response_content: str) -> tuple[VisionClien
     mock_instance = MagicMock()
     mock_instance.chat.completions.create.return_value = mock_response
 
-    monkeypatch.setattr("src.llm.vision_client.OpenAI", lambda *a, **kw: mock_instance)
+    monkeypatch.setattr("src.llm.providers.openai.OpenAI", lambda *a, **kw: mock_instance)
     return VisionClient(), mock_instance
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.96.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -166,9 +166,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
 ]
 
 [[package]]
@@ -804,7 +804,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.30.0" },
+    { name = "anthropic", specifier = ">=0.87.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "boto3", specifier = ">=1.34.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -761,12 +761,14 @@ name = "filings-reviewer"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "charset-normalizer" },
     { name = "datasets" },
     { name = "flask" },
     { name = "flask-talisman" },
+    { name = "google-genai" },
     { name = "joblib" },
     { name = "lxml" },
     { name = "nh3" },
@@ -786,9 +788,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-annotation = [
-    { name = "anthropic" },
-]
 dev = [
     { name = "black" },
     { name = "memory-profiler" },
@@ -805,7 +804,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'annotation'", specifier = ">=0.30.0" },
+    { name = "anthropic", specifier = ">=0.30.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "boto3", specifier = ">=1.34.0" },
@@ -813,6 +812,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=2.0.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-talisman", specifier = ">=1.1.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "joblib", specifier = ">=1.3.0" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61.0" },
@@ -840,7 +840,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "waitress", specifier = ">=3.0.0" },
 ]
-provides-extras = ["dev", "annotation"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "flask"
@@ -985,6 +985,45 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -2473,6 +2512,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3184,6 +3244,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3406,6 +3475,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refactors `VisionClient` into a provider-agnostic dispatcher behind a `VisionProvider` interface with OpenAI, Gemini, and Anthropic adapters. **Behavior is identical under default flags** — this PR adds capability, does not change the production code path.

Part of the image-extraction synthesis plan. Lands concurrently with the benchmark harness (#122) and observability counters (#121); two-stage routing (Wave B4) and the bake-off (Wave B5) follow.

## New modules

- `src/llm/providers/base.py` — `VisionProvider` protocol + `VisionResponse` dataclass
- `src/llm/providers/openai.py` — preserves current gpt-4o behavior
- `src/llm/providers/gemini.py` — google-genai SDK, `GOOGLE_API_KEY` env (no Vertex/GCP project)
- `src/llm/providers/anthropic.py` — `ANTHROPIC_API_KEY` env
- `src/llm/providers/retry_shim.py` — shared retry/backoff

## Env config

| Var | Default | Purpose |
|---|---|---|
| `VISION_PROVIDER` | `openai` | Which adapter to dispatch to |
| `VISION_MODEL_OCR` | provider default | OCR task override |
| `VISION_MODEL_CHART` | provider default | Chart task override |
| `VISION_ROUTING_MODE` | `legacy` | `legacy` \| `two_stage` (two_stage lands in Wave B4) |

## Cache hygiene

`LLM_CACHE_VERSION` default bumped from `v1` → `v2` to invalidate single-provider GPT-4o cached responses under the new multi-provider dispatch. Cache key already includes model name; re-verified.

## Call-site audit

`VisionClient.analyze_image(image_bytes, prompt, ...)` public signature preserved. All call sites checked:
- `src/extraction_v2/stages/ocr_extraction.py` (chart + table paths)
- `tests/unit/llm/test_vision_client.py`
- `tests/unit/extraction_v2/test_ocr_extraction.py`
- fixture scripts (no direct imports)

All 160 LLM unit tests pass; OCR-extraction + chart-fact-bridge regression tests (46 tests) green.

## Pre-implementation checklist

- [x] Assumptions audit: existing analyze_image signature preserved across all call sites
- [x] Scope check: no routing/two-stage logic added (B4 territory); no prompt changes
- [x] Rules compliance: OpenAI default preserved; cache key includes model name
- [x] Risk assessment: cache version bump invalidates existing entries (one-time cost, expected)
- [x] Minimal path: thin dispatcher + three adapters + retry shim
- [x] Worktree confirmation: implemented in isolated worktree

## Dep changes

- pyproject.toml: added `google-genai`, `anthropic`
- uv.lock: regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)