### PR TITLE
test(integration): cover filings-list reviewer aggregation (resolves #76, replays #109)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 28 |
+| Open | 27 |
 | Partially Resolved | 3 |
 | Archived | 46 |
-| Resolved | 5 |
+| Resolved | 6 |
 
 
 ## Nightly Sweeper Classification
@@ -45,7 +45,6 @@
 | #72 | review | S | `pyproject.toml` `uv.lock` | Boto3 fix unblocks ingestion (stage 1); R2 image-bytes layer still needs separate fix before baseline refresh |
 | #74 | safe | XS | `.gitignore` | One-line addition to root `.gitignore` |
 | #75 | skip | S | `tests/ui/*.spec.js` `tests/ui/test_server.py` | Playwright E2E gap — cross-filing auto-advance; needs stub-server extension |
-| #76 | safe | S | `tests/integration/test_db_filings_reviewers.py` | New integration test for filings-list reviewer aggregate; isolated file |
 | #77 | skip | M | — | Second layer of #72 — R2 chart-image bytes missing/mis-keyed for HOOD S-1; partial code fix shipped, prod backfill needs explicit auth (R2 + Neon writes) |
 | #79 | safe | XS | `scripts/known_issues_selector.py` | Filter selector picks on status=open or partially-resolved |
 | #80 | review | S | `src/infra/image_storage.py` `src/gold_standard/v2_validator.py` `.claude/rules/infrastructure.md` | Add env-scoped guard against unintended prod R2 writes from CLI tools; design call (storage-layer vs validator-layer) needed |
@@ -696,23 +695,6 @@ The "auto-advance to next filing when queue empties" behavior is tested at the r
 - Add a Playwright spec in `tests/ui/` that seeds two filings with pending facts, sets sort to `company asc` on the list, approves the last pending fact in filing A, and asserts the browser lands on filing B (not the list, not default date-desc order).
 - Repeat the assertion with image-queue completion as the trigger (relevant → non-relevant → skip the last image).
 - Reuse the stub-server pattern in `tests/ui/test_server.py`; extend it with a `/filings-list-stub` route that renders `unified_filing_list.html` with two seeded filings.
-
-## #76. Missing Integration Test for Filings-List Reviewer Aggregate
-
-**Status**: Open
-**Severity**: low
-**Discovered**: 2026-04-21
-**Updated**: 2026-04-21
-
-### Problem
-
-`get_unified_filings_for_review` now UNIONs text + image decision tables and projects a `reviewers` array per filing, plus an optional `reviewer_ids` filter using `ARRAY_AGG(...) && ...`. Unit tests cover the route layer threading this kwarg, but there's no integration test asserting: (a) mixed-reviewer filings return distinct reviewers from both text and image sources; (b) the `&&` overlap filter correctly narrows the list without false positives; (c) filings with only NULL reviewer_ids render as an empty array. Without this test, a future CTE refactor could silently lose reviewers from one source.
-
-### Next Steps
-
-- Add `tests/integration/test_db_filings_reviewers.py` that seeds a filing with text decisions by Alice + image decisions by Bob, calls `get_unified_filings_for_review`, and asserts `row["reviewers"] == ["alice", "bob"]`.
-- Add a second case: call with `reviewer_ids=["alice"]`, assert the filing is returned; call with `reviewer_ids=["zoe"]`, assert it is not.
-- Add a third case: a filing with only NULL reviewer_id decisions (legacy image rows) returns `reviewers == []`.
 
 ## #79. Nightly Sweeper Selector Picks Resolved/Archived Issues
 
@@ -1548,6 +1530,23 @@ Remaining narrow gaps (POST stub shape drift; non-rendering template files) are 
 - Mirror the UI E2E filter structure (`ci.yml:49-69`) on the `integration-tests` job. Same allowlist (`docs/`, `.claude/`, `CLAUDE.md`, `README.md`, `.gitignore`, `.github/CODEOWNERS`) — err on the side of running when in doubt.
 - Verify by opening a docs-only PR and confirming `Integration Tests` reports `skipped` in Actions.
 - Do NOT remove Integration Tests from required status checks — a skipped job still counts as passing for branch protection, so the gate stays intact.
+
+## #76. Missing Integration Test for Filings-List Reviewer Aggregate
+
+**Status**: Resolved
+**Severity**: low
+**Discovered**: 2026-04-21
+**Updated**: 2026-04-22
+
+### Problem
+
+`get_unified_filings_for_review` now UNIONs text + image decision tables and projects a `reviewers` array per filing, plus an optional `reviewer_ids` filter using `ARRAY_AGG(...) && ...`. Unit tests cover the route layer threading this kwarg, but there's no integration test asserting: (a) mixed-reviewer filings return distinct reviewers from both text and image sources; (b) the `&&` overlap filter correctly narrows the list without false positives; (c) filings with only NULL reviewer_ids render as an empty array. Without this test, a future CTE refactor could silently lose reviewers from one source.
+
+### Next Steps
+
+- Add `tests/integration/test_db_filings_reviewers.py` that seeds a filing with text decisions by Alice + image decisions by Bob, calls `get_unified_filings_for_review`, and asserts `row["reviewers"] == ["alice", "bob"]`.
+- Add a second case: call with `reviewer_ids=["alice"]`, assert the filing is returned; call with `reviewer_ids=["zoe"]`, assert it is not.
+- Add a third case: a filing with only NULL reviewer_id decisions (legacy image rows) returns `reviewers == []`.
 
 
 ## Change Log

--- a/docs/known-issues/legacy-076-missing-integration-test-for-filings-list-reviewer-aggregate.md
+++ b/docs/known-issues/legacy-076-missing-integration-test-for-filings-list-reviewer-aggregate.md
@@ -1,17 +1,17 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-21'
-estimated: S
+estimated: —
 id: 76
-note: New integration test for filings-list reviewer aggregate; isolated file
+note: Resolved in fresh-branch replay of PR #109
+pr_refs: []
 severity: low
 slug: missing-integration-test-for-filings-list-reviewer-aggregate
 source: legacy
-status: open
+status: resolved
 title: Missing Integration Test for Filings-List Reviewer Aggregate
-touches:
-- tests/integration/test_db_filings_reviewers.py
-updated: '2026-04-21'
+touches: []
+updated: '2026-04-22'
 ---
 
 ### Problem

--- a/tests/integration/test_db_filings_reviewers.py
+++ b/tests/integration/test_db_filings_reviewers.py
@@ -1,0 +1,131 @@
+"""Integration tests for get_unified_filings_for_review reviewer aggregation (KNOWN_ISSUES #76).
+
+Guards `DatabaseAdapter.get_unified_filings_for_review` against future CTE refactors
+silently dropping a reviewer source from the text+image UNION.
+"""
+
+from __future__ import annotations
+
+from src.infra.db import DatabaseAdapter
+from tests.integration.conftest import (
+    create_test_company_and_filing,
+    create_test_v2_decision,
+    create_test_v2_document,
+    create_test_v2_fact,
+)
+
+
+def _insert_v2_image(
+    db: DatabaseAdapter,
+    filing_id: int,
+    filename: str,
+    classification: str = "chart",
+    review_status: str = "pending",
+) -> str:
+    """Insert a v2_image_assets row and return img_id as string."""
+    rows = db.query(
+        """
+        INSERT INTO v2_image_assets
+            (doc_id, filename, dom_locator, width, height, nearby_text,
+             classification, relevance_score, review_status, section_type)
+        VALUES
+            (%(doc_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
+             %(nearby_text)s, %(classification)s, %(relevance_score)s,
+             %(review_status)s, %(section_type)s)
+        RETURNING img_id
+        """,
+        {
+            "doc_id": filing_id,
+            "filename": filename,
+            "dom_locator": f"body > img[src='{filename}']",
+            "width": 600,
+            "height": 400,
+            "nearby_text": "retention chart",
+            "classification": classification,
+            "relevance_score": 0.8,
+            "review_status": review_status,
+            "section_type": "mda",
+        },
+    )
+    return str(rows[0]["img_id"])
+
+
+def _insert_image_decision(
+    db: DatabaseAdapter,
+    img_id: str,
+    reviewer_id: str | None = "reviewer",
+) -> int:
+    """Insert a v2_image_review_decisions row and return image_decision_id."""
+    rows = db.query(
+        """
+        INSERT INTO v2_image_review_decisions
+            (img_id, decision, chart_type, reviewer_id)
+        VALUES
+            (%(img_id)s, %(decision)s, %(chart_type)s, %(reviewer_id)s)
+        RETURNING image_decision_id
+        """,
+        {
+            "img_id": img_id,
+            "decision": "relevant",
+            "chart_type": "cohort_table",
+            "reviewer_id": reviewer_id,
+        },
+    )
+    return int(rows[0]["image_decision_id"])
+
+
+def _find_filing_row(rows: list[dict], filing_id: int) -> dict | None:
+    for row in rows:
+        if row["filing_id"] == filing_id:
+            return row
+    return None
+
+
+class TestReviewerAggregation:
+    def test_reviewers_aggregates_text_and_image_sources(self, clean_db: DatabaseAdapter) -> None:
+        """Text decision from alice + image decision from bob both appear in reviewers."""
+        _, filing_id = create_test_company_and_filing(clean_db)
+        create_test_v2_document(clean_db, filing_id)
+
+        fact_id = create_test_v2_fact(clean_db, filing_id)
+        create_test_v2_decision(clean_db, fact_id, reviewer_id="alice")
+
+        img_id = _insert_v2_image(clean_db, filing_id, "chart.jpg", review_status="reviewed")
+        _insert_image_decision(clean_db, img_id, reviewer_id="bob")
+
+        rows = clean_db.get_unified_filings_for_review()
+        row = _find_filing_row(rows, filing_id)
+
+        assert row is not None
+        assert sorted(row["reviewers"]) == ["alice", "bob"]
+
+    def test_reviewer_ids_filter_narrows_correctly(self, clean_db: DatabaseAdapter) -> None:
+        """reviewer_ids kwarg returns filing for matched reviewer and excludes it for others."""
+        _, filing_id = create_test_company_and_filing(clean_db)
+        create_test_v2_document(clean_db, filing_id)
+
+        fact_id = create_test_v2_fact(clean_db, filing_id)
+        create_test_v2_decision(clean_db, fact_id, reviewer_id="alice")
+
+        img_id = _insert_v2_image(clean_db, filing_id, "chart.jpg", review_status="reviewed")
+        _insert_image_decision(clean_db, img_id, reviewer_id="bob")
+
+        matched = clean_db.get_unified_filings_for_review(reviewer_ids=["alice"])
+        assert _find_filing_row(matched, filing_id) is not None
+
+        not_matched = clean_db.get_unified_filings_for_review(reviewer_ids=["zoe"])
+        assert _find_filing_row(not_matched, filing_id) is None
+
+    def test_null_reviewer_ids_yield_empty_reviewer_list(self, clean_db: DatabaseAdapter) -> None:
+        """Image decision rows with NULL reviewer_id produce an empty reviewers array."""
+        _, filing_id = create_test_company_and_filing(clean_db)
+        create_test_v2_document(clean_db, filing_id)
+
+        img_id = _insert_v2_image(clean_db, filing_id, "anon.jpg", review_status="reviewed")
+        _insert_image_decision(clean_db, img_id, reviewer_id=None)
+
+        rows = clean_db.get_unified_filings_for_review()
+        row = _find_filing_row(rows, filing_id)
+
+        assert row is not None
+        assert row["reviewers"] == []


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_db_filings_reviewers.py` — exact content from PR #109 — covering three cases: (a) mixed text+image reviewer aggregation, (b) `reviewer_ids` filter narrows correctly, (c) NULL reviewer_id yields empty array
- Marks known-issue fragment `legacy-076` as `resolved` with `status: resolved`
- Regenerates `docs/KNOWN_ISSUES.md` rollup

## Background

PR #109 was blocked because it hand-edited `docs/KNOWN_ISSUES.md` directly, before the fragment-based rollup workflow landed in PRs #115/#116/#117/#119. This fresh-branch replay carries identical test content and closes the gap cleanly. PR #109 should be closed once this merges.

## Test plan

- [ ] Unit pre-push hook passed locally
- [ ] Integration tests (`test_db_filings_reviewers.py`) will run in CI against the test DB
- [ ] `python3 scripts/validate_known_issues_fragments.py` — clean
- [ ] `python3 scripts/regenerate_known_issues.py --check` — exit 0
- [ ] `ruff check` — clean
- [ ] `pre-commit run --files ...` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)