### PR TITLE
feat(llm): VisionClient.analyze_image_for_metric_classification (closes #92)

### DIFF
--- a/src/llm/vision_client.py
+++ b/src/llm/vision_client.py
@@ -50,6 +50,8 @@ import os
 import re
 import time
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 from openai import APIConnectionError, APIError, RateLimitError
 
@@ -633,6 +635,58 @@ class VisionClient:
             raw_response=response.content,
         )
 
+    def analyze_image_for_metric_classification(
+        self,
+        image_bytes: bytes,
+        *,
+        detail: str = "high",
+        max_tokens: int = 400,
+    ) -> dict[str, Any] | None:
+        """Classify which customer metrics are disclosed in a chart image.
+
+        Sends the image to the Vision LLM using ``CLASSIFY_PROMPT`` and
+        ``response_format={"type": "json_object"}``, then parses and
+        normalises the response via ``_parse_classify_response``.
+
+        Args:
+            image_bytes: Raw JPEG/PNG/GIF/WebP bytes.
+            detail: Image detail level passed to ``analyze_image``.
+                Default ``"high"`` — metric-classify needs full resolution.
+            max_tokens: Ceiling on output tokens. 400 comfortably fits the
+                compact JSON response schema.
+
+        Returns:
+            Parsed dict with keys ``predicted_metrics``, ``confidence``,
+            ``rejection_reason``, and ``reasoning``; or ``None`` on API
+            failure or unparseable response.
+
+        Notes:
+            - Uses the module-level ``CLASSIFY_PROMPT`` constant (built from
+              ``config/metric_keywords.yaml`` at import time).
+            - No prod pipeline stage wires this yet — Leg B adds that.
+        """
+        try:
+            response = self.analyze_image(
+                image_bytes=image_bytes,
+                prompt=CLASSIFY_PROMPT,
+                detail=detail,
+                max_tokens=max_tokens,
+                response_format={"type": "json_object"},
+            )
+        except Exception:
+            logger.exception("analyze_image_for_metric_classification: API call failed")
+            return None
+
+        parsed = _parse_classify_response(response.content)
+        if parsed is None:
+            logger.warning(
+                "analyze_image_for_metric_classification: failed to parse response "
+                "(len=%d, first_80=%r)",
+                len(response.content),
+                response.content[:80],
+            )
+        return parsed
+
     @staticmethod
     def _parse_text_ocr_json(content: str) -> dict | None:
         """Parse the JSON body of an ``analyze_image_for_text`` response.
@@ -658,6 +712,170 @@ class VisionClient:
             return json.loads(repaired)
         except json.JSONDecodeError:
             return None
+
+
+# ---------------------------------------------------------------------------
+# Metric-classify helpers — ported from metric-classify-harness
+# ---------------------------------------------------------------------------
+
+# Repo root: two levels up from src/llm/vision_client.py
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def _load_tier_metric_ids() -> tuple[list[str], list[str]]:
+    """Return ``(tier1_ids, tier2_ids)`` from config/metric_keywords.yaml.
+
+    Reads yaml at call time so the prompt can never drift from the
+    authoritative tier assignment in CLAUDE.md. Returns deterministically
+    sorted ids (alphabetical) so the prompt is stable across runs.
+    """
+    import yaml
+
+    yaml_path = _REPO_ROOT / "config" / "metric_keywords.yaml"
+    with yaml_path.open(encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh) or {}
+
+    tier1: list[str] = []
+    tier2: list[str] = []
+    for metric_id, body in cfg.items():
+        if not isinstance(body, dict):
+            continue
+        tier = body.get("tier")
+        if tier == 1:
+            tier1.append(metric_id)
+        elif tier == 2:
+            tier2.append(metric_id)
+    return sorted(tier1), sorted(tier2)
+
+
+#: Allowed ``rejection_reason`` values in a metric-classify response.
+#: ``table_handled_elsewhere`` is added here (preemptive #93 fix) so this
+#: frozenset is the single-source of truth; ``v2_image_review_decisions``
+#: CHECK constraint will reference it once Leg B lands.
+CLASSIFY_REJECTION_REASONS: frozenset[str] = frozenset(
+    {
+        "decorative",
+        "not_a_chart",
+        "wrong_subject",
+        "duplicate",
+        "unreadable",
+        "other",
+        "table_handled_elsewhere",
+    }
+)
+
+
+def _build_classify_prompt(tier1: list[str], tier2: list[str]) -> str:
+    """Assemble the metric-classification prompt.
+
+    Returns JSON-only; paired with ``response_format={"type": "json_object"}``
+    on the API call. Tier lists are injected from ``metric_keywords.yaml``
+    at import time so tier assignments are always in sync with CLAUDE.md.
+    """
+    tier1_block = "\n".join(f"  - {m}" for m in tier1)
+    tier2_block = "\n".join(f"  - {m}" for m in tier2)
+    reasons = sorted(CLASSIFY_REJECTION_REASONS)
+    reasons_block = ", ".join(reasons)
+    return (
+        "You are classifying a customer-metrics disclosure image from an SEC "
+        "filing.\n\n"
+        f"TIER-1 metrics (must-not-miss; {len(tier1)}):\n{tier1_block}\n\n"
+        f"TIER-2 metrics (nice-to-have; {len(tier2)}):\n{tier2_block}\n\n"
+        "A metric is DISCLOSED in this image if the image depicts meaningful "
+        "chart data for that metric — even if data points are unlabeled, axes "
+        "are missing, or numeric values aren't visible. Base your judgment on "
+        "the chart SHAPE (cohort parfait / layer cake / stacked-area-by-cohort "
+        "/ triangle / retention curve / bar-by-cohort), the title, the legend, "
+        "and any surrounding text. Labeled values are sufficient evidence; "
+        "they are NOT required. Unlabeled cohort-waterfall / layer-cake "
+        "visuals are valid disclosures when the shape depicts per-cohort data.\n\n"
+        "Images that are TABLES of numbers should be returned with "
+        'predicted_metrics=[] and rejection_reason="other" (tables are handled '
+        "by a different pipeline).\n\n"
+        "Return JSON exactly:\n"
+        "{\n"
+        '  "predicted_metrics": [metric_ids from the lists above; [] if none],\n'
+        '  "confidence": float in 0.0 to 1.0 over the predicted set,\n'
+        f'  "rejection_reason": one of {{{reasons_block}}} when '
+        "predicted_metrics is empty, else null,\n"
+        '  "reasoning": one sentence explaining the call (for audit)\n'
+        "}\n\n"
+        "Only emit metric_ids exactly as listed above."
+    )
+
+
+_TIER1_METRIC_IDS, _TIER2_METRIC_IDS = _load_tier_metric_ids()
+
+#: Pre-built classification prompt (stable across runs; built from yaml at import).
+CLASSIFY_PROMPT: str = _build_classify_prompt(_TIER1_METRIC_IDS, _TIER2_METRIC_IDS)
+
+
+def _strip_markdown_fences(raw: str) -> str:
+    """Strip ```json … ``` fences that Gemini often wraps JSON responses in.
+
+    Returns the stripped payload when the full content is a single fenced
+    block; otherwise returns ``raw`` unchanged. Conservative: only triggers
+    when the text starts with \"```\" so clean JSON is left alone.
+    """
+    if not raw:
+        return raw
+    stripped = raw.strip()
+    if not stripped.startswith("```"):
+        return raw
+    first_newline = stripped.find("\n")
+    if first_newline == -1:
+        return raw
+    body = stripped[first_newline + 1 :]
+    if body.rstrip().endswith("```"):
+        body = body.rstrip()[:-3]
+    return body
+
+
+def _parse_classify_response(raw: str) -> dict[str, Any] | None:
+    """Parse and lightly normalise the metric-classify JSON response.
+
+    Returns ``None`` if JSON parsing fails. Accepts missing optional fields
+    and coerces common shape bugs (e.g. ``null`` confidence → 0.0, string
+    metric list → wrapped in list, unknown rejection_reason → ``"other"``)
+    so minor provider drift doesn't bubble up as a parse failure.
+    """
+    try:
+        obj = json.loads(_strip_markdown_fences(raw))
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+
+    raw_metrics = obj.get("predicted_metrics", []) or []
+    if isinstance(raw_metrics, str):
+        raw_metrics = [raw_metrics]
+    known_ids = set(_TIER1_METRIC_IDS) | set(_TIER2_METRIC_IDS)
+    metrics = [str(m).strip() for m in raw_metrics if str(m).strip() in known_ids]
+
+    try:
+        confidence = float(obj.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    reason = obj.get("rejection_reason")
+    if reason is not None:
+        reason = str(reason).strip()
+        if reason not in CLASSIFY_REJECTION_REASONS:
+            reason = "other"
+        if metrics:
+            # Classifier emitted metrics AND a reason; the schema says the
+            # reason only applies when metrics is empty. Drop it to keep
+            # downstream scoring unambiguous.
+            reason = None
+    reasoning = str(obj.get("reasoning") or "")
+
+    return {
+        "predicted_metrics": metrics,
+        "confidence": confidence,
+        "rejection_reason": reason,
+        "reasoning": reasoning,
+    }
 
 
 def _repair_truncated_json_object(text: str) -> str | None:

--- a/tests/unit/llm/test_vision_client_classify.py
+++ b/tests/unit/llm/test_vision_client_classify.py
@@ -1,0 +1,468 @@
+"""Unit tests for metric-classify helpers in VisionClient.
+
+Covers:
+- CLASSIFY_PROMPT / CLASSIFY_REJECTION_REASONS module constants
+- _strip_markdown_fences
+- _parse_classify_response (happy path + edge cases)
+- VisionClient.analyze_image_for_metric_classification (mocked)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from src.llm.vision_client import (
+    _TIER1_METRIC_IDS,
+    _TIER2_METRIC_IDS,
+    CLASSIFY_PROMPT,
+    CLASSIFY_REJECTION_REASONS,
+    VisionClient,
+    VisionResponse,
+    _parse_classify_response,
+    _strip_markdown_fences,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_response_json(
+    *,
+    predicted_metrics: list[str] | None = None,
+    confidence: float = 0.9,
+    rejection_reason: str | None = None,
+    reasoning: str = "Test reason.",
+) -> str:
+    """Return a valid JSON string for a classify response."""
+    if predicted_metrics is None:
+        predicted_metrics = []
+    return json.dumps(
+        {
+            "predicted_metrics": predicted_metrics,
+            "confidence": confidence,
+            "rejection_reason": rejection_reason,
+            "reasoning": reasoning,
+        }
+    )
+
+
+def _make_vision_response(content: str) -> VisionResponse:
+    return VisionResponse(
+        content=content,
+        model="gemini-2.5-flash-lite",
+        prompt_tokens=100,
+        completion_tokens=50,
+        cost_usd=0.001,
+        latency_ms=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder / module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPromptConstants:
+    def test_prompt_builds_at_import_without_raising(self):
+        """CLASSIFY_PROMPT is non-empty string built at module import."""
+        assert isinstance(CLASSIFY_PROMPT, str)
+        assert len(CLASSIFY_PROMPT) > 100
+
+    def test_tier1_ids_match_yaml(self):
+        """_TIER1_METRIC_IDS is non-empty and sorted."""
+        assert len(_TIER1_METRIC_IDS) > 0
+        assert list(_TIER1_METRIC_IDS) == sorted(_TIER1_METRIC_IDS)
+
+    def test_tier2_ids_match_yaml(self):
+        """_TIER2_METRIC_IDS is non-empty and sorted."""
+        assert len(_TIER2_METRIC_IDS) > 0
+        assert list(_TIER2_METRIC_IDS) == sorted(_TIER2_METRIC_IDS)
+
+    def test_tier_lists_are_disjoint(self):
+        """A metric should not appear in both tiers."""
+        overlap = set(_TIER1_METRIC_IDS) & set(_TIER2_METRIC_IDS)
+        assert overlap == set()
+
+    def test_prompt_contains_tier1_metric(self):
+        """At least one tier-1 metric id appears in the prompt text."""
+        assert any(m in CLASSIFY_PROMPT for m in _TIER1_METRIC_IDS)
+
+    def test_prompt_contains_tier2_metric(self):
+        """At least one tier-2 metric id appears in the prompt text."""
+        assert any(m in CLASSIFY_PROMPT for m in _TIER2_METRIC_IDS)
+
+    def test_rejection_reasons_contains_all_seven(self):
+        """CLASSIFY_REJECTION_REASONS contains exactly the required 7 values."""
+        expected = {
+            "decorative",
+            "not_a_chart",
+            "wrong_subject",
+            "duplicate",
+            "unreadable",
+            "other",
+            "table_handled_elsewhere",
+        }
+        assert CLASSIFY_REJECTION_REASONS == expected
+
+    def test_table_handled_elsewhere_present(self):
+        """table_handled_elsewhere is explicitly present (preemptive #93 fix)."""
+        assert "table_handled_elsewhere" in CLASSIFY_REJECTION_REASONS
+
+    def test_prompt_contains_rejection_reasons(self):
+        """All rejection reason values appear in the prompt text."""
+        for reason in CLASSIFY_REJECTION_REASONS:
+            assert reason in CLASSIFY_PROMPT, f"Missing reason {reason!r} in prompt"
+
+
+# ---------------------------------------------------------------------------
+# _strip_markdown_fences
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarkdownFences:
+    def test_clean_json_unchanged(self):
+        raw = '{"key": "value"}'
+        assert _strip_markdown_fences(raw) == raw
+
+    def test_strips_json_fence(self):
+        raw = '```json\n{"key": "value"}\n```'
+        result = _strip_markdown_fences(raw)
+        assert "```" not in result
+        assert '"key"' in result
+
+    def test_strips_plain_fence(self):
+        raw = '```\n{"key": 1}\n```'
+        result = _strip_markdown_fences(raw)
+        assert "```" not in result
+        assert '"key"' in result
+
+    def test_empty_string_unchanged(self):
+        assert _strip_markdown_fences("") == ""
+
+    def test_no_fence_unchanged(self):
+        raw = "just some text"
+        assert _strip_markdown_fences(raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# _parse_classify_response — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestParseClassifyResponseHappyPath:
+    def test_valid_full_response(self):
+        """A well-formed JSON response is parsed and returned."""
+        # Use a known tier-1 metric
+        metric = _TIER1_METRIC_IDS[0]
+        raw = _valid_response_json(
+            predicted_metrics=[metric],
+            confidence=0.85,
+            rejection_reason=None,
+            reasoning="Cohort chart detected.",
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["predicted_metrics"] == [metric]
+        assert result["confidence"] == pytest.approx(0.85)
+        assert result["rejection_reason"] is None
+        assert result["reasoning"] == "Cohort chart detected."
+
+    def test_empty_metrics_with_reason(self):
+        """Empty predicted_metrics + valid rejection_reason is accepted."""
+        raw = _valid_response_json(
+            predicted_metrics=[],
+            confidence=0.0,
+            rejection_reason="decorative",
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["predicted_metrics"] == []
+        assert result["rejection_reason"] == "decorative"
+
+    def test_confidence_clamped_above_1(self):
+        """Confidence > 1.0 is clamped to 1.0."""
+        raw = json.dumps(
+            {
+                "predicted_metrics": [],
+                "confidence": 1.5,
+                "rejection_reason": "other",
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["confidence"] == 1.0
+
+    def test_confidence_clamped_below_0(self):
+        """Confidence < 0.0 is clamped to 0.0."""
+        raw = json.dumps(
+            {
+                "predicted_metrics": [],
+                "confidence": -0.3,
+                "rejection_reason": "other",
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["confidence"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_classify_response — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestParseClassifyResponseEdgeCases:
+    def test_null_confidence_becomes_zero(self):
+        """null confidence is coerced to 0.0."""
+        raw = json.dumps(
+            {
+                "predicted_metrics": [],
+                "confidence": None,
+                "rejection_reason": "unreadable",
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["confidence"] == 0.0
+
+    def test_string_metric_wrapped_in_list(self):
+        """A bare string for predicted_metrics is wrapped into a list."""
+        metric = _TIER1_METRIC_IDS[0]
+        raw = json.dumps(
+            {
+                "predicted_metrics": metric,
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["predicted_metrics"] == [metric]
+
+    def test_unknown_rejection_reason_becomes_other(self):
+        """An unrecognised rejection_reason is normalised to 'other'."""
+        raw = json.dumps(
+            {
+                "predicted_metrics": [],
+                "confidence": 0.0,
+                "rejection_reason": "totally_made_up",
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["rejection_reason"] == "other"
+
+    def test_malformed_json_returns_none(self):
+        """Malformed JSON returns None."""
+        assert _parse_classify_response("{not valid json") is None
+
+    def test_empty_string_returns_none(self):
+        """Empty input returns None."""
+        assert _parse_classify_response("") is None
+
+    def test_markdown_fenced_json_parsed(self):
+        """Markdown-fenced JSON is unwrapped before parsing."""
+        metric = _TIER1_METRIC_IDS[0]
+        inner = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.7,
+                "rejection_reason": None,
+                "reasoning": "ok",
+            }
+        )
+        fenced = f"```json\n{inner}\n```"
+        result = _parse_classify_response(fenced)
+        assert result is not None
+        assert result["predicted_metrics"] == [metric]
+
+    def test_metrics_and_reason_both_present_drops_reason(self):
+        """When metrics are predicted AND rejection_reason is set, reason is dropped."""
+        metric = _TIER1_METRIC_IDS[0]
+        raw = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.8,
+                "rejection_reason": "decorative",
+                "reasoning": "mixed signal",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["predicted_metrics"] == [metric]
+        assert result["rejection_reason"] is None
+
+    def test_non_dict_json_returns_none(self):
+        """A valid JSON array (not dict) returns None."""
+        assert _parse_classify_response("[1, 2, 3]") is None
+
+    def test_unknown_metric_ids_filtered(self):
+        """Metric ids not in the tier lists are silently filtered out."""
+        valid_metric = _TIER1_METRIC_IDS[0]
+        raw = json.dumps(
+            {
+                "predicted_metrics": [valid_metric, "cm_does_not_exist_xyz"],
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "",
+            }
+        )
+        result = _parse_classify_response(raw)
+        assert result is not None
+        assert result["predicted_metrics"] == [valid_metric]
+
+
+# ---------------------------------------------------------------------------
+# VisionClient.analyze_image_for_metric_classification — mocked
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImageForMetricClassification:
+    """All tests mock analyze_image — no real API calls."""
+
+    FAKE_IMAGE = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100  # valid PNG magic
+
+    def _make_client(self) -> VisionClient:
+        """Create a VisionClient without a real API key (provider is mocked)."""
+        with patch("src.llm.providers.openai.OpenAI"):
+            client = VisionClient(model="gpt-4o-mini")
+        return client
+
+    def test_uses_classify_prompt(self):
+        """analyze_image is called with CLASSIFY_PROMPT."""
+        client = self._make_client()
+        metric = _TIER1_METRIC_IDS[0]
+        response_json = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "ok",
+            }
+        )
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response(response_json)
+        ) as mock_ai:
+            result = client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        call_kwargs = mock_ai.call_args
+        assert (
+            call_kwargs.kwargs["prompt"] == CLASSIFY_PROMPT
+            or call_kwargs.args[1] == CLASSIFY_PROMPT
+        )
+        assert result is not None
+
+    def test_uses_json_object_response_format(self):
+        """analyze_image is called with response_format={"type": "json_object"}."""
+        client = self._make_client()
+        metric = _TIER1_METRIC_IDS[0]
+        response_json = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "",
+            }
+        )
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response(response_json)
+        ) as mock_ai:
+            client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs.get("response_format") == {"type": "json_object"}
+
+    def test_happy_path_returns_parsed_dict(self):
+        """A valid API response returns the parsed dict."""
+        client = self._make_client()
+        metric = _TIER1_METRIC_IDS[0]
+        response_json = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.88,
+                "rejection_reason": None,
+                "reasoning": "Cohort parfait visible.",
+            }
+        )
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response(response_json)
+        ):
+            result = client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        assert result is not None
+        assert result["predicted_metrics"] == [metric]
+        assert result["confidence"] == pytest.approx(0.88)
+        assert result["rejection_reason"] is None
+        assert result["reasoning"] == "Cohort parfait visible."
+
+    def test_api_error_returns_none(self):
+        """An exception from analyze_image is caught and returns None."""
+        client = self._make_client()
+
+        with patch.object(client, "analyze_image", side_effect=RuntimeError("API down")):
+            result = client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        assert result is None
+
+    def test_unparseable_response_returns_none(self):
+        """A response that fails JSON parsing returns None."""
+        client = self._make_client()
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response("not json at all")
+        ):
+            result = client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        assert result is None
+
+    def test_default_max_tokens_is_400(self):
+        """Default max_tokens passed to analyze_image is 400."""
+        client = self._make_client()
+        metric = _TIER1_METRIC_IDS[0]
+        response_json = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "",
+            }
+        )
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response(response_json)
+        ) as mock_ai:
+            client.analyze_image_for_metric_classification(self.FAKE_IMAGE)
+
+        assert mock_ai.call_args.kwargs.get("max_tokens") == 400
+
+    def test_custom_max_tokens_forwarded(self):
+        """Explicit max_tokens is forwarded to analyze_image."""
+        client = self._make_client()
+        metric = _TIER1_METRIC_IDS[0]
+        response_json = json.dumps(
+            {
+                "predicted_metrics": [metric],
+                "confidence": 0.9,
+                "rejection_reason": None,
+                "reasoning": "",
+            }
+        )
+
+        with patch.object(
+            client, "analyze_image", return_value=_make_vision_response(response_json)
+        ) as mock_ai:
+            client.analyze_image_for_metric_classification(self.FAKE_IMAGE, max_tokens=200)
+
+        assert mock_ai.call_args.kwargs.get("max_tokens") == 200


### PR DESCRIPTION
## Summary

Leg A of the metric-classify tripod plan — ports `CLASSIFY_PROMPT` + parse/prompt-builder helpers from `metric-classify-harness:scripts/benchmark_vision.py` into `src/llm/vision_client.py` so the prompt has a single canonical home when classify lands in prod.

- New public method: `VisionClient.analyze_image_for_metric_classification(image_bytes, *, detail="high", max_tokens=400) -> dict | None`
- Module-level constants: `CLASSIFY_PROMPT`, `CLASSIFY_REJECTION_REASONS` (frozenset with **`"table_handled_elsewhere"` added** — preemptive fix for #93 at the enum's single-source home)
- Module-private helpers: `_load_tier_metric_ids`, `_build_classify_prompt`, `_strip_markdown_fences`, `_parse_classify_response`
- 34 new unit tests in `tests/unit/llm/test_vision_client_classify.py`, all mocking `analyze_image` at the call boundary (no real Gemini/OpenAI calls)

No prod caller yet. The pipeline stage + persistence + env gate are Leg B of the tripod plan.

## Scope

Closes #92 preemptively. The `docs/known-issues/legacy-092-*.md` fragment remains on `metric-classify-harness` until Leg B lands the fragment to main (its fix condition is met by this PR but the fragment file itself isn't here).

Part of the ongoing work captured in `~/.claude/plans/let-s-tackle-known-issues-md-92-tidy-cake.md`.

## Test plan

- [x] `pytest tests/unit/llm/test_vision_client_classify.py -v` — 34 passed
- [x] `pytest -x -q` — **4189 passed / 67 skipped** (was 4155 before this PR, net +34)
- [x] `ruff check src/ tests/` — clean
- [x] Import smoke test — `CLASSIFY_PROMPT` builds at import, `CLASSIFY_REJECTION_REASONS` has all 7 values
- [ ] CI green on all required checks

## Follow-up (not in this PR)

- Once this lands, the `metric-classify-harness` branch should be rebased onto main and updated to import `CLASSIFY_PROMPT` from `vision_client` instead of redefining it (risk register "Prompt drift" in plan doc)
- Leg B adds the pipeline stage, `v2_image_classifications` table, and `ENABLE_METRIC_CLASSIFY` env gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)