### PR TITLE
feat(review-ui): require named reviewer before any decision write

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -27,7 +27,9 @@ Static: `src/web/static/js/review_images_v2.js`, `static/css/review.css`.
 
 ## Reviewer identity invariant
 
-**Every decision-persisting API endpoint MUST accept and forward `reviewer_id`** to the DB write so per-filing "Reviewed by" aggregation keeps working. Mirror the text-decision pattern at `src/web/routes/api_unified.py:129` (`reviewer_id=data.get("reviewer_id", ...)`). The paired JS client must include `reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous'` in the request payload. Historical bug: image decisions silently persisted `NULL` for months because the endpoint never forwarded the value — resulting in "(unattributed)" rows that can't be filtered. Don't repeat it.
+**Every decision-persisting API endpoint MUST (a) forward `reviewer_id` to the DB write and (b) reject missing / blocklisted values via `_require_reviewer_id(data)` in `src/web/routes/api_unified.py`.** The gate returns HTTP 403 with `{"error": "reviewer_name_required"}`. Blocklist: `""`, `"anonymous"`, `"web_reviewer"`, `"test"`, `"test_user"`, anything prefixed `bulk:`. Mirror the same blocklist client-side via `window.requireReviewerName()` (defined in `base.html`) — it returns the valid name or opens the reviewer modal and returns `null`, so callers bail before the fetch. Do NOT fall back to `"anonymous"` / `"web_reviewer"` in payloads; those sentinels only exist in historical data (rewritten to `RGM` on 2026-04-23 per the v2_review_decisions / v2_image_review_decisions cleanup).
+
+Historical bug: image decisions silently persisted `NULL` for months because the endpoint never forwarded the value — resulting in "(unattributed)" rows that can't be filtered. Don't repeat it.
 
 ## View persistence (localStorage)
 

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -44,6 +44,37 @@ V2_REJECTION_CATEGORIES = (
 
 VALID_UNITS = ("percent", "currency", "count", "ratio", "basis_points", "other")
 
+# Reviewer-id gate: decision-writing endpoints must carry a real reviewer name.
+# Empty / NULL / fallback sentinels / historical bulk prefixes are all rejected
+# with 403 so the client is forced to open the "Who are you?" modal in base.html.
+# See .claude/rules/web.md "Reviewer identity invariant".
+_BLOCKED_REVIEWER_IDS = frozenset({"", "anonymous", "web_reviewer", "test", "test_user"})
+
+
+def _require_reviewer_id(data: dict[str, Any]) -> tuple[str | None, tuple[Any, int] | None]:
+    """Validate the reviewer_id in a decision payload.
+
+    Returns (reviewer_id, None) when the caller can proceed, or
+    (None, (json_response, status_code)) when the request must be rejected.
+    """
+    raw = data.get("reviewer_id")
+    rid = (raw or "").strip() if isinstance(raw, str) else ""
+    if not rid or rid in _BLOCKED_REVIEWER_IDS or rid.startswith("bulk:"):
+        return None, (
+            jsonify(
+                {
+                    "status": "error",
+                    "error": "reviewer_name_required",
+                    "message": (
+                        "Set your reviewer name before making decisions. "
+                        "The UI will open a prompt — enter a name, then retry."
+                    ),
+                }
+            ),
+            403,
+        )
+    return rid, None
+
 
 @api_unified_bp.after_request
 def _log_request_complete(response):
@@ -105,6 +136,10 @@ def create_decision():
         if errors:
             return jsonify({"status": "error", "errors": errors}), 400
 
+        reviewer_id, gate_reject = _require_reviewer_id(data)
+        if gate_reject is not None:
+            return gate_reject
+
         fact_id = data["fact_id"]
         decision = data["decision"]
 
@@ -127,7 +162,7 @@ def create_decision():
         decision_id = db.insert_v2_review_decision(
             fact_id=fact_id,
             decision=decision,
-            reviewer_id=data.get("reviewer_id", "web_reviewer"),
+            reviewer_id=reviewer_id,
             assigned_metric_id=data.get("assigned_metric_id"),
             corrected_value=data.get("corrected_value"),
             rejection_reason=data.get("rejection_reason"),
@@ -284,6 +319,10 @@ def create_image_decision():
             logger.warning(f"Validation error: {error}")
             return jsonify({"status": "error", "message": error}), 400
 
+        reviewer_id, gate_reject = _require_reviewer_id(data)
+        if gate_reject is not None:
+            return gate_reject
+
         # Extract fields
         img_id = data["img_id"]
         decision = data["decision"]
@@ -291,7 +330,6 @@ def create_image_decision():
         rejection_reason = data.get("rejection_reason")
         reviewer_notes = data.get("reviewer_notes")
         review_time_seconds = data.get("review_time_seconds")
-        reviewer_id = data.get("reviewer_id", "anonymous")
 
         # Validate candidate exists
         candidate = db.get_image_review_candidate_v2(img_id)
@@ -595,12 +633,12 @@ def add_missed_metric():
         elif unit not in VALID_UNITS:
             errors["unit"] = f"Must be one of: {', '.join(VALID_UNITS)}"
 
-        reviewer_id = data.get("reviewer_id") or "anonymous"
-        if not reviewer_id:
-            errors["reviewer_id"] = "Required field"
-
         if errors:
             return jsonify({"status": "error", "errors": errors}), 400
+
+        reviewer_id, gate_reject = _require_reviewer_id(data)
+        if gate_reject is not None:
+            return gate_reject
 
         period_end = data.get("period_end") or None
         period_type = data.get("period_type") or None
@@ -743,7 +781,9 @@ def create_image_metric_confirmations():
         except (ValueError, AttributeError):
             return jsonify({"error": "img_id must be a valid UUID"}), 400
 
-        reviewer_id = data.get("reviewer_id") or "anonymous"
+        reviewer_id, gate_reject = _require_reviewer_id(data)
+        if gate_reject is not None:
+            return gate_reject
 
         decisions_raw = data.get("decisions")
         if decisions_raw is None:

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -196,6 +196,10 @@
 
     async function submitDecision(selectedValue) {
         if (state.submitting) return;
+        const reviewerName = (typeof window.requireReviewerName === 'function')
+            ? window.requireReviewerName()
+            : localStorage.getItem('reviewer_name');
+        if (!reviewerName) return;
         state.submitting = true;
 
         const reviewTime = Math.round((Date.now() - state.reviewStartTime) / 1000);
@@ -206,7 +210,7 @@
             chart_type: state.activeDropdown === 'chart_type' ? selectedValue : null,
             rejection_reason: state.activeDropdown === 'rejection' ? selectedValue : null,
             review_time_seconds: reviewTime,
-            reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous',
+            reviewer_id: reviewerName,
         };
 
         const notesTextarea = document.getElementById('reviewer-notes');
@@ -790,10 +794,15 @@
             return;
         }
 
+        const reviewerName = (typeof window.requireReviewerName === 'function')
+            ? window.requireReviewerName()
+            : localStorage.getItem('reviewer_name');
+        if (!reviewerName) return;
+
         state.submitting = true;
         const payload = {
             img_id: state.imgId,
-            reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous',
+            reviewer_id: reviewerName,
             decisions,
         };
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -121,10 +121,34 @@
         }
         window.showReviewerModal = showReviewerModal;
 
