### PR TITLE
chore(gitignore): ignore .claude/*.lock runtime files (resolves #74, replays #104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ htmlcov/
 # But keep project-specific Claude settings
 !.claude/settings.json
 
+# Claude Code runtime locks (created by the scheduled-tasks system)
+.claude/*.lock
+
 # Python tool caches
 .mypy_cache/
 .pytest_cache/

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 28 |
+| Open | 27 |
 | Partially Resolved | 3 |
 | Archived | 46 |
-| Resolved | 5 |
+| Resolved | 6 |
 
 
 ## Nightly Sweeper Classification
@@ -43,7 +43,6 @@
 | #66 | review | S | `render.yaml` `.claude/rules/infrastructure.md` | Wire apply_migrations into Render deploy; infra-change risk |
 | #69 | review | S | `Dockerfile.nightly-sweep` | Pin claude + gh versions; needs validation step |
 | #72 | review | S | `pyproject.toml` `uv.lock` | Boto3 fix unblocks ingestion (stage 1); R2 image-bytes layer still needs separate fix before baseline refresh |
-| #74 | safe | XS | `.gitignore` | One-line addition to root `.gitignore` |
 | #75 | skip | S | `tests/ui/*.spec.js` `tests/ui/test_server.py` | Playwright E2E gap — cross-filing auto-advance; needs stub-server extension |
 | #76 | safe | S | `tests/integration/test_db_filings_reviewers.py` | New integration test for filings-list reviewer aggregate; isolated file |
 | #77 | skip | M | — | Second layer of #72 — R2 chart-image bytes missing/mis-keyed for HOOD S-1; partial code fix shipped, prod backfill needs explicit auth (R2 + Neon writes) |
@@ -663,22 +662,6 @@ The functional behavior is correct — the hook fires and blocks the operation a
 - `docs/development/claude-sessions-and-worktrees.md` — § Orchestration pattern
 - `~/.claude/hooks/guard-destructive-git.sh` — the hook that blocks `git checkout -b` in the primary tree
 - PR #71 — added `/supervise-prs` and orchestration guidance to the worktree guide
-
-## #74. `.claude/scheduled_tasks.lock` Not Gitignored
-
-**Status**: Open
-**Severity**: low
-**Discovered**: 2026-04-22
-**Updated**: 2026-04-22
-
-### Problem
-
-`.claude/scheduled_tasks.lock` is created at runtime by the Claude Code scheduled-tasks system but is not covered by any `.gitignore` rule — `git check-ignore -v .claude/scheduled_tasks.lock` returns no match. Every `git status` run in an active session lists it as untracked, which inflates status output and creates a small risk of accidental staging if someone invokes `git add -A` or `git add .` (already an anti-pattern per CLAUDE.md, but worth hardening against).
-
-### Next Steps
-
-- Add `.claude/scheduled_tasks.lock` (or a broader `.claude/*.lock` glob) to the root `.gitignore`.
-- Quick audit of `.claude/` for other runtime-only files (e.g., `.claude/sweep-digests/` is already tracked separately — confirm nothing else needs ignoring).
 
 ## #75. Missing Playwright E2E for Cross-Filing Auto-Advance
 
@@ -1548,6 +1531,22 @@ Remaining narrow gaps (POST stub shape drift; non-rendering template files) are 
 - Mirror the UI E2E filter structure (`ci.yml:49-69`) on the `integration-tests` job. Same allowlist (`docs/`, `.claude/`, `CLAUDE.md`, `README.md`, `.gitignore`, `.github/CODEOWNERS`) — err on the side of running when in doubt.
 - Verify by opening a docs-only PR and confirming `Integration Tests` reports `skipped` in Actions.
 - Do NOT remove Integration Tests from required status checks — a skipped job still counts as passing for branch protection, so the gate stays intact.
+
+## #74. `.claude/scheduled_tasks.lock` Not Gitignored
+
+**Status**: Resolved
+**Severity**: low
+**Discovered**: 2026-04-22
+**Updated**: 2026-04-22
+
+### Problem
+
+`.claude/scheduled_tasks.lock` is created at runtime by the Claude Code scheduled-tasks system but is not covered by any `.gitignore` rule — `git check-ignore -v .claude/scheduled_tasks.lock` returns no match. Every `git status` run in an active session lists it as untracked, which inflates status output and creates a small risk of accidental staging if someone invokes `git add -A` or `git add .` (already an anti-pattern per CLAUDE.md, but worth hardening against).
+
+### Next Steps
+
+- Add `.claude/scheduled_tasks.lock` (or a broader `.claude/*.lock` glob) to the root `.gitignore`.
+- Quick audit of `.claude/` for other runtime-only files (e.g., `.claude/sweep-digests/` is already tracked separately — confirm nothing else needs ignoring).
 
 
 ## Change Log

--- a/docs/known-issues/legacy-074-claude-scheduled-tasks-lock-not-gitignored.md
+++ b/docs/known-issues/legacy-074-claude-scheduled-tasks-lock-not-gitignored.md
@@ -1,16 +1,16 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-22'
-estimated: XS
+estimated: —
 id: 74
-note: One-line addition to root `.gitignore`
+note: Resolved in fresh-branch replay of PR #104
+pr_refs: []
 severity: low
 slug: claude-scheduled-tasks-lock-not-gitignored
 source: legacy
-status: open
+status: resolved
 title: '`.claude/scheduled_tasks.lock` Not Gitignored'
-touches:
-- .gitignore
+touches: []
 updated: '2026-04-22'
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.claude/*.lock` to `.gitignore` so runtime lock files (e.g. `scheduled_tasks.lock`) are no longer listed as untracked in every `git status`.
- Marks known-issue fragment #74 as resolved.
- Regenerates the `docs/KNOWN_ISSUES.md` rollup.

## Why a fresh branch?

PR #104 contained the same `.gitignore` change but included a hand-edit to `docs/KNOWN_ISSUES.md`. That file is now auto-generated from `docs/known-issues/` fragments (migration in #115/#116/#117/#119), so the hand-edit could not merge cleanly. This replay applies the change via the fragments workflow instead.

PR #104 should be closed once this merges.

## Test plan

- [x] `git diff --stat` — exactly 3 files: `.gitignore`, fragment `legacy-074-*.md`, `docs/KNOWN_ISSUES.md`
- [x] `python3 scripts/validate_known_issues_fragments.py` — clean (82 fragments OK)
- [x] `python3 scripts/regenerate_known_issues.py --check` — exit 0
- [x] `pre-commit run --files ...` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)