### PR TITLE
feat(extraction-v2): Wave B5.x chart-read bake-off harness + decision memo

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,7 +7,7 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 26 |
+| Open | 27 |
 | Partially Resolved | 2 |
 | Archived | 46 |
 | Resolved | 13 |
@@ -319,6 +319,49 @@ directly or pull up individual image-review pages.
   adds the UI-surfacing layer to that integration gap.
 - PR #139 — landed the three backfill fixes that made filing 1748
   ingest cleanly; this issue is the logical follow-up.
+
+## #90. Integration Tests Fail at Startup on sql/37 Migration-Checksum Drift
+
+**Status**: Open
+**Severity**: medium
+**Discovered**: 2026-04-23
+**Updated**: 2026-04-23
+
+### Problem
+
+Running `pytest` without `--ignore=tests/integration` fails before any
+test body executes with:
+
+```
+RuntimeError: Checksum mismatch for 37_create_analytics_role.sql:
+expected e7b06ff3…, got a589d96a…. Migration file was modified
+after it was applied.
+```
+
+Surfaced today while running the full suite for the B5.x chart-read
+commit gate. `sql/37_create_analytics_role.sql` has been edited after
+the shared test DB had already applied the earlier content (PRs #111
+touched it for hook guards), so the `schema_migrations` checksum no
+longer matches the file. Hitting this on any dev machine that rebuilds
+its test DB from a snapshot, or that runs integration tests after
+pulling a branch that touches migration 37.
+
+Unit-only runs (`pytest --ignore=tests/integration`) are unaffected —
+the full 3833-test unit suite passes cleanly. Blast radius is CI
+integration jobs + local integration runs.
+
+### Next Steps
+
+- Add a "rebuild test DB" runbook entry under
+  `docs/operations/setup-guide.md` documenting the drop/recreate
+  workflow when checksums drift after a migration edit.
+- Alternatively: loosen `scripts/apply_migrations.py:137` to `WARN` when
+  the file is in a known "intentional edit" allowlist (the hook-guard
+  migrations) rather than hard-failing. Risky — checksum mismatches
+  usually indicate a real problem. Prefer the runbook entry.
+- Could also add a `conftest.py` pre-check that drops the
+  `schema_migrations` row for a modified migration before re-applying,
+  scoped to test DBs only. More invasive.
 
 ## #4. Spelled-Out Number Parsing Limitations
 

--- a/docs/known-issues/legacy-090-integration-tests-fail-on-sql37-checksum.md
+++ b/docs/known-issues/legacy-090-integration-tests-fail-on-sql37-checksum.md
@@ -1,0 +1,52 @@
+---
+autonomy: n/a
+discovered: '2026-04-23'
+estimated: S
+id: 90
+severity: medium
+slug: integration-tests-fail-on-sql37-checksum
+source: legacy
+status: open
+title: Integration Tests Fail at Startup on sql/37 Migration-Checksum Drift
+touches:
+  - tests/integration/conftest.py
+  - scripts/apply_migrations.py
+  - sql/37_create_analytics_role.sql
+updated: '2026-04-23'
+---
+
+### Problem
+
+Running `pytest` without `--ignore=tests/integration` fails before any
+test body executes with:
+
+```
+RuntimeError: Checksum mismatch for 37_create_analytics_role.sql:
+expected e7b06ff3…, got a589d96a…. Migration file was modified
+after it was applied.
+```
+
+Surfaced today while running the full suite for the B5.x chart-read
+commit gate. `sql/37_create_analytics_role.sql` has been edited after
+the shared test DB had already applied the earlier content (PRs #111
+touched it for hook guards), so the `schema_migrations` checksum no
+longer matches the file. Hitting this on any dev machine that rebuilds
+its test DB from a snapshot, or that runs integration tests after
+pulling a branch that touches migration 37.
+
+Unit-only runs (`pytest --ignore=tests/integration`) are unaffected —
+the full 3833-test unit suite passes cleanly. Blast radius is CI
+integration jobs + local integration runs.
+
+### Next Steps
+
+- Add a "rebuild test DB" runbook entry under
+  `docs/operations/setup-guide.md` documenting the drop/recreate
+  workflow when checksums drift after a migration edit.
+- Alternatively: loosen `scripts/apply_migrations.py:137` to `WARN` when
+  the file is in a known "intentional edit" allowlist (the hook-guard
+  migrations) rather than hard-failing. Risky — checksum mismatches
+  usually indicate a real problem. Prefer the runbook entry.
+- Could also add a `conftest.py` pre-check that drops the
+  `schema_migrations` row for a modified migration before re-applying,
+  scoped to test DBs only. More invasive.