+        // Reviewer-name gate: decision-writing endpoints require a real name.
+        // Mirrors the server-side blocklist in api_unified.py::_BLOCKED_REVIEWER_IDS.
+        var BLOCKED_REVIEWER_IDS = ['', 'anonymous', 'web_reviewer', 'test', 'test_user'];
+
+        function isValidReviewerName(name) {
+            var trimmed = (name || '').trim();
+            if (!trimmed) return false;
+            if (BLOCKED_REVIEWER_IDS.indexOf(trimmed) !== -1) return false;
+            if (trimmed.indexOf('bulk:') === 0) return false;
+            return true;
+        }
+        window.isValidReviewerName = isValidReviewerName;
+
+        // Call before any decision POST. Returns a valid name or null (modal opens).
+        function requireReviewerName() {
+            var name = (localStorage.getItem('reviewer_name') || '').trim();
+            if (isValidReviewerName(name)) return name;
+            // Wipe a blocklisted stored value so the modal's input starts empty.
+            if (name) localStorage.removeItem('reviewer_name');
+            showReviewerModal();
+            return null;
+        }
+        window.requireReviewerName = requireReviewerName;
+
         function saveReviewerName() {
             var input = document.getElementById('reviewer-name-input');
             var name = input.value.trim();
-            if (!name) { input.focus(); return; }
+            if (!isValidReviewerName(name)) { input.focus(); return; }
             localStorage.setItem('reviewer_name', name);
             updateNavDisplay(name);
             var modalEl = document.getElementById('reviewerModal');
@@ -142,9 +166,10 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             var name = localStorage.getItem('reviewer_name');
-            if (name) {
+            if (isValidReviewerName(name)) {
                 updateNavDisplay(name);
             } else {
+                if (name) localStorage.removeItem('reviewer_name');
                 showReviewerModal();
             }
             // Allow submitting with Enter key in the modal

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -1159,13 +1159,15 @@ function navigateFact(direction) {
 }
 
 function submitDecision(decision) {
+  const reviewerName = requireReviewerName();
+  if (!reviewerName) return;
   const reviewTime = Math.round((Date.now() - reviewStartTime) / 1000);
   const body = {
     fact_id: CURRENT_FACT_ID,
     decision: decision,
     review_time_seconds: reviewTime,
     reviewer_notes: document.getElementById('reviewer-notes')?.value || null,
-    reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous',
+    reviewer_id: reviewerName,
   };
 
   if (decision === 'reject') {
@@ -1250,6 +1252,8 @@ function hideCorrectForm() {
 }
 
 function addMissedMetric() {
+  const reviewerName = requireReviewerName();
+  if (!reviewerName) return;
   const body = {
     filing_id: FILING_ID,
     canonical_metric_id: document.getElementById('missed-metric-id').value,
@@ -1259,7 +1263,7 @@ function addMissedMetric() {
     period_type: document.getElementById('missed-period-type').value || null,
     period_end: document.getElementById('missed-period-end').value || null,
     scope: document.getElementById('missed-scope').value || 'company',
-    reviewer_id: localStorage.getItem('reviewer_name') || 'anonymous',
+    reviewer_id: reviewerName,
     reviewer_notes: document.getElementById('missed-notes').value || null,
   };
   if (!body.canonical_metric_id || !body.value_raw || !body.unit) {

--- a/tests/integration/web/test_v2_review_workflow.py
+++ b/tests/integration/web/test_v2_review_workflow.py
@@ -85,9 +85,7 @@ class TestV2FilingList:
             # Page should contain filing/v2 related content
             assert b"v2" in response.data.lower() or b"filing" in response.data.lower()
         finally:
-            db_adapter.execute(
-                "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-            )
+            db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
             db_adapter.execute("DELETE FROM companies WHERE cik = '0009991001'")
 
     def test_filing_list_empty(self, client):
@@ -130,9 +128,7 @@ class TestV2FactReview:
         )
         yield filing_id, fact_id
 
-        db_adapter.execute(
-            "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-        )
+        db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
         db_adapter.execute("DELETE FROM companies WHERE cik = '0009992001'")
 
     def test_review_page_loads_with_facts(self, client, filing_with_facts):
@@ -172,9 +168,7 @@ class TestV2FactReview:
             response = client.get(f"/v2/review/{filing_id}?page=1&per_page=1")
             assert response.status_code == 200
         finally:
-            db_adapter.execute(
-                "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-            )
+            db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
             db_adapter.execute("DELETE FROM companies WHERE cik = '0009992002'")
 
     def test_review_page_status_filter(self, client, db_adapter):
@@ -191,9 +185,7 @@ class TestV2FactReview:
             response = client.get(f"/v2/review/{filing_id}?status=pending_review")
             assert response.status_code == 200
         finally:
-            db_adapter.execute(
-                "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-            )
+            db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
             db_adapter.execute("DELETE FROM companies WHERE cik = '0009992003'")
 
     def test_review_page_missing_filing_redirects(self, client):
@@ -231,9 +223,7 @@ class TestV2DecisionAPI:
         yield filing_id, fact_id
 
         # CASCADE handles v2_metric_facts + v2_review_decisions via FK
-        db_adapter.execute(
-            "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-        )
+        db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
         db_adapter.execute("DELETE FROM companies WHERE cik = '0009993001'")
 
     def test_accept_decision(self, client, db_adapter, filing_and_fact):
@@ -242,7 +232,7 @@ class TestV2DecisionAPI:
 
         response = client.post(
             "/api/v2/decisions",
-            json={"fact_id": fact_id, "decision": "accept"},
+            json={"fact_id": fact_id, "decision": "accept", "reviewer_id": "RGM"},
         )
         assert response.status_code == 201
         data = json.loads(response.data)
@@ -268,6 +258,7 @@ class TestV2DecisionAPI:
                 "decision": "reject",
                 "rejection_reason": "Not a customer metric",
                 "rejection_category": "not_a_metric",
+                "reviewer_id": "RGM",
             },
         )
         assert response.status_code == 201
@@ -291,6 +282,7 @@ class TestV2DecisionAPI:
                 "decision": "correct",
                 "assigned_metric_id": "cm_active_customers_total",
                 "corrected_value": 9500,
+                "reviewer_id": "RGM",
             },
         )
         assert response.status_code == 201
@@ -307,13 +299,13 @@ class TestV2DecisionAPI:
 
         r1 = client.post(
             "/api/v2/decisions",
-            json={"fact_id": fact_id, "decision": "accept"},
+            json={"fact_id": fact_id, "decision": "accept", "reviewer_id": "RGM"},
         )
         assert r1.status_code == 201
 
         r2 = client.post(
             "/api/v2/decisions",
-            json={"fact_id": fact_id, "decision": "reject"},
+            json={"fact_id": fact_id, "decision": "reject", "reviewer_id": "RGM"},
         )
         assert r2.status_code == 409
         data = json.loads(r2.data)
@@ -326,6 +318,7 @@ class TestV2DecisionAPI:
             json={
                 "fact_id": "00000000-0000-0000-0000-000000000000",
                 "decision": "accept",
+                "reviewer_id": "RGM",
             },
         )
         assert response.status_code == 404
@@ -370,7 +363,7 @@ class TestV2DecisionAPI:
         # Create a decision first
         r = client.post(
             "/api/v2/decisions",
-            json={"fact_id": fact_id, "decision": "accept"},
+            json={"fact_id": fact_id, "decision": "accept", "reviewer_id": "RGM"},
         )
         assert r.status_code == 201
         decision_id = json.loads(r.data)["decision_id"]
@@ -392,9 +385,7 @@ class TestV2DecisionAPI:
 
     def test_undo_nonexistent_decision_404(self, client):
         """DELETE with a nonexistent decision_id returns 404."""
-        response = client.delete(
-            "/api/v2/decisions/00000000-0000-0000-0000-000000000000"
-        )
+        response = client.delete("/api/v2/decisions/00000000-0000-0000-0000-000000000000")
         assert response.status_code == 404
         data = json.loads(response.data)
         assert data["status"] == "error"
@@ -425,7 +416,7 @@ class TestV2DecisionAPI:
         try:
             response = client.post(
                 "/api/v2/decisions",
-                json={"fact_id": fact_id_1, "decision": "accept"},
+                json={"fact_id": fact_id_1, "decision": "accept", "reviewer_id": "RGM"},
             )
             assert response.status_code == 201
             data = json.loads(response.data)
@@ -436,9 +427,7 @@ class TestV2DecisionAPI:
                 assert "fact_id" in data["next_fact"]
                 assert "url" in data["next_fact"]
         finally:
-            db_adapter.execute(
-                "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-            )
+            db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
             db_adapter.execute("DELETE FROM companies WHERE cik = '0009993002'")
 
     def test_decision_response_structure(self, client, db_adapter, filing_and_fact):
@@ -452,6 +441,7 @@ class TestV2DecisionAPI:
                 "decision": "accept",
                 "reviewer_notes": "Looks good",
                 "review_time_seconds": 15,
+                "reviewer_id": "RGM",
             },
         )
         assert response.status_code == 201
@@ -515,7 +505,7 @@ class TestV2ReviewWorkflowEnd2End:
             # 4. Accept the first fact
             r_accept = client.post(
                 "/api/v2/decisions",
-                json={"fact_id": fact_id_1, "decision": "accept"},
+                json={"fact_id": fact_id_1, "decision": "accept", "reviewer_id": "RGM"},
             )
             assert r_accept.status_code == 201
             accept_data = json.loads(r_accept.data)
@@ -536,6 +526,7 @@ class TestV2ReviewWorkflowEnd2End:
                     "decision": "reject",
                     "rejection_category": "wrong_metric",
                     "rejection_reason": "This is a subtotal, not aggregate",
+                    "reviewer_id": "RGM",
                 },
             )
             assert r_reject.status_code == 201
@@ -561,7 +552,5 @@ class TestV2ReviewWorkflowEnd2End:
             assert r_review2.status_code == 200
 
         finally:
-            db_adapter.execute(
-                "DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id}
-            )
+            db_adapter.execute("DELETE FROM filings WHERE filing_id = %(id)s", {"id": filing_id})
             db_adapter.execute("DELETE FROM companies WHERE cik = '0009994001'")

--- a/tests/unit/web/test_api_v2_images_routes.py
+++ b/tests/unit/web/test_api_v2_images_routes.py
@@ -65,6 +65,7 @@ class TestCreateImageDecisionV2:
                     "img_id": IMG_ID,
                     "decision": "relevant",
                     "chart_type": "cohort_table",
+                    "reviewer_id": "RGM",
                 }
             ),
             content_type="application/json",
@@ -105,33 +106,37 @@ class TestCreateImageDecisionV2:
         call_kwargs = mock_db.insert_image_review_decision_v2.call_args.kwargs
         assert call_kwargs["reviewer_id"] == "alice@example.com"
 
-    def test_reviewer_id_defaults_to_anonymous(self, client, monkeypatch):
+    @pytest.mark.parametrize(
+        "reviewer_id",
+        [None, "", "   ", "anonymous", "web_reviewer", "test", "test_user", "bulk:old_import"],
+    )
+    def test_reviewer_id_gate_blocks_missing_or_blocklisted(self, client, monkeypatch, reviewer_id):
+        """Gate rejects empty / blocklisted / bulk-prefixed reviewer_ids with 403.
+
+        Historical "anonymous" / "web_reviewer" fallbacks are no longer accepted —
+        clients must send a real name or land on the reviewer-modal prompt.
+        """
         mock_db = MagicMock()
         _patch_get_db(monkeypatch, mock_db)
-        mock_db.get_image_review_candidate_v2.return_value = {
+
+        body: dict[str, object] = {
             "img_id": IMG_ID,
-            "filing_id": 5,
-            "review_status": "pending",
-            "decision": None,
+            "decision": "relevant",
+            "chart_type": "cohort_table",
         }
-        mock_db.insert_image_review_decision_v2.return_value = 790
-        mock_db.get_next_pending_image_candidate_v2.return_value = None
+        if reviewer_id is not None:
+            body["reviewer_id"] = reviewer_id
 
         resp = client.post(
             "/api/v2/image-decisions",
-            data=json.dumps(
-                {
-                    "img_id": IMG_ID,
-                    "decision": "relevant",
-                    "chart_type": "cohort_table",
-                }
-            ),
+            data=json.dumps(body),
             content_type="application/json",
         )
 
-        assert resp.status_code == 201
-        call_kwargs = mock_db.insert_image_review_decision_v2.call_args.kwargs
-        assert call_kwargs["reviewer_id"] == "anonymous"
+        assert resp.status_code == 403
+        payload = resp.get_json()
+        assert payload["error"] == "reviewer_name_required"
+        mock_db.insert_image_review_decision_v2.assert_not_called()
 
     def test_missing_img_id_returns_400(self, client, monkeypatch):
         mock_db = MagicMock()
@@ -175,6 +180,7 @@ class TestCreateImageDecisionV2:
                     "img_id": IMG_ID,
                     "decision": "relevant",
                     "chart_type": "cohort_table",
+                    "reviewer_id": "RGM",
                 }
             ),
             content_type="application/json",
