### PR TITLE
feat(web): add Data Explorer nav link to Metabase

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -72,6 +72,7 @@ Rules for any DB-touching command in this repo:
 | `R2_SECRET_ACCESS_KEY` | With `R2_BUCKET` | R2 API token secret |
 | `R2_ENDPOINT_URL` | With `R2_BUCKET` | R2 S3-compatible endpoint (`https://<account-id>.r2.cloudflarestorage.com`) |
 | `IMAGE_CACHE_DIR` | Dev only (optional) | Override local filesystem image-cache root. Ignored when `R2_BUCKET` is set |
+| `METABASE_URL` | Optional | Target of the "Data Explorer" nav link in the Flask UI. Defaults to `https://filings-metabase.onrender.com` when unset. |
 
 ## Image Storage
 

--- a/.env.template
+++ b/.env.template
@@ -97,6 +97,12 @@ V2_MIN_CONFIDENCE=0.5
 # R2_SECRET_ACCESS_KEY=
 # R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
 
+# Analytics / BI
+#
+# Target of the "Data Explorer" nav link in the Flask review UI. Defaults to the
+# production Metabase service; override only if you self-host a second instance.
+# METABASE_URL=https://filings-metabase.onrender.com
+
 # Error Tracking (optional — uncomment to enable Sentry)
 # SENTRY_DSN=https://...@sentry.io/...
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -456,6 +456,7 @@ def _register_context_processors(app: Flask) -> None:
         return {
             "app_name": "CMASB Disclosures Review",
             "app_version": "0.5.0",
+            "metabase_url": os.environ.get("METABASE_URL", "https://filings-metabase.onrender.com"),
         }
 
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -40,6 +40,11 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('ingest.ingest_form') }}">Ingest</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ metabase_url }}" target="_blank" rel="noopener">
+                            Data Explorer <span aria-hidden="true">&#8599;</span>
+                        </a>
+                    </li>
                     {% endblock %}
                 </ul>
                 <span class="navbar-text text-light">

--- a/tests/ui/test_server.py
+++ b/tests/ui/test_server.py
@@ -25,7 +25,11 @@ review_images_bp = Blueprint("review_images", __name__)
 @app.context_processor
 def inject_app_globals():
     """Mirror real app's context processor."""
-    return {"app_name": "Filings Review", "app_version": "0.1.0"}
+    return {
+        "app_name": "Filings Review",
+        "app_version": "0.1.0",
+        "metabase_url": "https://filings-metabase.onrender.com",
+    }
 
 
 # --- Blueprint stub routes ---


### PR DESCRIPTION
## Summary

Closes **Phase 4** of the browser-based query-UI plan. The filings-reviewer nav bar now includes a "Data Explorer ↗" link that opens the self-hosted Metabase service in a new tab.

- Link URL is driven by the optional `METABASE_URL` env var. When unset, defaults to `https://filings-metabase.onrender.com` (the production service from PR #143 / #144), so local dev points at prod Metabase without any extra config.
- Visible to all authenticated reviewers. Role-based gating is deferred until the app has reviewer-role differentiation.

## Changes

- `src/web/app.py` — `metabase_url` added to the template context processor.
- `src/web/templates/base.html` — new nav `<li>` with `target="_blank" rel="noopener"` and a small ↗ glyph.
- `.env.template` — documents the optional `METABASE_URL` override.
- `.claude/rules/infrastructure.md` — `METABASE_URL` in the env-var table.
- `tests/ui/test_server.py` — Playwright mock server mirrors the new context key. (`test_mock_server_contract.py` caught the drift before push.)

## Test plan

- [x] `ruff check` / `ruff format` — pass.
- [x] `pytest tests/unit -x -q` — 3771 passed.
- [x] Template smoke test: default + `METABASE_URL` override both render correctly.
- [ ] CI green (lint, vuln scan, unit, integration, Playwright).
- [ ] After merge: visit filings-reviewer and click "Data Explorer ↗" — opens Metabase in a new tab.

## Pre-existing failure (not blocking)

Locally, `tests/integration/` fails at setup with `Checksum mismatch for 37_create_analytics_role.sql: expected e7b06ff3…, got a589d96a…`. Reproduces on bare `main` with this branch's changes stashed — it's drift between the file-on-disk and a checksum recorded in the local test DB from an earlier run. CI spins up a fresh DB per job so this doesn't block. Reset locally with `docker compose down -v && docker compose up -d` when next running integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)