### PR TITLE
fix(ingest): add per-filing checkboxes to preview table

### DIFF
--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -291,16 +291,20 @@ def ingest_start():
             400,
         )
 
-    # Determine per-filing bucket and reextract flag
+    # Determine per-filing bucket and reextract flag.
+    # Inclusion is signalled by the filing_id checkbox being submitted (preview
+    # template — only checked rows reach us). The bucket hidden field carries
+    # the filing's classification; for the two "reextract*" buckets inclusion
+    # implies re-extraction, so we derive the decision from bucket rather than
+    # from a redundant per-row reextract checkbox.
     filing_buckets: dict[int, str] = {}
     reextract_decisions: dict[int, bool] = {}
     has_reviewed_reextract = False
 
     for fid in filing_ids:
-        reextract_cb = request.form.get(f"reextract_{fid}") == "on"
         bucket_hidden = request.form.get(f"bucket_{fid}", "new")
         filing_buckets[fid] = bucket_hidden
-        if reextract_cb:
+        if bucket_hidden in ("reextract", "reextract_reviewed"):
             reextract_decisions[fid] = True
             if bucket_hidden == "reextract_reviewed":
                 has_reviewed_reextract = True

--- a/src/web/templates/ingest_preview.html
+++ b/src/web/templates/ingest_preview.html
@@ -46,7 +46,9 @@
       ================================================================ -->
       <h4 class="mt-4">New Filings <span class="badge bg-primary">{{ new_candidates | length }}</span></h4>
       {% if new_candidates %}
-      <p class="text-muted small">These filings have not been extracted yet. All will be included in the batch.</p>
+      <p class="text-muted small">
+        All are checked by default — uncheck any filing you don't want in this batch.
+      </p>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
           <thead class="table-dark">
@@ -56,7 +58,12 @@
               <th>Company</th>
               <th>Form</th>
               <th>Date</th>
-              <th>Include</th>
+              <th>
+                <input class="form-check-input select-all-cb" type="checkbox"
+                       data-section="new" checked
+                       title="Select / deselect all filings in this section">
+                Include
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -68,10 +75,11 @@
               <td>{{ c.form_type }}</td>
               <td>{{ c.filing_date }}</td>
               <td>
-                <!-- Always included; hidden filing_id signals inclusion -->
-                <input type="hidden" name="filing_id" value="{{ c.filing_id }}">
                 <input type="hidden" name="bucket_{{ c.filing_id }}" value="new">
-                <span class="badge bg-success">Yes</span>
+                <input class="form-check-input filing-include-cb"
+                       type="checkbox" name="filing_id"
+                       value="{{ c.filing_id }}"
+                       data-section="new" checked>
               </td>
             </tr>
             {% endfor %}
@@ -91,7 +99,8 @@
       </h4>
       {% if already_no_review %}
       <p class="text-muted small">
-        These filings have already been extracted. Check the box to re-extract (overwrites existing facts).
+        These filings have already been extracted. Include them only if you want to re-extract (overwrites existing facts).
+        All are <strong>unchecked</strong> by default.
       </p>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
@@ -102,7 +111,12 @@
               <th>Company</th>
               <th>Form</th>
               <th>Date</th>
-              <th>Re-extract?</th>
+              <th>
+                <input class="form-check-input select-all-cb" type="checkbox"
+                       data-section="reextract"
+                       title="Select / deselect all filings in this section">
+                Include &amp; re-extract
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -114,10 +128,11 @@
               <td>{{ c.form_type }}</td>
               <td>{{ c.filing_date }}</td>
               <td>
-                <input type="hidden" name="filing_id" value="{{ c.filing_id }}">
                 <input type="hidden" name="bucket_{{ c.filing_id }}" value="reextract">
-                <input class="form-check-input" type="checkbox"
-                       name="reextract_{{ c.filing_id }}" value="on">
+                <input class="form-check-input filing-include-cb"
+                       type="checkbox" name="filing_id"
+                       value="{{ c.filing_id }}"
+                       data-section="reextract">
               </td>
             </tr>
             {% endfor %}
@@ -137,8 +152,9 @@
       </h4>
       {% if already_reviewed %}
       <div class="alert alert-warning mb-2" role="alert">
-        <strong>Warning:</strong> Re-extracting these filings will permanently delete
-        human review decisions. Use the checkbox with caution.
+        <strong>Warning:</strong> Including these filings will re-extract them and
+        permanently delete human review decisions. All are <strong>unchecked</strong> by default —
+        check with caution.
       </div>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
@@ -150,7 +166,12 @@
               <th>Form</th>
               <th>Date</th>
               <th>Decisions</th>