--- a/docs/operations/vision-bakeoff-chart-read-2026-04-23.md
+++ b/docs/operations/vision-bakeoff-chart-read-2026-04-23.md
@@ -1,0 +1,220 @@
+# Wave B5.x Vision Bake-off — Chart-READ Mode — 2026-04-23
+
+**Status:** Companion to [`vision-bakeoff-2026-04-23.md`](./vision-bakeoff-2026-04-23.md).
+That run measured chart DETECTION (`contains_chart` + `chart_hint`) and
+saturated at F1=1.0 for every provider, which couldn't separate them on the
+dimension that actually matters (per-point data fidelity). This run
+exercises `VisionClient.analyze_image_targeted(task_type="chart_read")`
+— the prod chart-extraction path — across the same 7-image corpus, scores
+extracted values against `extracted_values.csv` rows where
+`source_type="chart"`, and for the first time includes `two-stage`
+(B4 routing) in the sweep.
+
+**Scope of this run:** 6 provider configurations (`current`,
+`openai-vnext`, `gemini-flash`, `gemini-pro`, `anthropic`, `two-stage`)
+benchmarked via `scripts/benchmark_vision.py --bakeoff --mode chart-read`
+against the same hand-picked 7-image corpus (3 Farfetch + 4 Slack).
+Total real spend $0.34 under a $5 cap. Ran with
+`LLM_CACHE_ENABLED=false` so every $ number reflects a real API call,
+not a cache hit.
+
+## TL;DR
+
+Per-value data fidelity is a **tie** across the field in this corpus:
+every provider scored P=0.111 / R=0.500 / F1=0.182 on the one image with
+CSV-mapped ground truth. That's not a null result — it's a measurement
+ceiling that the current 7-image corpus can't break through. Providers
+DO separate on cost, latency, structural completeness, and reliability;
+and the PR #142 default-provider decision (`gemini-flash`) no longer
+has the cost margin it had on detection.
+
+## Results
+
+| Provider | Model | Detect F1 (from #142) | Chart-read F1 | Parse fail % | Data-P | Data-R | Data-F1 | Cost/image | 7-img total | Mean latency |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `current` | `gpt-4o` | 1.000 | 1.000 | 0% | 0.111 | 0.500 | 0.182 | **$0.00575** | $0.0402 | 3347 ms |
+| `openai-vnext` | `gpt-4o-2024-11-20` | 1.000 | 1.000 | 0% | 0.111 | 0.500 | 0.182 | $0.00673 | $0.0471 | 3862 ms |
+| `gemini-flash` | `gemini-2.5-flash-lite` | 1.000 | 1.000 | 0% | 0.111 | 0.500 | 0.182 | $0.00759 | $0.0531 | **2755 ms** |
+| `gemini-pro` | `gemini-2.5-pro` | 1.000 | 0.923 | 14% | 0.111 | 0.500 | 0.182 | **$0.00411** | **$0.0288** | 12641 ms |
+| `anthropic` | `claude-sonnet-4-6` | 1.000 | 1.000 | 0% | 0.111 | 0.500 | 0.182 | $0.01158 | $0.0810 | 6355 ms |
+| `two-stage` | gemini-flash OCR → sonnet-4-6 | — | 0.923 | 14% | 0.111 | 0.500 | 0.182 | $0.01268 | $0.0887 | 6280 ms |
+
+Detection F1 dropped for gemini-pro and two-stage because each hit one
+parse failure (gemini-pro returned unparseable JSON on one image;
+two-stage got a transient Gemini 503 on `slack-mdaa3`'s OCR pass). The
+rest held at 1.000.
+
+### Structural fidelity (where providers actually separate)
+
+Which image fields did each provider populate? (7 images total.)
+
+| Provider | title | axes labels | legend | annotation points | parse fails |
+|---|---:|---:|---:|---:|---:|
+| `current` | 5/7 | 2/7 | 2/7 | 6 | 0 |
+| `openai-vnext` | 5/7 | 2/7 | 2/7 | 6 | 0 |
+| `gemini-flash` | 4/7 | 2/7 | **6/7** | **7** | 0 |
+| `gemini-pro` | 3/7 | 1/7 | 4/7 | 6 | 1 |
+| `anthropic` | 4/7 | 2/7 | 5/7 | 6 | 0 |
+| `two-stage` | 4/7 | 2/7 | 4/7 | 4 | 1 |
+
+Gemini-flash wins on legend + annotations coverage (catches series names
+on 6 / 7 charts vs 2 / 7 for GPT-4o). OpenAI providers win on title
+recognition but leave more series unnamed. Axis labels are a weak spot
+across the board (2 / 7 at best).
+
+## Decision
+
+**Provisional default for chart-read stays with the PR #142 winner,
+`gemini-flash`, but the rationale changes**:
+
+- Cost is no longer the dominant reason. On chart-read, `gemini-flash`
+  ($0.0076/image) is **32% more expensive than `current` GPT-4o
+  ($0.0058)** — the inverse of the detection ranking where it was 34%
+  cheaper. The chart-read prompt is longer (both input and output
+  tokens) and Gemini-flash-lite's output-token pricing erodes its
+  input-side advantage.
+- Latency is the dominant reason. `gemini-flash` is still the fastest
+  at 2.8 s vs GPT-4o's 3.3 s — and it's ~5× faster than `gemini-pro`
+  (12.6 s) and ~2× faster than Claude Sonnet (6.4 s). Chart extraction
+  is already the slowest hop in the per-filing pipeline; keeping this
+  budget tight matters more than shaving a fraction of a cent.
+- Structural completeness is a secondary reason. `gemini-flash` produced
+  legend / annotation content on more images (6 / 7 legend, 7 / 7 images
+  with at least one annotation point) than any other provider.
+
+**`two-stage` does NOT justify its cost today.** At $0.0127/image it is
+the most expensive config by a small margin over `anthropic` ($0.0116),
+and on this corpus its chart-read data F1 is identical to every other
+provider's. The second Gemini call (OCR grounding) adds latency + a new
+failure mode (503s) without visibly improving the premium reader's
+output. Revisit this after corpus expansion — two-stage's thesis
+(ground the premium model with fast OCR text) can't fail gracefully or
+succeed meaningfully until there's enough value-level ground truth to
+score it.
+
+**`gemini-pro` is not a sensible default.** 7× slower than
+`gemini-flash` on chart-read with no fidelity gain and one transient
+parse failure.
+
+## Caveats — why this decision is still provisional
+
+1. **Ground-truth scarcity is the blocker.** Of 7 corpus images, only
+   one (`Farfetch_Limited/g607688g09d00.jpg`) has value-level ground
+   truth in `data/gold_standard/*/extracted_values.csv` — the two
+   `cm_revenue_by_cohort` annotation rows (44.4, 55.6). The other 3
+   Farfetch images have 0 chart rows in the CSV; Slack has 0 chart
+   rows across the entire file. Every provider's data-value F1 of
+   0.182 is the result of every provider correctly reading the 44%
+   series label (matched to 44.4 within 2% tolerance) and missing the
+   55.6 annotation — a near-identical output pattern. **With n = 2
+   reference values scored on n = 1 image, data-value F1 cannot
+   separate providers here.** That's a corpus problem, not a provider
+   problem; the harness does score correctly once real signal arrives.
+
+2. **Structural saturation too.** Title / axes / legend scoring is
+   limited because the manifest tracks `reviewer_notes` (free-text
+   reviewer comments) rather than per-image ground-truth titles and
+   labels. The "is the title populated?" tally in the table above is
+   the best we can do today; a proper title-match score needs
+   hand-annotated per-image references.
+
+3. **One transient 503 biased two-stage.** Gemini's Flash-Lite OCR pass
+   hit a `503 UNAVAILABLE` on one image and propagated through as a
+   parse failure. That's a real operational concern for two-stage in
+   production (two upstream providers = union of their failure modes)
+   but it's a single data point here — don't read too much into
+   the 14% parse-failure rate.
+
+4. **Order `BAKEOFF_PROVIDER_ORDER` vs `_ORDER_CHART_READ`.** This
+   run uses the new `BAKEOFF_PROVIDER_ORDER_CHART_READ` constant which
+   includes `two-stage`. The older detect-mode order (the one PR #142
+   bakeoffs use) deliberately still excludes `two-stage` — running
+   two-stage under `analyze_image_for_text` would burn spend without
+   exercising B4 routing, since that method ignores
+   `VISION_ROUTING_MODE`. The split is by design and the memo's
+   comparison table handles it: `two-stage` has no detect-F1 number.
+
+## Next steps
+
+1. **Corpus expansion is the highest-leverage follow-up.** `data/gold_standard/`
+   has 65 chart-source rows across 5 companies
+   (Farfetch + Maplebear, Robinhood, Samsara, Torrid) but JPGs only for
+   Farfetch + Slack. Populating the JPG fixtures from the corresponding
+   filings' images, plus adding `ground_truth_value_ids` mappings on
+   the manifest entries, would turn data-value F1 into a real signal
+   overnight.
+
+2. **`v2_image_review_decisions` hydration.** Once the test DB has
+   review rows, re-run `scripts/benchmark_vision.py --build-corpus`
+   to get the stratified multi-hundred-image manifest. The
+   `_load_chart_ground_truth` helper already derives CSV lookups from
+   `storage_key`; every reviewed image mapped to a filing with
+   gold-standard chart rows becomes scorable.
+
+3. **Per-image title / axis-label ground truth in the manifest.**
+   A modest hand-curation pass on 7 images (pull the title, x-axis
+   label, y-axis label, legend list into each manifest entry) would
+   let us replace the "reviewer_notes-proxy" scoring in `image_eval.py`
+   with real string-accuracy numbers.
+
+4. **Defer `B5.4 shadow + canary`** until data-value separation
+   actually exists. Shadowing a chart-read provider on 50 reviewed
+   filings is meaningful only if we can measure whether its output
+   differs from prod on the dimensions users care about.
+
+## Reproducing this bake-off
+
+```bash
+# Prerequisites:
+#   .env has OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY
+#   pip install google-genai
+#
+# From the repo root (or any worktree):
+LLM_CACHE_ENABLED=false MAX_BAKEOFF_USD=5.0 \
+    python3 scripts/benchmark_vision.py --bakeoff --mode chart-read
+
+# Per-provider JSONs land in data/image_benchmarks/bakeoff_chart_read_<date>/<provider>.json
+# Summary lands in                      data/image_benchmarks/bakeoff_chart_read_<date>/summary.json
+# (both gitignored — regenerate on demand)
+
+# Single-provider smoke (cheap):
+LLM_CACHE_ENABLED=false python3 scripts/benchmark_vision.py \
+    --provider gemini-flash --mode chart-read --limit 1
+
+# Two-stage end-to-end (exercises B4 routing):
+LLM_CACHE_ENABLED=false python3 scripts/benchmark_vision.py \
+    --provider two-stage --mode chart-read --limit 1
+```
+
+Total cost: $0.34 per full 6-provider sweep. Cap is $5 so margin is
+roughly 15×.
+
+## Appendix — raw cost + latency (chart-read mode)
+
+7 real API calls per single-provider config (2× that for `two-stage`,
+which makes both an OCR grounding call and a chart-read call per image).
+
+| Provider | $ / image | 7-img total | Latency (ms) |
+|---|---:|---:|---:|
+| current | 0.00575 | 0.04023 | 3347 |
+| openai-vnext | 0.00673 | 0.04713 | 3862 |
+| gemini-flash | 0.00759 | 0.05313 | 2755 |
+| gemini-pro | 0.00411 | 0.02880 | 12641 |
+| anthropic | 0.01158 | 0.08104 | 6355 |
+| two-stage | 0.01268 | 0.08873 | 6280 |
+| **Total** | — | **$0.33907** | — |
+
+## Detection vs chart-read cost inflation
+
+| Provider | Detect $/img | Chart-read $/img | Ratio |
+|---|---:|---:|---:|
+| current | 0.00330 | 0.00575 | 1.74× |
+| openai-vnext | 0.00341 | 0.00673 | 1.97× |
+| gemini-flash | 0.00218 | 0.00759 | 3.48× |
+| gemini-pro | 0.00200 | 0.00411 | 2.06× |
+| anthropic | 0.00572 | 0.01158 | 2.03× |
+
+`gemini-flash` takes the biggest cost hit going from detection to
+chart-read (3.48× vs ~2× for everyone else). This is what flipped the
+PR #142 winner ranking and is worth re-checking if Google changes
+Flash-Lite pricing.

--- a/scripts/benchmark_vision.py
+++ b/scripts/benchmark_vision.py
@@ -123,18 +123,36 @@ BAKEOFF_PROVIDER_ORDER: list[str] = [
     "gemini-flash",
     "gemini-pro",
     "anthropic",
-    # NOTE: "two-stage" is intentionally excluded from the default bake-off.
-    # The harness invokes VisionClient.analyze_image_for_text(), which
-    # bypasses VisionClient.analyze_image_targeted() — the only call site
-    # where VISION_ROUTING_MODE=two_stage actually fires. Benchmarking the
-    # real B4 two-stage path needs a harness that exercises
-    # analyze_image_targeted(task_type="chart_read"); deferred to a B5.x
-    # follow-up. The config for "two-stage" is still in PROVIDER_CONFIGS so
-    # the targeted harness can reuse it unchanged.
+    # NOTE: "two-stage" is intentionally excluded from the DETECT bake-off.
+    # analyze_image_for_text() ignores VISION_ROUTING_MODE, so running a
+    # two-stage provider in detect mode would burn spend without
+    # exercising B4. The chart-read bake-off uses
+    # BAKEOFF_PROVIDER_ORDER_CHART_READ below, which DOES include
+    # "two-stage" because analyze_image_targeted() honors routing.
+]
+
+# Wave B5.x — chart-read bake-off order. Adds "two-stage" because
+# analyze_image_targeted(task_type="chart_read") is the call site where
+# VISION_ROUTING_MODE=two_stage actually fires (see
+# src/llm/vision_client.py:527 and src/extraction_v2/stages/ocr_extraction.py:826).
+BAKEOFF_PROVIDER_ORDER_CHART_READ: list[str] = [
+    "current",
+    "openai-vnext",
+    "gemini-flash",
+    "gemini-pro",
+    "anthropic",
+    "two-stage",
 ]
 
 # Spend cap for the full bake-off sweep. Override via $MAX_BAKEOFF_USD.
 DEFAULT_MAX_BAKEOFF_USD = 15.0
+
+# Available harness modes. ``detect`` is the PR #142 path (chart detection
+# only); ``chart-read`` is the B5.x extension that calls
+# VisionClient.analyze_image_targeted(task_type="chart_read") with the prod
+# chart-extraction prompt and scores per-point data fidelity against the
+# gold-standard ``extracted_values.csv`` rows.
+BENCHMARK_MODES: tuple[str, ...] = ("detect", "chart-read")
 
 
 # ---- DB query -----------------------------------------------------------------
@@ -371,20 +389,29 @@ def _force_local_storage_for_fixtures() -> None:
     logger.info("Benchmark storage: %s", os.environ["IMAGE_CACHE_DIR"])
 
 
-def _run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
+def _run_provider(entry: dict[str, Any], provider: str, mode: str = "detect") -> dict[str, Any]:
     """Run one vision provider against one corpus image.
 
     Returns a dict with benchmark fields compatible with ImageRunRecord.
     Does NOT re-persist any facts (read-only).
 
-    All providers exercise `VisionClient.analyze_image_for_text` — the same
-    method the prod chart-detection path uses. `PROVIDER_CONFIGS[provider]`
-    is applied to the process env for the duration of the call so the B2
-    `VisionClient` picks the right adapter + model, and B4's two-stage
-    routing fires for `provider == "two-stage"`.
+    ``mode="detect"`` calls ``VisionClient.analyze_image_for_text`` — the
+    PR #142 path that measures chart DETECTION. ``mode="chart-read"``
+    calls ``VisionClient.analyze_image_targeted(task_type="chart_read")``
+    with the prod chart-extraction prompt (Wave B5.x). For the
+    ``two-stage`` provider under chart-read mode, the harness replicates
+    the double-call (``chart_ocr`` grounding pass then ``chart_read``
+    premium reader) that ``src/extraction_v2/stages/ocr_extraction.py``
+    makes in production so costs and outputs match the real routing.
+
+    In either mode ``PROVIDER_CONFIGS[provider]`` is applied to the
+    process env for the duration of the call so the B2 ``VisionClient``
+    picks the right adapter + model.
     """
+    if mode not in BENCHMARK_MODES:
+        raise ValueError(f"Unknown mode {mode!r}. Known: {BENCHMARK_MODES}")
+
     from src.infra.image_storage import get_image_storage
-    from src.llm.vision_client import VisionClient
 
     storage = get_image_storage()
     storage_key = entry.get("storage_key", "")
@@ -402,6 +429,7 @@ def _run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
         "ocr_cells_extracted": [],
         "axis_labels_extracted": [],
         "tier1_facts_extracted": 0,
+        "extracted_points": [],
         "skipped": False,
         "skip_reason": None,
     }
@@ -413,13 +441,28 @@ def _run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
         logger.warning("Image not found in storage: %s (img_id=%s)", storage_key, entry["img_id"])
         return {**skeleton, "skipped": True, "skip_reason": "missing_bytes"}
 
+    if mode == "detect":
+        return _run_provider_detect(entry, provider, image_bytes, skeleton, t0)
+    return _run_provider_chart_read(entry, provider, image_bytes, skeleton, t0)
+
+
+def _run_provider_detect(
+    entry: dict[str, Any],
+    provider: str,
+    image_bytes: bytes,
+    skeleton: dict[str, Any],
+    t0: float,
+) -> dict[str, Any]:
+    """Detect-mode path: the PR #142 ``analyze_image_for_text`` call."""
+    from src.llm.vision_client import VisionClient
+
     try:
         with _ProviderEnv(provider):
             client = VisionClient()
             result = client.analyze_image_for_text(image_bytes)
     except Exception as exc:
         logger.warning(
-            "Vision API error for provider=%s img_id=%s: %s",
+            "Vision API error (detect) for provider=%s img_id=%s: %s",
             provider,
             entry["img_id"],
             exc,
@@ -441,6 +484,219 @@ def _run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
     }
 
 
+def _run_provider_chart_read(
+    entry: dict[str, Any],
+    provider: str,
+    image_bytes: bytes,
+    skeleton: dict[str, Any],
+    t0: float,
+) -> dict[str, Any]:
+    """Chart-read mode: call ``analyze_image_targeted(task_type='chart_read')``.
+
+    For the ``two-stage`` provider this fires the OCR grounding pass
+    first (``chart_ocr``) then the premium reader (``chart_read``), with
+    the OCR blob injected into the chart-read prompt. Prompt text is
+    pulled from the prod stage so the benchmark can't drift from prod.
+    """
+    from src.extraction_v2.stages.ocr_extraction import OCRExtractionStage
+    from src.llm.vision_client import VisionClient
+
+    stage = OCRExtractionStage()  # no-arg init; just for prompt methods
+    cost = 0.0
+    ocr_blob = ""
+    raw_ocr = ""
+    raw_chart = ""
+
+    try:
+        with _ProviderEnv(provider):
+            client = VisionClient()
+            two_stage = os.environ.get("VISION_ROUTING_MODE", "").strip().lower() == "two_stage"
+
+            if two_stage:
+                ocr_resp = client.analyze_image_targeted(
+                    image_bytes=image_bytes,
+                    prompt=stage._get_chart_ocr_prompt(),
+                    task_type="chart_ocr",
+                    detail="high",
+                    max_tokens=1500,
+                    response_format={"type": "json_object"},
+                )
+                cost += float(getattr(ocr_resp, "cost_usd", 0.0))
+                raw_ocr = getattr(ocr_resp, "content", "") or ""
+                parsed_ocr = OCRExtractionStage._parse_chart_json(raw_ocr) or {}
+                ocr_blob = str(parsed_ocr.get("text", "") or "")
+
+            chart_resp = client.analyze_image_targeted(
+                image_bytes=image_bytes,
+                prompt=stage._get_chart_extraction_prompt(ocr_text=ocr_blob),
+                task_type="chart_read",
+                detail="high",
+                max_tokens=2000,
+                response_format={"type": "json_object"},
+            )
+            cost += float(getattr(chart_resp, "cost_usd", 0.0))
+            raw_chart = getattr(chart_resp, "content", "") or ""
+    except Exception as exc:
+        logger.warning(
+            "Vision API error (chart-read) for provider=%s img_id=%s: %s",
+            provider,
+            entry["img_id"],
+            exc,
+        )
+        return {
+            **skeleton,
+            "parse_failed": True,
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+            "cost_usd": cost,
+            "raw_output": str(exc),
+        }
+
+    parsed = OCRExtractionStage._parse_chart_json(raw_chart)
+    latency_ms = int((time.perf_counter() - t0) * 1000)
+    if parsed is None:
+        return {
+            **skeleton,
+            "parse_failed": True,
+            "cost_usd": cost,
+            "latency_ms": latency_ms,
+            "raw_output": raw_chart[:4000],
+        }
+
+    title = str(parsed.get("title", "") or "")
+    x_axis = str(parsed.get("x_axis_label", "") or "")
+    y_axis = str(parsed.get("y_axis_label", "") or "")
+    series = parsed.get("series", []) or []
+    annotations = parsed.get("annotations", []) or []
+
+    axis_labels: list[str] = []
+    if x_axis:
+        axis_labels.append(x_axis)
+    if y_axis:
+        axis_labels.append(y_axis)
+
+    legend_parts = [str(s.get("name", "") or "") for s in series]
+    legend = "\n".join(p for p in legend_parts if p)
+
+    predicted_chart_type = str(parsed.get("chart_type", "") or "") or None
+    # If the model returns a chart_type + any structured output, count it
+    # as "relevant" for detection purposes in chart-read mode too.
+    predicted_relevant = bool(predicted_chart_type) or bool(series) or bool(annotations)
+
+    extracted_points = _flatten_chart_points(series, annotations)
+
+    return {
+        **skeleton,
+        "predicted_relevant": predicted_relevant,
+        "predicted_chart_type": predicted_chart_type,
+        "cost_usd": cost,
+        "latency_ms": latency_ms,
+        "raw_output": raw_chart[:4000],
+        "title_extracted": title,
+        "legend_extracted": legend,
+        "axis_labels_extracted": axis_labels,
+        "extracted_points": extracted_points,
+    }
+
+
+def _flatten_chart_points(
+    series: list[dict[str, Any]], annotations: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Flatten model output into ``[{"value": float, "period": str|None, "source": str}, ...]``.
+
+    Used by the chart-read scorer. Non-numeric values are dropped (a
+    missing ``y`` or ``value`` can't contribute to a value match).
+    """
+    out: list[dict[str, Any]] = []
+    for s in series:
+        name = s.get("name")
+        for p in s.get("points", []) or []:
+            y = p.get("y")
+            try:
+                y_float = float(y)
+            except (TypeError, ValueError):
+                continue
+            out.append(
+                {
+                    "value": y_float,
+                    "period": p.get("x"),
+                    "source": "series",
+                    "series_name": name,
+                    "label": p.get("label"),
+                }
+            )
+    for a in annotations:
+        v = a.get("value")
+        if v is None:
+            continue
+        try:
+            v_float = float(v)
+        except (TypeError, ValueError):
+            continue
+        out.append(
+            {
+                "value": v_float,
+                "period": a.get("period"),
+                "source": "annotation",
+                "category": a.get("category"),
+                "text": a.get("text"),
+            }
+        )
+    return out
+
+
+def _load_chart_ground_truth(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Load ground-truth chart rows for a manifest entry, if mapped.
+
+    Honors the optional ``ground_truth_value_ids`` field on each manifest
+    entry. The scorer derives the gold-standard company directory from
+    the ``storage_key`` prefix (e.g. ``Farfetch_Limited/foo.jpg`` →
+    ``data/gold_standard/Farfetch_Limited/extracted_values.csv``) and
+    returns the CSV rows whose ``metric_value_id`` appears in
+    ``ground_truth_value_ids`` AND whose ``source_type == "chart"``.
+
+    Returns an empty list if the entry has no mapping or the CSV is
+    missing; callers should treat that as "structural fidelity only, no
+    data-value scoring for this image".
+    """
+    ids = entry.get("ground_truth_value_ids")
+    if not ids:
+        return []
+    storage_key = entry.get("storage_key", "") or ""
+    if "/" not in storage_key:
+        return []
+    company_dir = storage_key.split("/", 1)[0]
+    csv_path = REPO_ROOT / "data" / "gold_standard" / company_dir / "extracted_values.csv"
+    if not csv_path.exists():
+        logger.warning("ground_truth CSV not found for %s (expected %s)", entry["img_id"], csv_path)
+        return []
+
+    id_set = {str(i) for i in ids}
+    import csv as _csv
+
+    rows: list[dict[str, Any]] = []
+    with csv_path.open(encoding="utf-8") as fh:
+        for row in _csv.DictReader(fh):
+            if row.get("source_type") != "chart":
+                continue
+            if str(row.get("metric_value_id", "")).strip() not in id_set:
+                continue
+            try:
+                value = float(row["value_numeric"])
+            except (TypeError, ValueError, KeyError):
+                continue
+            rows.append(
+                {
+                    "metric_value_id": row.get("metric_value_id"),
+                    "metric_id": row.get("metric_id"),
+                    "value": value,
+                    "unit": row.get("unit"),
+                    "period_start": row.get("period_start") or None,
+                    "period_end": row.get("period_end") or None,
+                }
+            )
+    return rows
+
+
 def _run_current_provider(entry: dict[str, Any]) -> dict[str, Any]:
     """Legacy shim — kept for back-compat with external callers / tests."""
     return _run_provider(entry, "current")
@@ -450,8 +706,16 @@ def _run_benchmark(
     corpus: list[dict[str, Any]],
     provider: str,
     limit: int | None,
+    mode: str = "detect",
 ) -> list[dict[str, Any]]:
-    """Run the benchmark harness against the corpus and return raw run records."""
+    """Run the benchmark harness against the corpus and return raw run records.
+
+    ``mode`` is forwarded to ``_run_provider``. In ``chart-read`` mode,
+    each result is augmented with per-image data-value TP/FP/FN scored
+    against any ground-truth CSV rows mapped by the manifest entry.
+    """
+    if mode not in BENCHMARK_MODES:
+        raise ValueError(f"Unknown mode {mode!r}. Known: {BENCHMARK_MODES}")
     if limit is not None:
         corpus = corpus[:limit]
 
@@ -466,7 +730,7 @@ def _run_benchmark(
             raise ValueError(
                 f"Unknown provider {provider!r}. Known: {sorted(PROVIDER_CONFIGS.keys())}"
             )
-        result = _run_provider(entry, provider)
+        result = _run_provider(entry, provider, mode=mode)
 
         result["reviewer_decision"] = entry["decision"]
         result["reviewer_chart_type"] = entry.get("chart_type")
@@ -475,6 +739,23 @@ def _run_benchmark(
         result["stratum"] = entry.get("stratum", "unknown")
         result["is_tier1"] = entry.get("is_tier1", False)
         result["provider"] = provider
+        result["mode"] = mode
+
+        if mode == "chart-read" and not result.get("skipped"):
+            reference = _load_chart_ground_truth(entry)
+            from src.gold_standard.image_eval import data_value_match
+
+            tp, fp, fn = data_value_match(result.get("extracted_points", []), reference)
+            result["reference_points"] = reference
+            result["data_value_tp"] = tp
+            result["data_value_fp"] = fp
+            result["data_value_fn"] = fn
+        else:
+            result.setdefault("reference_points", [])
+            result.setdefault("data_value_tp", 0)
+            result.setdefault("data_value_fp", 0)
+            result.setdefault("data_value_fn", 0)
+
         run_records.append(result)
 
     return run_records
@@ -509,6 +790,11 @@ def _build_eval_results(run_records: list[dict[str, Any]]) -> dict[str, Any]:
                 latency_ms=int(r.get("latency_ms", 0)),
                 raw_output=r.get("raw_output", ""),
                 provider=r.get("provider", "unknown"),
+                extracted_points=r.get("extracted_points", []),
+                reference_points=r.get("reference_points", []),
+                data_value_tp=int(r.get("data_value_tp", 0)),
+                data_value_fp=int(r.get("data_value_fp", 0)),
+                data_value_fn=int(r.get("data_value_fn", 0)),
             )
         )
 
@@ -528,6 +814,10 @@ def _build_eval_results(run_records: list[dict[str, Any]]) -> dict[str, Any]:
         "n_images": agg.n_images,
         "n_relevant": agg.n_relevant,
         "n_not_relevant": agg.n_not_relevant,
+        "data_value_precision": agg.data_value_precision,
+        "data_value_recall": agg.data_value_recall,
+        "data_value_f1": agg.data_value_f1,
+        "n_images_scored_on_data": agg.n_images_scored_on_data,
         "n_skipped": sum(1 for r in run_records if r.get("skipped")),
         "n_missing_bytes": sum(1 for r in run_records if r.get("skip_reason") == "missing_bytes"),
     }
@@ -578,7 +868,20 @@ Examples:
             "Run the full Wave B5 sweep: every provider in PROVIDER_CONFIGS, "
             "sequentially, with a cumulative spend cap ($MAX_BAKEOFF_USD, "
             f"default ${DEFAULT_MAX_BAKEOFF_USD:.0f}). Writes per-provider "
-            "reports to data/image_benchmarks/bakeoff_<date>/ plus a summary."
+            "reports to data/image_benchmarks/bakeoff_<date>/ plus a summary. "
+            "In chart-read mode the order also includes 'two-stage'."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="detect",
+        choices=sorted(BENCHMARK_MODES),
+        help=(
+            "Benchmark mode. 'detect' = PR #142 chart-detection path "
+            "(analyze_image_for_text). 'chart-read' = Wave B5.x per-point "
+            "data-fidelity path (analyze_image_targeted, exercises B4 "
+            "two-stage routing for provider=two-stage)."
         ),
     )
     parser.add_argument(
@@ -623,16 +926,18 @@ def _run_single_provider_report(
     limit: int | None,
     manifest_path: Path,
     output_path: Path,
+    mode: str = "detect",
 ) -> dict[str, Any]:
     """Run one provider, aggregate metrics, write the JSON report, return it."""
-    logger.info("Running benchmark with provider=%r ...", provider)
-    run_records = _run_benchmark(corpus, provider, limit)
+    logger.info("Running benchmark with provider=%r mode=%r ...", provider, mode)
+    run_records = _run_benchmark(corpus, provider, limit, mode=mode)
 
     logger.info("Computing metrics ...")
     eval_metrics = _build_eval_results(run_records)
 
     report = {
         "provider": provider,
+        "mode": mode,
         "run_date": date.today().isoformat(),
         "manifest_path": str(manifest_path),
         "limit": limit,
@@ -644,7 +949,7 @@ def _run_single_provider_report(
     with open(output_path, "w", encoding="utf-8") as fh:
         json.dump(report, fh, indent=2, default=str)
 
-    logger.info("\n=== Provider: %s ===", provider)
+    logger.info("\n=== Provider: %s (mode=%s) ===", provider, mode)
     m = eval_metrics
     logger.info(
         "  Chart detection  P=%.3f  R=%.3f  F1=%.3f",
@@ -654,6 +959,14 @@ def _run_single_provider_report(
     )
     logger.info("  Tier-1 fact recall     : %.3f", m["tier1_fact_recall"])
     logger.info("  Parse failure rate     : %.3f", m["parse_failure_rate"])
+    if mode == "chart-read":
+        logger.info(
+            "  Data-value P/R/F1      : %.3f / %.3f / %.3f  (scored on %d img)",
+            m["data_value_precision"],
+            m["data_value_recall"],
+            m["data_value_f1"],
+            m["n_images_scored_on_data"],
+        )
     logger.info(
         "  Cost / image           : $%.5f  |  Latency: %dms",
         m["mean_cost_usd"],
@@ -668,29 +981,43 @@ def _cumulative_cost(report: dict[str, Any]) -> float:
     return sum(float(r.get("cost_usd", 0.0)) for r in report.get("run_records", []))
 
 
+def _bakeoff_order_for(mode: str) -> list[str]:
+    """Return the provider order for the bake-off given the benchmark mode."""
+    if mode == "chart-read":
+        return list(BAKEOFF_PROVIDER_ORDER_CHART_READ)
+    return list(BAKEOFF_PROVIDER_ORDER)
+
+
 def _run_bakeoff(
     corpus: list[dict[str, Any]],
     limit: int | None,
     manifest_path: Path,
     output_root: Path,
     max_usd: float,
+    mode: str = "detect",
 ) -> dict[str, Any]:
-    """Run every provider in PROVIDER_CONFIGS sequentially with a spend cap.
+    """Run every provider for ``mode`` sequentially with a spend cap.
 
     Aborts mid-sweep if cumulative cost crosses ``max_usd``. Writes a
     per-provider JSON to ``output_root / <provider>.json`` plus a
     ``summary.json`` comparing metrics across providers.
+
+    Provider order is mode-dependent:
+    - ``detect`` → ``BAKEOFF_PROVIDER_ORDER`` (excludes two-stage).
+    - ``chart-read`` → ``BAKEOFF_PROVIDER_ORDER_CHART_READ`` (includes two-stage).
     """
     output_root.mkdir(parents=True, exist_ok=True)
 
     per_provider: dict[str, dict[str, Any]] = {}
     cumulative = 0.0
     aborted_at: str | None = None
+    order = _bakeoff_order_for(mode)
 
-    for provider in BAKEOFF_PROVIDER_ORDER:
+    for provider in order:
         logger.info(
-            "\n--- Bake-off provider %s (cumulative spend: $%.4f / $%.2f cap) ---",
+            "\n--- Bake-off provider %s (mode=%s, cumulative spend: $%.4f / $%.2f cap) ---",
             provider,
+            mode,
             cumulative,
             max_usd,
         )
@@ -710,12 +1037,14 @@ def _run_bakeoff(
             limit=limit,
             manifest_path=manifest_path,
             output_path=provider_output,
+            mode=mode,
         )
         per_provider[provider] = report
         cumulative += _cumulative_cost(report)
 
     summary = {
         "run_date": date.today().isoformat(),
+        "mode": mode,
         "manifest_path": str(manifest_path),
         "providers_run": list(per_provider.keys()),
         "aborted_at": aborted_at,
@@ -733,7 +1062,7 @@ def _run_bakeoff(
     with open(summary_path, "w", encoding="utf-8") as fh:
         json.dump(summary, fh, indent=2, default=str)
 
-    logger.info("\n=== Bake-off summary ===")
+    logger.info("\n=== Bake-off summary (mode=%s) ===", mode)
     logger.info("  Providers run: %s", ", ".join(per_provider.keys()))
     logger.info("  Total spend  : $%.4f (cap $%.2f)", cumulative, max_usd)
     logger.info("  Summary JSON : %s", summary_path)
@@ -818,13 +1147,17 @@ def main() -> None:
     if args.limit:
         logger.info("  Limiting to %d images (--limit)", args.limit)
 
+    mode = args.mode
+    mode_prefix = "bakeoff_chart_read" if mode == "chart-read" else "bakeoff"
+    single_prefix = "chart-read" if mode == "chart-read" else args.provider
+
     if args.bakeoff:
         max_usd_raw = os.environ.get("MAX_BAKEOFF_USD", "").strip()
         max_usd = float(max_usd_raw) if max_usd_raw else DEFAULT_MAX_BAKEOFF_USD
         output_root = (
             Path(args.output)
             if args.output
-            else BENCHMARK_OUTPUT_DIR / f"bakeoff_{date.today().isoformat()}"
+            else BENCHMARK_OUTPUT_DIR / f"{mode_prefix}_{date.today().isoformat()}"
         )
         _run_bakeoff(
             corpus=corpus,
@@ -832,6 +1165,7 @@ def main() -> None:
             manifest_path=manifest_path,
             output_root=output_root,
             max_usd=max_usd,
+            mode=mode,
         )
         return
 
@@ -839,7 +1173,11 @@ def main() -> None:
         output_path = Path(args.output)
     else:
         BENCHMARK_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-        output_path = BENCHMARK_OUTPUT_DIR / f"{args.provider}_{date.today().isoformat()}.json"
+        if mode == "chart-read":
+            filename = f"{single_prefix}_{args.provider}_{date.today().isoformat()}.json"
+        else:
+            filename = f"{args.provider}_{date.today().isoformat()}.json"
+        output_path = BENCHMARK_OUTPUT_DIR / filename
 
     _run_single_provider_report(
         corpus=corpus,
@@ -847,6 +1185,7 @@ def main() -> None:
         limit=args.limit,
         manifest_path=manifest_path,
         output_path=output_path,
+        mode=mode,
     )
 
 

--- a/src/gold_standard/image_eval.py
+++ b/src/gold_standard/image_eval.py
@@ -110,6 +110,20 @@ class ImageRunRecord:
     latency_ms: int = 0
     raw_output: str = ""
     provider: str = "unknown"
+    # Wave B5.x — per-image chart-DATA fidelity (chart-read mode only).
+    # ``extracted_points`` holds the flattened numeric payload that the
+    # model returned (series points + annotations, normalised to
+    # ``{"value": float, "period": str|None, "source": "series"|"annotation"}``);
+    # ``reference_points`` holds the ground-truth rows pulled from
+    # ``data/gold_standard/<company>/extracted_values.csv`` for entries
+    # carrying a ``ground_truth_value_ids`` manifest field. TP/FP/FN are
+    # the per-record match counters computed by the harness before the
+    # record is constructed.
+    extracted_points: list[dict[str, Any]] = field(default_factory=list)
+    reference_points: list[dict[str, Any]] = field(default_factory=list)
+    data_value_tp: int = 0
+    data_value_fp: int = 0
+    data_value_fn: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +164,15 @@ class ImageEvalResult:
     n_images: int
     n_relevant: int  # ground-truth relevant
     n_not_relevant: int
+
+    # Wave B5.x — chart-DATA fidelity (chart-read mode only). Micro-averaged
+    # TP/FP/FN over records that carry ``reference_points``; unscored
+    # records do not contribute. ``n_images_scored_on_data`` is how many
+    # records had non-empty ``reference_points``.
+    data_value_precision: float = 0.0
+    data_value_recall: float = 0.0
+    data_value_f1: float = 0.0
+    n_images_scored_on_data: int = 0
 
     # Extra diagnostics
     extra: dict[str, Any] = field(default_factory=dict)
@@ -284,6 +307,98 @@ def parse_failure_rate(records: list[ImageRunRecord]) -> float:
     return sum(1 for r in records if r.parse_failed) / len(records)
 
 
+def data_value_match(
+    extracted: list[dict[str, Any]],
+    reference: list[dict[str, Any]],
+    rel_tol: float = 0.02,
+) -> tuple[int, int, int]:
+    """Compare extracted chart data against ground-truth values.
+
+    Used by the Wave B5.x chart-read harness to score per-point fidelity
+    for corpus entries that have an explicit ``ground_truth_value_ids``
+    mapping to CSV chart rows.
+
+    Parameters
+    ----------
+    extracted
+        Flattened model output. Each dict must carry a numeric ``"value"``;
+        other keys are ignored.
+    reference
+        Ground-truth rows. Each dict must carry a numeric ``"value"``
+        (already cast to float); other keys are ignored.
+    rel_tol
+        Relative tolerance for a numeric match. Two values ``a`` and ``b``
+        match when ``abs(a - b) <= rel_tol * max(abs(a), abs(b), 1.0)``.
+        The ``max(..., 1.0)`` floor keeps very small values (e.g. 0.0)
+        from demanding absurd precision.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        ``(tp, fp, fn)`` counted greedily: every reference point is
+        matched against at most one extracted point (first hit wins), so
+        duplicates in the extracted list do not inflate TP. Unmatched
+        extracted → FP; unmatched reference → FN.
+    """
+    if not reference and not extracted:
+        return 0, 0, 0
+
+    def _coerce(d: dict[str, Any]) -> float | None:
+        v = d.get("value")
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    extracted_values: list[float] = []
+    for d in extracted:
+        v = _coerce(d)
+        if v is not None:
+            extracted_values.append(v)
+    reference_values: list[float] = []
+    for d in reference:
+        v = _coerce(d)
+        if v is not None:
+            reference_values.append(v)
+
+    used: set[int] = set()
+    tp = 0
+    for ref_val in reference_values:
+        for i, ext_val in enumerate(extracted_values):
+            if i in used:
+                continue
+            denom = max(abs(ref_val), abs(ext_val), 1.0)
+            if abs(ref_val - ext_val) <= rel_tol * denom:
+                used.add(i)
+                tp += 1
+                break
+
+    fn = len(reference_values) - tp
+    fp = len(extracted_values) - len(used)
+    return tp, fp, fn
+
+
+def data_value_scores(records: list[ImageRunRecord]) -> tuple[float, float, float, int]:
+    """Micro-average chart-data TP/FP/FN across records and compute P/R/F1.
+
+    Only records with a non-empty ``reference_points`` contribute to the
+    aggregates. Returns ``(precision, recall, f1, n_scored)``. When no
+    record carries reference points, every number is 0.0 / 0.
+    """
+    scored = [r for r in records if r.reference_points]
+    if not scored:
+        return 0.0, 0.0, 0.0, 0
+    tp = sum(r.data_value_tp for r in scored)
+    fp = sum(r.data_value_fp for r in scored)
+    fn = sum(r.data_value_fn for r in scored)
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1, len(scored)
+
+
 # ---------------------------------------------------------------------------
 # Aggregate function
 # ---------------------------------------------------------------------------
@@ -323,6 +438,7 @@ def aggregate_results(records: list[ImageRunRecord]) -> ImageEvalResult:
 
     n = len(records)
     prec, rec, f1 = chart_detection_metrics(records)
+    dv_p, dv_r, dv_f1, dv_n = data_value_scores(records)
 
     return ImageEvalResult(
         chart_detection_precision=prec,
@@ -339,6 +455,10 @@ def aggregate_results(records: list[ImageRunRecord]) -> ImageEvalResult:
         n_images=n,
         n_relevant=sum(1 for r in records if r.reviewer_decision == "relevant"),
         n_not_relevant=sum(1 for r in records if r.reviewer_decision != "relevant"),
+        data_value_precision=dv_p,
+        data_value_recall=dv_r,
+        data_value_f1=dv_f1,
+        n_images_scored_on_data=dv_n,
     )
 
 

--- a/tests/fixtures/image_benchmark/manifest.json
+++ b/tests/fixtures/image_benchmark/manifest.json
@@ -21,7 +21,8 @@
       "filename": "g607688g09d00.jpg",
       "cik": "1720990",
       "company_name": "Farfetch Limited",
-      "relevance_score": 0.85
+      "relevance_score": 0.85,
+      "ground_truth_value_ids": [10001, 10100]
     },
     {
       "img_id": "gs-farfetch-g607688g12o45",

--- a/tests/unit/gold_standard/test_image_eval.py
+++ b/tests/unit/gold_standard/test_image_eval.py
@@ -16,6 +16,8 @@ from src.gold_standard.image_eval import (
     _str_similarity,
     aggregate_results,
     chart_detection_metrics,
+    data_value_match,
+    data_value_scores,
     is_hard_ocr_image,
     is_tier1_image,
     legend_match_score,
@@ -434,3 +436,140 @@ class TestStratumHelpers:
         assert "decorative" in REJECTION_REASONS
         assert "not_a_chart" in REJECTION_REASONS
         assert len(REJECTION_REASONS) == 6
+
+
+# ---------------------------------------------------------------------------
+# Wave B5.x — chart-data fidelity (chart-read mode)
+# ---------------------------------------------------------------------------
+
+
+class TestDataValueMatch:
+    """`data_value_match` pairs numeric values within relative tolerance."""
+
+    def test_empty_inputs(self) -> None:
+        assert data_value_match([], []) == (0, 0, 0)
+
+    def test_empty_reference_all_extracted_become_fp(self) -> None:
+        tp, fp, fn = data_value_match([{"value": 1.0}, {"value": 2.0}], [])
+        assert (tp, fp, fn) == (0, 2, 0)
+
+    def test_empty_extracted_all_reference_become_fn(self) -> None:
+        tp, fp, fn = data_value_match([], [{"value": 3.0}, {"value": 4.0}])
+        assert (tp, fp, fn) == (0, 0, 2)
+
+    def test_exact_match_counts_as_tp(self) -> None:
+        tp, fp, fn = data_value_match(
+            [{"value": 44.4}, {"value": 55.6}],
+            [{"value": 44.4}, {"value": 55.6}],
+        )
+        assert (tp, fp, fn) == (2, 0, 0)
+
+    def test_tolerance_window(self) -> None:
+        # 0.5% off a value of 100 is within the default 2% tolerance.
+        tp, fp, fn = data_value_match([{"value": 100.5}], [{"value": 100.0}], rel_tol=0.02)
+        assert (tp, fp, fn) == (1, 0, 0)
+        # 5% off is outside.
+        tp, fp, fn = data_value_match([{"value": 105.0}], [{"value": 100.0}], rel_tol=0.02)
+        assert (tp, fp, fn) == (0, 1, 1)
+
+    def test_partial_match_mixed_tp_fp_fn(self) -> None:
+        # Model emits [44.4, 99.9]; truth is [44.4, 55.6].
+        tp, fp, fn = data_value_match(
+            [{"value": 44.4}, {"value": 99.9}],
+            [{"value": 44.4}, {"value": 55.6}],
+        )
+        assert (tp, fp, fn) == (1, 1, 1)
+
+    def test_duplicate_extracted_does_not_double_count(self) -> None:
+        # Two extracted 44.4s, one truth 44.4 → TP=1, FP=1 (the spare
+        # extracted is not re-matched).
+        tp, fp, fn = data_value_match(
+            [{"value": 44.4}, {"value": 44.4}],
+            [{"value": 44.4}],
+        )
+        assert (tp, fp, fn) == (1, 1, 0)
+
+    def test_non_numeric_extracted_is_ignored(self) -> None:
+        tp, fp, fn = data_value_match(
+            [{"value": "not a number"}, {"value": 44.4}, {"value": None}],
+            [{"value": 44.4}],
+        )
+        assert (tp, fp, fn) == (1, 0, 0)
+
+
+def _record_with_data(*, tp: int, fp: int, fn: int, img_id: str = "img") -> ImageRunRecord:
+    """Minimal record carrying chart-read scoring fields."""
+    return ImageRunRecord(
+        img_id=img_id,
+        reviewer_decision="relevant",
+        reviewer_chart_type="cohort_table",
+        reviewer_notes="",
+        tier1_facts_in_db=0,
+        predicted_chart_type="cohort_table",
+        predicted_relevant=True,
+        reference_points=[{"value": 1.0}] * (tp + fn),
+        extracted_points=[{"value": 1.0}] * (tp + fp),
+        data_value_tp=tp,
+        data_value_fp=fp,
+        data_value_fn=fn,
+    )
+
+
+class TestDataValueScores:
+    """`data_value_scores` micro-averages TP/FP/FN across records."""
+
+    def test_no_records_scored_returns_zeros(self) -> None:
+        # Record has no reference_points → not scored.
+        rec = ImageRunRecord(
+            img_id="x",
+            reviewer_decision="relevant",
+            reviewer_chart_type="cohort_table",
+            reviewer_notes="",
+            tier1_facts_in_db=0,
+            predicted_chart_type="cohort_table",
+            predicted_relevant=True,
+        )
+        p, r, f1, n = data_value_scores([rec])
+        assert (p, r, f1, n) == (0.0, 0.0, 0.0, 0)
+
+    def test_micro_average_across_records(self) -> None:
+        # Record A: TP=1, FP=1, FN=1.  Record B: TP=2, FP=0, FN=0.
+        # Micro: TP=3, FP=1, FN=1 → P=3/4=0.75, R=3/4=0.75, F1=0.75.
+        records = [
+            _record_with_data(tp=1, fp=1, fn=1, img_id="a"),
+            _record_with_data(tp=2, fp=0, fn=0, img_id="b"),
+        ]
+        p, r, f1, n = data_value_scores(records)
+        assert n == 2
+        assert p == pytest.approx(0.75)
+        assert r == pytest.approx(0.75)
+        assert f1 == pytest.approx(0.75)
+
+
+class TestAggregateResultsDataFields:
+    """`aggregate_results` populates the new chart-data fields."""
+
+    def test_new_fields_defaulted_when_no_data_scoring(self) -> None:
+        # A record with no reference_points should leave data fields zeroed.
+        rec = ImageRunRecord(
+            img_id="x",
+            reviewer_decision="relevant",
+            reviewer_chart_type="cohort_table",
+            reviewer_notes="",
+            tier1_facts_in_db=0,
+            predicted_chart_type="cohort_table",
+            predicted_relevant=True,
+        )
+        agg = aggregate_results([rec])
+        assert agg.data_value_precision == 0.0
+        assert agg.data_value_recall == 0.0
+        assert agg.data_value_f1 == 0.0
+        assert agg.n_images_scored_on_data == 0
+
+    def test_new_fields_populated_when_records_carry_reference(self) -> None:
+        records = [_record_with_data(tp=1, fp=1, fn=1)]
+        agg = aggregate_results(records)
+        assert agg.data_value_precision == pytest.approx(0.5)
+        assert agg.data_value_recall == pytest.approx(0.5)
+        assert agg.data_value_f1 == pytest.approx(0.5)
+        assert agg.n_images_scored_on_data == 1

--- a/tests/unit/scripts/test_benchmark_vision_bakeoff.py
+++ b/tests/unit/scripts/test_benchmark_vision_bakeoff.py
@@ -75,7 +75,9 @@ class TestRunBenchmarkDispatch:
     def test_rejects_unknown_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
         called = {"count": 0}
 
-        def _fake_run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
+        def _fake_run_provider(
+            entry: dict[str, Any], provider: str, mode: str = "detect"
+        ) -> dict[str, Any]:
             called["count"] += 1
             return {}
 
@@ -85,7 +87,9 @@ class TestRunBenchmarkDispatch:
         assert called["count"] == 0
 
     def test_dispatches_for_known_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def _fake_run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
+        def _fake_run_provider(
+            entry: dict[str, Any], provider: str, mode: str = "detect"
+        ) -> dict[str, Any]:
             return {
                 "img_id": entry["img_id"],
                 "predicted_relevant": True,
@@ -121,7 +125,9 @@ class TestBakeoffSpendCap:
         # providers to run, third to be rejected at the top of the loop.
         per_call_cost = 5.0
 
-        def _fake_run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
+        def _fake_run_provider(
+            entry: dict[str, Any], provider: str, mode: str = "detect"
+        ) -> dict[str, Any]:
             return {
                 "img_id": entry["img_id"],
                 "predicted_relevant": True,
@@ -164,7 +170,9 @@ class TestBakeoffSpendCap:
     def test_runs_all_providers_under_cap(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        def _fake_run_provider(entry: dict[str, Any], provider: str) -> dict[str, Any]:
+        def _fake_run_provider(
+            entry: dict[str, Any], provider: str, mode: str = "detect"
+        ) -> dict[str, Any]:
             return {
                 "img_id": entry["img_id"],
                 "predicted_relevant": True,
@@ -195,3 +203,154 @@ class TestBakeoffSpendCap:
         assert summary["providers_run"] == bv.BAKEOFF_PROVIDER_ORDER
         for provider in bv.BAKEOFF_PROVIDER_ORDER:
             assert (tmp_path / "out" / f"{provider}.json").exists()
+
+
+class TestChartReadMode:
+    """Wave B5.x `--mode chart-read` dispatch + scoring."""
+
+    def test_chart_read_order_includes_two_stage(self) -> None:
+        assert "two-stage" in bv.BAKEOFF_PROVIDER_ORDER_CHART_READ
+        assert "two-stage" not in bv.BAKEOFF_PROVIDER_ORDER
+        # Detect order is a strict subset (same providers minus two-stage).
+        assert set(bv.BAKEOFF_PROVIDER_ORDER).issubset(set(bv.BAKEOFF_PROVIDER_ORDER_CHART_READ))
+
+    def test_bakeoff_order_for_resolves_per_mode(self) -> None:
+        assert bv._bakeoff_order_for("detect") == list(bv.BAKEOFF_PROVIDER_ORDER)
+        assert bv._bakeoff_order_for("chart-read") == list(bv.BAKEOFF_PROVIDER_ORDER_CHART_READ)
+
+    def test_run_benchmark_rejects_unknown_mode(self) -> None:
+        with pytest.raises(ValueError, match="Unknown mode"):
+            bv._run_benchmark([{"img_id": "x", "decision": "chart"}], "current", None, mode="bogus")
+
+    def test_run_provider_dispatches_on_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`_run_provider` routes to detect vs chart-read branch on `mode`."""
+        calls: list[str] = []
+
+        def _fake_detect(entry: Any, provider: Any, image_bytes: Any, skel: Any, t0: Any) -> Any:
+            calls.append("detect")
+            return {**skel, "predicted_relevant": True, "cost_usd": 0.001}
+
+        def _fake_chart(entry: Any, provider: Any, image_bytes: Any, skel: Any, t0: Any) -> Any:
+            calls.append("chart-read")
+            return {
+                **skel,
+                "predicted_relevant": True,
+                "cost_usd": 0.01,
+                "title_extracted": "t",
+                "axis_labels_extracted": ["x", "y"],
+                "legend_extracted": "series",
+                "extracted_points": [{"value": 44.4, "period": "2017", "source": "annotation"}],
+            }
+
+        class _FakeStorage:
+            def get_bytes(self, key: str) -> bytes:
+                return b"\xff\xd8\xffJPEG"
+
+        monkeypatch.setattr(bv, "_run_provider_detect", _fake_detect)
+        monkeypatch.setattr(bv, "_run_provider_chart_read", _fake_chart)
+        monkeypatch.setattr("src.infra.image_storage.get_image_storage", lambda: _FakeStorage())
+
+        entry = {"img_id": "x", "storage_key": "Farfetch_Limited/g.jpg", "decision": "chart"}
+        bv._run_provider(entry, "gemini-flash", mode="detect")
+        bv._run_provider(entry, "gemini-flash", mode="chart-read")
+        assert calls == ["detect", "chart-read"]
+
+    def test_run_provider_rejects_unknown_mode(self) -> None:
+        with pytest.raises(ValueError, match="Unknown mode"):
+            bv._run_provider({"img_id": "x", "storage_key": "x/y.jpg"}, "current", mode="bogus")
+
+    def test_flatten_chart_points_handles_series_and_annotations(self) -> None:
+        series = [
+            {"name": "A", "points": [{"x": "2020", "y": 10.5}, {"x": "2021", "y": "bad"}]},
+            {"name": "B", "points": [{"x": "2020", "y": 20}]},
+        ]
+        annotations = [
+            {"text": "44.4%", "value": 44.4, "period": "2017"},
+            {"text": "n/a", "value": None},
+            {"text": "bad-value", "value": "unparseable"},
+        ]
+        out = bv._flatten_chart_points(series, annotations)
+        values = sorted(p["value"] for p in out)
+        assert values == [10.5, 20.0, 44.4]
+        assert any(p["source"] == "annotation" for p in out)
+        assert any(p["source"] == "series" for p in out)
+
+    def test_load_chart_ground_truth_empty_without_mapping(self) -> None:
+        """No ground_truth_value_ids → no reference points."""
+        entry = {
+            "img_id": "no-gt",
+            "storage_key": "Farfetch_Limited/g607688g12o45.jpg",
+        }
+        assert bv._load_chart_ground_truth(entry) == []
+
+    def test_load_chart_ground_truth_pulls_mapped_rows(self) -> None:
+        """Farfetch g09d00 entry maps to the 2 CSV chart rows (10001, 10100)."""
+        entry = {
+            "img_id": "gs-farfetch-g607688g09d00",
+            "storage_key": "Farfetch_Limited/g607688g09d00.jpg",
+            "ground_truth_value_ids": [10001, 10100],
+        }
+        rows = bv._load_chart_ground_truth(entry)
+        assert len(rows) == 2
+        values = sorted(r["value"] for r in rows)
+        assert values == [44.4, 55.6]
+        assert all(r["metric_id"] == "cm_revenue_by_cohort" for r in rows)
+
+    def test_chart_read_end_to_end_per_point_scoring(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Chart-read run against a mapped fixture entry scores TP/FP/FN.
+
+        Uses a fake `_run_provider` that mimics a model returning 44.4 +
+        a spurious 99.9. Ground-truth is [44.4, 55.6] → TP=1, FP=1, FN=1.
+        """
+
+        def _fake_run_provider(
+            entry: dict[str, Any], provider: str, mode: str = "detect"
+        ) -> dict[str, Any]:
+            assert mode == "chart-read"
+            return {
+                "img_id": entry["img_id"],
+                "predicted_relevant": True,
+                "predicted_chart_type": "bar",
+                "parse_failed": False,
+                "cost_usd": 0.01,
+                "latency_ms": 100,
+                "raw_output": "",
+                "title_extracted": "Revenue by cohort",
+                "legend_extracted": "",
+                "ocr_cells_extracted": [],
+                "axis_labels_extracted": ["Year", "%"],
+                "tier1_facts_extracted": 0,
+                "extracted_points": [
+                    {"value": 44.4, "period": "2017", "source": "annotation"},
+                    {"value": 99.9, "period": "2017", "source": "annotation"},
+                ],
+                "skipped": False,
+                "skip_reason": None,
+            }
+
+        monkeypatch.setattr(bv, "_run_provider", _fake_run_provider)
+
+        corpus = [
+            {
+                "img_id": "gs-farfetch-g607688g09d00",
+                "storage_key": "Farfetch_Limited/g607688g09d00.jpg",
+                "decision": "relevant",
+                "ground_truth_value_ids": [10001, 10100],
+            }
+        ]
+        records = bv._run_benchmark(corpus, "gemini-flash", None, mode="chart-read")
+        assert len(records) == 1
+        r = records[0]
+        assert r["data_value_tp"] == 1
+        assert r["data_value_fp"] == 1
+        assert r["data_value_fn"] == 1
+        assert len(r["reference_points"]) == 2
+
+        metrics = bv._build_eval_results(records)
+        # P=1/(1+1)=0.5, R=1/(1+1)=0.5, F1=0.5, n_scored=1
+        assert metrics["data_value_precision"] == 0.5
+        assert metrics["data_value_recall"] == 0.5
+        assert metrics["data_value_f1"] == 0.5
+        assert metrics["n_images_scored_on_data"] == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/benchmark_vision.py --mode chart-read` — the second bake-off mode that calls `VisionClient.analyze_image_targeted(task_type="chart_read")` with the prod chart-extraction prompt (imported from `OCRExtractionStage`, so the harness can't drift from prod). Exercises B4 two-stage routing end-to-end for the first time; scores per-point data fidelity against `data/gold_standard/<company>/extracted_values.csv` rows mapped via a new `ground_truth_value_ids` manifest field.
- Decision memo at `docs/operations/vision-bakeoff-chart-read-2026-04-23.md` compares the new numbers against PR #142's detection numbers side-by-side. Full 6-provider sweep spent **$0.34** under the $5 cap.

## What the results say

| Provider | Detect F1 (#142) | Chart-read F1 | Parse fail | Data-F1 | Cost/image | Latency |
|---|---:|---:|---:|---:|---:|---:|
| current (gpt-4o) | 1.000 | 1.000 | 0% | 0.182 | $0.00575 | 3347 ms |
| openai-vnext | 1.000 | 1.000 | 0% | 0.182 | $0.00673 | 3862 ms |
| gemini-flash | 1.000 | 1.000 | 0% | 0.182 | $0.00759 | **2755 ms** |
| gemini-pro | 1.000 | 0.923 | 14% | 0.182 | **$0.00411** | 12641 ms |
| anthropic | 1.000 | 1.000 | 0% | 0.182 | $0.01158 | 6355 ms |
| two-stage | — | 0.923 | 14% | 0.182 | $0.01268 | 6280 ms |

Data-value F1 is a tie at 0.182 across all providers — corpus saturation (n=1 image with 2 mapped GT values: `cm_revenue_by_cohort` 44.4 / 55.6). The infrastructure is correct; the corpus can't separate providers on value accuracy today. Memo explicitly flags corpus expansion as the #1 follow-up.

Structural signals do separate providers (gemini-flash catches legend/annotation text on 6 / 7 + 7 / 7 images vs 2 / 7 for GPT-4o). Cost ranking inverts vs detection — `gemini-flash` is now 32% *more* expensive than GPT-4o on chart-read (chart-read prompts are 2–3.5× bigger). Memo retains gemini-flash as the provisional default on **latency + structural completeness** grounds rather than cost.

## Scope

- `scripts/benchmark_vision.py` (+350 lines): new `--mode {detect,chart-read}` flag, `BAKEOFF_PROVIDER_ORDER_CHART_READ` (detect order stays unchanged for back-compat), `_run_provider_detect` / `_run_provider_chart_read` dispatch split, `_flatten_chart_points` + `_load_chart_ground_truth` helpers.
- `src/gold_standard/image_eval.py` (+120 lines): 5 additive `ImageRunRecord` fields (all defaulted), 4 additive `ImageEvalResult` fields, `data_value_match` + `data_value_scores` helpers, `aggregate_results` extended.
- `tests/fixtures/image_benchmark/manifest.json`: 2-line change — `ground_truth_value_ids: [10001, 10100]` on Farfetch `g607688g09d00` so CSV chart rows only score against their true image.
- `tests/unit/scripts/test_benchmark_vision_bakeoff.py` (+175 lines): `TestChartReadMode` covers dispatch, order invariants, per-point scoring end-to-end with fake providers.
- `tests/unit/gold_standard/test_image_eval.py` (+145 lines): 11 new cases covering `data_value_match` edge cases, `data_value_scores` micro-averaging, and `aggregate_results` population of new fields.
- `docs/operations/vision-bakeoff-chart-read-2026-04-23.md`: decision memo.

21 new unit tests (3833 passing total, 0 regressions).

## Test plan

- [x] Baseline `pytest -x -q --ignore=tests/integration` clean pre-change
- [x] `pytest -x -q` on the two changed test files (75 passed)
- [x] `pytest -x -q --ignore=tests/integration` post-change (3833 passed, +21 new)
- [x] `ruff check` clean on all 4 changed code files
- [x] Single-provider smoke: `--provider gemini-flash --mode chart-read --limit 1` → TP=1, FP=8, FN=1, cost $0.006 ✓
- [x] Two-stage smoke: `--provider two-stage --mode chart-read --limit 1` → both Gemini OCR and Claude chart-read HTTP calls fire, cost $0.011 ✓
- [x] Full sweep: `--bakeoff --mode chart-read --MAX_BAKEOFF_USD=5` → 6 providers × 7 images, total $0.34 under cap ✓

## Follow-ups (from the memo)

1. **Corpus expansion is the #1 blocker.** Populate JPG fixtures for Maplebear/Robinhood/Samsara/Torrid (4 companies with 47 combined chart-value CSV rows but no JPGs yet); add `ground_truth_value_ids` mappings. Would turn data-value F1 into a real signal overnight.
2. Per-image title / axis-label ground truth in the manifest — replaces the `reviewer_notes`-proxy scoring in `image_eval.py`.
3. B5.4 shadow + canary — defer until corpus expansion actually separates providers.

Follow-up commit `ce7e7bc` logs a known issue (#90) discovered during the commit gate: `sql/37_create_analytics_role.sql` checksum drift blocks integration tests from running locally. Unrelated to this PR; surfaced when running the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)