### PR TITLE
chore(gitignore): ignore .claude/*.lock runtime files (resolves #74, replays #104, supersedes #125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ htmlcov/
 # But keep project-specific Claude settings
 !.claude/settings.json
 
+# Claude Code runtime locks (created by the scheduled-tasks system)
+.claude/*.lock
+
 # Python tool caches
 .mypy_cache/
 .pytest_cache/

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 26 |
+| Open | 25 |
 | Partially Resolved | 3 |
 | Archived | 46 |
-| Resolved | 7 |
+| Resolved | 8 |
 
 
 ## Nightly Sweeper Classification
@@ -43,7 +43,6 @@
 | #66 | review | S | `render.yaml` `.claude/rules/infrastructure.md` | Wire apply_migrations into Render deploy; infra-change risk |
 | #69 | review | S | `Dockerfile.nightly-sweep` | Pin claude + gh versions; needs validation step |
 | #72 | review | S | `pyproject.toml` `uv.lock` | Boto3 fix unblocks ingestion (stage 1); R2 image-bytes layer still needs separate fix before baseline refresh |
-| #74 | safe | XS | `.gitignore` | One-line addition to root `.gitignore` |
 | #75 | skip | S | `tests/ui/*.spec.js` `tests/ui/test_server.py` | Playwright E2E gap — cross-filing auto-advance; needs stub-server extension |
 | #77 | skip | M | — | Second layer of #72 — R2 chart-image bytes missing/mis-keyed for HOOD S-1; partial code fix shipped, prod backfill needs explicit auth (R2 + Neon writes) |
 | #79 | safe | XS | `scripts/known_issues_selector.py` | Filter selector picks on status=open or partially-resolved |
@@ -633,22 +632,6 @@ Wave C documents the cancel-during-populate flow (cancel flips `status='cancelle
 - Pin the `claude` installer to a specific version once the installer supports a version argument; otherwise cache a specific binary in the image.
 - Pin `gh` to a specific apt version (`gh=2.X.Y`) or switch to the GitHub Releases tarball.
 - Consider adding a build-time smoke test: `claude --version && gh --version` to fail the build on unexpected drift.
-
-## #74. `.claude/scheduled_tasks.lock` Not Gitignored
-
-**Status**: Open
-**Severity**: low
-**Discovered**: 2026-04-22
-**Updated**: 2026-04-22
-
-### Problem
-
-`.claude/scheduled_tasks.lock` is created at runtime by the Claude Code scheduled-tasks system but is not covered by any `.gitignore` rule — `git check-ignore -v .claude/scheduled_tasks.lock` returns no match. Every `git status` run in an active session lists it as untracked, which inflates status output and creates a small risk of accidental staging if someone invokes `git add -A` or `git add .` (already an anti-pattern per CLAUDE.md, but worth hardening against).
-
-### Next Steps
-
-- Add `.claude/scheduled_tasks.lock` (or a broader `.claude/*.lock` glob) to the root `.gitignore`.
-- Quick audit of `.claude/` for other runtime-only files (e.g., `.claude/sweep-digests/` is already tracked separately — confirm nothing else needs ignoring).
 
 ## #75. Missing Playwright E2E for Cross-Filing Auto-Advance
 
@@ -1530,6 +1513,22 @@ The functional behavior is correct — the hook fires and blocks the operation a
 - Mirror the UI E2E filter structure (`ci.yml:49-69`) on the `integration-tests` job. Same allowlist (`docs/`, `.claude/`, `CLAUDE.md`, `README.md`, `.gitignore`, `.github/CODEOWNERS`) — err on the side of running when in doubt.
 - Verify by opening a docs-only PR and confirming `Integration Tests` reports `skipped` in Actions.
 - Do NOT remove Integration Tests from required status checks — a skipped job still counts as passing for branch protection, so the gate stays intact.
+
+## #74. `.claude/scheduled_tasks.lock` Not Gitignored
+
+**Status**: Resolved
+**Severity**: low
+**Discovered**: 2026-04-22
+**Updated**: 2026-04-22
+
+### Problem
+
+`.claude/scheduled_tasks.lock` is created at runtime by the Claude Code scheduled-tasks system but is not covered by any `.gitignore` rule — `git check-ignore -v .claude/scheduled_tasks.lock` returns no match. Every `git status` run in an active session lists it as untracked, which inflates status output and creates a small risk of accidental staging if someone invokes `git add -A` or `git add .` (already an anti-pattern per CLAUDE.md, but worth hardening against).
+
+### Next Steps
+
+- Add `.claude/scheduled_tasks.lock` (or a broader `.claude/*.lock` glob) to the root `.gitignore`.
+- Quick audit of `.claude/` for other runtime-only files (e.g., `.claude/sweep-digests/` is already tracked separately — confirm nothing else needs ignoring).
 
 ## #76. Missing Integration Test for Filings-List Reviewer Aggregate
 

--- a/docs/known-issues/legacy-074-claude-scheduled-tasks-lock-not-gitignored.md
+++ b/docs/known-issues/legacy-074-claude-scheduled-tasks-lock-not-gitignored.md
@@ -1,16 +1,16 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-22'
-estimated: XS
+estimated: —
 id: 74
-note: One-line addition to root `.gitignore`
+note: Resolved in fresh-branch replay of PR #104
+pr_refs: []
 severity: low
 slug: claude-scheduled-tasks-lock-not-gitignored
 source: legacy
-status: open
+status: resolved
 title: '`.claude/scheduled_tasks.lock` Not Gitignored'
-touches:
-- .gitignore
+touches: []
 updated: '2026-04-22'
 ---
 


### PR DESCRIPTION
Second fresh-branch replay of #104. Supersedes #125.

#125's merge commit needed to pull in #131/#132's extraction changes from main, which trip the gold-standard regression guard unrelated to this PR (the `feedback_extraction_guard_merge_trap` pattern from memory). Starting fresh off latest main avoids the merge entirely since this PR doesn't touch extraction files.

## Changes (3 files)

- `.gitignore` — add `.claude/*.lock` glob after the `!.claude/settings.json` keep rule
- `docs/known-issues/legacy-074-*.md` — `status: open → resolved`, `autonomy: safe → n/a`, `touches: []`, note updated
- `docs/KNOWN_ISSUES.md` — regenerated from fragments (deterministic)

## Supersession chain

#104 (original, pre-migration, hand-edit to KNOWN_ISSUES.md conflicts with auto-generated rollup) → #125 (replay, hit extraction-guard trap on merge) → **#129 (this, fresh branch)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)