### PR TITLE
feat(extraction-v2): chart-presence pivot — emit metric-presence, not facts (#86 PR 1/4)

### DIFF
--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -82,6 +82,7 @@ MIGRATIONS = [
     "38_create_analytics_views.sql",
     "39_v2_ingest_batches.sql",
     "40_full_page_scan_and_ocr_provenance.sql",
+    "42_add_detected_metrics_to_v2_image_assets.sql",
 ]
 
 BOOTSTRAP_DDL = """

--- a/sql/42_add_detected_metrics_to_v2_image_assets.sql
+++ b/sql/42_add_detected_metrics_to_v2_image_assets.sql
@@ -1,0 +1,2 @@
+ALTER TABLE v2_image_assets
+  ADD COLUMN IF NOT EXISTS detected_metrics JSONB DEFAULT '[]'::jsonb;

--- a/src/extraction_v2/chart/metric_classifier.py
+++ b/src/extraction_v2/chart/metric_classifier.py
@@ -66,16 +66,16 @@ def _metric_gate(metric_id: str, chart: ChartData, nearby_text: str = "") -> boo
         # Fallback for OCR outputs with missing y_axis_label: require margin /
         # contribution keyword somewhere in chart text OR nearby_text, AND a
         # percentage signal (point labels or axis).
-        text_blob = " ".join([
-            chart.title or "",
-            chart.x_axis_label or "",
-            chart.y_axis_label or "",
-            " ".join(s.name or "" for s in chart.series),
-            nearby_text[:1500] if nearby_text else "",
-        ])
-        has_margin = bool(
-            re.search(r"\b(?:margin|contribution)\b", text_blob, re.IGNORECASE)
+        text_blob = " ".join(
+            [
+                chart.title or "",
+                chart.x_axis_label or "",
+                chart.y_axis_label or "",
+                " ".join(s.name or "" for s in chart.series),
+                nearby_text[:1500] if nearby_text else "",
+            ]
         )
+        has_margin = bool(re.search(r"\b(?:margin|contribution)\b", text_blob, re.IGNORECASE))
         has_percent = "%" in (chart.y_axis_label or "") or any(
             "%" in (p.label or "") for s in chart.series for p in s.points
         )
@@ -151,9 +151,7 @@ def _score_metric(
     # (e.g. FTCH Order Contribution Margin) that lacks title/axes but is
     # structurally a gross-margin-by-cohort chart.
     if metric_id == "cm_gross_margin_by_cohort":
-        has_pct_labels = any(
-            "%" in (p.label or "") for s in chart.series for p in s.points
-        )
+        has_pct_labels = any("%" in (p.label or "") for s in chart.series for p in s.points)
         point_years = {
             m.group()
             for s in chart.series
@@ -178,7 +176,8 @@ class ChartMetricClassifier:
         self._specific = get_specific_patterns_by_metric()
         self._exclusions = get_exclusion_patterns()
 
-    def classify(self, chart: ChartData, nearby_text: str = "") -> tuple[str | None, float]:
+    def _build_candidates(self, chart: ChartData, nearby_text: str) -> list[tuple[str, float]]:
+        """Compute gated candidate list (shared by classify and classify_all)."""
         scores = {
             mid: _score_metric(
                 mid,
@@ -202,7 +201,36 @@ class ChartMetricClassifier:
                 if cohort_passed and _metric_gate(mid, chart, nearby_text):
                     candidates.append((mid, scores[mid]))
 
+        return candidates
+
+    def classify_all(self, chart: ChartData, nearby_text: str = "") -> list[tuple[str, float]]:
+        """Return all candidates passing _cohort_gate + _metric_gate, sorted by score desc.
+
+        Unlike ``classify()``, this does NOT apply the revenue/transactions
+        unit-disambiguation filter and does NOT collapse to a single winner.
+        Suitable for metric-presence detection where multiple metrics may be
+        present on the same chart (e.g. a stacked-bar cohort chart covering
+        both cm_revenue_by_cohort and cm_balance_by_cohort).
+        """
+        candidates = self._build_candidates(chart, nearby_text)
+        return sorted(candidates, key=lambda x: x[1], reverse=True)
+
+    def classify(self, chart: ChartData, nearby_text: str = "") -> tuple[str | None, float]:
+        """Return the single best-matching metric, or (None, raw_best) if none pass gates."""
+        candidates = self._build_candidates(chart, nearby_text)
+
         if not candidates:
+            scores = {
+                mid: _score_metric(
+                    mid,
+                    chart,
+                    nearby_text,
+                    self._keywords,
+                    self._specific,
+                    self._exclusions,
+                )
+                for mid in _SUPPORTED_METRICS
+            }
             best_raw = max(scores.values()) if scores else 0.0
             return (None, best_raw)
 

--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -663,6 +663,14 @@ class Segment:
 
 
 @dataclass
+class DetectedMetric:
+    """Metric-presence signal detected on a chart image by the classifier."""
+
+    metric_id: str
+    score: float
+
+
+@dataclass
 class DataPoint:
     """Single data point extracted from a chart."""
 
@@ -748,6 +756,10 @@ class ImageAsset:
 
     # ML triage score (populated by learned gate when USE_LEARNED_TRIAGE=true)
     predicted_relevance: float | None = None
+
+    # Metric-presence signals detected by ChartMetricClassifier (chart images only).
+    # Populated by ChartFactBridgeStage; persisted to v2_image_assets.detected_metrics.
+    detected_metrics: list[DetectedMetric] = field(default_factory=list)
 
     def is_relevant(self, threshold: float = 0.3) -> bool:
         """Check if image is relevant for metric extraction."""

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -711,7 +711,7 @@ class V2PersistenceAdapter:
                 classification, relevance_score,
                 ocr_text, ocr_table_id, chart_type, chart_data,
                 processed, confidence, requires_manual,
-                detected_keywords, created_at
+                detected_keywords, detected_metrics, created_at
             )
             VALUES (
                 %(img_id)s, %(doc_id)s, %(filename)s, %(file_path)s,
@@ -720,7 +720,7 @@ class V2PersistenceAdapter:
                 %(classification)s, %(relevance_score)s,
                 %(ocr_text)s, %(ocr_table_id)s, %(chart_type)s, %(chart_data)s,
                 %(processed)s, %(confidence)s, %(requires_manual)s,
-                %(detected_keywords)s, NOW()
+                %(detected_keywords)s, %(detected_metrics)s, NOW()
             )
             ON CONFLICT (doc_id, filename) DO UPDATE SET
                 file_path = EXCLUDED.file_path,
@@ -739,7 +739,8 @@ class V2PersistenceAdapter:
                 processed = EXCLUDED.processed,
                 confidence = EXCLUDED.confidence,
                 requires_manual = EXCLUDED.requires_manual,
-                detected_keywords = EXCLUDED.detected_keywords
+                detected_keywords = EXCLUDED.detected_keywords,
+                detected_metrics = EXCLUDED.detected_metrics
             RETURNING img_id
         """
 
@@ -768,6 +769,7 @@ class V2PersistenceAdapter:
                     ((image.nearby_text or "") + " " + (image.ocr_text or "")).strip()
                 )
                 or None,
