### PR TITLE
feat(review-ui): detected-metrics card + JS + Playwright E2E (#86 PR 3b/4)

### DIFF
--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -397,6 +397,28 @@ def review_filing(filing_id: int):
 
         current_image = _select_current_image(image_candidates, request.args.get("img_id"))
 
+        # Per-metric confirmations for the currently-focused image
+        # (chart-presence pivot, #86 PR 3b). Loaded only for the active image
+        # since the full queue does not need prior decisions preloaded.
+        current_image_confirmations: list[dict[str, Any]] = []
+        if current_image and current_image.get("img_id"):
+            try:
+                current_image_confirmations = db.get_image_metric_confirmations(
+                    current_image["img_id"]
+                )
+                for c in current_image_confirmations:
+                    for ts_key in ("created_at", "updated_at"):
+                        ts = c.get(ts_key)
+                        if ts is not None and hasattr(ts, "isoformat"):
+                            c[ts_key] = ts.isoformat()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to load image metric confirmations for img_id=%s: %s",
+                    current_image.get("img_id"),
+                    exc,
+                )
+                current_image_confirmations = []
+
         # Image progress counts
         image_pending = sum(1 for c in all_image_candidates if c["review_status"] == "pending")
         image_reviewed = sum(1 for c in all_image_candidates if c["review_status"] == "reviewed")
@@ -452,6 +474,7 @@ def review_filing(filing_id: int):
             image_candidates=image_candidates,
             all_image_candidates=all_image_candidates,
             current_image=current_image,
+            current_image_confirmations=current_image_confirmations,
             image_pending=image_pending,
             image_reviewed=image_reviewed,
             image_skipped=image_skipped,

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -414,3 +414,446 @@
     }
 
 })();
