### PR TITLE
docs(contributing): rewrite /commit step 1 to reflect worktree-required flow (resolves #70, replays #105)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 28 |
+| Open | 27 |
 | Partially Resolved | 3 |
 | Archived | 46 |
-| Resolved | 5 |
+| Resolved | 6 |
 
 
 ## Nightly Sweeper Classification
@@ -634,35 +634,6 @@ Wave C documents the cancel-during-populate flow (cancel flips `status='cancelle
 - Pin the `claude` installer to a specific version once the installer supports a version argument; otherwise cache a specific binary in the image.
 - Pin `gh` to a specific apt version (`gh=2.X.Y`) or switch to the GitHub Releases tarball.
 - Consider adding a build-time smoke test: `claude --version && gh --version` to fail the build on unexpected drift.
-
-## #70. CONTRIBUTING.md `/commit` Step 1 Wording Is Stale Post-Worktree-Hook
-
-**Status**: Open
-**Severity**: low
-**Discovered**: 2026-04-21
-**Updated**: 2026-04-21
-
-### Problem
-
-`docs/development/CONTRIBUTING.md` § "Committing via `/commit`" step 1 currently reads:
-
-> "If on `main`, auto-creates `claude/<type>-<slug>` and switches to it. Otherwise stays on the current branch."
-
-This implies `/commit` can be invoked from the primary worktree while on `main`. In practice, `~/.claude/hooks/guard-destructive-git.sh` (the PreToolUse hook) now denies `git checkout -b` in the primary tree, so running `/commit` from there will fail with a hook block. The step 1 description does not reflect the worktree-required model that is actually enforced.
-
-The functional behavior is correct — the hook fires and blocks the operation as intended. Only the documentation lags behind.
-
-### Next Steps
-
-- Rewrite step 1 to state that `/commit` must be invoked from a `ccw` worktree (or via an `Agent` call with `isolation: "worktree"`), and that invoking it from the primary tree will be refused by the PreToolUse hook.
-- Cross-link `docs/development/claude-sessions-and-worktrees.md` § Orchestration pattern for the recommended workflow.
-
-### Cross-References
-
-- `docs/development/CONTRIBUTING.md` — § "Committing via `/commit`", step 1
-- `docs/development/claude-sessions-and-worktrees.md` — § Orchestration pattern
-- `~/.claude/hooks/guard-destructive-git.sh` — the hook that blocks `git checkout -b` in the primary tree
-- PR #71 — added `/supervise-prs` and orchestration guidance to the worktree guide
 
 ## #74. `.claude/scheduled_tasks.lock` Not Gitignored
 
@@ -1530,6 +1501,35 @@ Remaining narrow gaps (POST stub shape drift; non-rendering template files) are 
 
 - Detect `timeout` vs `gtimeout` vs neither at script start; fall back to `gtimeout` on macOS (via `brew install coreutils`) or to a no-timeout code path with a warning log.
 - Alternatively, install `coreutils` as part of the local-dev setup docs for the `/sweep` skill.
+
+## #70. CONTRIBUTING.md `/commit` Step 1 Wording Is Stale Post-Worktree-Hook
+
+**Status**: Resolved
+**Severity**: low
+**Discovered**: 2026-04-21
+**Updated**: 2026-04-22
+
+### Problem
+
+`docs/development/CONTRIBUTING.md` § "Committing via `/commit`" step 1 currently reads:
+
+> "If on `main`, auto-creates `claude/<type>-<slug>` and switches to it. Otherwise stays on the current branch."
+
+This implies `/commit` can be invoked from the primary worktree while on `main`. In practice, `~/.claude/hooks/guard-destructive-git.sh` (the PreToolUse hook) now denies `git checkout -b` in the primary tree, so running `/commit` from there will fail with a hook block. The step 1 description does not reflect the worktree-required model that is actually enforced.
+
+The functional behavior is correct — the hook fires and blocks the operation as intended. Only the documentation lags behind.
+
+### Next Steps
+
+- Rewrite step 1 to state that `/commit` must be invoked from a `ccw` worktree (or via an `Agent` call with `isolation: "worktree"`), and that invoking it from the primary tree will be refused by the PreToolUse hook.
+- Cross-link `docs/development/claude-sessions-and-worktrees.md` § Orchestration pattern for the recommended workflow.
+
+### Cross-References
+
+- `docs/development/CONTRIBUTING.md` — § "Committing via `/commit`", step 1
+- `docs/development/claude-sessions-and-worktrees.md` — § Orchestration pattern
+- `~/.claude/hooks/guard-destructive-git.sh` — the hook that blocks `git checkout -b` in the primary tree
+- PR #71 — added `/supervise-prs` and orchestration guidance to the worktree guide
 
 ## #71. Integration Tests Job Has No Path Filter
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -37,8 +37,14 @@ Run `/commit` from a `ccw` worktree. HEAD-moving git commands in the primary tre
 The project-local `/commit` skill (`.claude/commands/commit.md`) handles the
 full flow in one invocation:
 
-1. **Branch preflight.** If on `main`, auto-creates `claude/<type>-<slug>` and
-   switches to it. Otherwise stays on the current branch.
+1. **Branch preflight.** `/commit` must run inside a `ccw` worktree — the
+   PreToolUse hook in `~/.claude/hooks/guard-destructive-git.sh` refuses
+   `git checkout -b` in the primary tree. If no worktree exists yet, enter
+   one first (`EnterWorktree` from a Claude session, or `ccw [branch]`
+   from a shell). See [§ Orchestration pattern](claude-sessions-and-worktrees.md#orchestration-pattern-planning-session--parallel-subagents)
+   for the recommended flow. On first-commit for a branch, `/commit` derives
+   the branch name (`claude/<type>-<slug>`) from the staged diff; on a
+   pre-existing branch it reuses the current one.
 2. **Pre-commit framework check.** Verifies `.git/hooks/pre-commit` is
    installed; if missing, runs `make hooks-install`.
 3. **Lint + tests + doc-freshness + known-issues triage** (unchanged).

--- a/docs/known-issues/legacy-070-contributing-md-commit-step-1-wording-is-stale-post-worktree.md
+++ b/docs/known-issues/legacy-070-contributing-md-commit-step-1-wording-is-stale-post-worktree.md
@@ -3,13 +3,15 @@ autonomy: n/a
 discovered: '2026-04-21'
 estimated: —
 id: 70
+note: Resolved in fresh-branch replay of PR #105
+pr_refs: []
 severity: low
 slug: contributing-md-commit-step-1-wording-is-stale-post-worktree
 source: legacy
-status: open
+status: resolved
 title: CONTRIBUTING.md `/commit` Step 1 Wording Is Stale Post-Worktree-Hook
 touches: []
-updated: '2026-04-21'
+updated: '2026-04-22'
 ---
 
 ### Problem


### PR DESCRIPTION
## Summary

- Rewrites CONTRIBUTING.md step 1 of the `/commit` workflow to state that `/commit` must be invoked from a `ccw` worktree — the PreToolUse hook in `~/.claude/hooks/guard-destructive-git.sh` refuses `git checkout -b` in the primary tree. Includes a cross-link to the orchestration-pattern section in `claude-sessions-and-worktrees.md`.
- Marks the `legacy-070` known-issue fragment as `resolved`.
- Regenerates `docs/KNOWN_ISSUES.md` rollup via `scripts/regenerate_known_issues.py`.

## Why a fresh branch?

PR #105 carried a hand-edit to `docs/KNOWN_ISSUES.md`. That file is now auto-generated by `scripts/regenerate_known_issues.py` (migration completed in PRs #115/#116/#117/#119), so the original PR's diff conflicts with the canonical rollup and cannot merge. This PR is a clean replay.

PR #105 should be closed once this merges.

## Test plan

- [x] `python3 scripts/validate_known_issues_fragments.py` — OK (82 fragments)
- [x] `python3 scripts/regenerate_known_issues.py --check` — exit 0
- [x] `pre-commit run --files docs/development/CONTRIBUTING.md docs/known-issues/legacy-070-*.md docs/KNOWN_ISSUES.md` — all passed
- [x] `git diff --stat` — exactly 3 files changed

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)