+                "detected_metrics": json.dumps([asdict(d) for d in image.detected_metrics]),
             }
             for image in images
         ]

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -167,6 +167,18 @@ class PipelineConfig:
     Tier 1 recall because legitimate cohort charts (e.g. HOOD ``cm_balance_by_cohort``)
     classify barely above the 0.6 gate."""
 
+    # Chart metric-presence (pivot: charts emit presence signals, not per-value facts)
+    chart_presence_min_score: float = 0.5
+    """Minimum classifier score for a metric to appear in image.detected_metrics.
+    Lower than chart_image_min_confidence (0.6) to allow secondary candidates onto
+    the reviewer checklist; reviewers adjudicate. Tune via PR 2 baseline sweep."""
+
+    # Candidate generation from chart text
+    enable_chart_candidate_emission: bool = False
+    """When False (default), CandidateGenerationStage._scan_chart is suppressed:
+    chart-sourced text candidates no longer enter the text pipeline. Set True
+    for debug/comparison runs only."""
+
     @classmethod
     def for_transcript(cls, **overrides) -> PipelineConfig:
         """Create a config tuned for earnings call transcripts."""

--- a/src/extraction_v2/stages/candidate_generation.py
+++ b/src/extraction_v2/stages/candidate_generation.py
@@ -214,20 +214,24 @@ class CandidateGenerationStage:
                     logger.error(error_msg)
                     errors.append(error_msg)
 
-            # Scan chart data from processed images
+            # Scan chart data from processed images.
+            # enable_chart_candidate_emission defaults to False (chart-presence pivot):
+            # chart-sourced text candidates no longer enter the text pipeline.
+            # Set True via PipelineConfig for debug/comparison runs only.
             charts_scanned = 0
-            for asset in context.images:
-                if asset.chart_data is not None:
-                    try:
-                        chart_candidates = self._scan_chart(asset)
-                        for candidate in chart_candidates:
-                            context.candidates.append(candidate)
-                            candidates_found += 1
-                        charts_scanned += 1
-                    except Exception as e:
-                        error_msg = f"Error scanning chart {asset.img_id}: {e}"
-                        logger.error(error_msg)
-                        errors.append(error_msg)
+            if getattr(context.config, "enable_chart_candidate_emission", False):
+                for asset in context.images:
+                    if asset.chart_data is not None:
+                        try:
+                            chart_candidates = self._scan_chart(asset)
+                            for candidate in chart_candidates:
+                                context.candidates.append(candidate)
+                                candidates_found += 1
+                            charts_scanned += 1
+                        except Exception as e:
+                            error_msg = f"Error scanning chart {asset.img_id}: {e}"
+                            logger.error(error_msg)
+                            errors.append(error_msg)
 
             items_processed = len(context.segments) + len(context.tables) + charts_scanned
 

--- a/src/extraction_v2/stages/chart_fact_bridge.py
+++ b/src/extraction_v2/stages/chart_fact_bridge.py
@@ -1,42 +1,16 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from src.extraction_v2.chart.cohort_parser import CohortParser
 from src.extraction_v2.chart.metric_classifier import ChartMetricClassifier
-from src.extraction_v2.chart.unit_inference import infer_unit_and_currency
-from src.extraction_v2.models import (
-    EvidencePack,
-    MetricFact,
-    PeriodType,
-    Scope,
-    SourceLocator,
-    SourceType,
-    Unit,
-)
+from src.extraction_v2.models import DetectedMetric
 
 if TYPE_CHECKING:
     from src.extraction_v2.pipeline import PipelineContext, StageResult
 
 logger = logging.getLogger(__name__)
-
-_CURRENCY_OR_COUNT_METRICS = frozenset(
-    {
-        "cm_revenue_by_cohort",
-        "cm_transactions_by_cohort",
-        "cm_balance_by_cohort",
-        # Add new currency/count cohort metrics here if the classifier targets them
-    }
-)
-
-
-def _annotation_compatible_with_metric(metric_id: str, ann: object) -> bool:
-    if getattr(ann, "unit", None) == "percent" and metric_id in _CURRENCY_OR_COUNT_METRICS:
-        return False
-    return True
 
 
 class ChartFactBridgeStage:
@@ -56,33 +30,10 @@ class ChartFactBridgeStage:
             )
 
         classifier = ChartMetricClassifier()
-        parser = CohortParser()
-        filing_date = context.document_date
-        if filing_date is None:
-            logger.warning(
-                "ChartFactBridgeStage: no document_date on context for filing_id=%s; skipping chart fact emission",
-                context.filing_id,
-            )
-            duration_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
-            return StageResult(
-                stage=PipelineStage.CHART_FACT_BRIDGE,
-                success=True,
-                duration_ms=duration_ms,
-                items_processed=0,
-                items_output=0,
-            )
-        doc_id = str(context.filing_id)
 
-        items_processed = 0
-        items_output = 0
-
-        # Guard counters — initialised before the image loop
-        result_metadata: dict = {
-            "guard_skipped_low_image_confidence": 0,
-            "guard_skipped_missing_label": 0,
-            "guard_skipped_out_of_range": 0,
-            "guard_skipped_future_cohort": 0,
-        }
+        images_scanned = 0
+        metrics_detected = 0
+        images_below_confidence = 0
 
         for image in context.images:
             if image.chart_data is None:
@@ -93,199 +44,36 @@ class ChartFactBridgeStage:
                 image.confidence is not None
                 and image.confidence < context.config.chart_image_min_confidence
             ):
-                result_metadata["guard_skipped_low_image_confidence"] += 1
+                images_below_confidence += 1
                 continue
 
-            items_processed += 1
-            chart = image.chart_data
+            images_scanned += 1
 
-            metric_id, score = classifier.classify(chart, image.nearby_text or "")
-            if metric_id is None or score < context.config.chart_metric_classification_min_score:
-                continue
+            candidates = classifier.classify_all(image.chart_data, image.nearby_text or "")
+            image.detected_metrics = [
+                DetectedMetric(metric_id=m, score=s)
+                for m, s in candidates
+                if s >= context.config.chart_presence_min_score
+            ]
+            metrics_detected += len(image.detected_metrics)
 
-            # Guard 6 — metric confidence floor (Issue #54)
-            # Keeps weak top-match binds out of the fact queue; fires AFTER the 0.6
-            # classification gate so only near-miss scores (0.6–0.70) are suppressed.
-            if score < context.config.chart_metric_min_confidence:
+            if image.detected_metrics:
                 logger.debug(
-                    "ChartFactBridgeStage: skipping low-confidence metric bind "
-                    "doc_id=%s img_id=%s top_metric=%s score=%.4f",
-                    doc_id,
+                    "ChartFactBridgeStage: img_id=%s detected_metrics=%s",
                     image.img_id,
-                    metric_id,
-                    score,
+                    [(d.metric_id, d.score) for d in image.detected_metrics],
                 )
-                continue
-
-            unit, currency = infer_unit_and_currency(chart.y_axis_label)
-            if unit is None:
-                unit = Unit.OTHER
-
-            annotations_only = not chart.series or all(not s.points for s in chart.series)
-
-            if annotations_only:
-                cohort_period = parser.parse(chart, None, None, filing_date)
-                if cohort_period is None:
-                    continue
-                for ann in chart.annotations:
-                    if ann.value is None:
-                        continue
-                    if not _annotation_compatible_with_metric(metric_id, ann):
-                        continue
-                    value_raw = str(ann.value)
-                    fact = MetricFact(
-                        fact_id=str(uuid.uuid4()),
-                        doc_id=doc_id,
-                        canonical_metric_id=metric_id,
-                        value=ann.value,
-                        value_raw=value_raw,
-                        unit=unit,
-                        currency=currency,
-                        period_type=PeriodType.POINT_IN_TIME,
-                        period_start=cohort_period.period_start,
-                        period_end=cohort_period.period_end,
-                        scope=Scope.COMPANY,
-                        cohort_def=cohort_period.cohort_def,
-                        source_type=SourceType.CHART,
-                        source_locator=SourceLocator(img_id=image.img_id, bbox=None),
-                        evidence_pack=EvidencePack(
-                            snippet_html="",
-                            raw_value_text=value_raw,
-                            context_before=f"Chart: {chart.title}",
-                        ),
-                        confidence=0.55,
-                        requires_review=True,
-                    )
-                    # Guard 5 — fact review threshold (annotations branch already sets True;
-                    # keep consistent by applying the threshold check uniformly)
-                    if fact.confidence < context.config.chart_fact_review_threshold:
-                        fact.requires_review = True
-                    context.facts.append(fact)
-                    items_output += 1
-            elif metric_id == "cm_ltv_to_cac_ratio":
-                for series in chart.series:
-                    # Guard 3 — axis-range sanity: compute reference max from labeled points
-                    labeled_points = [p for p in series.points if p.label is not None]
-                    if labeled_points:
-                        labeled_max = max(abs(p.y) for p in labeled_points)
-                    else:
-                        labeled_max = 0.0
-
-                    for point in series.points:
-                        # Guard 3 — axis-range sanity (runs before label guard so it can
-                        # reject unlabeled noise points that exceed the labeled reference range)
-                        if (
-                            labeled_max > 0
-                            and abs(point.y)
-                            > labeled_max * context.config.chart_axis_range_multiplier
-                        ):
-                            result_metadata["guard_skipped_out_of_range"] += 1
-                            continue
-
-                        # Guard 2 — label-required gate
-                        if point.label is None:
-                            result_metadata["guard_skipped_missing_label"] += 1
-                            continue
-
-                        value_raw = point.label
-                        fact = MetricFact(
-                            fact_id=str(uuid.uuid4()),
-                            doc_id=doc_id,
-                            canonical_metric_id=metric_id,
-                            value=point.y,
-                            value_raw=value_raw,
-                            unit=unit,
-                            currency=currency,
-                            period_type=PeriodType.POINT_IN_TIME,
-                            period_start=filing_date,
-                            period_end=filing_date,
-                            scope=Scope.CUSTOMER_TYPE,
-                            cohort_def=str(point.x),
-                            source_type=SourceType.CHART,
-                            source_locator=SourceLocator(img_id=image.img_id, bbox=point.bbox),
-                            evidence_pack=EvidencePack(
-                                snippet_html="",
-                                raw_value_text=value_raw,
-                                context_before=f"Chart: {chart.title}",
-                            ),
-                            confidence=0.80,
-                            requires_review=False,
-                        )
-                        # Guard 5 — fact review threshold
-                        if fact.confidence < context.config.chart_fact_review_threshold:
-                            fact.requires_review = True
-                        context.facts.append(fact)
-                        items_output += 1
-            else:
-                for series in chart.series:
-                    # Guard 3 — axis-range sanity: compute reference max from labeled points
-                    labeled_points = [p for p in series.points if p.label is not None]
-                    if labeled_points:
-                        labeled_max = max(abs(p.y) for p in labeled_points)
-                    else:
-                        labeled_max = 0.0
-
-                    for point in series.points:
-                        # Guard 3 — axis-range sanity (runs before label guard so it can
-                        # reject unlabeled noise points that exceed the labeled reference range)
-                        if (
-                            labeled_max > 0
-                            and abs(point.y)
-                            > labeled_max * context.config.chart_axis_range_multiplier
-                        ):
-                            result_metadata["guard_skipped_out_of_range"] += 1
-                            continue
-
-                        # Guard 2 — label-required gate
-                        if point.label is None:
-                            result_metadata["guard_skipped_missing_label"] += 1
-                            continue
-
-                        cohort_period = parser.parse(chart, series, point, filing_date)
-                        if cohort_period is None:
-                            continue
-
-                        # Guard 4 — cohort-year sanity (default cohort branch only)
-                        if cohort_period.period_end.year > filing_date.year + 1:
-                            result_metadata["guard_skipped_future_cohort"] += 1
-                            continue
-
-                        value_raw = point.label
-                        fact = MetricFact(
-                            fact_id=str(uuid.uuid4()),
-                            doc_id=doc_id,
-                            canonical_metric_id=metric_id,
-                            value=point.y,
-                            value_raw=value_raw,
-                            unit=unit,
-                            currency=currency,
-                            period_type=PeriodType.POINT_IN_TIME,
-                            period_start=cohort_period.period_start,
-                            period_end=cohort_period.period_end,
-                            scope=Scope.COMPANY,
-                            cohort_def=cohort_period.cohort_def,
-                            source_type=SourceType.CHART,
-                            source_locator=SourceLocator(img_id=image.img_id, bbox=point.bbox),
-                            evidence_pack=EvidencePack(
-                                snippet_html="",
-                                raw_value_text=value_raw,
-                                context_before=f"Chart: {chart.title}",
-                            ),
-                            confidence=cohort_period.confidence,
-                            requires_review=cohort_period.requires_review,
-                        )
-                        # Guard 5 — fact review threshold
-                        if fact.confidence < context.config.chart_fact_review_threshold:
-                            fact.requires_review = True
-                        context.facts.append(fact)
-                        items_output += 1
 
         duration_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
         return StageResult(
             stage=PipelineStage.CHART_FACT_BRIDGE,
             success=True,
             duration_ms=duration_ms,
-            items_processed=items_processed,
-            items_output=items_output,
-            metadata=result_metadata,
+            items_processed=images_scanned,
+            items_output=metrics_detected,
+            metadata={
+                "images_scanned": images_scanned,
+                "metrics_detected": metrics_detected,
+                "images_below_confidence": images_below_confidence,
+            },
         )

--- a/tests/extraction_v2/chart/test_chart_fact_bridge_stage.py
+++ b/tests/extraction_v2/chart/test_chart_fact_bridge_stage.py
@@ -1,3 +1,11 @@
+"""Presence-pivot contract smoke tests for ChartFactBridgeStage.
+
+The detailed behavioural assertions live in
+``tests/unit/extraction_v2/test_chart_fact_bridge_stage.py``. This file keeps
+a narrower set of scope-guard cases to prevent silent regressions on the
+"charts no longer emit facts" invariant from the `chart/` test package.
+"""
+
 from __future__ import annotations
 
 from datetime import date
@@ -10,33 +18,22 @@ from src.extraction_v2.models import (
     ChartType,
     DataPoint,
     ImageAsset,
-    SourceType,
 )
 from src.extraction_v2.pipeline import PipelineConfig, PipelineContext
 from src.extraction_v2.stages.chart_fact_bridge import ChartFactBridgeStage
 
 
-def _make_context(
-    images: list[ImageAsset],
-    enable_bridge: bool = True,
-    min_score: float = 0.6,
-    document_date: date | None = None,
-) -> PipelineContext:
-    config = PipelineConfig(
-        enable_chart_fact_bridge=enable_bridge,
-        chart_metric_classification_min_score=min_score,
-    )
-    ctx = PipelineContext(
+def _make_context(images: list[ImageAsset]) -> PipelineContext:
+    return PipelineContext(
         html_path=Path("/dev/null"),
         filing_id=42,
-        config=config,
-        document_date=document_date or date(2021, 10, 8),
+        config=PipelineConfig(),
+        document_date=date(2021, 10, 8),
+        images=images,
     )
-    ctx.images = images
-    return ctx
 
 
-def _cohort_stacked_bar_image() -> ImageAsset:
+def _cohort_series_image() -> ImageAsset:
     chart = ChartData(
         chart_type=ChartType.STACKED_BAR,
         title="Cumulative Net Deposits by Cohort",
@@ -52,90 +49,85 @@ def _cohort_stacked_bar_image() -> ImageAsset:
             ),
             ChartSeries(
                 name="2019",
+                points=[DataPoint(x="2020", y=9.0, label="9.0")],
+            ),
+        ],
+    )
+    img = ImageAsset(img_id="img-cohort", nearby_text="")
+    img.chart_data = chart
+    img.confidence = 0.8
+    return img
+
+
+def _ltv_cac_image() -> ImageAsset:
+    chart = ChartData(
+        chart_type=ChartType.BAR,
+        title="LTV to CAC Ratio by Cohort",
+        x_axis_label="Cohort",
+        y_axis_label="LTV/CAC",
+        series=[
+            ChartSeries(
+                name="Enterprise",
                 points=[
-                    DataPoint(x="2020", y=9.0, label="9.0"),
+                    DataPoint(x="Cohort 2018", y=3.5, label="3.5x"),
+                    DataPoint(x="Cohort 2019", y=4.0, label="4.0x"),
                 ],
             ),
         ],
     )
-    img = ImageAsset(img_id="img-001", nearby_text="")
+    img = ImageAsset(img_id="img-ltv", nearby_text="")
     img.chart_data = chart
-    img.confidence = 0.8  # above chart_image_min_confidence threshold (0.6)
+    img.confidence = 0.9
     return img
 
 
-def test_emits_facts_for_classified_chart() -> None:
-    image = _cohort_stacked_bar_image()
-    ctx = _make_context([image])
-    ChartFactBridgeStage().process(ctx)
-    assert len(ctx.facts) >= 1
-
-
-def test_skips_chart_below_classification_threshold() -> None:
+def _annotation_only_image() -> ImageAsset:
     chart = ChartData(
         chart_type=ChartType.BAR,
-        title="Annual Revenue",
-        y_axis_label="USD millions",
+        title="Revenue by Cohort",
         x_axis_label="Year",
-        series=[ChartSeries(name="Revenue", points=[DataPoint(x="2020", y=100.0)])],
-    )
-    img = ImageAsset(img_id="img-low", nearby_text="")
-    img.chart_data = chart
-    ctx = _make_context([img])
-    ChartFactBridgeStage().process(ctx)
-    assert ctx.facts == []
-
-
-def test_sets_source_type_chart_and_img_id_locator() -> None:
-    image = _cohort_stacked_bar_image()
-    ctx = _make_context([image])
-    ChartFactBridgeStage().process(ctx)
-    assert len(ctx.facts) >= 1
-    fact = ctx.facts[0]
-    assert fact.source_type == SourceType.CHART
-    assert fact.source_locator.img_id == "img-001"
-
-
-def test_marks_requires_review_for_annotations_only_facts() -> None:
-    ann = ChartAnnotation(
-        text="2019 cohort data",
-        value=44.4,
-        unit="billions",
-        category="2019 Cohort",
-        period="2019",
-    )
-    chart = ChartData(
-        chart_type=ChartType.STACKED_BAR,
-        title="Cumulative Net Deposits by Cohort",
-        y_axis_label="Cumulative Net Deposits ($ Billions)",
-        x_axis_label="Year",
+        y_axis_label="USDm",
         series=[],
-        annotations=[ann],
+        annotations=[
+            ChartAnnotation(text="$2.8M 2014 new customer revenue", value=2.8, unit="USD"),
+        ],
     )
-    img = ImageAsset(img_id="img-ann", nearby_text="")
+    img = ImageAsset(img_id="img-ann", nearby_text="new customer revenue by cohort")
     img.chart_data = chart
-    img.confidence = 0.8
-    ctx = _make_context([img])
+    img.confidence = 0.9
+    return img
+
+
+def test_cohort_series_shape_emits_zero_facts() -> None:
+    ctx = _make_context([_cohort_series_image()])
     ChartFactBridgeStage().process(ctx)
-    assert len(ctx.facts) >= 1
-    fact = ctx.facts[0]
-    assert fact.requires_review is True
-    assert fact.confidence == 0.55
+    assert ctx.facts == []
 
 
-def test_populates_cohort_def_and_period_end() -> None:
-    image = _cohort_stacked_bar_image()
+def test_ltv_cac_shape_emits_zero_facts() -> None:
+    ctx = _make_context([_ltv_cac_image()])
+    ChartFactBridgeStage().process(ctx)
+    assert ctx.facts == []
+
+
+def test_annotation_only_shape_emits_zero_facts() -> None:
+    ctx = _make_context([_annotation_only_image()])
+    ChartFactBridgeStage().process(ctx)
+    assert ctx.facts == []
+
+
+def test_cohort_series_shape_populates_detected_metrics() -> None:
+    image = _cohort_series_image()
     ctx = _make_context([image])
     ChartFactBridgeStage().process(ctx)
-    assert len(ctx.facts) >= 1
-    fact = ctx.facts[0]
-    assert fact.cohort_def is not None
-    assert fact.period_end is not None
+    assert len(image.detected_metrics) >= 1
+    for detected in image.detected_metrics:
+        assert isinstance(detected.metric_id, str) and detected.metric_id
+        assert 0.0 <= detected.score <= 1.0
 
 
-def test_bridge_noop_when_enable_chart_fact_bridge_false() -> None:
-    image = _cohort_stacked_bar_image()
-    ctx = _make_context([image], enable_bridge=False)
-    result = ChartFactBridgeStage().process(ctx)
-    assert result.items_output == 0
-    assert ctx.facts == []
+def test_ltv_cac_shape_populates_detected_metrics() -> None:
+    image = _ltv_cac_image()
+    ctx = _make_context([image])
+    ChartFactBridgeStage().process(ctx)
+    assert len(image.detected_metrics) >= 1

--- a/tests/integration/extraction_v2/test_persistence_detected_metrics.py
+++ b/tests/integration/extraction_v2/test_persistence_detected_metrics.py
@@ -1,0 +1,187 @@
+"""
+Integration test: round-trip ImageAsset.detected_metrics through Postgres.
+
+Verifies that `V2PersistenceAdapter._persist_images_in_tx` serializes and
+persists ``detected_metrics`` to the ``v2_image_assets.detected_metrics``
+JSONB column, and that re-extraction via ON CONFLICT (doc_id, filename)
+overwrites the column with the latest values.
+
+Requires ``TEST_DATABASE_URL``; skips otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+from src.extraction_v2.models import (
+    DetectedMetric,
+    ImageAsset,
+    ImageClassification,
+)
+from src.extraction_v2.persistence import V2PersistenceAdapter
+from src.infra.db import DatabaseAdapter
+
+pytestmark = pytest.mark.integration
+
+
+def _test_db_url() -> str | None:
+    return os.environ.get("TEST_DATABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def db_adapter() -> DatabaseAdapter:
+    url = _test_db_url()
+    if not url:
+        pytest.skip("TEST_DATABASE_URL not set")
+    return DatabaseAdapter(url)
+
+
+@pytest.fixture(scope="module")
+def persistence_adapter(db_adapter: DatabaseAdapter) -> V2PersistenceAdapter:
+    return V2PersistenceAdapter(db_adapter)
+
+
+@pytest.fixture
+def test_filing_id(db_adapter: DatabaseAdapter) -> int:
+    with db_adapter.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO companies (cik, company_name, ticker)
+                VALUES ('9999999998', 'V2 Presence Test Co', 'V2PRES')
+                ON CONFLICT (cik) DO UPDATE SET company_name = EXCLUDED.company_name
+                RETURNING company_id
+                """
+            )
+            company_id = cur.fetchone()["company_id"]
+            cur.execute(
+                """
+                INSERT INTO filings (
+                    company_id, cik, accession_number, form_type, filing_date, sec_html_url
+                )
+                VALUES (
+                    %(company_id)s, '9999999998', '9999999998-99-999998',
+                    'S-1', '2026-01-01', 'https://www.sec.gov/presence-test/filing.htm'
+                )
+                ON CONFLICT (company_id, accession_number) DO UPDATE SET
+                    form_type = EXCLUDED.form_type
+                RETURNING filing_id
+                """,
+                {"company_id": company_id},
+            )
+            return cur.fetchone()["filing_id"]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_image_rows(db_adapter: DatabaseAdapter, test_filing_id: int):
+    def _cleanup():
+        with db_adapter.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+
+    _cleanup()
+    yield
+    _cleanup()
+
+
+def _read_detected_metrics(db: DatabaseAdapter, doc_id: int, filename: str):
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT detected_metrics
+                  FROM v2_image_assets
+                 WHERE doc_id = %s AND filename = %s
+                """,
+                (doc_id, filename),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return row["detected_metrics"]
+
+
+def _new_image(filename: str, metrics: list[DetectedMetric]) -> ImageAsset:
+    return ImageAsset(
+        img_id=str(uuid.uuid4()),
+        filename=filename,
+        classification=ImageClassification.CHART,
+        detected_metrics=metrics,
+    )
+
+
+class TestDetectedMetricsPersistence:
+    def test_persists_detected_metrics_as_jsonb(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        image = _new_image(
+            "chart_001.png",
+            [
+                DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.95),
+                DetectedMetric(metric_id="cm_balance_by_cohort", score=0.72),
+            ],
+        )
+
+        persistence_adapter.persist_images([image], test_filing_id)
+
+        stored = _read_detected_metrics(db_adapter, test_filing_id, "chart_001.png")
+        assert stored is not None
+        if isinstance(stored, str):
+            stored = json.loads(stored)
+        assert stored == [
+            {"metric_id": "cm_revenue_by_cohort", "score": 0.95},
+            {"metric_id": "cm_balance_by_cohort", "score": 0.72},
+        ]
+
+    def test_empty_detected_metrics_round_trips_as_empty_list(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        image = _new_image("chart_empty.png", [])
+
+        persistence_adapter.persist_images([image], test_filing_id)
+
+        stored = _read_detected_metrics(db_adapter, test_filing_id, "chart_empty.png")
+        assert stored is not None
+        if isinstance(stored, str):
+            stored = json.loads(stored)
+        assert stored == []
+
+    def test_reextraction_overwrites_detected_metrics(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        first = _new_image(
+            "chart_002.png",
+            [DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.80)],
+        )
+        persistence_adapter.persist_images([first], test_filing_id)
+
+        second = _new_image(
+            "chart_002.png",
+            [
+                DetectedMetric(metric_id="cm_gross_margin_by_cohort", score=0.91),
+                DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.85),
+            ],
+        )
+        persistence_adapter.persist_images([second], test_filing_id)
+
+        stored = _read_detected_metrics(db_adapter, test_filing_id, "chart_002.png")
+        assert stored is not None
+        if isinstance(stored, str):
+            stored = json.loads(stored)
+        assert stored == [
+            {"metric_id": "cm_gross_margin_by_cohort", "score": 0.91},
+            {"metric_id": "cm_revenue_by_cohort", "score": 0.85},
+        ]

--- a/tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py
+++ b/tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py
@@ -1,12 +1,15 @@
 """
 Invariant tests for `ChartFactBridgeStage`.
 
-The review UI's "Chart Evidence" block depends on every chart-sourced fact
-carrying a non-null `source_locator.img_id` — the CI integrity gate treats a
-null img_id on a `source_type='chart'` fact as a blocking violation (see
-`scripts/check_image_referential_integrity.py`). These tests lock that
-invariant in at unit-test granularity so regressions surface locally before
-they reach the DB.
+Under the presence-pivot contract (see PR rewriting `ChartFactBridgeStage`),
+chart images no longer emit per-value `MetricFact` rows — they carry
+image-level metric-presence signals on `ImageAsset.detected_metrics`.
+
+The persistence layer writes these signals to `v2_image_assets.detected_metrics`
+keyed by `img_id`, so every `DetectedMetric` must belong to an image with a
+non-null `img_id`. These tests lock that invariant at unit-test granularity
+across the historical chart shapes (cohort series, LTV/CAC, annotations-only)
+so regressions surface locally before they reach the DB.
 """
 
 from __future__ import annotations
@@ -40,7 +43,6 @@ def _context(images: list[ImageAsset]) -> PipelineContext:
 
 
 def _ltv_image(img_id: str = "img-ltv-invariant") -> ImageAsset:
-    """LTV/CAC ratio chart that exercises the cm_ltv_to_cac_ratio branch."""
     chart = ChartData(
         chart_type=ChartType.BAR,
         title="LTV to CAC Ratio by Cohort",
@@ -67,7 +69,6 @@ def _ltv_image(img_id: str = "img-ltv-invariant") -> ImageAsset:
 
 
 def _cohort_series_image(img_id: str = "img-cohort-invariant") -> ImageAsset:
-    """Cohort revenue chart that exercises the default series branch."""
     chart = ChartData(
         chart_type=ChartType.BAR,
         title="GMV by Consumer Cohort",
@@ -95,7 +96,6 @@ def _cohort_series_image(img_id: str = "img-cohort-invariant") -> ImageAsset:
 
 
 def _annotation_only_image(img_id: str = "img-ann-invariant") -> ImageAsset:
-    """Annotation-only chart that exercises the annotations-only branch."""
     chart = ChartData(
         chart_type=ChartType.BAR,
         title="Revenue by Cohort",
@@ -117,41 +117,78 @@ def _annotation_only_image(img_id: str = "img-ann-invariant") -> ImageAsset:
     )
 
 
-def _assert_img_id_on_every_fact(facts: list, expected_img_id: str) -> None:
-    assert facts, "expected at least one chart fact to be emitted"
-    for fact in facts:
-        assert fact.source_locator is not None, f"fact {fact.fact_id} has no source_locator"
-        assert fact.source_locator.img_id == expected_img_id, (
-            f"fact {fact.fact_id} img_id={fact.source_locator.img_id!r} "
-            f"expected {expected_img_id!r}"
-        )
+class TestNoChartFactsEmitted:
+    """Presence-pivot contract: `ChartFactBridgeStage` never emits MetricFacts."""
+
+    def test_cohort_series_shape_emits_zero_facts(self) -> None:
+        context = _context([_cohort_series_image()])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
+
+    def test_ltv_shape_emits_zero_facts(self) -> None:
+        context = _context([_ltv_image()])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
+
+    def test_annotation_only_shape_emits_zero_facts(self) -> None:
+        context = _context([_annotation_only_image()])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
 
 
-class TestChartFactBridgeImgIdInvariant:
-    def test_series_branch_always_sets_img_id(self) -> None:
+class TestDetectedMetricsImgIdInvariant:
+    """Every detected_metrics entry must belong to an image with a non-null img_id.
+
+    This replaces the prior "every chart fact has img_id" invariant — under the
+    presence-pivot contract, metric-presence signals are keyed to the image
+    row in v2_image_assets by img_id, so the img_id must always be present on
+    any image that carries detected_metrics.
+    """
+
+    def test_cohort_series_image_img_id_non_null(self) -> None:
         image = _cohort_series_image("img-cohort-A")
         context = _context([image])
 
         ChartFactBridgeStage().process(context)
 
-        _assert_img_id_on_every_fact(context.facts, "img-cohort-A")
+        if image.detected_metrics:
+            assert image.img_id is not None
+            assert image.img_id == "img-cohort-A"
 
-    def test_ltv_branch_always_sets_img_id(self) -> None:
+    def test_ltv_image_img_id_non_null(self) -> None:
         image = _ltv_image("img-ltv-A")
         context = _context([image])
 
         ChartFactBridgeStage().process(context)
 
-        _assert_img_id_on_every_fact(context.facts, "img-ltv-A")
+        if image.detected_metrics:
+            assert image.img_id is not None
+            assert image.img_id == "img-ltv-A"
 
-    def test_annotation_only_branch_always_sets_img_id(self) -> None:
+    def test_annotation_only_image_img_id_non_null(self) -> None:
         image = _annotation_only_image("img-ann-A")
         context = _context([image])
 
         ChartFactBridgeStage().process(context)
 
-        # Annotation-only branch may be filtered by classifier; the invariant
-        # only applies to facts that were emitted.
-        for fact in context.facts:
-            assert fact.source_locator is not None
-            assert fact.source_locator.img_id == "img-ann-A"
+        # Annotation-only charts may or may not detect metrics; the invariant
+        # only applies to images that did populate detected_metrics.
+        if image.detected_metrics:
+            assert image.img_id is not None
+            assert image.img_id == "img-ann-A"
+
+    def test_invariant_holds_across_multiple_images(self) -> None:
+        images = [
+            _cohort_series_image("img-multi-cohort"),
+            _ltv_image("img-multi-ltv"),
+            _annotation_only_image("img-multi-ann"),
+        ]
+        context = _context(images)
+
+        ChartFactBridgeStage().process(context)
+
+        for image in images:
+            if image.detected_metrics:
+                assert image.img_id is not None, (
+                    f"image with detected_metrics has null img_id: {image!r}"
+                )

--- a/tests/unit/extraction_v2/test_chart_fact_bridge_stage.py
+++ b/tests/unit/extraction_v2/test_chart_fact_bridge_stage.py
@@ -1,30 +1,30 @@
 """
-Unit tests for ChartFactBridgeStage hallucination guards (Cluster A).
+Unit tests for ChartFactBridgeStage — presence-pivot contract.
 
-Tests Guard 1–6 and config override behaviour.
+After the chart-presence pivot (PR 1), ChartFactBridgeStage no longer emits
+MetricFact rows. Instead it populates image.detected_metrics with
+DetectedMetric records. All three historical chart shapes (annotations-only,
+LTV/CAC, default-series) must produce zero facts and non-empty detected_metrics
+when the classifier finds a match.
 """
 
 from __future__ import annotations
 
-import logging
 from datetime import date
 from pathlib import Path
-from unittest.mock import patch
 
 from src.extraction_v2.models import (
+    ChartAnnotation,
     ChartData,
     ChartSeries,
     ChartType,
     DataPoint,
+    DetectedMetric,
     ImageAsset,
     ImageClassification,
 )
 from src.extraction_v2.pipeline import PipelineConfig, PipelineContext
 from src.extraction_v2.stages.chart_fact_bridge import ChartFactBridgeStage
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 _FILING_DATE = date(2020, 12, 31)
 
@@ -43,26 +43,22 @@ def _make_context(
     )
 
 
-def _make_ltv_image(
-    confidence: float = 0.9,
-    series_data: list[tuple[str, list[tuple[str, float, str | None]]]] | None = None,
-) -> ImageAsset:
-    """Build a minimal LTV/CAC chart asset that the classifier will route to cm_ltv_to_cac_ratio."""
-    if series_data is None:
-        series_data = [
-            ("Enterprise", [("Cohort 2018", 3.5, "3.5x"), ("Cohort 2019", 4.0, "4.0x")]),
-        ]
-    series = []
-    for name, pts in series_data:
-        points = [DataPoint(x=x, y=y, label=label) for x, y, label in pts]
-        series.append(ChartSeries(name=name, points=points))
-
+def _make_ltv_image(confidence: float = 0.9) -> ImageAsset:
+    """LTV/CAC chart — previously exercised the cm_ltv_to_cac_ratio branch."""
     chart = ChartData(
         chart_type=ChartType.BAR,
         title="LTV to CAC Ratio by Cohort",
         x_axis_label="Cohort",
         y_axis_label="LTV/CAC",
-        series=series,
+        series=[
+            ChartSeries(
+                name="Enterprise",
+                points=[
+                    DataPoint(x="Cohort 2018", y=3.5, label="3.5x"),
+                    DataPoint(x="Cohort 2019", y=4.0, label="4.0x"),
+                ],
+            ),
+        ],
     )
     return ImageAsset(
         img_id="img-ltv-1",
@@ -74,26 +70,22 @@ def _make_ltv_image(
     )
 
 
-def _make_cohort_image(
-    confidence: float = 0.9,
-    series_data: list[tuple[str, list[tuple[str, float, str | None]]]] | None = None,
-) -> ImageAsset:
-    """Build a cohort revenue chart asset routed to a non-LTV metric."""
-    if series_data is None:
-        series_data = [
-            ("2017 Cohort", [("2017", 100.0, "100"), ("2018", 120.0, "120")]),
-        ]
-    series = []
-    for name, pts in series_data:
-        points = [DataPoint(x=x, y=y, label=label) for x, y, label in pts]
-        series.append(ChartSeries(name=name, points=points))
-
+def _make_cohort_series_image(confidence: float = 0.9) -> ImageAsset:
+    """Cohort revenue chart — previously exercised the default-series branch."""
     chart = ChartData(
         chart_type=ChartType.BAR,
         title="GMV by Consumer Cohort",
         x_axis_label="Year",
         y_axis_label="GMV (USDm)",
-        series=series,
+        series=[
+            ChartSeries(
+                name="2017 Cohort",
+                points=[
+                    DataPoint(x="2017", y=100.0, label="100"),
+                    DataPoint(x="2018", y=120.0, label="120"),
+                ],
+            ),
+        ],
     )
     return ImageAsset(
         img_id="img-cohort-1",
@@ -106,326 +98,207 @@ def _make_cohort_image(
     )
 
 
+def _make_annotations_only_image(confidence: float = 0.9) -> ImageAsset:
+    """Annotation-only chart — previously exercised the annotations-only branch."""
+    chart = ChartData(
+        chart_type=ChartType.BAR,
+        title="Revenue by Cohort",
+        x_axis_label="Year",
+        y_axis_label="USDm",
+        series=[],
+        annotations=[
+            ChartAnnotation(
+                text="$2.8M 2014 new customer revenue",
+                value=2.8,
+                unit="USD",
+            ),
+        ],
+    )
+    return ImageAsset(
+        img_id="img-ann-1",
+        classification=ImageClassification.CHART,
+        chart_data=chart,
+        processed=True,
+        confidence=confidence,
+        relevance_score=0.9,
+        nearby_text="new customer revenue by cohort",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core contract: zero facts, populated detected_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPresencePivotContract:
+    def test_emits_zero_facts_for_ltv_shape(self) -> None:
+        image = _make_ltv_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
+
+    def test_emits_zero_facts_for_default_series_shape(self) -> None:
+        image = _make_cohort_series_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
+
+    def test_emits_zero_facts_for_annotations_only_shape(self) -> None:
+        image = _make_annotations_only_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        assert context.facts == []
+
+    def test_populates_detected_metrics_for_ltv_shape(self) -> None:
+        image = _make_ltv_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        assert len(image.detected_metrics) >= 1
+        assert all(isinstance(d, DetectedMetric) for d in image.detected_metrics)
+
+    def test_populates_detected_metrics_for_cohort_series_shape(self) -> None:
+        image = _make_cohort_series_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        assert len(image.detected_metrics) >= 1
+
+    def test_detected_metric_has_valid_score(self) -> None:
+        image = _make_ltv_image()
+        context = _make_context([image])
+        ChartFactBridgeStage().process(context)
+        for dm in image.detected_metrics:
+            assert 0.0 <= dm.score <= 1.0
+            assert isinstance(dm.metric_id, str)
+            assert len(dm.metric_id) > 0
+
+    def test_detected_metrics_score_above_presence_min(self) -> None:
+        """All detected_metrics entries must have score >= chart_presence_min_score."""
+        config = PipelineConfig(chart_presence_min_score=0.5)
+        image = _make_ltv_image()
+        context = _make_context([image], config=config)
+        ChartFactBridgeStage().process(context)
+        for dm in image.detected_metrics:
+            assert dm.score >= 0.5
+
+
+# ---------------------------------------------------------------------------
+# Stage metadata: new counter keys
+# ---------------------------------------------------------------------------
+
+
+class TestStageMetadata:
+    def test_metadata_has_new_counter_keys(self) -> None:
+        image = _make_ltv_image()
+        context = _make_context([image])
+        result = ChartFactBridgeStage().process(context)
+        assert "images_scanned" in result.metadata
+        assert "metrics_detected" in result.metadata
+        assert "images_below_confidence" in result.metadata
+
+    def test_images_scanned_counts_processed_chart_images(self) -> None:
+        images = [_make_ltv_image(), _make_cohort_series_image()]
+        context = _make_context(images)
+        result = ChartFactBridgeStage().process(context)
+        assert result.metadata["images_scanned"] == 2
+
+    def test_images_below_confidence_counts_skipped(self) -> None:
+        low_conf = _make_ltv_image(confidence=0.1)
+        context = _make_context([low_conf])
+        result = ChartFactBridgeStage().process(context)
+        assert result.metadata["images_below_confidence"] == 1
+        assert result.metadata["images_scanned"] == 0
+
+    def test_metrics_detected_reflects_total_detected_metrics(self) -> None:
+        image = _make_ltv_image()
+        context = _make_context([image])
+        result = ChartFactBridgeStage().process(context)
+        total = sum(len(img.detected_metrics) for img in context.images)
+        assert result.metadata["metrics_detected"] == total
+
+
 # ---------------------------------------------------------------------------
 # Guard 1: image confidence gate
 # ---------------------------------------------------------------------------
 
 
 class TestGuard1ImageConfidence:
-    def test_guard_skips_chart_when_image_confidence_below_threshold(self) -> None:
-        """Images with confidence below chart_image_min_confidence (default 0.6) are skipped."""
+    def test_skips_image_below_confidence_threshold(self) -> None:
         image = _make_ltv_image(confidence=0.3)
         context = _make_context([image])
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
+        result = ChartFactBridgeStage().process(context)
         assert result.success
-        assert len(context.facts) == 0
-        assert result.metadata["guard_skipped_low_image_confidence"] == 1
+        assert context.facts == []
+        assert result.metadata["images_below_confidence"] == 1
+        assert image.detected_metrics == []
 
     def test_image_without_confidence_is_not_skipped(self) -> None:
-        """Images where confidence is None pass the gate regardless of threshold."""
-        image = _make_cohort_image(confidence=0.9)
+        image = _make_ltv_image()
         image.confidence = None  # type: ignore[assignment]
         context = _make_context([image])
-        stage = ChartFactBridgeStage()
+        result = ChartFactBridgeStage().process(context)
+        assert result.metadata["images_below_confidence"] == 0
+        assert result.metadata["images_scanned"] == 1
 
-        result = stage.process(context)
-
-        assert result.success
-        assert result.metadata["guard_skipped_low_image_confidence"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Guard 2: label-required gate
-# ---------------------------------------------------------------------------
-
-
-class TestGuard2LabelRequired:
-    def test_guard_skips_point_when_label_missing(self) -> None:
-        """Points with label=None are skipped; labeled points contribute facts."""
-        image = _make_ltv_image(
-            series_data=[
-                (
-                    "Enterprise",
-                    [
-                        ("Cohort 2018", 3.5, "3.5x"),  # labeled — should emit
-                        ("Cohort 2019", 4.0, None),  # no label — should skip
-                    ],
-                )
-            ]
-        )
-        context = _make_context([image])
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        # Only the labeled point should produce a fact
-        assert len(context.facts) == 1
-        assert result.metadata["guard_skipped_missing_label"] == 1
-
-
-# ---------------------------------------------------------------------------
-# Guard 3: axis-range sanity
-# ---------------------------------------------------------------------------
-
-
-class TestGuard3AxisRange:
-    def test_guard_skips_point_out_of_axis_range(self) -> None:
-        """An unlabeled point whose abs(y) > 10× the labeled-max is skipped before label gate."""
-        # labeled_max = max(abs(3.5), abs(4.0)) = 4.0
-        # 4.0 * 10 = 40.0 — unlabeled point with y=1000 should be filtered by axis-range guard
-        # (axis-range guard runs before the label-required guard, so unlabeled outliers are caught)
-        image = _make_ltv_image(
-            series_data=[
-                (
-                    "Enterprise",
-                    [
-                        ("Cohort 2018", 3.5, "3.5x"),  # labeled, in-range → emits fact
-                        ("Cohort 2019", 4.0, "4.0x"),  # labeled, in-range → emits fact
-                        ("Noise", 1000.0, None),  # unlabeled, out-of-range → skipped by G3
-                    ],
-                )
-            ]
-        )
-        context = _make_context([image])
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) == 2  # Only the two labeled in-range points
-        assert result.metadata["guard_skipped_out_of_range"] == 1
-        # Guard 2 counter should be 0 because axis-range guard fired first
-        assert result.metadata["guard_skipped_missing_label"] == 0
-
-    def test_guard_skips_nothing_when_labeled_max_is_zero(self) -> None:
-        """When all labeled y-values are 0, the axis-range guard is skipped (no division risk)."""
-        image = _make_ltv_image(
-            series_data=[
-                (
-                    "Enterprise",
-                    [
-                        ("Cohort 2018", 0.0, "0"),
-                        ("Cohort 2019", 0.0, "0"),
-                    ],
-                )
-            ]
-        )
-        context = _make_context([image])
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.metadata["guard_skipped_out_of_range"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Guard 4: cohort-year sanity
-# ---------------------------------------------------------------------------
-
-
-class TestGuard4CohortYear:
-    def test_guard_skips_cohort_year_beyond_filing_year_plus_one(self) -> None:
-        """Cohort points whose resolved period_end.year > filing_date.year + 1 are rejected."""
-        # filing_date = 2020-12-31, so max allowed year = 2021
-        # series name "2023 Cohort" → cohort_year=2023 → period_end.year=2023 > 2021 → skip
-        image = _make_cohort_image(
-            series_data=[
-                (
-                    "2023 Cohort",
-                    [("2023", 150.0, "150")],
-                ),
-            ]
-        )
-        context = _make_context([image], filing_date=date(2020, 12, 31))
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        assert result.metadata["guard_skipped_future_cohort"] >= 1
-
-    def test_cohort_within_allowed_window_passes(self) -> None:
-        """A cohort year at filing_date.year + 1 (boundary) is allowed through."""
-        # filing_date = 2020, so year 2021 should NOT be blocked
-        image = _make_cohort_image(
-            series_data=[
-                (
-                    "2017 Cohort",
-                    [("2017", 100.0, "100"), ("2018", 120.0, "120")],
-                ),
-            ]
-        )
-        context = _make_context([image], filing_date=date(2020, 12, 31))
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.metadata["guard_skipped_future_cohort"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Guard 5: fact review threshold
-# ---------------------------------------------------------------------------
-
-
-class TestGuard5FactReviewThreshold:
-    def test_ltv_cac_branch_respects_fact_review_threshold(self) -> None:
-        """LTV/CAC facts with confidence < 0.80 get requires_review=True."""
-        # The LTV/CAC branch sets confidence=0.80; default threshold is also 0.80.
-        # Override threshold to 0.85 to force requires_review=True on those facts.
-        config = PipelineConfig(chart_fact_review_threshold=0.85)
-        image = _make_ltv_image(
-            series_data=[
-                ("Enterprise", [("Cohort 2018", 3.5, "3.5x")]),
-            ]
-        )
-        context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) == 1
-        assert context.facts[0].requires_review is True
-
-    def test_high_confidence_fact_does_not_force_review(self) -> None:
-        """A fact with confidence >= threshold retains the branch-set requires_review value."""
-        # LTV/CAC branch sets confidence=0.80, requires_review=False; threshold=0.70
-        config = PipelineConfig(chart_fact_review_threshold=0.70)
-        image = _make_ltv_image(
-            series_data=[
-                ("Enterprise", [("Cohort 2018", 3.5, "3.5x")]),
-            ]
-        )
-        context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) == 1
-        assert context.facts[0].requires_review is False
-
-
-# ---------------------------------------------------------------------------
-# Config override test
-# ---------------------------------------------------------------------------
-
-
-class TestConfigOverrides:
-    def test_guards_respect_config_overrides(self) -> None:
-        """Setting chart_image_min_confidence=0.0 passes images that would normally be skipped."""
+    def test_config_override_zero_threshold_passes_all(self) -> None:
         config = PipelineConfig(chart_image_min_confidence=0.0)
-        image = _make_ltv_image(confidence=0.1)  # Would be skipped at default 0.6
+        image = _make_ltv_image(confidence=0.1)
         context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
-
-        result = stage.process(context)
-
-        assert result.success
-        assert result.metadata["guard_skipped_low_image_confidence"] == 0
-        # Should have emitted facts (image passes through)
-        assert len(context.facts) > 0
+        result = ChartFactBridgeStage().process(context)
+        assert result.metadata["images_below_confidence"] == 0
+        assert result.metadata["images_scanned"] == 1
 
 
 # ---------------------------------------------------------------------------
-# Guard 6: metric confidence floor (Issue #54)
+# Presence min-score gate
 # ---------------------------------------------------------------------------
 
 
-class TestGuard6MetricConfidenceFloor:
-    """Adds a configurable floor on classifier score, distinct from
-    ``chart_metric_classification_min_score`` (0.6 default gate). The floor
-    default matches the classification gate — no change at default — but
-    operators can set it higher (e.g. 0.70) during backfills to reject
-    weak top-match binds. See Issue #54."""
-
-    def test_tightened_floor_suppresses_weak_bind(self, caplog) -> None:
-        """With floor raised to 0.70, classifier scores below that are suppressed."""
-        config = PipelineConfig(chart_metric_min_confidence=0.70)
-        image = _make_ltv_image(confidence=0.9)
+class TestPresenceMinScore:
+    def test_candidates_below_min_score_excluded(self) -> None:
+        """With chart_presence_min_score=1.0, no candidate passes."""
+        config = PipelineConfig(chart_presence_min_score=1.0)
+        image = _make_ltv_image()
         context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
+        ChartFactBridgeStage().process(context)
+        assert image.detected_metrics == []
+        assert context.facts == []
 
-        with patch(
-            "src.extraction_v2.stages.chart_fact_bridge.ChartMetricClassifier.classify",
-            return_value=("cm_ltv_to_cac_ratio", 0.65),
-        ):
-            with caplog.at_level(
-                logging.DEBUG, logger="src.extraction_v2.stages.chart_fact_bridge"
-            ):
-                result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) == 0
-        assert any(
-            "skipping low-confidence metric bind" in rec.message and "score=0.6500" in rec.message
-            for rec in caplog.records
-        )
-
-    def test_tightened_floor_emits_at_threshold(self) -> None:
-        """With floor raised to 0.70, scores at or above 0.70 still emit."""
-        config = PipelineConfig(chart_metric_min_confidence=0.70)
-        image = _make_ltv_image(confidence=0.9)
+    def test_candidates_at_min_score_included(self) -> None:
+        """With chart_presence_min_score=0.0, all gated candidates are included."""
+        config = PipelineConfig(chart_presence_min_score=0.0)
+        image = _make_ltv_image()
         context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
+        ChartFactBridgeStage().process(context)
+        assert len(image.detected_metrics) >= 1
 
-        with patch(
-            "src.extraction_v2.stages.chart_fact_bridge.ChartMetricClassifier.classify",
-            return_value=("cm_ltv_to_cac_ratio", 0.70),
-        ):
-            result = stage.process(context)
 
-        assert result.success
-        assert len(context.facts) > 0
+# ---------------------------------------------------------------------------
+# Bridge disabled
+# ---------------------------------------------------------------------------
 
-    def test_default_floor_does_not_suppress_tier1_boundary(self) -> None:
-        """Default floor (0.60) does NOT suppress Tier 1 scores that barely clear
-        the classification gate (e.g. HOOD ``cm_balance_by_cohort`` at ~0.60)."""
-        image = _make_ltv_image(confidence=0.9)
-        context = _make_context([image])  # default config
-        stage = ChartFactBridgeStage()
 
-        with patch(
-            "src.extraction_v2.stages.chart_fact_bridge.ChartMetricClassifier.classify",
-            return_value=("cm_ltv_to_cac_ratio", 0.6024),
-        ):
-            result = stage.process(context)
+class TestBridgeDisabled:
+    def test_bridge_noop_when_disabled(self) -> None:
+        config = PipelineConfig(enable_chart_fact_bridge=False)
+        image = _make_ltv_image()
+        context = _make_context([image], config=config)
+        result = ChartFactBridgeStage().process(context)
+        assert result.items_processed == 0
+        assert result.items_output == 0
+        assert context.facts == []
+        assert image.detected_metrics == []
 
-        assert result.success
-        assert len(context.facts) > 0
 
-    def test_high_score_still_emits(self) -> None:
-        """Positive-control regression: score of 0.95 still emits under default."""
-        image = _make_ltv_image(confidence=0.9)
+# ---------------------------------------------------------------------------
+# Image without chart_data is skipped
+# ---------------------------------------------------------------------------
+
+
+class TestNonChartImages:
+    def test_image_without_chart_data_is_skipped(self) -> None:
+        image = ImageAsset(img_id="img-no-chart")
+        image.chart_data = None
         context = _make_context([image])
-        stage = ChartFactBridgeStage()
-
-        with patch(
-            "src.extraction_v2.stages.chart_fact_bridge.ChartMetricClassifier.classify",
-            return_value=("cm_ltv_to_cac_ratio", 0.95),
-        ):
-            result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) > 0
-
-    def test_extreme_tightening_suppresses_all(self) -> None:
-        """Setting the floor above any realistic score suppresses all chart facts."""
-        config = PipelineConfig(chart_metric_min_confidence=0.99)
-        image = _make_ltv_image(confidence=0.9)
-        context = _make_context([image], config=config)
-        stage = ChartFactBridgeStage()
-
-        with patch(
-            "src.extraction_v2.stages.chart_fact_bridge.ChartMetricClassifier.classify",
-            return_value=("cm_ltv_to_cac_ratio", 0.85),
-        ):
-            result = stage.process(context)
-
-        assert result.success
-        assert len(context.facts) == 0
+        result = ChartFactBridgeStage().process(context)
+        assert result.metadata["images_scanned"] == 0
+        assert image.detected_metrics == []

--- a/tests/unit/extraction_v2/test_chart_metric_classifier.py
+++ b/tests/unit/extraction_v2/test_chart_metric_classifier.py
@@ -1,0 +1,172 @@
+"""
+Unit tests for ChartMetricClassifier.classify_all and backward-compat classify().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.extraction_v2.chart.metric_classifier import ChartMetricClassifier
+from src.extraction_v2.models import ChartData, ChartSeries, ChartType, DataPoint
+
+
+@pytest.fixture
+def classifier() -> ChartMetricClassifier:
+    return ChartMetricClassifier()
+
+
+# ---------------------------------------------------------------------------
+# classify_all — multi-label output
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAll:
+    def test_returns_list(self, classifier: ChartMetricClassifier) -> None:
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Cumulative Net Deposits by Cohort",
+            y_axis_label="$ billions",
+            series=[ChartSeries(name="2018"), ChartSeries(name="2019")],
+        )
+        result = classifier.classify_all(chart)
+        assert isinstance(result, list)
+
+    def test_returns_empty_for_non_cohort_chart(self, classifier: ChartMetricClassifier) -> None:
+        chart = ChartData(
+            chart_type=ChartType.BAR,
+            title="Annual Revenue",
+            y_axis_label="USD millions",
+            series=[ChartSeries(name="Revenue")],
+        )
+        result = classifier.classify_all(chart)
+        assert result == []
+
+    def test_sorted_by_score_descending(self, classifier: ChartMetricClassifier) -> None:
+        """All returned (metric_id, score) pairs must be sorted score-desc."""
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Cumulative Net Deposits by Cohort",
+            y_axis_label="$ billions",
+            series=[ChartSeries(name="2018"), ChartSeries(name="2019"), ChartSeries(name="2020")],
+        )
+        result = classifier.classify_all(chart)
+        scores = [s for _, s in result]
+        assert scores == sorted(scores, reverse=True), "Results must be sorted by score desc"
+
+    def test_each_result_is_tuple_str_float(self, classifier: ChartMetricClassifier) -> None:
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Revenue by Cohort",
+            y_axis_label="$ Millions",
+            series=[ChartSeries(name="2019"), ChartSeries(name="2020")],
+        )
+        result = classifier.classify_all(chart)
+        for metric_id, score in result:
+            assert isinstance(metric_id, str)
+            assert isinstance(score, float)
+            assert 0.0 <= score <= 1.0
+
+    def test_respects_cohort_gate(self, classifier: ChartMetricClassifier) -> None:
+        """Generic revenue chart (no cohort/vintage signal) produces no candidates."""
+        chart = ChartData(
+            chart_type=ChartType.BAR,
+            title="Revenue by Segment",
+            y_axis_label="$ millions",
+            series=[ChartSeries(name="North America"), ChartSeries(name="Europe")],
+        )
+        result = classifier.classify_all(chart)
+        assert result == []
+
+    def test_respects_metric_gate(self, classifier: ChartMetricClassifier) -> None:
+        """A cohort chart without balance/deposit signals should not return cm_balance_by_cohort."""
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Revenue by Cohort",
+            y_axis_label="$ Millions",
+            series=[ChartSeries(name="2019"), ChartSeries(name="2020")],
+        )
+        result = classifier.classify_all(chart)
+        metric_ids = [m for m, _ in result]
+        assert "cm_balance_by_cohort" not in metric_ids
+
+    def test_ltv_cac_bypasses_cohort_gate(self, classifier: ChartMetricClassifier) -> None:
+        """cm_ltv_to_cac_ratio should appear even for non-vintage-year charts."""
+        chart = ChartData(
+            chart_type=ChartType.BAR,
+            title="LTV to CAC Ratio by Tenure",
+            y_axis_label="Ratio (x)",
+            series=[
+                ChartSeries(
+                    name="All Customers",
+                    points=[DataPoint(x="1 Year Tenure", y=1.8)],
+                )
+            ],
+        )
+        result = classifier.classify_all(chart)
+        metric_ids = [m for m, _ in result]
+        assert "cm_ltv_to_cac_ratio" in metric_ids
+
+    def test_balance_cohort_chart_returns_balance_metric(
+        self, classifier: ChartMetricClassifier
+    ) -> None:
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Cumulative Net Deposits by Cohort",
+            y_axis_label="$ billions",
+            series=[ChartSeries(name="2018"), ChartSeries(name="2019")],
+        )
+        result = classifier.classify_all(chart)
+        metric_ids = [m for m, _ in result]
+        assert "cm_balance_by_cohort" in metric_ids
+
+
+# ---------------------------------------------------------------------------
+# classify() backward compatibility — must still return top-1
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyBackwardCompat:
+    def test_classify_returns_top1_from_classify_all(
+        self, classifier: ChartMetricClassifier
+    ) -> None:
+        """classify() must return the highest-scoring candidate from classify_all()."""
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Cumulative Net Deposits by Cohort",
+            y_axis_label="$ billions",
+            series=[ChartSeries(name="2018"), ChartSeries(name="2019")],
+        )
+        all_candidates = classifier.classify_all(chart)
+        single = classifier.classify(chart)
+
+        assert single[0] is not None
+        if all_candidates:
+            # The single result should correspond to the top score from classify_all,
+            # possibly after revenue/transactions disambiguation.
+            assert single[1] >= min(s for _, s in all_candidates)
+
+    def test_classify_returns_none_when_no_candidates(
+        self, classifier: ChartMetricClassifier
+    ) -> None:
+        chart = ChartData(
+            chart_type=ChartType.BAR,
+            title="Annual Revenue",
+            y_axis_label="USD millions",
+            series=[ChartSeries(name="Revenue")],
+        )
+        metric_id, score = classifier.classify(chart)
+        assert metric_id is None
+        assert isinstance(score, float)
+
+    def test_classify_returns_single_tuple(self, classifier: ChartMetricClassifier) -> None:
+        chart = ChartData(
+            chart_type=ChartType.STACKED_BAR,
+            title="Revenue by Cohort",
+            y_axis_label="$ Millions",
+            series=[ChartSeries(name="2019"), ChartSeries(name="2020")],
+        )
+        result = classifier.classify(chart)
+        assert len(result) == 2
+        metric_id, score = result
+        assert metric_id is None or isinstance(metric_id, str)
+        assert isinstance(score, float)

--- a/tests/unit/extraction_v2/test_image_pipeline_integration.py
+++ b/tests/unit/extraction_v2/test_image_pipeline_integration.py
@@ -686,13 +686,18 @@ class TestChartScanning:
             ), f"Confidence too low: {[c.confidence for c in candidates]}"
 
     def test_chart_candidates_in_pipeline_context(self, stage: CandidateGenerationStage) -> None:
-        """Chart candidates are added to context.candidates during process()."""
+        """Chart candidates are added to context.candidates during process() when the
+        chart-candidate-emission flag is explicitly enabled. The flag defaults to False
+        under the chart-presence pivot (`PipelineConfig.enable_chart_candidate_emission`);
+        this test continues to cover the debug/comparison code path.
+        """
         asset = _make_chart_asset(
             title="Annual Recurring Revenue by Cohort",
             y_axis_label="ARR ($M)",
         )
 
         context = MockPipelineContext()
+        context.config = PipelineConfig(enable_chart_candidate_emission=True)
         context.images = [asset]
 
         result = stage.process(context)
@@ -700,6 +705,23 @@ class TestChartScanning:
         assert result.success
         chart_candidates = [c for c in context.candidates if c.source_type == SourceType.CHART]
         assert len(chart_candidates) >= 1
+
+    def test_chart_candidates_gated_off_by_default(self, stage: CandidateGenerationStage) -> None:
+        """Under the chart-presence pivot default, chart candidates are not emitted."""
+        asset = _make_chart_asset(
+            title="Annual Recurring Revenue by Cohort",
+            y_axis_label="ARR ($M)",
+        )
+
+        context = MockPipelineContext()
+        context.config = PipelineConfig()  # enable_chart_candidate_emission=False (default)
+        context.images = [asset]
+
+        result = stage.process(context)
+
+        assert result.success
+        chart_candidates = [c for c in context.candidates if c.source_type == SourceType.CHART]
+        assert len(chart_candidates) == 0
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR 1 of 4 in the chart-stage presence pivot for Issue #86. Emission side only — **no doc/UX/validator changes** (those land in PRs 2–4 per the parent plan).

**Pivot motivation.** The V2 chart pipeline currently emits per-value \`MetricFact\` rows from chart images. Ambiguous vision output (e.g. HOOD's stacked-bar cohort chart) produces multiple facts with identical identity tuples that collapse to 1 under \`sql/23\` + \`sql/33\` unique indices — losing 9/10 cohort bars. The fix isn't branch-specific; the premise "the vision model returns structures we can map cleanly to \`(value, cohort_def, period)\`" is unreliable across real charts.

**New contract.** Chart images carry image-level metric-presence records (\`[{metric_id, score}, ...]\`) on \`v2_image_assets.detected_metrics\`. Reviewers will adjudicate in PR 3 (accept / reject / correct / add). Values, when needed, continue through the existing \`POST /api/v2/missed-metric\` path.

## What this PR changes

- \`sql/42\` adds \`detected_metrics JSONB DEFAULT '[]'::jsonb\` on \`v2_image_assets\`; registered in \`scripts/apply_migrations.py\`.
- \`ChartMetricClassifier\` gains \`classify_all()\` (all gated candidates sorted by score desc); \`classify()\` kept for back-compat.
- \`ChartFactBridgeStage\` collapses the 3 emission branches (annotations-only, LTV/CAC, default-series) into one presence-emission path. New stage metadata counters: \`images_scanned\`, \`metrics_detected\`, \`images_below_confidence\`.
- \`PipelineConfig\` gains \`chart_presence_min_score: float = 0.5\` and \`enable_chart_candidate_emission: bool = False\`. The latter gates the legacy \`_scan_chart\` path in \`candidate_generation\` — default-off; code kept for debug/comparison runs.
- \`_persist_images_in_tx\` serializes \`detected_metrics\` as JSONB via the existing \`ON CONFLICT (doc_id, filename) DO UPDATE\` upsert.
- \`DetectedMetric\` dataclass added to \`models.py\`.

## What this PR does NOT change

- Validator / baseline (PR 2)
- Reviewer UI / confirmation schema (PR 3)
- Production chart-fact drain / doc updates / rules / architecture (PR 4)

\`_scan_chart\` code path is **gated off by default, not deleted**, so comparison runs remain easy until PR 4.

## Tests

- **New** \`tests/unit/extraction_v2/test_chart_metric_classifier.py\` — \`classify_all\` behaviour + back-compat \`classify()\`.
- **Rewritten** \`tests/unit/extraction_v2/test_chart_fact_bridge_stage.py\` — presence-pivot contract: zero facts, populated \`detected_metrics\`, stage metadata keys, guard/gating behaviour.
- **Rewritten** \`tests/extraction_v2/chart/test_chart_fact_bridge_stage.py\` — minimal scope-guard smoke tests (non-overlapping with the unit tests above).
- **Re-targeted** \`tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py\` — invariant shifts from "every chart fact has img_id" to "every image with \`detected_metrics\` has non-null img_id".
- **New** \`tests/integration/extraction_v2/test_persistence_detected_metrics.py\` — DB round-trip for JSONB column (requires \`TEST_DATABASE_URL\`; skips otherwise).
- **Updated** \`tests/unit/extraction_v2/test_image_pipeline_integration.py\` — existing \`_scan_chart\` pipeline-context test now sets \`enable_chart_candidate_emission=True\` explicitly; added a companion test asserting default-off gating.

Full unit + extraction_v2 suite: **3851 passed, 11 skipped, 14 deselected**. \`scripts/check_image_referential_integrity.py\` (CI integration-test step) becomes trivially green once the drain lands in PR 4 — no changes needed here.

## Known carry-overs

- Docs deferred to PR 4 — \`.claude/rules/v2-pipeline.md\` "Chart Fact Bridge Config" / "Chart bridge extension point" sections become partially stale post-merge but stabilise at PR 4. Parent plan at \`~/.claude/plans/pick-up-issue-86-tranquil-piglet.md\`.
- Chart facts already in the DB remain until the PR 4 \`--chart-only\` drain.
- Baseline numbers don't move: chart gold rows (\`raw_value="chart"\`) currently contribute zero to value-level P/R, so removing chart-fact emission cannot regress a metric below a floor that was already zero.

## Test plan

- [ ] CI lint, unit tests, vulnerability scan, integration tests, Playwright — all green
- [ ] Reviewer post-merge: confirm \`v2_image_assets.detected_metrics\` populates on a fresh chart-containing extraction (e.g. Robinhood filing)
- [ ] Confirm \`v2_metric_facts\` chart-fact row count is non-decreasing on existing filings (no auto-drain yet; drain is PR 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)