### PR TITLE
feat(gold-standard): chart-presence P/R validator + baseline schema (#86 PR 2/4)

### DIFF
--- a/docs/GOLD_STANDARD_SPECIFICATION.md
+++ b/docs/GOLD_STANDARD_SPECIFICATION.md
@@ -60,11 +60,16 @@ A gold standard entry is a **chart entry** if the metric value appears only in a
 - Set `segment_type` to `chart`.
 - Leave `Scaled value` blank.
 
-**Validation behavior for chart entries:**
-- `normalize_value("chart")` returns `None`.
-- Chart entries can match on metric ID only — not on value.
-- A chart entry is counted as a TP if any candidate with the correct `cm_*` metric ID is generated for the filing, regardless of value.
-- Chart entries are **not** excluded from recall computation — they represent real disclosures the system should detect.
+**Validation behavior for chart entries (post-2026-04 chart-stage pivot):**
+
+Chart entries are evaluated via **metric-presence P/R**, not value-level P/R. The validator checks whether `ChartMetricClassifier` surfaced the expected metric on any image in the filing (via `v2_image_assets.detected_metrics`).
+
+- `segment_type='chart'` entries always bypass value normalization — `Raw value` is advisory/archival only. Even numeric values like `"3.5x"` on a chart row are forced to `None` by the validator.
+- **TP** if the metric appears in the filing's `detected_metrics` set (any image, score ≥ `chart_presence_min_score`, default 0.5) OR a text/table-sourced `v2_metric_facts` row exists for the same `(filing, metric)` — mixed-source fallback.
+- **FN** otherwise. Diagnostics distinguish `presence_not_detected` (chart image exists but metric scored below threshold) from `image_missing` (no chart images processed).
+- **FP** if a metric is detected on a filing's images but no chart gold row for that metric exists.
+
+Chart-presence aggregates surface as `presence_f1` on the baseline JSON alongside the existing overall precision/recall/f1. Pre-pivot baselines without `presence_f1` remain loadable — the regression check skips presence comparison when either side lacks the field.
 
 **Table entries:** Values from HTML tables should be marked `segment_type = table` but otherwise treated the same as text entries (value must be parseable).
 

--- a/src/gold_standard/baseline.py
+++ b/src/gold_standard/baseline.py
@@ -50,6 +50,11 @@ class BaselineMetrics:
     overall: MetricScores
     by_company: dict[str, MetricScores]
     unique_recall: float | None = None  # Recall after deduplicating repeated gold entries
+    # Chart-presence F1 (post-PR-1 chart-stage pivot). Independent of the
+    # value-level overall metrics; measures whether the classifier surfaces
+    # expected chart-native metrics on any image in the filing. None on
+    # pre-pivot baselines — loader tolerates missing field.
+    presence_f1: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
@@ -57,12 +62,12 @@ class BaselineMetrics:
             "baseline_date": self.baseline_date,
             "description": self.description,
             "overall": asdict(self.overall),
-            "by_company": {
-                company: asdict(scores) for company, scores in self.by_company.items()
-            },
+            "by_company": {company: asdict(scores) for company, scores in self.by_company.items()},
         }
         if self.unique_recall is not None:
             d["unique_recall"] = self.unique_recall
+        if self.presence_f1 is not None:
+            d["presence_f1"] = self.presence_f1
         return d
 
     @classmethod
@@ -104,9 +109,7 @@ class BaselineMetrics:
                     f1=scores["f1"],
                 )
             except KeyError as e:
-                raise ValueError(
-                    f"Missing field in scores for company '{company}': {e}"
-                ) from e
+                raise ValueError(f"Missing field in scores for company '{company}': {e}") from e
 
         return cls(
             baseline_date=data["baseline_date"],
@@ -114,6 +117,7 @@ class BaselineMetrics:
             overall=overall,
             by_company=by_company,
             unique_recall=data.get("unique_recall"),
+            presence_f1=data.get("presence_f1"),
         )
 
 
@@ -127,6 +131,10 @@ class ComparisonResult:
     has_regression: bool  # True if any metric dropped beyond tolerance
     regressed_companies: list[str]  # Companies with regressions
     regressed_metrics: list[str]  # Which overall metrics regressed
+    # Chart-presence F1 delta (post-PR-1 pivot). None when either baseline or
+    # current lacks a presence_f1 value (pre-pivot baseline, or no chart gold
+    # rows evaluated in this run).
+    presence_f1_delta: float | None = None
 
     def summary(self) -> str:
         """Generate a human-readable summary."""
@@ -134,6 +142,8 @@ class ComparisonResult:
         parts.append(f"Precision: {self.precision_delta:+.1%}")
         parts.append(f"Recall: {self.recall_delta:+.1%}")
         parts.append(f"F1: {self.f1_delta:+.1%}")
+        if self.presence_f1_delta is not None:
+            parts.append(f"Presence-F1: {self.presence_f1_delta:+.1%}")
 
         if self.has_regression:
             parts.append(f"REGRESSION DETECTED in: {', '.join(self.regressed_metrics)}")
@@ -182,8 +192,7 @@ def load_baseline(path: str | Path) -> BaselineMetrics:
 
     if not path.exists():
         raise FileNotFoundError(
-            f"Baseline file not found: {path}. "
-            f"Run validation with --update-baseline to create one."
+            f"Baseline file not found: {path}. Run validation with --update-baseline to create one."
         )
 
     with open(path, encoding="utf-8") as f:
@@ -248,6 +257,15 @@ def compare_to_baseline(
         if company_regressed:
             regressed_companies.append(company)
 
+    # Chart-presence F1 regression (Q1-5 pivot). Only compared when both the
+    # baseline and current run have a presence_f1 value; tolerates pre-pivot
+    # baselines (None → skip check).
+    presence_f1_delta: float | None = None
+    if current.presence_f1 is not None and baseline.presence_f1 is not None:
+        presence_f1_delta = current.presence_f1 - baseline.presence_f1
+        if presence_f1_delta < -tolerance:
+            regressed_metrics.append("presence_f1")
+
     has_regression = bool(regressed_metrics) or bool(regressed_companies)
 
     return ComparisonResult(
@@ -257,6 +275,7 @@ def compare_to_baseline(
         has_regression=has_regression,
         regressed_companies=sorted(regressed_companies),
         regressed_metrics=regressed_metrics,
+        presence_f1_delta=presence_f1_delta,
     )
 
 

--- a/src/gold_standard/v2_validator.py
+++ b/src/gold_standard/v2_validator.py
@@ -146,12 +146,24 @@ class GoldStandardEntry:
 
     @property
     def has_numeric_value(self) -> bool:
-        """Check if entry has a numeric value (not definition-only)."""
+        """Check if entry has a numeric value (not definition-only).
+
+        Chart entries (segment_type='chart') are always presence-only —
+        Raw value is advisory/archival and never used for value-level matching.
+        """
         if self.is_definition_only:
+            return False
+        # Q2a: all chart-segment entries are presence-only regardless of raw_value.
+        if self.segment_type.strip().lower() == "chart":
             return False
         if not self.raw_value or self.raw_value.lower() in ("", "chart", "n/a", "-"):
             return False
         return True
+
+    @property
+    def is_chart_presence_entry(self) -> bool:
+        """True when this gold row should be evaluated via presence P/R, not value-level."""
+        return self.segment_type.strip().lower() == "chart"
 
     @property
     def normalized_value(self) -> float | None:
@@ -255,10 +267,38 @@ class ValidationResult:
     # metrics can be recomputed at a different threshold.
     expected_entries_for_recompute: list[GoldStandardEntry] = field(default_factory=list)
 
+    # Presence P/R counters for chart gold rows (post-PR-1 pivot).
+    # Chart gold rows no longer contribute to value-level TP/FP/FN; they are
+    # measured here via metric-presence signals from v2_image_assets.detected_metrics.
+    presence_tp: int = 0
+    presence_fp: int = 0
+    presence_fn: int = 0
+
+    # Presence diagnostics for FN chart rows.
+    presence_fn_diagnostics: list[FNDiagnostic] = field(default_factory=list)
+
     # Per-stage pipeline timings for this filing (stage name → duration_ms).
     # Populated from v2_result.stage_results; empty if the pipeline failed.
     stage_timings: dict[str, int] = field(default_factory=dict)
     total_pipeline_ms: int = 0
+
+    @property
+    def presence_precision(self) -> float:
+        """Presence precision = pTP / (pTP + pFP)."""
+        total = self.presence_tp + self.presence_fp
+        return self.presence_tp / total if total > 0 else 0.0
+
+    @property
+    def presence_recall(self) -> float:
+        """Presence recall = pTP / (pTP + pFN)."""
+        total = self.presence_tp + self.presence_fn
+        return self.presence_tp / total if total > 0 else 0.0
+
+    @property
+    def presence_f1(self) -> float:
+        """Presence F1 = harmonic mean of presence_precision and presence_recall."""
+        p, r = self.presence_precision, self.presence_recall
+        return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
 
     @property
     def precision(self) -> float:
@@ -302,6 +342,25 @@ class AggregateMetrics:
     chart_facts_text_derivable_total: int = 0
     chart_facts_text_derivable_cross_confirmed: int = 0
     chart_facts_by_chart_native_metric: dict[str, int] = field(default_factory=dict)
+    # Chart-presence aggregates (post-PR-1 pivot).
+    total_presence_tp: int = 0
+    total_presence_fp: int = 0
+    total_presence_fn: int = 0
+
+    @property
+    def presence_precision(self) -> float:
+        total = self.total_presence_tp + self.total_presence_fp
+        return self.total_presence_tp / total if total > 0 else 0.0
+
+    @property
+    def presence_recall(self) -> float:
+        total = self.total_presence_tp + self.total_presence_fn
+        return self.total_presence_tp / total if total > 0 else 0.0
+
+    @property
+    def presence_f1(self) -> float:
+        p, r = self.presence_precision, self.presence_recall
+        return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
 
     def to_baseline_metrics(
         self,
@@ -310,6 +369,11 @@ class AggregateMetrics:
         """Convert to BaselineMetrics for saving."""
         from datetime import UTC, datetime
 
+        # Emit presence_f1 only when there were chart-presence gold rows to evaluate;
+        # keeps pre-pivot baselines loadable without spurious 0.0 defaults.
+        has_presence = (
+            self.total_presence_tp + self.total_presence_fp + self.total_presence_fn
+        ) > 0
         return BaselineMetrics(
             baseline_date=datetime.now(UTC).isoformat(),
             description=description or "V2 pipeline validation",
@@ -319,6 +383,7 @@ class AggregateMetrics:
                 f1=self.f1,
             ),
             by_company=self.by_company,
+            presence_f1=self.presence_f1 if has_presence else None,
             # V2 baseline marker (via description)
         )
 
@@ -711,6 +776,61 @@ class V2GoldStandardValidator:
                     )
                     result.fp_diagnostics.append(diag)
 
+        # --- Presence-pivot: chart gold rows (post-PR-1 chart-stage pivot) ---
+        # Chart gold rows (segment_type='chart') are evaluated via metric-presence
+        # P/R, not value-level P/R. Source of truth: v2_context.images[*].detected_metrics
+        # (in-memory; validator runs pipeline with filing_id=0, no persistence).
+        # Mixed-source fallback (Q1a): a text/table-sourced fact for the same
+        # (filing, metric) also counts as presence TP.
+        if v2_context is not None:
+            chart_gold_set = self._chart_gold_presence_set(expected_entries)
+            chart_detected_set = self._chart_presence_set_from_context(v2_context)
+
+            text_table_metric_ids = {
+                normalize_metric_id(f.canonical_metric_id)
+                for f in v2_facts
+                if f.source_type != SourceType.CHART
+            }
+
+            has_chart_images = any(img.chart_data is not None for img in v2_context.images)
+
+            for metric_id in chart_gold_set:
+                if metric_id in chart_detected_set or metric_id in text_table_metric_ids:
+                    result.presence_tp += 1
+                else:
+                    result.presence_fn += 1
+                    if self.fn_diagnostics:
+                        entries_for_metric = [
+                            e
+                            for e in expected_entries
+                            if e.is_chart_presence_entry
+                            and normalize_metric_id(e.metric_id) == metric_id
+                        ]
+                        if entries_for_metric:
+                            category = (
+                                "presence_not_detected" if has_chart_images else "image_missing"
+                            )
+                            detail = (
+                                f"chart image(s) present but {metric_id} scored below threshold"
+                                if has_chart_images
+                                else f"no chart images processed; {metric_id} expected"
+                            )
+                            result.presence_fn_diagnostics.append(
+                                FNDiagnostic(
+                                    entry=entries_for_metric[0],
+                                    company_name=company_name,
+                                    root_cause=FNRootCause(
+                                        category=category,
+                                        detail=detail,
+                                        stage="chart_fact_bridge",
+                                    ),
+                                )
+                            )
+
+            # FPs: metrics detected but not expected in this filing's chart-gold set
+            for _ in chart_detected_set - chart_gold_set:
+                result.presence_fp += 1
+
         # Store all pre-threshold facts and gold entries so metrics can be
         # recomputed at a different confidence threshold without re-running
         # the full pipeline (see compute_metrics_at_threshold).
@@ -718,6 +838,34 @@ class V2GoldStandardValidator:
         result.expected_entries_for_recompute = list(expected_entries)
 
         return result
+
+    def _chart_presence_set_from_context(
+        self,
+        context: PipelineContext,
+        threshold: float | None = None,
+    ) -> set[str]:
+        """Union of metric_ids detected on any chart image, above the presence threshold.
+
+        Uses `PipelineConfig.chart_presence_min_score` when `threshold` is None.
+        """
+        if threshold is None:
+            threshold = context.config.chart_presence_min_score
+        detected: set[str] = set()
+        for image in context.images:
+            for dm in image.detected_metrics:
+                if dm.score >= threshold:
+                    detected.add(normalize_metric_id(dm.metric_id))
+        return detected
+
+    def _chart_gold_presence_set(self, entries: list[GoldStandardEntry]) -> set[str]:
+        """Metric IDs appearing in chart-segment gold entries for a filing."""
+        return {
+            normalize_metric_id(e.metric_id)
+            for e in entries
+            if e.is_chart_presence_entry
+            and normalize_metric_id(e.metric_id)
+            and normalize_metric_id(e.metric_id) != "cm_not_a_customer_metric"
+        }
 
     def _find_matching_fact(
         self,
@@ -927,7 +1075,8 @@ class V2GoldStandardValidator:
 
         # Step 1: Check candidates for this metric_id
         matching_candidates = [
-            c for c in context.candidates
+            c
+            for c in context.candidates
             if normalize_metric_id(getattr(c, "metric_id", "")) == entry_metric_id
         ]
         candidate_count = len(matching_candidates)
@@ -947,7 +1096,8 @@ class V2GoldStandardValidator:
 
         # Step 2: Check pre-filter bound values for these candidates
         pre_filter_bindings = [
-            bv for bv in context._pre_filter_bound_values
+            bv
+            for bv in context._pre_filter_bound_values
             if getattr(bv, "candidate_id", None) in candidate_ids
         ]
         bound_value_count = len(pre_filter_bindings)
@@ -967,8 +1117,7 @@ class V2GoldStandardValidator:
 
         # Step 3: Check post-filter bound values — were bindings FP-filtered out?
         post_filter_bindings = [
-            bv for bv in context.bound_values
-            if getattr(bv, "candidate_id", None) in candidate_ids
+            bv for bv in context.bound_values if getattr(bv, "candidate_id", None) in candidate_ids
         ]
 
         if not post_filter_bindings and pre_filter_bindings:
@@ -980,9 +1129,9 @@ class V2GoldStandardValidator:
             value_matching_removed: list = []
             if expected_value is not None:
                 value_matching_removed = [
-                    bv for bv in pre_filter_bindings
-                    if bv.value is not None
-                    and self._values_match(expected_value, bv.value)
+                    bv
+                    for bv in pre_filter_bindings
+                    if bv.value is not None and self._values_match(expected_value, bv.value)
                 ]
             if expected_value is None or value_matching_removed:
                 return FNDiagnostic(
@@ -1020,13 +1169,13 @@ class V2GoldStandardValidator:
         # Step 4–7: Bindings survived FP filter — check facts
         # Look at ALL facts (pre-confidence-filter) for this metric
         metric_facts = [
-            f for f in all_facts
-            if normalize_metric_id(f.canonical_metric_id) == entry_metric_id
+            f for f in all_facts if normalize_metric_id(f.canonical_metric_id) == entry_metric_id
         ]
 
         # Also check context.facts (pre-dedup) directly
         context_facts = [
-            f for f in context.facts
+            f
+            for f in context.facts
             if normalize_metric_id(f.canonical_metric_id) == entry_metric_id
         ]
 
@@ -1052,7 +1201,8 @@ class V2GoldStandardValidator:
                 for f in all_metric_facts:
                     if f.value is not None and (
                         closest_fact is None
-                        or abs(f.value - expected_value) < abs((closest_fact.value or 0) - expected_value)
+                        or abs(f.value - expected_value)
+                        < abs((closest_fact.value or 0) - expected_value)
                     ):
                         closest_fact = f
             else:
@@ -1086,16 +1236,19 @@ class V2GoldStandardValidator:
         # the metric). This is the LTV/CAC case: three per-cohort values extracted pre-dedup
         # share identity tuple and get collapsed; only the highest-value sibling survives.
         post_dedup_metric_facts = [
-            f for f in (context.deduplicated_facts or [])
+            f
+            for f in (context.deduplicated_facts or [])
             if normalize_metric_id(f.canonical_metric_id) == entry_metric_id
         ]
         if expected_value is not None:
             pre_dedup_value_matches = [
-                f for f in context_facts
+                f
+                for f in context_facts
                 if f.value is not None and self._values_match(expected_value, f.value)
             ]
             post_dedup_value_matches = [
-                f for f in post_dedup_metric_facts
+                f
+                for f in post_dedup_metric_facts
                 if f.value is not None and self._values_match(expected_value, f.value)
             ]
             if pre_dedup_value_matches and not post_dedup_value_matches:
@@ -1119,14 +1272,8 @@ class V2GoldStandardValidator:
                 )
 
         # Step 6: Check confidence threshold
-        low_conf_facts = [
-            f for f in all_metric_facts
-            if f.confidence < self.min_confidence
-        ]
-        ok_conf_facts = [
-            f for f in all_metric_facts
-            if f.confidence >= self.min_confidence
-        ]
+        low_conf_facts = [f for f in all_metric_facts if f.confidence < self.min_confidence]
+        ok_conf_facts = [f for f in all_metric_facts if f.confidence >= self.min_confidence]
         if low_conf_facts and not ok_conf_facts:
             return FNDiagnostic(
                 entry=entry,
@@ -1147,7 +1294,8 @@ class V2GoldStandardValidator:
         # collapsed are classified as dedup_collision (Step 5b), not wrong_period.
         if expected_value is not None:
             value_matched_facts = [
-                f for f in post_dedup_metric_facts
+                f
+                for f in post_dedup_metric_facts
                 if f.value is not None and self._values_match(expected_value, f.value)
             ]
             if value_matched_facts:
@@ -1367,17 +1515,14 @@ class V2GoldStandardValidator:
             unknown = [c for c in companies if c not in valid_names]
             if unknown:
                 raise ValueError(
-                    f"Unknown company name(s): {unknown}. "
-                    f"Valid names: {sorted(valid_names)}"
+                    f"Unknown company name(s): {unknown}. Valid names: {sorted(valid_names)}"
                 )
             entries_by_company = {
                 k: v for k, v in entries_by_company.items() if k in set(companies)
             }
         if limit is not None:
             entries_by_company = dict(list(entries_by_company.items())[:limit])
-        logger.info(
-            f"Running {len(entries_by_company)} filing(s) with max_workers={max_workers}"
-        )
+        logger.info(f"Running {len(entries_by_company)} filing(s) with max_workers={max_workers}")
 
         if max_workers > 1:
             return self._validate_all_parallel(entries_by_company, max_workers)
@@ -1429,15 +1574,11 @@ class V2GoldStandardValidator:
 
         company_items = list(entries_by_company.items())
 
-        def make_task(
-            company_name: str, entries: list[GoldStandardEntry]
-        ):
+        def make_task(company_name: str, entries: list[GoldStandardEntry]):
             def task() -> ValidationResult | None:
                 filing_path = self._find_filing_path(company_name)
                 if filing_path is None:
-                    logger.warning(
-                        f"No filing found for {company_name}, skipping validation"
-                    )
+                    logger.warning(f"No filing found for {company_name}, skipping validation")
                     return None
                 metadata = self._load_filing_metadata(company_name)
                 fy_end_month = metadata.get("fiscal_year_end_month")
@@ -1597,8 +1738,7 @@ class V2GoldStandardValidator:
             s = metrics.by_metric[mid]
             tier = get_tier(mid)
             print(
-                f"  {mid:<{col_w}}   T{tier}  "
-                f"{s.precision:>6.1%}  {s.recall:>6.1%}  {s.f1:>6.1%}"
+                f"  {mid:<{col_w}}   T{tier}  {s.precision:>6.1%}  {s.recall:>6.1%}  {s.f1:>6.1%}"
             )
 
     @staticmethod
@@ -1716,9 +1856,7 @@ class V2GoldStandardValidator:
 
         chart_facts_total = sum(r.chart_facts_total for r in results)
         chart_facts_cross_confirmed = sum(r.chart_facts_cross_confirmed for r in results)
-        chart_facts_text_derivable_total = sum(
-            r.chart_facts_text_derivable_total for r in results
-        )
+        chart_facts_text_derivable_total = sum(r.chart_facts_text_derivable_total for r in results)
         chart_facts_text_derivable_cross_confirmed = sum(
             r.chart_facts_text_derivable_cross_confirmed for r in results
         )
@@ -1728,6 +1866,10 @@ class V2GoldStandardValidator:
                 chart_facts_by_chart_native_metric[metric_id] = (
                     chart_facts_by_chart_native_metric.get(metric_id, 0) + count
                 )
+
+        total_presence_tp = sum(r.presence_tp for r in results)
+        total_presence_fp = sum(r.presence_fp for r in results)
+        total_presence_fn = sum(r.presence_fn for r in results)
 
         return AggregateMetrics(
             precision=precision,
@@ -1744,6 +1886,9 @@ class V2GoldStandardValidator:
             chart_facts_text_derivable_total=chart_facts_text_derivable_total,
             chart_facts_text_derivable_cross_confirmed=chart_facts_text_derivable_cross_confirmed,
             chart_facts_by_chart_native_metric=chart_facts_by_chart_native_metric,
+            total_presence_tp=total_presence_tp,
+            total_presence_fp=total_presence_fp,
+            total_presence_fn=total_presence_fn,
         )
 
     def compute_metrics_at_threshold(
@@ -1837,11 +1982,7 @@ class V2GoldStandardValidator:
 
         precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) > 0 else 0.0
         recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) > 0 else 0.0
-        f1 = (
-            2 * (precision * recall) / (precision + recall)
-            if (precision + recall) > 0
-            else 0.0
-        )
+        f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
 
         return AggregateMetrics(
             precision=precision,
@@ -2033,7 +2174,9 @@ def run_validation(
         )
 
     # Run at the requested confidence threshold (default: high-confidence only)
-    validator = V2GoldStandardValidator(min_confidence=min_confidence, fn_diagnostics=fn_diagnostics)
+    validator = V2GoldStandardValidator(
+        min_confidence=min_confidence, fn_diagnostics=fn_diagnostics
+    )
     results = validator.validate_all(
         max_workers=max_workers,
         companies=companies,
@@ -2091,7 +2234,9 @@ def run_validation(
                 print(f"\n⚠ {comparison}")
                 print("\n  COMMIT BLOCKED: V2 gold standard regression detected")
                 print("  To update baseline after intentional changes:")
-                print('    python3 -m src.gold_standard.v2_validator --update-baseline --description "Reason"')
+                print(
+                    '    python3 -m src.gold_standard.v2_validator --update-baseline --description "Reason"'
+                )
                 sys.exit(1)
             else:
                 delta_f1 = comparison.f1_delta * 100
@@ -2173,11 +2318,7 @@ if __name__ == "__main__":
     _args = parser.parse_args()
     # With action="append", _args.companies is already a list[str] | None.
     # Strip whitespace and drop empties for robustness against quoting quirks.
-    companies_list = (
-        [c.strip() for c in _args.companies if c.strip()]
-        if _args.companies
-        else None
-    )
+    companies_list = [c.strip() for c in _args.companies if c.strip()] if _args.companies else None
     try:
         run_validation(
             update_baseline=_args.update_baseline,

--- a/tests/unit/gold_standard/test_unified_comparison.py
+++ b/tests/unit/gold_standard/test_unified_comparison.py
@@ -416,12 +416,20 @@ class TestPartitionBySourceType:
         assert result["text"].v2_text_only_result is None
 
     def test_partition_scores_computed_per_bucket(self) -> None:
-        """Each bucket gets its own MatchingResult from all extractions."""
+        """Each bucket gets its own MatchingResult from all extractions.
+
+        Post-2026-04 chart-stage pivot (Q2a): chart-segment gold entries are
+        evaluated via metric-presence P/R by the primary v2_validator, not by
+        the value-level matcher in unified_comparison. Their value is forced
+        to None (`has_numeric_value=False`), so they do not produce tp_pairs
+        through this partition API. Presence-level matching for chart entries
+        lives in `V2GoldStandardValidator._chart_presence_set_from_context`.
+        """
         gold = [
             make_gold_entry(
                 metric_id="cm_average_order_value", raw_value="100", segment_type="text"
             ),
-            make_gold_entry(metric_id="cm_nrr", raw_value="110", segment_type="chart"),
+            make_gold_entry(metric_id="cm_nrr", raw_value="110", segment_type="table"),
         ]
         extractions = [
             make_normalized(metric_id="cm_average_order_value", value=100.0),
@@ -436,8 +444,9 @@ class TestPartitionBySourceType:
 
         # text bucket: cm_average_order_value matched
         assert len(result["text"].v2_full_result.tp_pairs) == 1
-        # chart bucket: cm_nrr matched
-        assert len(result["chart"].v2_full_result.tp_pairs) == 1
+        # table bucket: cm_nrr matched (was "chart" pre-pivot; now exercises
+        # value-level matching in a bucket that still supports it).
+        assert len(result["table"].v2_full_result.tp_pairs) == 1
 
     def test_empty_gold_produces_empty_result(self) -> None:
         """Empty gold list returns empty partition dict."""

--- a/tests/unit/gold_standard/test_v2_validator.py
+++ b/tests/unit/gold_standard/test_v2_validator.py
@@ -42,6 +42,7 @@ def make_entry(
     period_start: date | None = None,
     period_end: date | None = None,
     period: str = "",
+    segment_type: str = "text",
 ) -> GoldStandardEntry:
     """Build a GoldStandardEntry with sensible defaults."""
     return GoldStandardEntry(
@@ -55,7 +56,7 @@ def make_entry(
         period=period,
         definition="",
         quote_context="",
-        segment_type="text",
+        segment_type=segment_type,
         is_definition_only=is_definition_only,
         value_context="",
         detection_difficulty="easy",
@@ -1991,6 +1992,7 @@ class TestDiagnosefalseNegative:
     def test_retain_context_false_no_context(self) -> None:
         """With retain_context=False, PipelineResult.context is None."""
         from src.extraction_v2.models import Document
+
         result = PipelineResult(
             document=Document(),
             facts=[],
@@ -2050,12 +2052,16 @@ class TestPrintFNDiagnostics:
         diag1 = FNDiagnostic(
             entry=entry1,
             company_name="Co1",
-            root_cause=FNRootCause(category="no_candidate", detail="x", stage="candidate_generation"),
+            root_cause=FNRootCause(
+                category="no_candidate", detail="x", stage="candidate_generation"
+            ),
         )
         diag2 = FNDiagnostic(
             entry=entry2,
             company_name="Co1",
-            root_cause=FNRootCause(category="fp_filtered", detail="y", stage="false_positive_filter"),
+            root_cause=FNRootCause(
+                category="fp_filtered", detail="y", stage="false_positive_filter"
+            ),
         )
         result = ValidationResult(
             company_name="Co1",
@@ -2190,9 +2196,7 @@ class TestValidateAllSubsetFlags:
         companies = ["A", "B", "C", "D", "E"]
         mock_load.return_value = _make_stub_entries(companies)
         mock_find_path.return_value = Path("/fake/filing.htm")
-        mock_validate_filing.side_effect = [
-            _make_validation_result(name) for name in companies[:2]
-        ]
+        mock_validate_filing.side_effect = [_make_validation_result(name) for name in companies[:2]]
 
         validator = V2GoldStandardValidator(gold_standard_path="/dev/null")
         results = validator.validate_all(limit=2)
@@ -2213,24 +2217,18 @@ class TestValidateAllSubsetFlags:
         companies = ["A", "B", "C", "D", "E"]
         mock_load.return_value = _make_stub_entries(companies)
         mock_find_path.return_value = Path("/fake/filing.htm")
-        mock_validate_filing.side_effect = [
-            _make_validation_result(name) for name in ["A", "B"]
-        ]
+        mock_validate_filing.side_effect = [_make_validation_result(name) for name in ["A", "B"]]
 
         validator = V2GoldStandardValidator(gold_standard_path="/dev/null")
         validator.validate_all(companies=["A", "B", "C"], limit=2)
 
         assert mock_validate_filing.call_count == 2
         # Both calls must be from within {A, B, C}
-        called_names = {
-            call.args[0] for call in mock_validate_filing.call_args_list
-        }
+        called_names = {call.args[0] for call in mock_validate_filing.call_args_list}
         assert called_names <= {"A", "B", "C"}
 
     @patch("src.gold_standard.v2_validator.V2GoldStandardValidator.load_gold_standard")
-    def test_validate_all_unknown_company_raises(
-        self, mock_load: MagicMock
-    ) -> None:
+    def test_validate_all_unknown_company_raises(self, mock_load: MagicMock) -> None:
         """Requesting a company name not in the CSV raises ValueError with valid names."""
         mock_load.return_value = _make_stub_entries(["RealCo", "AnotherCo"])
 
@@ -2257,9 +2255,7 @@ class TestRunValidationGuardsAndWorkers:
             run_validation(update_baseline=True, limit=3)
 
     @patch("src.gold_standard.v2_validator.V2GoldStandardValidator")
-    def test_run_validation_threads_workers(
-        self, mock_validator_cls: MagicMock
-    ) -> None:
+    def test_run_validation_threads_workers(self, mock_validator_cls: MagicMock) -> None:
         """run_validation(max_workers=4) passes max_workers=4 to validate_all."""
         mock_instance = mock_validator_cls.return_value
         mock_instance.validate_all.return_value = []
@@ -2316,9 +2312,7 @@ class TestStageTimingSummary:
         captured = capsys.readouterr()
         assert captured.out == ""
 
-    def test_all_results_missing_timings_silent(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_all_results_missing_timings_silent(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Results with empty stage_timings → silent return."""
         result = _make_validation_result("TestCo")
         V2GoldStandardValidator.print_stage_timing_summary([result])
@@ -2354,9 +2348,7 @@ class TestStageTimingSummary:
 class TestDeriveChartNativeMetrics:
     """Tests for _derive_chart_native_metrics()."""
 
-    def _write_rows(
-        self, path: Path, rows: list[tuple[str, str]]
-    ) -> None:
+    def _write_rows(self, path: Path, rows: list[tuple[str, str]]) -> None:
         """Write (metric_name, segment_type) rows to a gold standard CSV."""
         full_rows = [
             {
@@ -2384,18 +2376,14 @@ class TestDeriveChartNativeMetrics:
     def test_classifies_pure_chart_metric(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "gs.csv"
         # 5 rows all chart → chart-native
-        self._write_rows(
-            csv_path, [("cm_balance_by_cohort", "chart")] * 5
-        )
+        self._write_rows(csv_path, [("cm_balance_by_cohort", "chart")] * 5)
         native = _derive_chart_native_metrics(csv_path)
         assert "cm_balance_by_cohort" in native
 
     def test_borderline_metric_excluded(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "gs.csv"
         # 10 rows: 6 chart, 4 text → 60% chart, below 80% threshold
-        rows = [("cm_revenue_by_cohort", "chart")] * 6 + [
-            ("cm_revenue_by_cohort", "text")
-        ] * 4
+        rows = [("cm_revenue_by_cohort", "chart")] * 6 + [("cm_revenue_by_cohort", "text")] * 4
         self._write_rows(csv_path, rows)
         native = _derive_chart_native_metrics(csv_path)
         assert "cm_revenue_by_cohort" not in native
@@ -2422,50 +2410,45 @@ class TestCrossSourceGate:
         # Build a gold standard where cm_balance_by_cohort is chart-native
         # and cm_arr is text-derivable.
         csv_path = tmp_path / "gs.csv"
-        rows = (
-            [
-                {
-                    "Document URL": "https://sec.gov/x",
-                    "Company": "TestCo",
-                    "Standard Metric Name": "cm_balance_by_cohort",
-                    "Name in the text": "",
-                    "Raw value": "1",
-                    "Scaled value": "",
-                    "Scale/unit": "",
-                    "Period": "",
-                    "Definition": "",
-                    "Quote/context": "",
-                    "segment_type": "chart",
-                    "is_definition_only": "",
-                    "value_context": "",
-                    "detection_difficulty": "easy",
-                    "period_start": "",
-                    "period_end": "",
-                }
-            ]
-            * 5
-            + [
-                {
-                    "Document URL": "https://sec.gov/y",
-                    "Company": "TestCo",
-                    "Standard Metric Name": "cm_arr",
-                    "Name in the text": "",
-                    "Raw value": "1",
-                    "Scaled value": "",
-                    "Scale/unit": "",
-                    "Period": "",
-                    "Definition": "",
-                    "Quote/context": "",
-                    "segment_type": "text",
-                    "is_definition_only": "",
-                    "value_context": "",
-                    "detection_difficulty": "easy",
-                    "period_start": "",
-                    "period_end": "",
-                }
-            ]
-            * 5
-        )
+        rows = [
+            {
+                "Document URL": "https://sec.gov/x",
+                "Company": "TestCo",
+                "Standard Metric Name": "cm_balance_by_cohort",
+                "Name in the text": "",
+                "Raw value": "1",
+                "Scaled value": "",
+                "Scale/unit": "",
+                "Period": "",
+                "Definition": "",
+                "Quote/context": "",
+                "segment_type": "chart",
+                "is_definition_only": "",
+                "value_context": "",
+                "detection_difficulty": "easy",
+                "period_start": "",
+                "period_end": "",
+            }
+        ] * 5 + [
+            {
+                "Document URL": "https://sec.gov/y",
+                "Company": "TestCo",
+                "Standard Metric Name": "cm_arr",
+                "Name in the text": "",
+                "Raw value": "1",
+                "Scaled value": "",
+                "Scale/unit": "",
+                "Period": "",
+                "Definition": "",
+                "Quote/context": "",
+                "segment_type": "text",
+                "is_definition_only": "",
+                "value_context": "",
+                "detection_difficulty": "easy",
+                "period_start": "",
+                "period_end": "",
+            }
+        ] * 5
         write_gold_standard_csv(csv_path, rows)
 
         # Configure a validator that uses the synthetic CSV for chart-native
@@ -2517,9 +2500,7 @@ class TestCrossSourceGate:
         assert result.chart_facts_total == 5
         assert result.chart_facts_text_derivable_total == 3
         assert result.chart_facts_text_derivable_cross_confirmed == 1
-        assert result.chart_facts_by_chart_native_metric == {
-            "cm_balance_by_cohort": 2
-        }
+        assert result.chart_facts_by_chart_native_metric == {"cm_balance_by_cohort": 2}
 
     def test_gate_warning_respects_text_derivable_threshold(
         self, capsys: pytest.CaptureFixture[str]
@@ -2564,3 +2545,288 @@ class TestCrossSourceGate:
         assert "Chart-native metrics" in out_b
         assert "cm_balance_by_cohort: 10 chart facts" in out_b
         assert "WARNING" not in out_b
+
+
+# =============================================================================
+# Chart-presence pivot (PR 2 of #86 series)
+# =============================================================================
+
+
+class TestChartPresenceNormalization:
+    """Q2a: segment_type='chart' entries are presence-only regardless of raw_value."""
+
+    def test_chart_segment_with_literal_chart_value_has_no_numeric_value(self) -> None:
+        entry = make_entry(raw_value="chart", segment_type="chart")
+        assert entry.has_numeric_value is False
+        assert entry.is_chart_presence_entry is True
+
+    def test_chart_segment_with_numeric_raw_value_forced_to_none(self) -> None:
+        # Covers the 3 Farfetch LTV/CAC rows with numeric raw_values like "3.5x".
+        entry = make_entry(raw_value="3.5", segment_type="chart")
+        assert entry.has_numeric_value is False
+        assert entry.is_chart_presence_entry is True
+
+    def test_text_segment_with_numeric_still_has_value(self) -> None:
+        entry = make_entry(raw_value="1000", segment_type="text")
+        assert entry.has_numeric_value is True
+        assert entry.is_chart_presence_entry is False
+
+    def test_table_segment_with_numeric_still_has_value(self) -> None:
+        entry = make_entry(raw_value="1000", segment_type="table")
+        assert entry.has_numeric_value is True
+        assert entry.is_chart_presence_entry is False
+
+
+def _make_validator_no_pipeline() -> V2GoldStandardValidator:
+    """Build a validator instance without triggering pipeline construction."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tf:
+        # Minimal CSV header — body doesn't matter for the helpers under test.
+        tf.write(
+            "document_url,company_name,metric_id,name_in_text,raw_value,scaled_value,"
+            "scale_unit,period,definition,quote_context,segment_type,is_definition_only,"
+            "value_context,detection_difficulty,period_start,period_end\n"
+        )
+        path = Path(tf.name)
+    try:
+        return V2GoldStandardValidator(gold_standard_path=path)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+class TestChartGoldPresenceSet:
+    """_chart_gold_presence_set collects metric_ids from chart-segment gold rows."""
+
+    def test_returns_chart_metric_ids_only(self) -> None:
+        validator = _make_validator_no_pipeline()
+        entries = [
+            make_entry(metric_id="cm_revenue_by_cohort", segment_type="chart", raw_value="chart"),
+            make_entry(metric_id="cm_dau", segment_type="text", raw_value="1000"),
+            make_entry(metric_id="cm_balance_by_cohort", segment_type="chart", raw_value="chart"),
+        ]
+
+        result = validator._chart_gold_presence_set(entries)
+
+        assert result == {"cm_revenue_by_cohort", "cm_balance_by_cohort"}
+
+    def test_excludes_not_a_customer_metric(self) -> None:
+        validator = _make_validator_no_pipeline()
+        entries = [
+            make_entry(
+                metric_id="cm_not_a_customer_metric", segment_type="chart", raw_value="chart"
+            ),
+            make_entry(metric_id="cm_revenue_by_cohort", segment_type="chart", raw_value="chart"),
+        ]
+
+        result = validator._chart_gold_presence_set(entries)
+
+        assert result == {"cm_revenue_by_cohort"}
+
+
+class TestChartPresenceSetFromContext:
+    """_chart_presence_set_from_context unions detected_metrics from all images, above threshold."""
+
+    def test_union_across_images_above_threshold(self) -> None:
+        from src.extraction_v2.models import DetectedMetric, ImageAsset
+
+        validator = _make_validator_no_pipeline()
+        context = MagicMock(spec=PipelineContext)
+        context.config = PipelineConfig()
+        img1 = ImageAsset(img_id="img1")
+        img1.detected_metrics = [
+            DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.9),
+            DetectedMetric(metric_id="cm_balance_by_cohort", score=0.3),  # below default 0.5
+        ]
+        img2 = ImageAsset(img_id="img2")
+        img2.detected_metrics = [
+            DetectedMetric(metric_id="cm_gross_margin_by_cohort", score=0.7),
+            DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.6),  # dup
+        ]
+        context.images = [img1, img2]
+
+        result = validator._chart_presence_set_from_context(context)
+
+        assert result == {"cm_revenue_by_cohort", "cm_gross_margin_by_cohort"}
+
+    def test_threshold_override(self) -> None:
+        from src.extraction_v2.models import DetectedMetric, ImageAsset
+
+        validator = _make_validator_no_pipeline()
+        context = MagicMock(spec=PipelineContext)
+        context.config = PipelineConfig()
+        img = ImageAsset(img_id="img1")
+        img.detected_metrics = [
+            DetectedMetric(metric_id="cm_revenue_by_cohort", score=0.4),
+        ]
+        context.images = [img]
+
+        # Default threshold (0.5) excludes; explicit lower threshold includes.
+        assert validator._chart_presence_set_from_context(context) == set()
+        assert validator._chart_presence_set_from_context(context, threshold=0.3) == {
+            "cm_revenue_by_cohort"
+        }
+
+
+class TestValidationResultPresenceProperties:
+    """Presence F1 is the harmonic mean of presence_precision and presence_recall."""
+
+    def test_presence_f1_perfect(self) -> None:
+        result = ValidationResult(
+            company_name="X",
+            filing_path="/tmp/x.html",
+            total_expected=0,
+            matched=0,
+            missed=0,
+            extra=0,
+            true_positives=0,
+            false_positives=0,
+            false_negatives=0,
+            presence_tp=5,
+            presence_fp=0,
+            presence_fn=0,
+        )
+        assert result.presence_precision == 1.0
+        assert result.presence_recall == 1.0
+        assert result.presence_f1 == 1.0
+
+    def test_presence_f1_zero_when_no_evidence(self) -> None:
+        result = ValidationResult(
+            company_name="X",
+            filing_path="/tmp/x.html",
+            total_expected=0,
+            matched=0,
+            missed=0,
+            extra=0,
+            true_positives=0,
+            false_positives=0,
+            false_negatives=0,
+        )
+        assert result.presence_f1 == 0.0
+
+    def test_presence_f1_mixed(self) -> None:
+        # TP=4, FP=1, FN=1 → P=0.8, R=0.8, F1=0.8
+        result = ValidationResult(
+            company_name="X",
+            filing_path="/tmp/x.html",
+            total_expected=0,
+            matched=0,
+            missed=0,
+            extra=0,
+            true_positives=0,
+            false_positives=0,
+            false_negatives=0,
+            presence_tp=4,
+            presence_fp=1,
+            presence_fn=1,
+        )
+        assert result.presence_precision == pytest.approx(0.8)
+        assert result.presence_recall == pytest.approx(0.8)
+        assert result.presence_f1 == pytest.approx(0.8)
+
+
+class TestAggregateMetricsPresence:
+    """AggregateMetrics sums presence counts across filings and to_baseline_metrics passes presence_f1."""
+
+    def test_presence_f1_propagates_to_baseline_metrics_when_evaluated(self) -> None:
+        agg = AggregateMetrics(
+            precision=0.9,
+            recall=0.8,
+            f1=0.85,
+            total_true_positives=100,
+            total_false_positives=10,
+            total_false_negatives=25,
+            total_presence_tp=4,
+            total_presence_fp=1,
+            total_presence_fn=1,
+        )
+        baseline = agg.to_baseline_metrics(description="test")
+        assert baseline.presence_f1 == pytest.approx(0.8)
+
+    def test_presence_f1_omitted_when_no_presence_rows(self) -> None:
+        agg = AggregateMetrics(
+            precision=0.9,
+            recall=0.8,
+            f1=0.85,
+            total_true_positives=100,
+            total_false_positives=10,
+            total_false_negatives=25,
+            # No presence rows — presence_f1 should be None on baseline.
+        )
+        baseline = agg.to_baseline_metrics(description="test")
+        assert baseline.presence_f1 is None
+
+
+class TestBaselineMetricsPresenceF1Serialization:
+    """BaselineMetrics round-trips presence_f1 through JSON and tolerates absence."""
+
+    def test_round_trip_with_presence_f1(self) -> None:
+        original = BaselineMetrics(
+            baseline_date="2026-04-23T00:00:00+00:00",
+            description="test",
+            overall=MetricScores(precision=0.9, recall=0.8, f1=0.85),
+            by_company={},
+            presence_f1=0.72,
+        )
+        data = original.to_dict()
+        assert data["presence_f1"] == 0.72
+        restored = BaselineMetrics.from_dict(data)
+        assert restored.presence_f1 == 0.72
+
+    def test_tolerates_missing_presence_f1_on_legacy_baseline(self) -> None:
+        legacy_data = {
+            "baseline_date": "2026-01-01T00:00:00+00:00",
+            "description": "legacy",
+            "overall": {"precision": 0.9, "recall": 0.8, "f1": 0.85},
+            "by_company": {},
+            # No presence_f1 key.
+        }
+        restored = BaselineMetrics.from_dict(legacy_data)
+        assert restored.presence_f1 is None
+        # And re-serializing does not invent the field.
+        assert "presence_f1" not in restored.to_dict()
+
+
+class TestCompareBaselinePresenceRegression:
+    """compare_to_baseline detects presence_f1 regression and tolerates absence."""
+
+    def _make_baseline(self, f1: float, presence_f1: float | None = None) -> BaselineMetrics:
+        return BaselineMetrics(
+            baseline_date="2026-04-23T00:00:00+00:00",
+            description=None,
+            overall=MetricScores(precision=f1, recall=f1, f1=f1),
+            by_company={},
+            presence_f1=presence_f1,
+        )
+
+    def test_presence_f1_regression_flagged(self) -> None:
+        from src.gold_standard.baseline import compare_to_baseline
+
+        baseline = self._make_baseline(0.85, presence_f1=0.80)
+        current = self._make_baseline(0.85, presence_f1=0.60)
+
+        result = compare_to_baseline(current, baseline)
+
+        assert "presence_f1" in result.regressed_metrics
+        assert result.has_regression is True
+        assert result.presence_f1_delta == pytest.approx(-0.20)
+
+    def test_presence_f1_improvement_not_flagged(self) -> None:
+        from src.gold_standard.baseline import compare_to_baseline
+
+        baseline = self._make_baseline(0.85, presence_f1=0.60)
+        current = self._make_baseline(0.85, presence_f1=0.80)
+
+        result = compare_to_baseline(current, baseline)
+
+        assert "presence_f1" not in result.regressed_metrics
+        assert result.presence_f1_delta == pytest.approx(0.20)
+
+    def test_legacy_baseline_without_presence_f1_skipped(self) -> None:
+        from src.gold_standard.baseline import compare_to_baseline
+
+        baseline = self._make_baseline(0.85, presence_f1=None)
+        current = self._make_baseline(0.85, presence_f1=0.60)
+
+        result = compare_to_baseline(current, baseline)
+
+        assert "presence_f1" not in result.regressed_metrics
+        assert result.presence_f1_delta is None


### PR DESCRIPTION
## Summary

PR 2 of 4 in the chart-stage presence pivot for Issue #86. Validator side — rewrites chart-gold evaluation from value-level to presence-level P/R. Parent plan: \`~/.claude/plans/pick-up-issue-86-tranquil-piglet.md\`. PR 1 is on main (#147).

## What this PR changes

- **Validator** (\`src/gold_standard/v2_validator.py\`): chart-segment gold rows now evaluated via metric-presence P/R. Two new helpers (\`_chart_presence_set_from_context\`, \`_chart_gold_presence_set\`). \`validate_filing\` gains a chart-presence branch after the existing match loop. \`_diagnose_false_negative\` gains \`presence_not_detected\` and \`image_missing\` categories. \`GoldStandardEntry.has_numeric_value\` returns False for \`segment_type='chart'\` regardless of Raw value (Q2a). \`ValidationResult\` + \`AggregateMetrics\` gain \`presence_tp/fp/fn\` counters and presence P/R/F1 properties.
- **Baseline schema** (\`src/gold_standard/baseline.py\`): \`BaselineMetrics\` gains \`presence_f1: float | None = None\` (tolerates pre-pivot baselines via \`from_dict\`). \`ComparisonResult\` gains \`presence_f1_delta\`. \`compare_to_baseline\` flags \`presence_f1\` regression only when both sides have the field.
- **Gold-standard spec** (\`docs/GOLD_STANDARD_SPECIFICATION.md\`): rewrote "Validation behavior for chart entries" section to describe presence P/R, mixed-source fallback, and advisory Raw value.
- **Tests** (\`tests/unit/gold_standard/\`): 18 new presence-pivot tests covering normalization, helpers, properties, baseline serialization, and regression comparison. Updated one pre-existing unified-comparison test to reflect the chart→presence-only contract.

## User decisions implemented

- **Q1a Mixed-source TP:** a text/table-sourced \`v2_metric_facts\` row for the same \`(filing, metric)\` also counts as a presence TP.
- **Q2a Gold CSV policy:** all \`segment_type='chart'\` gold rows presence-only, regardless of Raw value. Covers the 3 Farfetch LTV/CAC rows with numeric raw_values (\`"3.5x"\`, etc.).

## What this PR does NOT change

- **\`data/gold_standard/v2_baseline.json\`** — baseline refresh requires a full validator run against real GS data. Follow-up after merge.
- **\`scripts/pre-commit-extraction-guard.sh\`** — untouched. Regression logic lives in Python (\`compare_to_baseline\`), which this PR extended. The bash wrapper already invokes \`--fail-on-regression\`.
- Reviewer UI / confirmation schema — that's PR 3.
- Production chart-fact drain / doc updates — that's PR 4.

## Tests

\`pytest -x -q tests/unit/\` → **3808 passed, 11 skipped**. Gold-standard subset → **293 passed** (18 new).

## Test plan

- [ ] CI: lint, unit tests, vulnerability scan, integration tests, Playwright — all green
- [ ] After merge: run \`python3 -m src.gold_standard.v2_validator --update-baseline --description "chart presence pivot (post-PR-\$N)"\` and open a follow-up PR with the refreshed \`v2_baseline.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)