@@ -198,6 +204,7 @@ class TestCreateImageDecisionV2:
                     "img_id": IMG_ID,
                     "decision": "relevant",
                     "chart_type": "cohort_table",
+                    "reviewer_id": "RGM",
                 }
             ),
             content_type="application/json",


### PR DESCRIPTION
## Summary

Companion to the 2026-04-23 historical cleanup (808 rows of anonymous/test/bulk reviewer_ids rewritten to `RGM`). New writes are now blocked at both layers unless a real reviewer name is set.

- **Server**: `_require_reviewer_id(data)` in `src/web/routes/api_unified.py` returns HTTP 403 `{"error": "reviewer_name_required"}` when `reviewer_id` is missing or in the blocklist `{"", "anonymous", "web_reviewer", "test", "test_user"}` or prefixed `bulk:`. Applied to the four decision-writing endpoints: `POST /decisions`, `POST /image-decisions`, `POST /missed-metric`, `POST /image-metric-confirmations`. Validation errors (400) still return before the gate so existing 400-path tests keep working.
- **Client**: `window.requireReviewerName()` in `base.html` returns a valid name or opens the reviewer modal and returns `null`; all four submit sites (`unified_review.html` × 2, `review_images_v2.js` × 2) now bail before the fetch instead of falling back to `"anonymous"`. A stored blocklisted value is wiped on page load so the modal's input starts empty.
- **Viewing is unchanged** — GETs are not gated; a reviewer without a name can still browse filings, look at facts, and see image candidates. They just can't write a decision.

Matches `.claude/rules/web.md` "Reviewer identity invariant" (updated in this PR with the gate spec and blocklist).

## Test plan
- [x] `pytest -x -q tests/unit/ tests/integration/web/` → **3939 passed, 11 skipped**
- [x] `ruff check src/ tests/` → clean
- [x] `mypy src/review/ --strict` → clean
- [x] New parametrized test `test_reviewer_id_gate_blocks_missing_or_blocklisted` covers `None`, `""`, `"   "`, `"anonymous"`, `"web_reviewer"`, `"test"`, `"test_user"`, `"bulk:old_import"` — all return 403, `insert_image_review_decision_v2` not called.
- [ ] Manual smoke on local server: clear `reviewer_name` from localStorage → click Accept on a fact → modal opens, no POST fires → enter a name → retry → decision saves.
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright).

## Behavior notes

- The modal is the same one `base.html` already shows on first visit; existing keyboard (Enter) + focus behavior unchanged.
- Old browser tabs with a `reviewer_name === "anonymous"` will get their stored value wiped on the next page load and be prompted for a real name.
- The `/api/v2/image-candidates/<id>/skip` and `unskip` endpoints do not write a decision row, so they are not gated. DELETE endpoints (undo) are also not gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)