-              <th>Re-extract?</th>
+              <th>
+                <input class="form-check-input select-all-cb" type="checkbox"
+                       data-section="reextract_reviewed"
+                       title="Select / deselect all filings in this section">
+                Include &amp; re-extract
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -163,10 +184,11 @@
               <td>{{ c.filing_date }}</td>
               <td><span class="badge bg-warning text-dark">{{ decision_count }}</span></td>
               <td>
-                <input type="hidden" name="filing_id" value="{{ c.filing_id }}">
                 <input type="hidden" name="bucket_{{ c.filing_id }}" value="reextract_reviewed">
-                <input class="form-check-input reviewed-reextract-cb" type="checkbox"
-                       name="reextract_{{ c.filing_id }}" value="on"
+                <input class="form-check-input filing-include-cb reviewed-reextract-cb"
+                       type="checkbox" name="filing_id"
+                       value="{{ c.filing_id }}"
+                       data-section="reextract_reviewed"
                        data-reviewed="true">
               </td>
             </tr>
@@ -202,7 +224,7 @@
         </p>
         {% else %}
         <button type="submit" class="btn btn-success btn-lg" id="start-btn">
-          Start Batch ({{ total }} filing{{ 's' if total != 1 else '' }})
+          Start Batch (<span id="start-btn-count">{{ new_candidates | length }}</span> filing<span id="start-btn-plural">{{ 's' if (new_candidates | length) != 1 else '' }}</span>)
         </button>
         {% endif %}
         <a href="{{ url_for('ingest.ingest_form') }}" class="btn btn-outline-secondary btn-lg ms-2">
@@ -222,6 +244,48 @@
 
   var form = document.getElementById('start-form');
   if (!form) return;
