### PR TITLE
feat(extraction-v2): ML triage Stage 1 — learned gate + retrain wrapper + tests (Wave B3)

### DIFF
--- a/scripts/retrain_image_triage.py
+++ b/scripts/retrain_image_triage.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Monthly retrain wrapper for the image relevance triage model.
+
+Orchestrates the two-step retrain pipeline:
+  1. export_image_training_data.py  — regenerate training CSV from live DB
+  2. train_image_relevance_model.py — retrain the gradient-boosted classifier
+
+Usage:
+    python3 scripts/retrain_image_triage.py
+    python3 scripts/retrain_image_triage.py --database-url postgresql://...
+    python3 scripts/retrain_image_triage.py --dry-run
+    python3 scripts/retrain_image_triage.py --model-type gbt
+
+Operator notes:
+    - Run monthly after a batch of new human image review decisions have been
+      collected in v2_image_review_decisions.
+    - Defaults to $TEST_DATABASE_URL (local Docker) so you must pass
+      --database-url explicitly for production Neon (or set DATABASE_URL to the
+      prod URL and pass --use-env-database-url).
+    - The trained artifact is written to data/image_model/relevance_model.joblib,
+      which src/shared/image_features.predict_relevance() loads at runtime.
+    - Set USE_LEARNED_TRIAGE=true in the environment to activate the model gate
+      in the extraction pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.infra.logging_config import configure_logging
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parent.parent
+EXPORT_SCRIPT = ROOT / "scripts" / "export_image_training_data.py"
+TRAIN_SCRIPT = ROOT / "scripts" / "train_image_relevance_model.py"
+DEFAULT_CSV = ROOT / "data" / "image_model" / "training_data.csv"
+DEFAULT_MODEL = ROOT / "data" / "image_model" / "relevance_model.joblib"
+DEFAULT_REPORT = ROOT / "data" / "image_model" / "model_report.txt"
+
+
+def _run(cmd: list[str], *, dry_run: bool) -> None:
+    """Log and optionally execute a subprocess command."""
+    pretty = " ".join(str(c) for c in cmd)
+    if dry_run:
+        logger.info("[dry-run] would run: %s", pretty)
+        return
+    logger.info("Running: %s", pretty)
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        logger.error("Command failed (exit %d): %s", result.returncode, pretty)
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Monthly retrain wrapper for the image relevance triage model",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--database-url",
+        type=str,
+        default=os.environ.get("TEST_DATABASE_URL"),
+        help=(
+            "Database connection string for the export step. "
+            "Defaults to $TEST_DATABASE_URL. Pass the Neon URL for production retrains."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log the commands that would run without executing them.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default=str(DEFAULT_CSV),
+        help=f"Path for the exported training CSV (default: {DEFAULT_CSV})",
+    )
+    parser.add_argument(
+        "--output-model",
+        type=str,
+        default=str(DEFAULT_MODEL),
+        help=f"Path for the saved model artifact (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--output-report",
+        type=str,
+        default=str(DEFAULT_REPORT),
+        help=f"Path for the training report (default: {DEFAULT_REPORT})",
+    )
+    parser.add_argument(
+        "--model-type",
+        choices=["logistic", "gbt"],
+        default="logistic",
+        help="Model class to train (default: logistic). Use 'gbt' for gradient-boosted.",
+    )
+    parser.add_argument(
+        "--source",
+        choices=["sec", "pres", "all"],
+        default="all",
+        help="Which source to export for training data (default: all).",
+    )
+    args = parser.parse_args()
+
+    configure_logging(level="INFO")
+
+    if not args.database_url and args.source in ("sec", "all"):
+        logger.error("No database URL available. Set $TEST_DATABASE_URL or pass --database-url.")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Step 1: Export training data from live DB
+    # ------------------------------------------------------------------
+    logger.info("=== Step 1: Export training data ===")
+    export_cmd: list[str] = [
+        sys.executable,
+        str(EXPORT_SCRIPT),
+        "--output",
+        args.output_csv,
+        "--source",
+        args.source,
+    ]
+    if args.database_url:
+        export_cmd += ["--database-url", args.database_url]
+
+    _run(export_cmd, dry_run=args.dry_run)
+
+    if not args.dry_run and not Path(args.output_csv).exists():
+        logger.error("Export step produced no output at %s — aborting.", args.output_csv)
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Step 2: Retrain the model
+    # ------------------------------------------------------------------
+    logger.info("=== Step 2: Retrain model ===")
+    train_cmd: list[str] = [
+        sys.executable,
+        str(TRAIN_SCRIPT),
+        "--input",
+        args.output_csv,
+        "--output",
+        args.output_model,
+        "--report",
+        args.output_report,
+        "--model-type",
+        args.model_type,
+    ]
+    _run(train_cmd, dry_run=args.dry_run)
+
+    if args.dry_run:
+        logger.info("Dry-run complete. No files were written.")
+    else:
+        logger.info(
+            "Retrain complete. Model: %s  Report: %s",
+            args.output_model,
+            args.output_report,
+        )
+        logger.info(
+            "Set USE_LEARNED_TRIAGE=true + LEARNED_TRIAGE_MIN=0.4 to activate the model gate."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -746,6 +746,9 @@ class ImageAsset:
     confidence: float = 0.0
     requires_manual_capture: bool = False  # True if values couldn't be extracted
 
+    # ML triage score (populated by learned gate when USE_LEARNED_TRIAGE=true)
+    predicted_relevance: float | None = None
+
     def is_relevant(self, threshold: float = 0.3) -> bool:
         """Check if image is relevant for metric extraction."""
         if self.classification == ImageClassification.DECORATIVE:

--- a/src/extraction_v2/stages/image_triage.py
+++ b/src/extraction_v2/stages/image_triage.py
@@ -14,6 +14,7 @@ Key responsibilities:
 from __future__ import annotations
 
 import logging
+import os
 import re
 from collections import Counter
 from datetime import UTC, datetime
@@ -26,11 +27,24 @@ from src.extraction_v2.models import (
     ImageClassification,
     SectionType,
 )
+from src.shared.image_features import predict_relevance, v2_row_to_features_input
 
 if TYPE_CHECKING:
     from src.extraction_v2 import pipeline
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Learned triage feature flags
+# ---------------------------------------------------------------------------
+# Set USE_LEARNED_TRIAGE=true to enable the gradient-boosted triage gate.
+# When true and the model artifact loads, predicted_relevance replaces the
+# heuristic relevance_score threshold for the pass/fail decision.
+# LEARNED_TRIAGE_MIN controls the minimum predicted score (default 0.4).
+# When false (default), or when the model is absent, existing heuristic
+# behavior is preserved exactly.
+_USE_LEARNED_TRIAGE: bool = os.environ.get("USE_LEARNED_TRIAGE", "false").lower() == "true"
+_LEARNED_TRIAGE_MIN: float = float(os.environ.get("LEARNED_TRIAGE_MIN", "0.4"))
 
 
 class ImageTriageStage:
@@ -586,7 +600,33 @@ class ImageTriageStage:
             # Score relevance
             asset.relevance_score = self.score_relevance(asset)
 
-            # Mark for manual capture if ambiguous
+            # Learned triage gate (USE_LEARNED_TRIAGE=true)
+            # When enabled and the model loads, write predicted_relevance onto
+            # the asset and use it in place of the heuristic threshold check.
+            # Falls back transparently to heuristic when model is absent.
+            queued: bool
+            if _USE_LEARNED_TRIAGE:
+                features = v2_row_to_features_input(
+                    {
+                        "nearby_text": asset.nearby_text,
+                        "relevance_score": asset.relevance_score,
+                        "width": asset.width or None,
+                        "height": asset.height or None,
+                        "classification": asset.classification.value,
+                        "filename": asset.filename,
+                    }
+                )
+                score = predict_relevance(features)
+                if score is not None:
+                    asset.predicted_relevance = score
+                    queued = score >= _LEARNED_TRIAGE_MIN
+                else:
+                    # Model absent — fall back to heuristic
+                    queued = asset.relevance_score >= self.MIN_RELEVANCE_FOR_PROCESSING
+            else:
+                queued = asset.relevance_score >= self.MIN_RELEVANCE_FOR_PROCESSING
+
+            # Mark for manual capture if ambiguous (heuristic; applies in both modes)
             if (
                 asset.classification == ImageClassification.UNKNOWN
                 and asset.relevance_score >= self.MIN_RELEVANCE_FOR_PROCESSING
@@ -595,7 +635,7 @@ class ImageTriageStage:
                 asset.requires_manual_capture = True
 
             # Queue for processing if relevant
-            if asset.relevance_score >= self.MIN_RELEVANCE_FOR_PROCESSING:
+            if queued:
                 images_for_processing.append(asset)
 
         logger.info(

--- a/src/shared/image_features.py
+++ b/src/shared/image_features.py
@@ -21,9 +21,84 @@ Expected row dict keys (common format):
 
 from __future__ import annotations
 
+import logging
 import re
+import threading
+from pathlib import Path
+from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cached model loader
+# ---------------------------------------------------------------------------
+
+_MODEL_LOCK = threading.Lock()
+_MODEL_CACHE: dict[str, Any] = {}  # path → loaded pipeline (or sentinel None)
+_MODEL_ABSENT: object = object()  # sentinel: model file was not found
+
+DEFAULT_MODEL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data"
+    / "image_model"
+    / "relevance_model.joblib"
+)
+
+
+def _load_model(model_path: Path | None = None) -> Any | None:
+    """Load (and cache) the sklearn pipeline from disk.
+
+    Returns the fitted pipeline, or None if the file is missing or fails to
+    load.  The result is cached per resolved path so subsequent calls are
+    free of I/O.
+    """
+    resolved = str((model_path or DEFAULT_MODEL_PATH).resolve())
+    with _MODEL_LOCK:
+        if resolved in _MODEL_CACHE:
+            cached = _MODEL_CACHE[resolved]
+            return None if cached is _MODEL_ABSENT else cached
+        path = Path(resolved)
+        if not path.exists():
+            logger.debug(
+                "Image relevance model not found at %s — falling back to heuristic", resolved
+            )
+            _MODEL_CACHE[resolved] = _MODEL_ABSENT
+            return None
+        try:
+            import joblib  # optional heavy import; only at prediction time
+
+            pipeline = joblib.load(path)
+            _MODEL_CACHE[resolved] = pipeline
+            logger.info("Loaded image relevance model from %s", resolved)
+            return pipeline
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to load image relevance model from %s: %s", resolved, exc)
+            _MODEL_CACHE[resolved] = _MODEL_ABSENT
+            return None
+
+
+def predict_relevance(features: dict, *, model_path: Path | None = None) -> float | None:
+    """Return a predicted relevance score (0–1) for a single image feature dict.
+
+    ``features`` must be in the same format accepted by ``engineer_features``
+    (i.e. the keys listed in the module docstring).
+
+    Returns ``None`` when the model is absent or fails — callers should fall
+    back to the heuristic relevance score in that case.
+    """
+    pipeline = _load_model(model_path)
+    if pipeline is None:
+        return None
+    try:
+        X = engineer_features([features])
+        prob: float = float(pipeline.predict_proba(X)[0, 1])
+        return prob
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("predict_relevance failed: %s", exc)
+        return None
+
 
 # Filename patterns common in SEC auto-generated chart images.
 # e.g. g665122g20q37.jpg, g468383g1r55k94.jpg — letter 'g' prefix followed by digits.
@@ -41,19 +116,39 @@ SEC_CHART_FILENAME_RE = re.compile(r"^g\d+", re.IGNORECASE)
 
 SEMANTIC_CATEGORIES: dict[str, list[str]] = {
     "text_cohort_terms": [
-        "cohort", "cohorts", "vintage", "vintages",
+        "cohort",
+        "cohorts",
+        "vintage",
+        "vintages",
     ],
     "text_retention_terms": [
-        "retention", "churn", "retain", "attrition",
+        "retention",
+        "churn",
+        "retain",
+        "attrition",
     ],
     "text_unit_econ_terms": [
-        "ltv", "cac", "lifetime value", "acquisition cost", "payback", "arpu",
+        "ltv",
+        "cac",
+        "lifetime value",
+        "acquisition cost",
+        "payback",
+        "arpu",
     ],
     "text_temporal_terms": [
-        "year", "quarter", "month", "annual", "fiscal", "period",
+        "year",
+        "quarter",
+        "month",
+        "annual",
+        "fiscal",
+        "period",
     ],
     "text_growth_terms": [
-        "growth", "increase", "grow", "expanding", "expansion",
+        "growth",
+        "increase",
+        "grow",
+        "expanding",
+        "expansion",
     ],
 }
 
@@ -75,10 +170,7 @@ def count_semantic_terms(text: str | None) -> dict[str, int]:
     """
     if not text:
         return {cat: 0 for cat in SEMANTIC_CATEGORIES}
-    return {
-        cat: len(pattern.findall(text))
-        for cat, pattern in _CATEGORY_PATTERNS.items()
-    }
+    return {cat: len(pattern.findall(text)) for cat, pattern in _CATEGORY_PATTERNS.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -87,28 +179,28 @@ def count_semantic_terms(text: str | None) -> dict[str, int]:
 
 FEATURE_NAMES: list[str] = [
     # --- original 16 features ---
-    "cohort_confidence",           # 0
-    "cohort_keyword_nearby",       # 1  (strongest signal)
-    "keyword_count",               # 2  (strong signal)
-    "text_long",                   # 3
-    "text_medium",                 # 4
-    "text_short",                  # 5
-    "has_dimensions",              # 6
-    "image_area_clipped",          # 7
-    "is_chart_classification",     # 8
-    "is_unknown_classification",   # 9
-    "is_tier_1",                   # 10
-    "is_tier_2",                   # 11
-    "filename_has_chart_hint",     # 12
-    "is_source_sec",               # 13
+    "cohort_confidence",  # 0
+    "cohort_keyword_nearby",  # 1  (strongest signal)
+    "keyword_count",  # 2  (strong signal)
+    "text_long",  # 3
+    "text_medium",  # 4
+    "text_short",  # 5
+    "has_dimensions",  # 6
+    "image_area_clipped",  # 7
+    "is_chart_classification",  # 8
+    "is_unknown_classification",  # 9
+    "is_tier_1",  # 10
+    "is_tier_2",  # 11
+    "filename_has_chart_hint",  # 12
+    "is_source_sec",  # 13
     "is_table_image_classification",  # 14
-    "log_keyword_count",           # 15
+    "log_keyword_count",  # 15
     # --- 5 semantic text features (positions 16-20) ---
-    "text_cohort_terms",           # 16
-    "text_retention_terms",        # 17
-    "text_unit_econ_terms",        # 18
-    "text_temporal_terms",         # 19
-    "text_growth_terms",           # 20
+    "text_cohort_terms",  # 16
+    "text_retention_terms",  # 17
+    "text_unit_econ_terms",  # 18
+    "text_temporal_terms",  # 19
+    "text_growth_terms",  # 20
 ]
 
 
@@ -216,27 +308,29 @@ def engineer_features(rows: list[dict]) -> np.ndarray:
         # Semantic text features
         semantic = count_semantic_terms(r.get("preceding_text"))
 
-        X.append([
-            cohort_confidence,                    # 0
-            cohort_keyword_nearby,                # 1
-            keyword_count,                        # 2
-            text_long,                            # 3
-            text_medium,                          # 4
-            text_short,                           # 5
-            has_dimensions,                       # 6
-            image_area_clipped,                   # 7
-            is_chart_classification,              # 8
-            is_unknown_classification,            # 9
-            is_tier_1,                            # 10
-            is_tier_2,                            # 11
-            filename_has_chart_hint,              # 12
-            is_source_sec,                        # 13
-            is_table_image_classification,        # 14
-            log_keyword_count,                    # 15
-            semantic["text_cohort_terms"],        # 16
-            semantic["text_retention_terms"],     # 17
-            semantic["text_unit_econ_terms"],     # 18
-            semantic["text_temporal_terms"],      # 19
-            semantic["text_growth_terms"],        # 20
-        ])
+        X.append(
+            [
+                cohort_confidence,  # 0
+                cohort_keyword_nearby,  # 1
+                keyword_count,  # 2
+                text_long,  # 3
+                text_medium,  # 4
+                text_short,  # 5
+                has_dimensions,  # 6
+                image_area_clipped,  # 7
+                is_chart_classification,  # 8
+                is_unknown_classification,  # 9
+                is_tier_1,  # 10
+                is_tier_2,  # 11
+                filename_has_chart_hint,  # 12
+                is_source_sec,  # 13
+                is_table_image_classification,  # 14
+                log_keyword_count,  # 15
+                semantic["text_cohort_terms"],  # 16
+                semantic["text_retention_terms"],  # 17
+                semantic["text_unit_econ_terms"],  # 18
+                semantic["text_temporal_terms"],  # 19
+                semantic["text_growth_terms"],  # 20
+            ]
+        )
     return np.array(X, dtype=float)

--- a/tests/unit/extraction_v2/test_image_triage.py
+++ b/tests/unit/extraction_v2/test_image_triage.py
@@ -11,6 +11,8 @@ Tests:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from src.extraction_v2.models import (
@@ -957,3 +959,128 @@ class TestPromoteToFullPageScan:
         # All 16 get queued for downstream OCR processing.
         assert result.items_output == 16
         assert context.full_page_scan_mode is True
+
+
+class TestLearnedTriageGate:
+    """Tests for the USE_LEARNED_TRIAGE feature-flag gate (Wave B3 Stage 1).
+
+    The gate is a module-level flag evaluated at import, so tests patch the
+    module attribute directly rather than setting env and reloading.
+    """
+
+    @pytest.fixture
+    def stage(self) -> ImageTriageStage:
+        return ImageTriageStage()
+
+    def _make_chart_asset(self, relevance_hint: float = 0.6) -> ImageAsset:
+        """Build a chart-ish asset whose heuristic score will be roughly the hint."""
+        return ImageAsset(
+            img_id=f"test_{relevance_hint}",
+            filename="chart.png",
+            nearby_text="Customer retention cohort",
+            width=800,
+            height=600,
+        )
+
+    def test_gate_off_by_default_matches_heuristic(
+        self, stage: ImageTriageStage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """USE_LEARNED_TRIAGE=false (default): behavior matches heuristic path."""
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
+            False,
+        )
+
+        asset = self._make_chart_asset()
+        result = stage.triage_images([asset])
+
+        # Heuristic should classify this as a chart and queue it.
+        assert asset.classification == ImageClassification.CHART
+        # predicted_relevance should NOT be set — the ML gate didn't run.
+        assert asset.predicted_relevance is None
+        assert len(result) == 1
+
+    def test_gate_on_but_model_absent_falls_back_to_heuristic(
+        self,
+        stage: ImageTriageStage,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """USE_LEARNED_TRIAGE=true + no model file: queueing uses heuristic.
+
+        This is the critical fallback path — if the model artifact never ships
+        or fails to load, the pipeline must not crash or silently drop images.
+        """
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
+            True,
+        )
+        # Point the loader at a non-existent path so predict_relevance returns None.
+        monkeypatch.setattr(
+            "src.shared.image_features.DEFAULT_MODEL_PATH",
+            tmp_path / "absent.joblib",
+        )
+        # Clear the module cache to avoid a cached result from a prior test.
+        from src.shared import image_features
+
+        image_features._MODEL_CACHE.clear()
+
+        asset = self._make_chart_asset()
+        result = stage.triage_images([asset])
+
+        # Heuristic should still queue it since the chart is classified and
+        # relevance meets MIN_RELEVANCE_FOR_PROCESSING.
+        assert asset.classification == ImageClassification.CHART
+        assert len(result) == 1
+        # predicted_relevance stays None (fallback path, no model score).
+        assert asset.predicted_relevance is None
+
+    def test_gate_on_with_model_uses_predicted_relevance(
+        self,
+        stage: ImageTriageStage,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """USE_LEARNED_TRIAGE=true + model present: queueing uses predicted_relevance.
+
+        Mocks predict_relevance to return 0.8 (above default LEARNED_TRIAGE_MIN=0.4);
+        asset should be queued regardless of its heuristic relevance_score and
+        predicted_relevance should land on the asset.
+        """
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
+            True,
+        )
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage.predict_relevance",
+            lambda features: 0.8,
+        )
+
+        asset = self._make_chart_asset()
+        result = stage.triage_images([asset])
+
+        assert asset.predicted_relevance == 0.8
+        assert len(result) == 1
+
+    def test_gate_on_below_min_threshold_skips(
+        self,
+        stage: ImageTriageStage,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """USE_LEARNED_TRIAGE=true + predicted_relevance < LEARNED_TRIAGE_MIN: skip."""
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
+            True,
+        )
+        # Default LEARNED_TRIAGE_MIN is 0.4; 0.2 is below threshold.
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage.predict_relevance",
+            lambda features: 0.2,
+        )
+
+        asset = self._make_chart_asset()
+        result = stage.triage_images([asset])
+
+        assert asset.predicted_relevance == 0.2
+        # Asset was classified but not queued (below learned threshold).
+        assert asset.classification == ImageClassification.CHART
+        assert len(result) == 0

--- a/tests/unit/shared/test_image_features_predict.py
+++ b/tests/unit/shared/test_image_features_predict.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for the learned-triage inference helper in image_features.
+
+Covers:
+- predict_relevance returns None when the model file is absent (graceful fallback)
+- predict_relevance returns a float in [0, 1] when a mocked pipeline is present
+- _load_model caches results so repeated calls do not re-load from disk
+- Bad pipelines surface as None rather than raising
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.shared import image_features
+from src.shared.image_features import _load_model, predict_relevance
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_cache() -> None:
+    """Ensure each test starts with a clean model cache."""
+    image_features._MODEL_CACHE.clear()
+    yield
+    image_features._MODEL_CACHE.clear()
+
+
+def _sample_features() -> dict:
+    """Minimal feature dict matching v2_row_to_features_input output shape."""
+    return {
+        "nearby_text": "Customer retention cohort",
+        "relevance_score": 0.75,
+        "width": 800,
+        "height": 600,
+        "classification": "chart",
+        "filename": "chart.png",
+    }
+
+
+def test_predict_relevance_returns_none_when_model_absent(tmp_path: Path) -> None:
+    """Graceful fallback: missing model artifact → None (caller uses heuristic)."""
+    missing = tmp_path / "does_not_exist.joblib"
+    assert not missing.exists()
+
+    result = predict_relevance(_sample_features(), model_path=missing)
+    assert result is None
+
+
+def test_predict_relevance_returns_float_when_pipeline_loads(tmp_path: Path) -> None:
+    """Happy path: mocked joblib.load returns a pipeline with predict_proba."""
+    model_path = tmp_path / "relevance_model.joblib"
+    model_path.write_bytes(b"sentinel")  # Content ignored; joblib.load is mocked.
+
+    mock_pipeline = MagicMock()
+    # predict_proba returns a (N, 2) array: [prob_not_relevant, prob_relevant]
+    mock_pipeline.predict_proba.return_value = np.array([[0.1, 0.9]])
+
+    with patch("joblib.load", return_value=mock_pipeline):
+        result = predict_relevance(_sample_features(), model_path=model_path)
+
+    assert result is not None
+    assert 0.0 <= result <= 1.0
+    assert result == pytest.approx(0.9)
+
+
+def test_predict_relevance_returns_none_on_bad_pipeline(tmp_path: Path) -> None:
+    """Pipeline that raises during predict_proba → None (no crash)."""
+    model_path = tmp_path / "relevance_model.joblib"
+    model_path.write_bytes(b"sentinel")
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.predict_proba.side_effect = RuntimeError("broken pipeline")
+
+    with patch("joblib.load", return_value=mock_pipeline):
+        result = predict_relevance(_sample_features(), model_path=model_path)
+
+    assert result is None
+
+
+def test_load_model_caches_per_path(tmp_path: Path) -> None:
+    """Cached loader: repeated calls for the same path hit disk exactly once."""
+    model_path = tmp_path / "relevance_model.joblib"
+    model_path.write_bytes(b"sentinel")
+
+    mock_pipeline = MagicMock()
+
+    with patch("joblib.load", return_value=mock_pipeline) as mock_load:
+        first = _load_model(model_path)
+        second = _load_model(model_path)
+        third = _load_model(model_path)
+
+        assert mock_load.call_count == 1
+        assert first is mock_pipeline
+        assert second is mock_pipeline
+        assert third is mock_pipeline
+
+
+def test_load_model_caches_absent_result(tmp_path: Path) -> None:
+    """Absent-model sentinel is cached too — don't stat the filesystem repeatedly."""
+    missing = tmp_path / "does_not_exist.joblib"
+    assert not missing.exists()
+
+    # First call caches the absent sentinel.
+    assert _load_model(missing) is None
+    # Second call returns None without attempting another stat/load.
+    assert _load_model(missing) is None
+    # Internal cache holds the sentinel, not a real pipeline.
+    resolved = str(missing.resolve())
+    assert resolved in image_features._MODEL_CACHE
+    assert image_features._MODEL_CACHE[resolved] is image_features._MODEL_ABSENT


### PR DESCRIPTION
## Summary

Completes **Wave B3 Stage 1** of the image-extraction synthesis plan. Introduces a learned gradient-boosted triage gate behind a feature flag, with a monthly retrain wrapper and full test coverage. Stage 2 (pixel embeddings via torch+timm) is explicitly deferred pending saturation measurement on the B1 benchmark harness.

## What's in this PR

Builds on WIP checkpoint \`af4a8fb\` which added:
- \`ImageAsset.predicted_relevance\` field
- \`predict_relevance()\` + cached joblib loader in \`src/shared/image_features.py\`
- \`USE_LEARNED_TRIAGE\` + \`LEARNED_TRIAGE_MIN\` env-var gate in \`image_triage.py\` with transparent fallback to heuristic when the model is absent

This commit adds the three missing pieces:

### \`scripts/retrain_image_triage.py\` (new)
Monthly operator wrapper that chains:
1. \`scripts/export_image_training_data.py\` (A1-fixed exporter, SEC keywords now propagate)
2. \`scripts/train_image_relevance_model.py\` (pre-existing; writes \`data/image_model/relevance_model.joblib\`)

Supports \`--dry-run\`, \`--database-url\` (defaults to \`\$TEST_DATABASE_URL\`), \`--model-type {logistic,gbt}\`, \`--source {sec,pres,all}\`.

### \`tests/unit/shared/test_image_features_predict.py\` (new, 5 tests)
- Returns \`None\` when model file is absent (graceful heuristic fallback)
- Returns a float in [0, 1] with a mocked joblib pipeline
- Returns \`None\` when \`predict_proba\` raises (no crash)
- \`_load_model\` caches per-path (one \`joblib.load\` call per unique path)
- Absent-model sentinel is cached too (no repeated stat calls)

### \`tests/unit/extraction_v2/test_image_triage.py\` (extended, 4 new in \`TestLearnedTriageGate\`)
- \`USE_LEARNED_TRIAGE=false\` (default) → heuristic behavior unchanged; \`predicted_relevance\` stays \`None\`
- \`USE_LEARNED_TRIAGE=true\` + model absent → falls back to heuristic (no NameError, no silent drops)
- \`USE_LEARNED_TRIAGE=true\` + mocked score 0.8 → uses \`predicted_relevance\`, asset queued
- \`USE_LEARNED_TRIAGE=true\` + score 0.2 (below \`LEARNED_TRIAGE_MIN=0.4\`) → asset skipped

## Pre-implementation checklist

- [x] Assumptions audit: \`joblib\` already in \`pyproject.toml\` + \`requirements.txt\` via sklearn. \`scripts/train_image_relevance_model.py\` already exists and writes to the path the loader reads from.
- [x] Scope check: Stage 1 only; no torch/timm/open_clip. Only new files + one extended test file.
- [x] Rules compliance: no extraction-behavior change when flag is off (default). Model-absent fallback preserves prod path.
- [x] Risk assessment: gate flag is module-level (evaluated at import). Tests patch the module attribute directly rather than reload.
- [x] Minimal path: script + 2 test files, no changes to core triage logic beyond the WIP checkpoint.
- [x] Worktree confirmation: isolated worktree, branched from \`feat/image-ml-triage-b3-wip\`.

## Test plan

- [x] 9 new tests green (5 predict + 4 gate)
- [x] All 68 existing \`test_image_triage.py\` tests still pass
- [x] \`ruff check src/ tests/ scripts/\` clean
- [x] \`python3 scripts/retrain_image_triage.py --help\` exits 0

## Deferred (follow-up waves)

- Stage 2: local pixel embeddings (MobileNetV3 / CLIP ViT-B/32). Only if Stage 1 saturates below target on the B1 harness. Dep-heavy — torch ~2GB install.
- DB backfill of \`v2_image_assets.predicted_relevance\` column is also a separate followup (this PR writes to an in-memory field only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)