### PR TITLE
fix(infra): bump filings-metabase plan starter → standard (OOM fix)

### DIFF
--- a/docs/operations/analytics-ui-runbook.md
+++ b/docs/operations/analytics-ui-runbook.md
@@ -117,14 +117,16 @@ Metabase runs as the `filings-metabase` service defined in `render.yaml`:
 - **Image:** `docker.io/metabase/metabase:v0.59.8` (pinned; see "Upgrade
   procedure" below for bumping).
 - **Region:** `ohio` (matches the other services).
-- **Plan:** Render Starter. Disk: 1 GB at `/metabase-data`.
+- **Plan:** Render Standard (2 GB RAM). Disk: 1 GB at `/metabase-data`.
+  Starter (512 MB) is not enough — Metabase's JVM OOMs during first-boot
+  schema migration with ~124 MB of available heap.
 - **App DB:** H2 file at `/metabase-data/metabase.db` (persistent). Upgrade to
   Postgres before opening to a wider audience — see "On-ramp to public access".
 - **Autodeploy:** off. Upgrades happen manually from the Render dashboard to
   avoid restarting Metabase (and dropping in-progress dashboard edits) on every
   `main` push.
 - **Health check:** `/api/health`.
-- **Cost:** ~$7/mo (Starter) + ~$0.25/mo (1 GB disk).
+- **Cost:** ~$25/mo (Standard) + ~$0.25/mo (1 GB disk).
 
 ### Env vars on the Metabase service
 

--- a/render.yaml
+++ b/render.yaml
@@ -103,7 +103,9 @@ services:
     runtime: image
     image:
       url: docker.io/metabase/metabase:v0.59.8
-    plan: starter
+    # Standard (2 GB RAM) required — Metabase's JVM needs ~1 GB heap minimum;
+    # Starter (512 MB) OOMs during the first-boot schema migration.
+    plan: standard
     autoDeploy: false  # upgrades are deliberate; don't restart on every main push
     healthCheckPath: /api/health
     disk:


### PR DESCRIPTION
## Summary

First deploy of `filings-metabase` (from #143) failed during blueprint sync with an OOM before the process could bind a port:

```
Maximum memory available to JVM: 123.8 MB
Aborting due to java.lang.OutOfMemoryError: Java heap space
fatal error: OutOfMemory encountered: Java heap space
```

Render Starter's 512 MB is below Metabase's documented 1 GB JVM heap minimum. Bumping `plan: starter → standard` (2 GB RAM) and updating the runbook cost line from ~\$7/mo to ~\$25/mo with an inline note explaining why Starter doesn't work.

## Changes

- `render.yaml`: `filings-metabase` `plan: starter → standard`, comment explaining the RAM floor.
- `docs/operations/analytics-ui-runbook.md`: cost line updated, plan line updated, one sentence about the Starter OOM so future operators don't retry it.

## Follow-up (after merge)

After this PR merges, the blueprint will resize the service on the next sync. Since `autoDeploy: false`, the redeploy is **manual**: open the Render dashboard → `filings-metabase` → Deploys → "Deploy latest commit". Boot logs should show the JVM getting ~1 GB heap this time and binding port 3000 (`MB_JETTY_PORT`) within a couple of minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)