+
+/**
+ * Detected Metrics confirmation module — chart-presence pivot (#86 PR 3b).
+ *
+ * Renders per-row accept/reject/correct state for the detected-metrics card
+ * inside the Images tab. Reviewers can also add metrics the classifier missed.
+ * Submits batched decisions to POST /api/v2/image-metric-confirmations.
+ *
+ * Keyboard shortcuts are scoped to a focused `.detected-metric-row` so they
+ * don't conflict with the Relevant/Not-Relevant handlers above (Y/N/S/U/F).
+ *   - A: accept focused metric
+ *   - R: reject focused metric (opens reason dropdown)
+ *   - C: correct focused metric (opens metric picker)
+ *   - N: focus next unreviewed metric row
+ *
+ * Reviewer identity follows .claude/rules/web.md: localStorage 'reviewer_name'
+ * with 'anonymous' fallback.
+ */
+(function() {
+    'use strict';
+
+    const CARD_ID = 'detected-metrics-card';
+    const ROW_SELECTOR = '.detected-metric-row';
+    const DATALIST_ID = 'detected-metrics-datalist';
+
+    const state = {
+        imgId: null,
+        detectedMetrics: [],
+        decisions: {},  // keyed by detected_metric_id or `__add_<metric>` for adds
+        submitting: false,
+        focusedRow: null,
+        metricsList: [],
+    };
+
+    function init() {
+        const card = document.getElementById(CARD_ID);
+        if (!card) return;
+
+        state.imgId = card.dataset.imgId || null;
+        try {
+            state.detectedMetrics = JSON.parse(card.dataset.detectedMetrics || '[]');
+        } catch (e) {
+            console.error('Failed to parse detected_metrics:', e);
+            state.detectedMetrics = [];
+        }
+
+        try {
+            const prior = JSON.parse(card.dataset.confirmations || '[]');
+            prior.forEach(c => hydrateConfirmation(c));
+        } catch (e) {
+            console.warn('Failed to parse confirmations:', e);
+        }
+
+        loadMetricsList();
+        applyInitialDecisionState();
+        bindCardEvents(card);
+        document.addEventListener('keydown', handleRowKeydown, true);
+    }
+
+    function hydrateConfirmation(c) {
+        if (c.decision === 'add') {
+            state.decisions[addKey(c.confirmed_metric_id)] = {
+                detected_metric_id: null,
+                confirmed_metric_id: c.confirmed_metric_id,
+                decision: 'add',
+                rejection_reason: null,
+            };
+        } else if (c.detected_metric_id) {
+            state.decisions[c.detected_metric_id] = {
+                detected_metric_id: c.detected_metric_id,
+                confirmed_metric_id: c.confirmed_metric_id || null,
+                decision: c.decision,
+                rejection_reason: c.rejection_reason || null,
+            };
+        }
+    }
+
+    function addKey(metricId) {
+        return `__add__${metricId}`;
+    }
+
+    async function loadMetricsList() {
+        try {
+            const resp = await fetch('/api/v2/metrics/list', {
+                headers: { 'Accept': 'application/json' },
+            });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (Array.isArray(data)) {
+                state.metricsList = data;
+                populateDatalist(data);
+            }
+        } catch (err) {
+            console.warn('Failed to load metrics list:', err);
+        }
+    }
+
+    function populateDatalist(metrics) {
+        const dl = document.getElementById(DATALIST_ID);
+        if (!dl) return;
+        dl.innerHTML = '';
+        metrics.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m.metric_id;
+            if (m.display_name && m.display_name !== m.metric_id) {
+                opt.label = m.display_name;
+                opt.textContent = m.display_name;
+            }
+            dl.appendChild(opt);
+        });
+    }
+
+    function applyInitialDecisionState() {
+        // Rows rendered by the template for detected metrics:
+        document.querySelectorAll(`#${CARD_ID} ${ROW_SELECTOR}`).forEach(row => {
+            const mid = row.dataset.metricId;
+            const d = state.decisions[mid];
+            if (d) applyRowState(row, d);
+        });
+        // Rows for 'add' decisions: append to the list.
+        Object.values(state.decisions)
+            .filter(d => d.decision === 'add')
+            .forEach(d => appendAddedRow(d));
+    }
+
+    function appendAddedRow(d) {
+        const list = document.getElementById('detected-metrics-list');
+        if (!list) return;
+        const existing = list.querySelector(`[data-added-metric="${cssEscape(d.confirmed_metric_id)}"]`);
+        if (existing) return;
+        const li = document.createElement('li');
+        li.className = 'list-group-item detected-metric-row added-metric-row decided-add';
+        li.tabIndex = 0;
+        li.dataset.addedMetric = d.confirmed_metric_id;
+        li.innerHTML = `
+            <div class="d-flex justify-content-between align-items-center">
+              <div>
+                <span class="metric-label fw-semibold">${escapeHtml(d.confirmed_metric_id)}</span>
+                <span class="badge bg-info ms-2">Added</span>
+              </div>
+              <button type="button" class="btn btn-outline-secondary btn-sm btn-remove-added">Remove</button>
+            </div>
+            <div class="metric-state-indicator small mt-1 text-muted">Will be submitted as 'add'</div>
+        `;
+        list.appendChild(li);
+        li.querySelector('.btn-remove-added').addEventListener('click', () => {
+            delete state.decisions[addKey(d.confirmed_metric_id)];
+            li.remove();
+        });
+    }
+
+    function bindCardEvents(card) {
+        card.querySelectorAll(ROW_SELECTOR).forEach(row => {
+            row.addEventListener('focus', () => { state.focusedRow = row; });
+            row.addEventListener('blur', () => {
+                if (state.focusedRow === row) state.focusedRow = null;
+            });
+            row.addEventListener('click', (e) => {
+                if (!e.target.closest('button, select, input')) row.focus();
+            });
+        });
+
+        card.querySelectorAll('.btn-accept-metric').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const row = e.target.closest(ROW_SELECTOR);
+                if (row) acceptRow(row);
+            });
+        });
+        card.querySelectorAll('.btn-reject-metric').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const row = e.target.closest(ROW_SELECTOR);
+                if (row) openReject(row);
+            });
+        });
+        card.querySelectorAll('.btn-correct-metric').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const row = e.target.closest(ROW_SELECTOR);
+                if (row) openCorrect(row);
+            });
+        });
+        card.querySelectorAll('.metric-reject-reason').forEach(sel => {
+            sel.addEventListener('change', (e) => {
+                const row = e.target.closest(ROW_SELECTOR);
+                if (!row) return;
+                const reason = e.target.value || null;
+                rejectRow(row, reason);
+            });
+        });
+        card.querySelectorAll('.metric-correct-input').forEach(inp => {
+            inp.addEventListener('change', (e) => {
+                const row = e.target.closest(ROW_SELECTOR);
+                if (!row) return;
+                correctRow(row, e.target.value.trim());
+            });
+        });
+
+        const btnAdd = document.getElementById('btn-add-missed-detected-metric');
+        if (btnAdd) {
+            btnAdd.addEventListener('click', () => {
+                const panel = document.getElementById('add-missed-detected-expansion');
+                if (panel) {
+                    panel.style.display = 'block';
+                    const input = document.getElementById('add-missed-detected-input');
+                    if (input) input.focus();
+                }
+            });
+        }
+        const btnAddConfirm = document.getElementById('btn-add-missed-detected-confirm');
+        if (btnAddConfirm) btnAddConfirm.addEventListener('click', addMissedMetric);
+
+        const btnSubmit = document.getElementById('btn-submit-detected-metrics');
+        if (btnSubmit) btnSubmit.addEventListener('click', submitDecisions);
+    }
+
+    function handleRowKeydown(event) {
+        if (!state.focusedRow) return;
+        if (event.target.matches('input, textarea, select')) return;
+        if (event.metaKey || event.ctrlKey || event.altKey) return;
+        const row = state.focusedRow;
+        const key = event.key.toLowerCase();
+
+        if (key === 'a') {
+            event.preventDefault();
+            event.stopPropagation();
+            acceptRow(row);
+        } else if (key === 'r') {
+            event.preventDefault();
+            event.stopPropagation();
+            openReject(row);
+        } else if (key === 'c') {
+            event.preventDefault();
+            event.stopPropagation();
+            openCorrect(row);
+        } else if (key === 'n') {
+            event.preventDefault();
+            event.stopPropagation();
+            focusNextUnreviewed(row);
+        }
+    }
+
+    function acceptRow(row) {
+        const detected = row.dataset.metricId;
+        if (!detected) return;
+        state.decisions[detected] = {
+            detected_metric_id: detected,
+            confirmed_metric_id: detected,
+            decision: 'accept',
+            rejection_reason: null,
+        };
+        applyRowState(row, state.decisions[detected]);
+    }
+
+    function openReject(row) {
+        const correct = row.querySelector('.correct-expansion');
+        if (correct) correct.style.display = 'none';
+        const exp = row.querySelector('.reject-expansion');
+        if (exp) {
+            exp.style.display = 'block';
+            const sel = exp.querySelector('.metric-reject-reason');
+            if (sel) sel.focus();
+        }
+    }
+
+    function rejectRow(row, reason) {
+        const detected = row.dataset.metricId;
+        if (!detected) return;
+        if (!reason) return;
+        state.decisions[detected] = {
+            detected_metric_id: detected,
+            confirmed_metric_id: null,
+            decision: 'reject',
+            rejection_reason: reason,
+        };
+        applyRowState(row, state.decisions[detected]);
+    }
+
+    function openCorrect(row) {
+        const reject = row.querySelector('.reject-expansion');
+        if (reject) reject.style.display = 'none';
+        const exp = row.querySelector('.correct-expansion');
+        if (exp) {
+            exp.style.display = 'block';
+            const inp = exp.querySelector('.metric-correct-input');
+            if (inp) inp.focus();
+        }
+    }
+
+    function correctRow(row, target) {
+        const detected = row.dataset.metricId;
+        if (!detected || !target) return;
+        const indicator = row.querySelector('.metric-state-indicator');
+        if (target === detected) {
+            if (indicator) {
+                indicator.textContent = 'Correct requires a different metric';
+                indicator.style.display = 'block';
+                indicator.classList.add('text-danger');
+            }
+            return;
+        }
+        if (indicator) indicator.classList.remove('text-danger');
+        state.decisions[detected] = {
+            detected_metric_id: detected,
+            confirmed_metric_id: target,
+            decision: 'correct',
+            rejection_reason: null,
+        };
+        applyRowState(row, state.decisions[detected]);
+    }
+
+    function addMissedMetric() {
+        const input = document.getElementById('add-missed-detected-input');
+        if (!input) return;
+        const metric = (input.value || '').trim();
+        if (!metric) return;
+        if (state.decisions[addKey(metric)]) return;
+        const d = {
+            detected_metric_id: null,
+            confirmed_metric_id: metric,
+            decision: 'add',
+            rejection_reason: null,
+        };
+        state.decisions[addKey(metric)] = d;
+        appendAddedRow(d);
+        input.value = '';
+        const panel = document.getElementById('add-missed-detected-expansion');
+        if (panel) panel.style.display = 'none';
+    }
+
+    function focusNextUnreviewed(current) {
+        const rows = Array.from(document.querySelectorAll(`#${CARD_ID} ${ROW_SELECTOR}:not(.added-metric-row)`));
+        if (!rows.length) return;
+        const idx = rows.indexOf(current);
+        const order = rows.slice(idx + 1).concat(rows.slice(0, idx));
+        for (const row of order) {
+            const mid = row.dataset.metricId;
+            if (!state.decisions[mid]) {
+                row.focus();
+                return;
+            }
+        }
+    }
+
+    function applyRowState(row, d) {
+        row.classList.remove('decided-accept', 'decided-reject', 'decided-correct');
+        row.classList.add(`decided-${d.decision}`);
+        const indicator = row.querySelector('.metric-state-indicator');
+        if (!indicator) return;
+        indicator.classList.remove('text-success', 'text-warning', 'text-info', 'text-danger');
+        indicator.style.display = 'block';
+        if (d.decision === 'accept') {
+            indicator.textContent = 'Accepted';
+            indicator.classList.add('text-success');
+        } else if (d.decision === 'reject') {
+            indicator.textContent = `Rejected${d.rejection_reason ? ` — ${d.rejection_reason}` : ''}`;
+            indicator.classList.add('text-warning');
+        } else if (d.decision === 'correct') {
+            indicator.textContent = `Corrected → ${d.confirmed_metric_id}`;
+            indicator.classList.add('text-info');
+        }
+    }
+
+    async function submitDecisions() {
+        if (state.submitting) return;
+        if (!state.imgId) return;
+
+        const decisions = Object.values(state.decisions).filter(d => {
+            if (d.decision === 'reject' && !d.rejection_reason) return false;
+            if (d.decision === 'correct' && !d.confirmed_metric_id) return false;
+            if (d.decision === 'add' && !d.confirmed_metric_id) return false;
+            return true;
+        });
+        if (decisions.length === 0) {
+            showMetricsToast('No decisions to submit', 'warning');
+            return;
+        }
+
+        state.submitting = true;
+        const payload = {
+            img_id: state.imgId,
+            reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous',
+            decisions,
+        };
+
+        try {
+            const resp = await fetch('/api/v2/image-metric-confirmations', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            const data = await resp.json();
+            if (resp.ok && data.ok) {
+                showMetricsToast('Decisions saved', 'success');
+                state.decisions = {};
+                (data.confirmations || []).forEach(hydrateConfirmation);
+                // Remove existing dynamically-added rows so we don't duplicate
+                document.querySelectorAll('#detected-metrics-list .added-metric-row')
+                    .forEach(n => n.remove());
+                applyInitialDecisionState();
+            } else {
+                showMetricsToast(data.error || 'Failed to save', 'danger');
+            }
+        } catch (err) {
+            console.error('Failed to submit detected-metric confirmations:', err);
+            showMetricsToast('Network error', 'danger');
+        } finally {
+            state.submitting = false;
+        }
+    }
+
+    function showMetricsToast(message, type = 'info') {
+        const alertType = type === 'danger' || type === 'warning' ? type
+            : (type === 'success' ? 'success' : 'info');
+        const toast = document.createElement('div');
+        toast.className = `alert alert-${alertType} alert-dismissible fade show position-fixed`;
+        toast.style.cssText = 'top: 80px; right: 20px; z-index: 1060; max-width: 320px;';
+        toast.setAttribute('role', 'alert');
+        toast.textContent = message;
+        document.body.appendChild(toast);
+        setTimeout(() => toast.remove(), 3000);
+    }
+
+    function escapeHtml(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function cssEscape(s) {
+        if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(s);
+        return String(s).replace(/["\\]/g, '\\$&');
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -861,6 +861,110 @@
           </div>
           {% endif %}
 
+          {# Detected Metrics card — chart-presence pivot (#86 PR 3b).
+             Rendered when the image carries classifier-detected metrics and the
+             reviewer has not marked the image as Not-Relevant. Reviewer
+             confirms each entry via accept / reject (reason) / correct
+             (replace) and may add metrics the classifier missed. #}
+          {% if current_image
+                and current_image.detected_metrics
+                and current_image.review_status in ('pending', 'reviewed')
+                and current_image.decision != 'not_relevant' %}
+          <div class="card detected-metrics-card mt-3"
+               id="detected-metrics-card"
+               data-img-id="{{ current_image.img_id }}"
+               data-detected-metrics='{{ current_image.detected_metrics|tojson }}'
+               data-confirmations='{{ (current_image_confirmations or [])|tojson }}'>
+            <div class="card-header py-2 d-flex justify-content-between align-items-center">
+              <h6 class="mb-0">Detected metrics</h6>
+              <span class="badge bg-secondary">
+                {{ current_image.detected_metrics|length }} detected
+              </span>
+            </div>
+            <div class="card-body">
+              <p class="small text-muted mb-2">
+                Confirm which metrics this chart covers. Values are entered
+                separately via <em>Add missed metric</em> if needed.
+              </p>
+              <ul class="list-group list-group-flush" id="detected-metrics-list">
+                {% for metric in current_image.detected_metrics %}
+                <li class="list-group-item detected-metric-row"
+                    tabindex="0"
+                    data-metric-id="{{ metric.metric_id }}"
+                    data-score="{{ '%.2f'|format(metric.score) }}">
+                  <div class="d-flex justify-content-between align-items-center gap-2">
+                    <div class="flex-grow-1">
+                      <span class="metric-label fw-semibold">{{ metric.metric_id }}</span>
+                      <span class="metric-score text-muted small ms-2">{{ '%.2f'|format(metric.score) }}</span>
+                    </div>
+                    <div class="btn-group btn-group-sm metric-actions" role="group">
+                      <button type="button" class="btn btn-outline-success btn-accept-metric"
+                              data-action="accept">
+                        Accept <span class="kbd ms-1">A</span>
+                      </button>
+                      <button type="button" class="btn btn-outline-danger btn-reject-metric"
+                              data-action="reject">
+                        Reject <span class="kbd ms-1">R</span>
+                      </button>
+                      <button type="button" class="btn btn-outline-primary btn-correct-metric"
+                              data-action="correct">
+                        Correct <span class="kbd ms-1">C</span>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="reject-expansion mt-2" style="display: none;">
+                    <label class="form-label small mb-1">Reason</label>
+                    <select class="form-select form-select-sm metric-reject-reason">
+                      <option value="">Select a reason…</option>
+                      <option value="not_present">Not present</option>
+                      <option value="decorative">Decorative</option>
+                      <option value="unrelated_chart">Unrelated chart</option>
+                      <option value="similar_metric_misclassified">Similar metric misclassified</option>
+                      <option value="too_low_confidence">Too low confidence</option>
+                      <option value="other">Other</option>
+                    </select>
+                  </div>
+                  <div class="correct-expansion mt-2" style="display: none;">
+                    <label class="form-label small mb-1">Correct to</label>
+                    <input type="text"
+                           class="form-control form-control-sm metric-correct-input"
+                           list="detected-metrics-datalist"
+                           placeholder="Search metrics…">
+                  </div>
+                  <div class="metric-state-indicator small mt-1 text-muted"
+                       style="display: none;"></div>
+                </li>
+                {% endfor %}
+              </ul>
+              <div class="mt-3 border-top pt-3">
+                <button type="button" class="btn btn-outline-secondary btn-sm"
+                        id="btn-add-missed-detected-metric">
+                  + Add metric the classifier missed
+                </button>
+                <div id="add-missed-detected-expansion" class="mt-2" style="display: none;">
+                  <label class="form-label small mb-1">Metric</label>
+                  <input type="text"
+                         id="add-missed-detected-input"
+                         class="form-control form-control-sm"
+                         list="detected-metrics-datalist"
+                         placeholder="Search metrics…">
+                  <button type="button" class="btn btn-outline-primary btn-sm mt-2"
+                          id="btn-add-missed-detected-confirm">
+                    Add
+                  </button>
+                </div>
+              </div>
+              <div class="d-flex justify-content-end mt-3">
+                <button type="button" class="btn btn-primary"
+                        id="btn-submit-detected-metrics">
+                  Submit decisions
+                </button>
+              </div>
+            </div>
+          </div>
+          <datalist id="detected-metrics-datalist"></datalist>
+          {% endif %}
+
           <form id="decision-form" style="display: none;"
                 data-img-id="{{ current_image.img_id }}"
                 data-filing-id="{{ filing.filing_id }}">

--- a/tests/ui/review_image_metric_confirmations.spec.js
+++ b/tests/ui/review_image_metric_confirmations.spec.js
@@ -1,0 +1,323 @@
+// @ts-check
+//
+// Chart-presence pivot — Detected Metrics card Playwright coverage (#86 PR 3b).
+//
+// Fixture routes live in test_server.py:
+//   /images-tab-detected            — detected_metrics populated, no prior confirmations
+//   /images-tab-detected-preseeded  — detected_metrics populated + one 'accept' prior confirmation
+//
+// The card wires to POST /api/v2/image-metric-confirmations and
+// GET /api/v2/metrics/list; both are mocked by the fixture server.
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const BOOTSTRAP_DIR = path.join(__dirname, '..', '..', 'node_modules', 'bootstrap', 'dist');
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('reviewer_name', 'test_reviewer');
+  });
+
+  await page.route('**/cdn.jsdelivr.net/**', async (route) => {
+    const url = route.request().url();
+    try {
+      if (url.includes('bootstrap.bundle.min.js')) {
+        const body = fs.readFileSync(path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.bundle.min.js'));
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body });
+      } else if (url.includes('bootstrap.min.css')) {
+        const body = fs.readFileSync(path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.min.css'));
+        await route.fulfill({ status: 200, contentType: 'text/css', body });
+      } else {
+        await route.continue();
+      }
+    } catch {
+      await route.continue();
+    }
+  });
+});
+
+// =========================================================================
+// Card rendering
+// =========================================================================
+test.describe('Detected Metrics card — rendering', () => {
+  test('card is visible when detected_metrics is non-empty', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    await expect(page.locator('#detected-metrics-card')).toBeVisible();
+  });
+
+  test('card is NOT rendered when detected_metrics is empty', async ({ page }) => {
+    await page.goto('/images-tab'); // default pending image carries detected_metrics=[]
+    await expect(page.locator('#detected-metrics-card')).toHaveCount(0);
+  });
+
+  test('card header shows detected count badge', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    await expect(page.locator('#detected-metrics-card .card-header')).toContainText('4 detected');
+  });
+
+  test('one row per detected metric', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const rows = page.locator('#detected-metrics-list .detected-metric-row');
+    await expect(rows).toHaveCount(4);
+  });
+
+  test('row shows metric id and score', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const firstRow = page.locator('#detected-metrics-list .detected-metric-row').first();
+    await expect(firstRow).toContainText('cm_customer_retention_rate');
+    await expect(firstRow).toContainText('0.95');
+  });
+
+  test('row has accept/reject/correct buttons', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const firstRow = page.locator('#detected-metrics-list .detected-metric-row').first();
+    await expect(firstRow.locator('.btn-accept-metric')).toBeVisible();
+    await expect(firstRow.locator('.btn-reject-metric')).toBeVisible();
+    await expect(firstRow.locator('.btn-correct-metric')).toBeVisible();
+  });
+
+  test('add-missed-metric button is visible', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    await expect(page.locator('#btn-add-missed-detected-metric')).toBeVisible();
+  });
+
+  test('submit-decisions button is visible', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    await expect(page.locator('#btn-submit-detected-metrics')).toBeVisible();
+  });
+
+  test('pre-seeded accept confirmation applies decided-accept class on load', async ({ page }) => {
+    await page.goto('/images-tab-detected-preseeded');
+    const acceptedRow = page.locator(
+      '#detected-metrics-list .detected-metric-row[data-metric-id="cm_customer_retention_rate"]',
+    );
+    await expect(acceptedRow).toHaveClass(/decided-accept/);
+    await expect(acceptedRow.locator('.metric-state-indicator')).toContainText('Accepted');
+  });
+});
+
+// =========================================================================
+// Decision interactions
+// =========================================================================
+test.describe('Detected Metrics card — decisions', () => {
+  test('Accept button marks row decided-accept', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').first();
+    await row.locator('.btn-accept-metric').click();
+    await expect(row).toHaveClass(/decided-accept/);
+    await expect(row.locator('.metric-state-indicator')).toContainText('Accepted');
+  });
+
+  test('Reject opens reason dropdown, selecting a reason marks decided-reject', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').nth(1);
+    await row.locator('.btn-reject-metric').click();
+    await expect(row.locator('.reject-expansion')).toBeVisible();
+    await row.locator('.metric-reject-reason').selectOption('similar_metric_misclassified');
+    await expect(row).toHaveClass(/decided-reject/);
+    await expect(row.locator('.metric-state-indicator'))
+      .toContainText('similar_metric_misclassified');
+  });
+
+  test('Correct opens metric picker, entering a different metric marks decided-correct', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').nth(2);
+    await row.locator('.btn-correct-metric').click();
+    await expect(row.locator('.correct-expansion')).toBeVisible();
+    await row.locator('.metric-correct-input').fill('cm_churn_rate');
+    await row.locator('.metric-correct-input').dispatchEvent('change');
+    await expect(row).toHaveClass(/decided-correct/);
+    await expect(row.locator('.metric-state-indicator')).toContainText('cm_churn_rate');
+  });
+
+  test('Correct to the same metric shows validation and does NOT mark decided', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').first();
+    const mid = await row.getAttribute('data-metric-id');
+    await row.locator('.btn-correct-metric').click();
+    await row.locator('.metric-correct-input').fill(mid);
+    await row.locator('.metric-correct-input').dispatchEvent('change');
+    await expect(row).not.toHaveClass(/decided-correct/);
+    await expect(row.locator('.metric-state-indicator')).toContainText(/different metric/i);
+  });
+
+  test('Add missed metric appends a new added row', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    await page.locator('#btn-add-missed-detected-metric').click();
+    await page.locator('#add-missed-detected-input').fill('cm_lifetime_value_per_customer');
+    await page.locator('#btn-add-missed-detected-confirm').click();
+    const addedRow = page.locator(
+      '#detected-metrics-list .added-metric-row[data-added-metric="cm_lifetime_value_per_customer"]',
+    );
+    await expect(addedRow).toBeVisible();
+    await expect(addedRow).toContainText('Added');
+  });
+});
+
+// =========================================================================
+// Keyboard shortcuts (focus-scoped)
+// =========================================================================
+test.describe('Detected Metrics card — keyboard shortcuts', () => {
+  test('A on focused row triggers accept', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').first();
+    await row.focus();
+    await page.keyboard.press('a');
+    await expect(row).toHaveClass(/decided-accept/);
+  });
+
+  test('R on focused row opens reject expansion', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').nth(1);
+    await row.focus();
+    await page.keyboard.press('r');
+    await expect(row.locator('.reject-expansion')).toBeVisible();
+  });
+
+  test('C on focused row opens correct expansion', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const row = page.locator('#detected-metrics-list .detected-metric-row').nth(2);
+    await row.focus();
+    await page.keyboard.press('c');
+    await expect(row.locator('.correct-expansion')).toBeVisible();
+  });
+
+  test('N on focused row advances focus to next unreviewed row', async ({ page }) => {
+    await page.goto('/images-tab-detected');
+    const first = page.locator('#detected-metrics-list .detected-metric-row').nth(0);
+    const second = page.locator('#detected-metrics-list .detected-metric-row').nth(1);
+    // Accept first, then press N to move to the next unreviewed row (second).
+    await first.focus();
+    await page.keyboard.press('a');
+    await first.focus();
+    await page.keyboard.press('n');
+    await expect(second).toBeFocused();
+  });
+});
+
+// =========================================================================
+// Submit flow
+// =========================================================================
+test.describe('Detected Metrics card — submit', () => {
+  test('Submit posts decisions array to /api/v2/image-metric-confirmations', async ({ page }) => {
+    const captured = [];
+    await page.route('/api/v2/image-metric-confirmations', async (route) => {
+      if (route.request().method() === 'POST') {
+        const body = await route.request().postDataJSON();
+        captured.push(body);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, upserted: body.decisions.length, confirmations: [] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/images-tab-detected');
+    // Accept the first row, then submit.
+    await page.locator('#detected-metrics-list .detected-metric-row').first()
+      .locator('.btn-accept-metric').click();
+    await page.locator('#btn-submit-detected-metrics').click();
+
+    await page.waitForTimeout(300);
+    expect(captured.length).toBe(1);
+    expect(captured[0].img_id).toBe('img-detected-12');
+    expect(captured[0].reviewer_id).toBe('test_reviewer');
+    expect(captured[0].decisions.length).toBe(1);
+    expect(captured[0].decisions[0].decision).toBe('accept');
+    expect(captured[0].decisions[0].detected_metric_id).toBe('cm_customer_retention_rate');
+  });
+
+  test('Submit rejects without reason are filtered out', async ({ page }) => {
+    const captured = [];
+    await page.route('/api/v2/image-metric-confirmations', async (route) => {
+      if (route.request().method() === 'POST') {
+        const body = await route.request().postDataJSON();
+        captured.push(body);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, upserted: body.decisions.length, confirmations: [] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/images-tab-detected');
+    // Open reject but don't pick a reason, then accept a different row.
+    await page.locator('#detected-metrics-list .detected-metric-row').first()
+      .locator('.btn-reject-metric').click();
+    await page.locator('#detected-metrics-list .detected-metric-row').nth(1)
+      .locator('.btn-accept-metric').click();
+    await page.locator('#btn-submit-detected-metrics').click();
+
+    await page.waitForTimeout(300);
+    // Only the accept should be submitted.
+    expect(captured[0].decisions.length).toBe(1);
+    expect(captured[0].decisions[0].decision).toBe('accept');
+  });
+
+  test('Full round-trip: accept / reject / correct / add — state preserved on reload', async ({ page }) => {
+    const captured = [];
+    await page.route('/api/v2/image-metric-confirmations', async (route) => {
+      if (route.request().method() === 'POST') {
+        const body = await route.request().postDataJSON();
+        captured.push(body);
+        const confirmations = body.decisions.map((d, i) => ({
+          confirmation_id: `c-${i}`,
+          img_id: body.img_id,
+          detected_metric_id: d.detected_metric_id,
+          confirmed_metric_id: d.confirmed_metric_id,
+          decision: d.decision,
+          rejection_reason: d.rejection_reason,
+          reviewer_id: body.reviewer_id,
+          created_at: '2026-04-23T00:00:00+00:00',
+          updated_at: '2026-04-23T00:00:00+00:00',
+        }));
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, upserted: body.decisions.length, confirmations }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto('/images-tab-detected');
+
+    const rows = page.locator('#detected-metrics-list .detected-metric-row');
+    // accept first
+    await rows.nth(0).locator('.btn-accept-metric').click();
+    // reject second with reason
+    await rows.nth(1).locator('.btn-reject-metric').click();
+    await rows.nth(1).locator('.metric-reject-reason').selectOption('not_present');
+    // correct third
+    await rows.nth(2).locator('.btn-correct-metric').click();
+    await rows.nth(2).locator('.metric-correct-input').fill('cm_lifetime_value_per_customer');
+    await rows.nth(2).locator('.metric-correct-input').dispatchEvent('change');
+    // add a fourth metric
+    await page.locator('#btn-add-missed-detected-metric').click();
+    await page.locator('#add-missed-detected-input').fill('cm_churn_rate');
+    await page.locator('#btn-add-missed-detected-confirm').click();
+
+    await page.locator('#btn-submit-detected-metrics').click();
+    await page.waitForTimeout(300);
+    expect(captured.length).toBe(1);
+    const decisions = captured[0].decisions;
+    expect(decisions.map(d => d.decision).sort()).toEqual(['accept', 'add', 'correct', 'reject']);
+
+    // Simulate the reload path using the preseeded route
+    // (the PR 3b backend serves existing confirmations via get_image_metric_confirmations).
+    await page.goto('/images-tab-detected-preseeded');
+    const acceptedRow = page.locator(
+      '#detected-metrics-list .detected-metric-row[data-metric-id="cm_customer_retention_rate"]',
+    );
+    await expect(acceptedRow).toHaveClass(/decided-accept/);
+  });
+});

--- a/tests/ui/test_server.py
+++ b/tests/ui/test_server.py
@@ -222,6 +222,39 @@ MOCK_IMAGE_CANDIDATE_PENDING = {
     "rejection_reason": None,
     "decision_notes": None,
     "image_index": 1,
+    "detected_metrics": [],
+}
+
+MOCK_IMAGE_CANDIDATE_WITH_DETECTED = {
+    **{
+        "image_candidate_id": 12,
+        "img_id": "img-detected-12",
+        "filing_id": 1,
+        "image_url": "https://via.placeholder.com/400x300?text=Chart3",
+        "image_src_url": "https://via.placeholder.com/400x300?text=Chart3",
+        "image_alt": "Cohort Retention Chart",
+        "image_src": "chart3.png",
+        "image_width": 600,
+        "image_height": 400,
+        "review_status": "pending",
+        "decision": None,
+        "image_decision_id": None,
+        "detection_tier": "tier_1_cohort",
+        "cohort_confidence": 0.90,
+        "preceding_text": "Retention by cohort.",
+        "detected_keywords": ["retention", "cohort"],
+        "is_decorative": False,
+        "chart_type": None,
+        "rejection_reason": None,
+        "decision_notes": None,
+        "image_index": 3,
+    },
+    "detected_metrics": [
+        {"metric_id": "cm_customer_retention_rate", "score": 0.95},
+        {"metric_id": "cm_net_revenue_retention", "score": 0.82},
+        {"metric_id": "cm_revenue_by_cohort", "score": 0.71},
+        {"metric_id": "cm_churn_rate", "score": 0.55},
+    ],
 }
 
 MOCK_IMAGE_CANDIDATE_REVIEWED = {
@@ -246,6 +279,7 @@ MOCK_IMAGE_CANDIDATE_REVIEWED = {
     "rejection_reason": None,
     "decision_notes": "Clear cohort retention chart",
     "image_index": 2,
+    "detected_metrics": [],
 }
 
 IMAGE_CHART_TYPES = [
@@ -279,6 +313,7 @@ def _shared_template_vars(
     image_candidates=_UNSET,
     all_image_candidates=_UNSET,
     current_image=_UNSET,
+    current_image_confirmations=None,
     facts=_UNSET,
 ):
     """Build shared template context."""
@@ -319,6 +354,7 @@ def _shared_template_vars(
         image_candidates=image_candidates,
         all_image_candidates=all_image_candidates,
         current_image=current_image,
+        current_image_confirmations=current_image_confirmations or [],
         image_pending=1,
         image_reviewed=1,
         image_skipped=0,
@@ -415,6 +451,48 @@ def review_images_tab_reviewed():
     )
 
 
+@app.route("/images-tab-detected")
+def review_images_tab_detected():
+    """Images tab with a current image carrying detected_metrics (PR 3b)."""
+    return render_template(
+        "unified_review.html",
+        **_shared_template_vars(
+            active_tab="images",
+            current_image=MOCK_IMAGE_CANDIDATE_WITH_DETECTED,
+            image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+            all_image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+        ),
+    )
+
+
+@app.route("/images-tab-detected-preseeded")
+def review_images_tab_detected_preseeded():
+    """Images tab with detected_metrics and pre-existing reviewer confirmations."""
+    preseeded = [
+        {
+            "confirmation_id": "c-1",
+            "img_id": MOCK_IMAGE_CANDIDATE_WITH_DETECTED["img_id"],
+            "detected_metric_id": "cm_customer_retention_rate",
+            "confirmed_metric_id": "cm_customer_retention_rate",
+            "decision": "accept",
+            "rejection_reason": None,
+            "reviewer_id": "test_reviewer",
+            "created_at": "2026-04-23T00:00:00+00:00",
+            "updated_at": "2026-04-23T00:00:00+00:00",
+        },
+    ]
+    return render_template(
+        "unified_review.html",
+        **_shared_template_vars(
+            active_tab="images",
+            current_image=MOCK_IMAGE_CANDIDATE_WITH_DETECTED,
+            image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+            all_image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+            current_image_confirmations=preseeded,
+        ),
+    )
+
+
 # --- Mock API endpoints ---
 
 
@@ -456,6 +534,60 @@ def mock_create_image_decision():
             "message": "All candidates reviewed for this filing",
         }
     ), 201
+
+
+@app.route("/api/v2/metrics/list", methods=["GET"])
+def mock_metrics_list():
+    return jsonify(
+        [
+            {
+                "metric_id": "cm_customer_retention_rate",
+                "display_name": "Customer Retention Rate",
+                "tier": "tier_1",
+            },
+            {
+                "metric_id": "cm_net_revenue_retention",
+                "display_name": "Net Revenue Retention",
+                "tier": "tier_1",
+            },
+            {
+                "metric_id": "cm_revenue_by_cohort",
+                "display_name": "Revenue by Cohort",
+                "tier": "tier_1",
+            },
+            {"metric_id": "cm_churn_rate", "display_name": "Churn Rate", "tier": "tier_2"},
+            {
+                "metric_id": "cm_lifetime_value_per_customer",
+                "display_name": "Lifetime Value per Customer",
+                "tier": "tier_1",
+            },
+        ]
+    ), 200
+
+
+@app.route("/api/v2/image-metric-confirmations", methods=["POST"])
+def mock_create_image_metric_confirmations():
+    data = request.get_json(silent=True) or {}
+    decisions = data.get("decisions", [])
+    img_id = data.get("img_id")
+    confirmations = []
+    for i, d in enumerate(decisions):
+        confirmations.append(
+            {
+                "confirmation_id": f"c-new-{i}",
+                "img_id": img_id,
+                "detected_metric_id": d.get("detected_metric_id"),
+                "confirmed_metric_id": d.get("confirmed_metric_id"),
+                "decision": d.get("decision"),
+                "rejection_reason": d.get("rejection_reason"),
+                "reviewer_id": data.get("reviewer_id", "anonymous"),
+                "created_at": "2026-04-23T00:00:00+00:00",
+                "updated_at": "2026-04-23T00:00:00+00:00",
+            }
+        )
+    return jsonify(
+        {"ok": True, "upserted": len(confirmations), "confirmations": confirmations}
+    ), 200
 
 
 @app.route("/api/v2/missed-metric", methods=["POST"])


### PR DESCRIPTION
## Summary

- Adds the Detected metrics card to the Images tab of the unified review UI, wiring the reviewer UX for the chart-presence pivot (Issue #86, PR 3b of 4).
- The card renders only when the current image carries classifier-detected metrics and has not been marked Not-Relevant. Each row supports **accept / reject (with reason) / correct (replace)**; a separate action lets reviewers **add** metrics the classifier missed.
- Submit batches the full decisions array to `POST /api/v2/image-metric-confirmations` (landed in PR 3a, #151).

## Scope context

- PR 3a (#151) landed the schema (`sql/43_create_v2_image_metric_confirmations.sql`), the `DatabaseAdapter.insert_image_metric_confirmations` / `get_image_metric_confirmations` helpers, and the `GET /api/v2/metrics/list` + `POST /api/v2/image-metric-confirmations` endpoints.
- This PR (3b) wires the reviewer UI against that stable API — template + JS + Playwright spec only. No schema or API changes.
- PR 4 will drain legacy chart `v2_metric_facts` rows, close issue #86 as "dissolved by pivot", and land the docs/rules cleanup inventoried in the parent plan.

Parent plan: `~/.claude/plans/pick-up-issue-86-tranquil-piglet.md`.

## Changes

| File | Change |
|---|---|
| `src/web/templates/unified_review.html` | New Detected-metrics card in the Images tab center column. Gated on `current_image.detected_metrics`, `review_status in ('pending','reviewed')`, `decision != 'not_relevant'`. Inline expansions for reject-reason and correct-metric picker; separate "+ Add metric" flow. Shared `<datalist>` populated via `/api/v2/metrics/list`. |
| `src/web/static/js/review_images_v2.js` | Appended a second IIFE managing per-row state (`accept`/`reject`/`correct`/`add`). Keyboard shortcuts `A` / `R` / `C` / `N` are **focus-scoped** to a detected-metric row so they don't conflict with the existing Y/N/S/U image-classification shortcuts. Submit POSTs `{img_id, reviewer_id, decisions[]}`, re-renders from server-returned confirmations on 200. |
| `src/web/routes/review_unified.py` | Loads existing `current_image_confirmations` via `db.get_image_metric_confirmations(img_id)` for the active image only (full queue does not preload prior decisions). Datetime fields are ISO-serialized before template rendering. |
| `tests/ui/test_server.py` | Adds `detected_metrics` to mock fixtures, a new `MOCK_IMAGE_CANDIDATE_WITH_DETECTED`, two render routes (`/images-tab-detected`, `/images-tab-detected-preseeded`), and stub endpoints for `GET /api/v2/metrics/list` + `POST /api/v2/image-metric-confirmations`. |
| `tests/ui/review_image_metric_confirmations.spec.js` | New Playwright spec covering card rendering, accept/reject/correct/add flows, focus-scoped keyboard shortcuts, submit round-trip, and pre-seeded confirmation hydration. Written in JS + placed under `tests/ui/` to match existing spec conventions (`playwright.config.js` is `testMatch: '*.spec.js'`). |

## Rules compliance

- `.claude/rules/web.md` **reviewer-id invariant**: POST payload includes `reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous'`.
- `.claude/rules/web.md` **view-persistence keys**: no new `cmasb:` keys; per-image decision state is transient in-memory.
- Existing Y/N/S/U image-classification keyboard shortcuts are preserved. A/R/C/N for the card only fire when a `.detected-metric-row` has focus (capture-phase listener + `stopPropagation`).

## Test plan

- [x] `pytest -x -q tests/unit/web/` — 127 passed
- [x] `pytest -x -q tests/integration/web/` — 49 passed
- [x] `pytest -x -q` (full) — 4150 passed, 67 skipped, 26 deselected
- [x] `ruff check src/web/ tests/ui/` — clean
- [x] `node -c` on the JS file + spec — clean
- [x] Flask test-client render of `/images-tab`, `/images-tab-detected`, `/images-tab-detected-preseeded`, `/images-tab-reviewed`, `/images-tab-empty` — all 200, card gating correct
- [ ] Playwright spec executed — written but not run per the brief (needs `playwright test` against the fixture server)
- [ ] Manual smoke via dev server — deferred to reviewer

## Follow-ups (for PR 4)

- Drain legacy `v2_metric_facts` rows with `source_type='chart'` via `scripts/batch_v2_extraction.py --chart-only`.
- Update `docs/HUMAN_REVIEW_SYSTEM.md`, `.claude/rules/v2-pipeline.md`, `docs/architecture/data-model.md`, and `CLAUDE.md` Core Design Principles §4 per the parent plan's documentation inventory.
- Close `docs/known-issues/legacy-086-*.md` as "dissolved by pivot".

🤖 Generated with [Claude Code](https://claude.com/claude-code)