### PR TITLE
docs(known-issues): log issue #94 — v2_audit_log rejects HEAD/OPTIONS

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,7 +7,7 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 29 |
+| Open | 30 |
 | Partially Resolved | 2 |
 | Archived | 46 |
 | Resolved | 14 |
@@ -49,6 +49,7 @@
 | #85 | safe | XS | `scripts/apply_all_migrations.py` | Recurrence of Issue |
 | #86 | review | M | `src/extraction_v2/stages/deduplication.py` | Chart extractor produces per-cohort bar values (visible pre-dedup), but deduplication stage collapses same-metric different-value facts. Surfaced post-#72 resolution as the residual HOOD `cm_revenue_by_cohort` 9/10 FN pattern. |
 | #88 | skip | S | `scripts/apply_all_migrations.py` `.pre-commit-config.yaml` | Add a pre-commit hook that fails if any sql/NN_*.sql on disk lacks an entry in MIGRATION_ORDER or EXCLUDED_FILES. |
+| #94 | safe | S | `sql/31_drop_v1_review_tables.sql` `sql/` `src/web/middleware.py` |  |
 
 
 ## Open Issues
@@ -886,6 +887,57 @@ genuinely unsure".
   manually (and so the classifier's emission maps cleanly).
 - Back-fill any existing `"other"` rows whose `reasoning` references
   a table — optional, tracked separately if useful.
+
+## #94. v2_audit_log.check_v2_audit_http_method Rejects HEAD and OPTIONS Requests
+
+**Status**: Open
+**Severity**: low
+**Discovered**: 2026-04-23
+**Updated**: 2026-04-23
+
+### Problem
+
+The `v2_audit_log.check_v2_audit_http_method` CHECK constraint
+(defined in `sql/31_drop_v1_review_tables.sql:57`) allowlists only
+`GET`, `POST`, `PUT`, `DELETE`, `PATCH`. When the audit middleware
+tries to log a `HEAD` or `OPTIONS` request the INSERT fails and the
+request transaction rolls back.
+
+Observed on `filings-reviewer` in Render logs on 2026-04-23 after a
+routine deploy:
+
+```
+Database error, rolling back: new row for relation "v2_audit_log"
+violates check constraint "check_v2_audit_http_method"
+DETAIL: Failing row contains (4228, ..., Go-http-client/1.1,
+review.index, HEAD, /, ..., 301, 0).
+```
+
+`Go-http-client/1.1` is Render's internal health prober, which hits
+`/` with `HEAD` on every probe cycle. Each probe generates one error
+log line + one transaction rollback on `filings-reviewer`. CORS
+preflights (`OPTIONS`) would hit the same wall if any cross-origin
+client ever reaches an audited route.
+
+Blast radius: log noise + per-probe rollback overhead. No user-facing
+breakage — the response itself (301 redirect) still returns. Pre-dates
+Wave B5 work; no single PR introduced it, and it has been firing
+quietly since `sql/31` was applied.
+
+### Next Steps
+
+- Add a migration extending the allowlist:
+  `ALTER TABLE v2_audit_log DROP CONSTRAINT check_v2_audit_http_method;`
+  `ALTER TABLE v2_audit_log ADD CONSTRAINT check_v2_audit_http_method CHECK (http_method IN ('GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'));`
+- Register it as the next-unused `sql/NN_*.sql` number (per
+  `.claude/rules/sql.md`).
+- Alternatively: have `src/web/middleware.py` skip audit logging for
+  `HEAD` / `OPTIONS` requests entirely — probe traffic arguably
+  doesn't belong in the audit trail. Slightly cleaner but changes
+  behaviour vs "log everything routed through Flask"; needs a call on
+  which semantics to keep.
+- Verify after: tail `filings-reviewer` Render logs for 5 minutes and
+  confirm the `check_v2_audit_http_method` violation is gone.
 
 ## #5. Revenue Synonym Context Gating
 

--- a/docs/known-issues/legacy-094-v2-audit-log-check-constraint-rejects-head-options.md
+++ b/docs/known-issues/legacy-094-v2-audit-log-check-constraint-rejects-head-options.md
@@ -1,0 +1,60 @@
+---
+autonomy: safe
+discovered: '2026-04-23'
+estimated: S
+id: 94
+severity: low
+slug: v2-audit-log-check-constraint-rejects-head-options
+source: legacy
+status: open
+title: v2_audit_log.check_v2_audit_http_method Rejects HEAD and OPTIONS Requests
+touches:
+  - sql/31_drop_v1_review_tables.sql
+  - sql/
+  - src/web/middleware.py
+updated: '2026-04-23'
+---
+
+### Problem
+
+The `v2_audit_log.check_v2_audit_http_method` CHECK constraint
+(defined in `sql/31_drop_v1_review_tables.sql:57`) allowlists only
+`GET`, `POST`, `PUT`, `DELETE`, `PATCH`. When the audit middleware
+tries to log a `HEAD` or `OPTIONS` request the INSERT fails and the
+request transaction rolls back.
+
+Observed on `filings-reviewer` in Render logs on 2026-04-23 after a
+routine deploy:
+
+```
+Database error, rolling back: new row for relation "v2_audit_log"
+violates check constraint "check_v2_audit_http_method"
+DETAIL: Failing row contains (4228, ..., Go-http-client/1.1,
+review.index, HEAD, /, ..., 301, 0).
+```
+
+`Go-http-client/1.1` is Render's internal health prober, which hits
+`/` with `HEAD` on every probe cycle. Each probe generates one error
+log line + one transaction rollback on `filings-reviewer`. CORS
+preflights (`OPTIONS`) would hit the same wall if any cross-origin
+client ever reaches an audited route.
+
+Blast radius: log noise + per-probe rollback overhead. No user-facing
+breakage — the response itself (301 redirect) still returns. Pre-dates
+Wave B5 work; no single PR introduced it, and it has been firing
+quietly since `sql/31` was applied.
+
+### Next Steps
+
+- Add a migration extending the allowlist:
+  `ALTER TABLE v2_audit_log DROP CONSTRAINT check_v2_audit_http_method;`
+  `ALTER TABLE v2_audit_log ADD CONSTRAINT check_v2_audit_http_method CHECK (http_method IN ('GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'));`
+- Register it as the next-unused `sql/NN_*.sql` number (per
+  `.claude/rules/sql.md`).
+- Alternatively: have `src/web/middleware.py` skip audit logging for
+  `HEAD` / `OPTIONS` requests entirely — probe traffic arguably
+  doesn't belong in the audit trail. Slightly cleaner but changes
+  behaviour vs "log everything routed through Flask"; needs a call on
+  which semantics to keep.
+- Verify after: tail `filings-reviewer` Render logs for 5 minutes and
+  confirm the `check_v2_audit_http_method` violation is gone.


### PR DESCRIPTION
## Summary

Files a known-issue fragment for a pre-existing bug surfaced in `filings-reviewer` Render logs on 2026-04-23:

\`\`\`
Database error, rolling back: new row for relation \"v2_audit_log\"
violates check constraint \"check_v2_audit_http_method\"
DETAIL: Failing row contains (..., Go-http-client/1.1, review.index, HEAD, /, ..., 301, 0).
\`\`\`

The `check_v2_audit_http_method` CHECK in `sql/31_drop_v1_review_tables.sql:57` allowlists only `GET/POST/PUT/DELETE/PATCH`. Render's internal health prober issues `HEAD /` — the audit middleware's INSERT rejects on the constraint and the request transaction rolls back. Log noise + per-probe rollback overhead; no user-facing breakage.

## Scope

Docs-only — one new fragment (`docs/known-issues/legacy-094-*.md`) plus the auto-regenerated rollup. Fix itself is tracked in the fragment and tagged `autonomy: safe` so the nightly sweeper can take it (trivial migration adding `HEAD` + `OPTIONS` to the allowlist).

## Test plan

- [x] `scripts/regenerate_known_issues.py` ran clean (92 fragments total)
- [x] `Validate known-issue fragment frontmatter` pre-commit hook passed
- [x] `Regenerate KNOWN_ISSUES.md rollup from fragments` pre-commit hook passed
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)