### PR TITLE
fix(deps): bump anthropic to >=0.87.0 (CVE-2026-34450, CVE-2026-34452)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "pre-commit>=3.7.0",
 ]
 annotation = [
-    "anthropic>=0.30.0",
+    "anthropic>=0.87.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.96.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -166,9 +166,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'annotation'", specifier = ">=0.30.0" },
+    { name = "anthropic", marker = "extra == 'annotation'", specifier = ">=0.87.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "boto3", specifier = ">=1.34.0" },


### PR DESCRIPTION
## Summary
- Bumps `anthropic` from `>=0.30.0` to `>=0.87.0` in `pyproject.toml`; lockfile resolves to `0.96.0`.
- Resolves two `pip-audit` findings in `anthropic 0.86.0` (both fixed in `0.87.0`).
- Unblocks the **Vulnerability Scan** CI check, which was failing on every PR.

## Why the GitHub advisor's suggestion was wrong

An advisor recommended adding `--ignore-unpublished` to `pip-audit`, claiming the failure was due to the local `filings-reviewer` package. Two problems with that:

1. The actual CI log shows `Found 2 known vulnerabilities in 1 package` — `anthropic 0.86.0` with CVE-2026-34450 and CVE-2026-34452. The `filings-reviewer` line is a "Skip Reason" (informational), already handled gracefully by pip-audit.
2. `pip-audit` does not support `--ignore-unpublished`. Available flags are `--skip-editable`, `--ignore-vuln`, `--no-deps`, `--disable-pip`. Adding `--ignore-unpublished` would fail with an argparse error.

## Risk

Low. `anthropic` is imported in exactly one file: `scripts/preannotate_transcript.py:392` (a gold-standard annotation helper, not a production runtime dependency). The API surface used (`Anthropic(api_key=...)`, `client.messages.create(...)`, `response.content[0].text`, `response.usage.*`) is stable across 0.86 → 0.96.

## Test plan
- [x] `uv run pip-audit` — now reports `No known vulnerabilities found`
- [x] `uv run pytest tests/unit/ -x -q` — 3706 passed, 17 skipped
- [x] `uv run ruff check src/ tests/` — all checks pass
- [ ] CI **Vulnerability Scan** goes green on this PR
- [ ] CI **Unit Tests**, **Lint**, **Integration Tests**, **UI E2E** all green

Generated with Claude Opus 4.7 (1M context).