+
+  var includeCbs = document.querySelectorAll('.filing-include-cb');
+  var selectAllCbs = document.querySelectorAll('.select-all-cb');
+  var countEl = document.getElementById('start-btn-count');
+  var pluralEl = document.getElementById('start-btn-plural');
+
+  function updateCount() {
+    var n = document.querySelectorAll('.filing-include-cb:checked').length;
+    if (countEl) countEl.textContent = String(n);
+    if (pluralEl) pluralEl.textContent = n === 1 ? '' : 's';
+  }
+
+  function syncSelectAll(section) {
+    var header = document.querySelector('.select-all-cb[data-section="' + section + '"]');
+    if (!header) return;
+    var sectionCbs = document.querySelectorAll('.filing-include-cb[data-section="' + section + '"]');
+    if (sectionCbs.length === 0) return;
+    var checkedCount = 0;
+    sectionCbs.forEach(function (cb) { if (cb.checked) checkedCount++; });
+    header.checked = (checkedCount === sectionCbs.length);
+    header.indeterminate = (checkedCount > 0 && checkedCount < sectionCbs.length);
+  }
+
+  selectAllCbs.forEach(function (header) {
+    var section = header.getAttribute('data-section');
+    header.addEventListener('change', function () {
+      document.querySelectorAll('.filing-include-cb[data-section="' + section + '"]')
+        .forEach(function (cb) { cb.checked = header.checked; });
+      updateCount();
+    });
+  });
+
+  includeCbs.forEach(function (cb) {
+    cb.addEventListener('change', function () {
+      syncSelectAll(cb.getAttribute('data-section'));
+      updateCount();
+    });
+  });
+
+  // Initial sync for sections whose defaults are mixed (e.g. none-checked reextract sections)
+  ['new', 'reextract', 'reextract_reviewed'].forEach(syncSelectAll);
+  updateCount();
 
   form.addEventListener('submit', function (e) {
     var reviewedBoxes = document.querySelectorAll('.reviewed-reextract-cb:checked');

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -317,6 +317,89 @@ def test_ingest_start_reviewed_filing_with_ack_proceeds(client):
 
 
 # ---------------------------------------------------------------------------
+# Selective inclusion — only filing_ids submitted via checkbox reach the batch
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_start_creates_batch_row_per_submitted_filing_id(client):
+    """Only the filing_ids that were submitted (checkbox-checked) get batch rows.
+
+    Regression test for the bug where the preview template always emitted a
+    hidden filing_id per candidate, so users who intended to pick one filing
+    ingested every candidate in the preview list.
+    """
+    form_data = {
+        # Only 1 filing submitted — simulates user unchecking 3 of 4 candidates
+        "filing_id": ["1748"],
+        "bucket_1748": "new",
+        "reviewer_name": "Rob",
+        "criteria_json": json.dumps({"year": "2023", "sic_codes": "7372"}),
+        "resolved_json": json.dumps({}),
+    }
+    mock_db = _make_db_mock(batch_id="bbbbbbbb-cccc-dddd-eeee-000000000001")
+
+    # Capture per-filing INSERTs into v2_ingest_batch_filings.
+    mock_cur = mock_db.transaction.return_value.__enter__.return_value.cursor.return_value
+    executed_sql: list[str] = []
+
+    def _record(sql, params=None):
+        executed_sql.append(str(sql))
+        return None
+
+    mock_cur.execute.side_effect = _record
+
+    with patch("src.web.routes.ingest.get_db", return_value=mock_db):
+        resp = client.post("/ingest/start", data=form_data)
+
+    assert resp.status_code == 302
+    per_filing_inserts = [s for s in executed_sql if "v2_ingest_batch_filings" in s]
+    assert len(per_filing_inserts) == 1, (
+        f"expected 1 filing row, got {len(per_filing_inserts)} — batch ingested unchecked candidates"
+    )
+
+
+def test_ingest_start_derives_reextract_from_bucket(client):
+    """bucket=reextract on a submitted filing implies reextract_decisions[fid]=True.
+
+    The preview template dropped the redundant per-row reextract checkbox —
+    inclusion of an already-extracted filing now implies re-extraction,
+    derived from the bucket classification.
+    """
+    form_data = {
+        "filing_id": ["99"],
+        "bucket_99": "reextract",  # user checked an already-extracted filing
+        "reviewer_name": "Rob",
+        "criteria_json": json.dumps({"year": "2023", "sic_codes": "7372"}),
+        "resolved_json": json.dumps({}),
+        # No reextract_99 field — the template no longer emits one
+    }
+    mock_db = _make_db_mock()
+    with patch("src.web.routes.ingest.get_db", return_value=mock_db):
+        resp = client.post("/ingest/start", data=form_data)
+    # Proceeds to batch creation — bucket-derived reextract is sufficient.
+    assert resp.status_code == 302
+    assert "/ingest/batch/" in resp.headers["Location"]
+
+
+def test_ingest_start_bucket_reextract_reviewed_without_ack_still_blocked(client):
+    """bucket=reextract_reviewed + submitted filing_id requires the ack checkbox.
+
+    Derived-from-bucket re-extract must not bypass the reviewed-filing guard.
+    """
+    form_data = {
+        "filing_id": ["42"],
+        "bucket_42": "reextract_reviewed",
+        "reviewer_name": "Rob",
+        "criteria_json": json.dumps({"year": "2023", "sic_codes": "7372"}),
+        "resolved_json": json.dumps({}),
+        # reextract_reviewed_ack intentionally omitted
+        # No reextract_42 — new template doesn't emit it
+    }
+    resp = client.post("/ingest/start", data=form_data)
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
 # Missing fields
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The preview table emitted an **unconditional** \`<input type=\"hidden\" name=\"filing_id\">\` for every candidate — the \"Include\" column was a static \"Yes\" badge with no way to deselect. Users who narrowed criteria and hit Start Batch ingested every candidate the query returned (reproduced in the field: picking 1 PayPal 8-K → 4 filings queued).
- Each row is now a real \`<input type=\"checkbox\" name=\"filing_id\">\`; new filings are default-checked, already-extracted rows default to **unchecked** (safer for destructive re-extract paths).
- Header \"select / deselect all\" per section plus a live submit-button count.
- Server-side: re-extract decisions now derived from the \`bucket\` classification, dropping the redundant per-row \`reextract_X\` field the template used to emit.

## Scope

- Fixes the symptom the user hit in prod — unintended extractions from over-inclusive preview.
- Does not change the reviewed-filing guard (still requires the JS confirmation + \`reextract_reviewed_ack\` hidden field).
- Unrelated to the batch-runner path-traversal \`ValueError\` the user also reported — that's a data bug in \`filings.accession_number\` (tracked separately).

## Test plan

- [x] \`pytest tests/unit/ -x -q\` — 3715 passed, 11 skipped
- [x] \`ruff check src/ tests/\` — clean
- [x] Three new unit tests:
  - \`test_ingest_start_creates_batch_row_per_submitted_filing_id\` — regression guard: submitting 1 filing creates exactly 1 batch row
  - \`test_ingest_start_derives_reextract_from_bucket\` — \`bucket=reextract\` with no \`reextract_X\` still triggers re-extraction
  - \`test_ingest_start_bucket_reextract_reviewed_without_ack_still_blocked\` — derived-from-bucket re-extract doesn't bypass the reviewed-filing guard
- [x] Existing \`test_ingest_start_reviewed_filing_{with,without}_ack\` tests still pass (new bucket logic fires the same guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)