### PR TITLE
ops(chart-presence-pivot): baseline refresh + defer drain (#86 PR 4b/4)

### DIFF
--- a/data/gold_standard/v2_baseline.json
+++ b/data/gold_standard/v2_baseline.json
@@ -1,10 +1,10 @@
 {
-  "baseline_date": "2026-04-23T01:56:55.638951+00:00",
-  "description": "Baseline refreshed post-image-pipeline-waves (A1/A2/A3/B1/B2/B3 landed 2026-04-22). Numbers here reflect actual validator output on post-#134 main in the canonical Python / lxml environment (lxml>=6.1.0 per pyproject). Issue #87 post-mortem confirms no extraction code regression exists: running the validator at commit 8840912 in the current environment reproduces these same per-company numbers (Farfetch recall 0.533, Robinhood 0.171, overall 0.459). The earlier `v2_baseline_pre_regression_2026-04-22.json` file (Farfetch 0.867, Robinhood 0.314, overall 0.498) was produced in a Python environment that no longer reproduces; it is a stale snapshot, not a reproducible 'good' baseline, and has been deleted. See docs/known-issues/legacy-087-text-recall-regression-farfetch-robinhood.md for the full bisect report.",
+  "baseline_date": "2026-04-24T02:16:24.878552+00:00",
+  "description": "post-pivot presence-F1 baseline (#86 PR 4b); drain deferred due to 18 reviewer decisions on chart facts",
   "overall": {
-    "precision": 0.6681222707423581,
-    "recall": 0.4594594594594595,
-    "f1": 0.5444839857651245
+    "precision": 0.6593886462882096,
+    "recall": 0.5807692307692308,
+    "f1": 0.6175869120654397
   },
   "by_company": {
     "Chewy, Inc.": {
@@ -19,8 +19,8 @@
     },
     "Farfetch Limited": {
       "precision": 0.5925925925925926,
-      "recall": 0.5333333333333333,
-      "f1": 0.5614035087719299
+      "recall": 1.0,
+      "f1": 0.7441860465116279
     },
     "Flywire Corp": {
       "precision": 1.0,
@@ -39,13 +39,13 @@
     },
     "Maplebear Inc.": {
       "precision": 0.5,
-      "recall": 0.35,
-      "f1": 0.4117647058823529
+      "recall": 0.6363636363636364,
+      "f1": 0.56
     },
     "Robinhood Markets, Inc.": {
       "precision": 0.5,
-      "recall": 0.17142857142857143,
-      "f1": 0.2553191489361702
+      "recall": 0.4,
+      "f1": 0.4444444444444445
     },
     "SAMSARA VISION INC.": {
       "precision": 1.0,
@@ -54,18 +54,18 @@
     },
     "Samsara Inc.": {
       "precision": 1.0,
-      "recall": 0.14634146341463414,
-      "f1": 0.2553191489361702
+      "recall": 0.2857142857142857,
+      "f1": 0.4444444444444445
     },
     "Slack Technologies": {
       "precision": 0.868421052631579,
-      "recall": 0.9428571428571428,
-      "f1": 0.904109589041096
+      "recall": 0.9705882352941176,
+      "f1": 0.9166666666666667
     },
     "Slack Technologies, Inc.": {
-      "precision": 0.5789473684210527,
-      "recall": 0.9166666666666666,
-      "f1": 0.7096774193548387
+      "precision": 0.5263157894736842,
+      "recall": 0.9090909090909091,
+      "f1": 0.6666666666666666
     },
     "Snowflake Inc": {
       "precision": 0.7586206896551724,
@@ -79,8 +79,8 @@
     },
     "Torrid Holdings Inc.": {
       "precision": 0.8181818181818182,
-      "recall": 0.2647058823529412,
-      "f1": 0.39999999999999997
+      "recall": 0.3333333333333333,
+      "f1": 0.4736842105263157
     }
   }
 }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 31 |
+| Open | 32 |
 | Partially Resolved | 1 |
 | Archived | 46 |
-| Resolved | 16 |
+| Resolved | 17 |
 
 
 ## Nightly Sweeper Classification
@@ -51,6 +51,8 @@
 | #88 | skip | S | `scripts/apply_all_migrations.py` `.pre-commit-config.yaml` | Add a pre-commit hook that fails if any sql/NN_*.sql on disk lacks an entry in MIGRATION_ORDER or EXCLUDED_FILES. |
 | #94 | safe | S | `sql/31_drop_v1_review_tables.sql` `sql/` `src/web/middleware.py` |  |
 | #95 | review | M | `scripts/apply_migrations.py` `render.yaml` `src/web/app.py` `sql/` |  |
+| #97 | review | M | — | Residual pre-pivot chart facts (30 rows across 10 filings) remain in v2_metric_facts post-#86 because 18 reviewer decisions on those facts would CASCADE-destroy on DELETE. Low blast radius — new UI does not read them, validator bypasses them — but analytics views filtering on source_type=chart still see them. |
+| #98 | review | S | `src/gold_standard/v2_validator.py` `src/extraction_v2/stages/chart_fact_bridge.py` | PR #150 added the presence P/R/F1 infrastructure to the validator + baseline, but presence_f1 is emitted as None because v2_context.images[*].detected_metrics is not populated during the validator's in-memory pipeline run. Baseline refresh in PR 4b (2026-04-24) has presence_f1=null as a result. |
 
 
 ## Open Issues
@@ -968,42 +970,101 @@ quietly since `sql/31` was applied.
 - Verify after: tail `filings-reviewer` Render logs for 5 minutes and
   confirm the `check_v2_audit_http_method` violation is gone.
 
-## #96. Chart-Presence Pivot — Multi-PR Rollout Tracking
+## #97. Residual Chart Facts Remain After Chart-Presence Pivot (Drain Deferred)
 
 **Status**: Open
 **Severity**: low
-**Discovered**: 2026-04-23
-**Updated**: 2026-04-23
-**PR refs**: #147, #150, #151, #154
+**Discovered**: 2026-04-24
+**Updated**: 2026-04-24
 
 ### Problem
 
-The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` emission with image-level metric-presence records on `v2_image_assets.detected_metrics`, adjudicated via `v2_image_metric_confirmations` (accept / reject / correct / add). Shipped as a four-PR sequence to bound scope, unblock parallel review, and isolate the prod drain from the code + docs cleanup.
+The chart-presence pivot (Issue #86, merged across PRs #147/#150/#151/#154/#158) stops new chart-fact emission but PR 4b deliberately **did not drain** the existing rows. Pre-flight audit on 2026-04-24:
 
-### Rollout
+| Metric | Count |
+|---|---|
+| Rows: `v2_metric_facts WHERE source_type='chart'` | 30 |
+| Distinct filings | 10 |
+| Reviewer decisions (`v2_review_decisions`) on chart facts | 18 |
 
-| PR | Scope | Status |
+The 18 decisions break down as:
+
+| Decision | Count | Metrics |
 |---|---|---|
-| [#147](https://github.com/RGMjr/filings_reviewer/pull/147) | `ChartFactBridgeStage` rewrite (emit presence on `v2_image_assets.detected_metrics`, no facts). `sql/42` adds the JSONB column. `_scan_chart` gated off. | Merged 2026-04-23 |
-| [#150](https://github.com/RGMjr/filings_reviewer/pull/150) | Gold-standard validator: presence P/R/F1; baseline schema extended; chart-row `Raw value` forced advisory. | Merged 2026-04-23 |
-| [#151](https://github.com/RGMjr/filings_reviewer/pull/151) | `sql/43_create_v2_image_metric_confirmations`; `DatabaseAdapter.insert/get_image_metric_confirmations`; `GET /api/v2/metrics/list`; `POST /api/v2/image-metric-confirmations`; Chart Evidence block + `_resolve_chart_image_status` deleted. | Merged 2026-04-23 |
-| [#154](https://github.com/RGMjr/filings_reviewer/pull/154) | Detected metrics card in `unified_review.html`; `review_images_v2.js` module (A/R/C/N focus-scoped keyboard); Playwright spec. | Merged 2026-04-23 |
-| PR 4a | Code + docs cleanup: delete `CohortParser`, rewrite `.claude/rules/v2-pipeline.md`, update `docs/architecture/data-model.md`, `CLAUDE.md` §4, `docs/development/metric-lifecycle-process.md`, close legacy-086/035 known-issues. | Open (this PR) |
-| PR 4b | Prod drain (`DELETE FROM v2_metric_facts WHERE source_type='chart'` — Option B per user decision, or `scripts/batch_v2_extraction.py --chart-only` — Option A), `pg_dump` snapshot pre-drain, baseline refresh. | Pending |
+| reject | 9 | cm_new_customers_acquired, cm_customers_period_end (bulk), cm_customers_period_end_by_tenure, cm_active_customers_total, cm_ltv_to_cac_ratio, cm_purchase_transactions_overall, cm_lifetime_value_per_customer, cm_customer_acquisition_cost |
+| accept | 5 | cm_revenue_by_cohort (×3), cm_large_customers_period_end, cm_customers_period_end |
+| correct | 4 | cm_average_order_value (×2), cm_monthly_active_users, cm_new_customers_acquired |
 
-### Next Steps
+17 are by reviewer `RGM`, 1 is a bulk-system entry (`bulk:superseded_slack_s1a_2019-05-20`).
 
-1. Land PR 4a (this PR).
-2. Ask user for drain method (Option A re-extract vs Option B SQL DELETE).
-3. Cut PR 4b worktree; execute the drain with approval gates at each step; refresh baseline.
-4. Close this fragment (`status: resolved`) in PR 4b.
+`v2_review_decisions.fact_id ON DELETE CASCADE` means a plain `DELETE FROM v2_metric_facts WHERE source_type='chart'` would silently destroy reviewer work. User chose to defer the drain (option B1 in the PR 4b exchange) to preserve those 18 pieces of work.
+
+### Impact (low)
+
+- **Review UI:** Chart Evidence block deleted in PR #151; detected-metrics card reads from `v2_image_assets.detected_metrics`, not `v2_metric_facts`. **No user-visible impact.**
+- **Validator:** PR #150 routes `segment_type='chart'` gold rows through presence P/R, not value-level P/R. Chart facts in `v2_metric_facts` are not considered when evaluating chart gold expectations. **No measurement impact.**
+- **Analytics views:** `v_analytics_*` views (sql/38, …) may include `source_type='chart'` rows in fact aggregates. If downstream reporting filters on source_type, the 30 residual rows will appear. Typical fix: add `AND source_type != 'chart'` at view level if unwanted. **Low impact, shimmable.**
+- **DB footprint:** 30 rows. Negligible.
+
+### Next Steps (if drain becomes needed later)
+
+Three paths, pick at triage time:
+
+1. **Archive decisions + DELETE.** Export the 18 `v2_review_decisions` rows (plus the 30 facts) to `data/audit/chart_fact_decisions_predrain_<ts>.json` for historical reference, then `DELETE FROM v2_metric_facts WHERE source_type='chart'` in a transaction. Reviewer work preserved as JSON, not queryable live.
+2. **Migrate accepts + corrects to `v2_image_metric_confirmations`.** For each chart fact with `source_locator.img_id` not null: derive a `(img_id, detected_metric_id=canonical_metric_id, decision)` row. Rejects have no natural img-level equivalent (the "this value is wrong" signal doesn't map cleanly to "this metric is not present"), so rejects would still be lost. Complex but preserves the most work as live signal.
+3. **Keep deferred.** No action; residual 30 rows are inert. Revisit only if analytics downstream actually needs them gone.
 
 ### Cross-References
 
-- Parent plan: `~/.claude/plans/pick-up-issue-86-tranquil-piglet.md`
-- PR 4a plan: `~/.claude/plans/let-s-move-on-to-snoopy-flamingo.md`
-- Dissolved issues: legacy-086 (dedup collapse), legacy-035 (chart-fact backfill).
-- Reduced-severity reference: legacy-053 (chart call limit — now affects presence coverage only).
+- Parent rollout: legacy-096 (chart-presence pivot rollout, resolved).
+- Dissolved root cause: legacy-086 (dedup stage collapse).
+- Dissolved consequence: legacy-035 (pre-2026-04-17 chart-fact backfill).
+- Reviewed-filing guard: `src/extraction_v2/persistence.py::_persist_facts_in_tx`, `ReviewedFilingError`.
+- Cascade path: `v2_review_decisions.fact_id ON DELETE CASCADE` (sql/05 originally; `chart_only=True` guard in `persist_pipeline_result` refuses when decisions exist).
+
+## #98. Validator presence_f1 Stays Null — detected_metrics Not Populated in-Memory
+
+**Status**: Open
+**Severity**: low
+**Discovered**: 2026-04-24
+**Updated**: 2026-04-24
+
+### Problem
+
+The chart-presence pivot landed presence P/R/F1 infrastructure in PR #150:
+
+- `FilingResult.presence_tp / presence_fp / presence_fn` fields (`src/gold_standard/v2_validator.py`).
+- `BaselineMetrics.presence_f1` field (`src/gold_standard/baseline.py`).
+- `to_dict()` emits `presence_f1` only when `has_presence = (total_presence_tp + total_presence_fp + total_presence_fn) > 0` (`src/gold_standard/v2_validator.py:374`).
+
+After the PR 4b baseline refresh on 2026-04-24, `v2_baseline.json` has `presence_f1` **absent at all scopes** (overall and per-company). The pre-PR-4a baseline (2026-04-23) also lacked it. That means the validator has been silently computing zero presence TP/FP/FN for every run since PR #150 landed.
+
+Root cause (likely): the validator calls `V2Pipeline(...).process(..., document_date=...)` with `filing_id=0` (no persistence). The pipeline's chart bridge stage writes `image.detected_metrics` in-memory. But either:
+
+1. The chart bridge stage isn't firing because chart images aren't reaching it — e.g., vision calls skipped under test harness, `chart_data` never populated → classifier runs on empty input → no presence emitted.
+2. The validator accesses `v2_context.images` via a getter that doesn't surface the in-memory `detected_metrics` populated by the bridge.
+3. Something else in the `filing_id=0` mode skips the full image pipeline.
+
+Confirmed via grep: `_chart_presence_set_from_context` (`v2_validator.py` around the presence block) reads `v2_context.images[*].detected_metrics`. The validator does walk through that code path. But `presence_tp/fp/fn` stay 0.
+
+### Impact
+
+- Presence-F1 is unmeasurable via the GS pipeline right now. Chart-native metric improvements can't be quantified — the baseline has no floor to regress against.
+- The 30% cross-source confirmation gate (`_derive_chart_native_metrics`) still works (it's CSV-driven, not pipeline-driven), so metric-aware classification isn't affected.
+- Not a correctness issue; it's a measurement gap.
+
+### Next Steps
+
+1. Instrument `_chart_presence_set_from_context` to log `len(v2_context.images)` and how many have non-empty `detected_metrics`. Run against one filing with a known chart (e.g., Robinhood S-1 has chart images).
+2. If images reach the validator but `detected_metrics` is empty → inspect `ChartFactBridgeStage.process()` — did vision OCR fire? Did `classify_all` return anything? Check `chart_presence_min_score` threshold.
+3. If the images list is empty → the validator's pipeline run is skipping image-processing stages. Check `PipelineConfig` defaults used by the validator vs. the prod config.
+4. Fix whichever gap is real, re-run the baseline refresh, confirm `presence_f1` field appears.
+
+### Cross-References
+
+- Parent rollout: legacy-096.
+- Introducing PR: #150.
+- Baseline refresh PR (where this was surfaced): PR 4b.
 
 ## #5. Revenue Synonym Context Gating
 
@@ -2134,6 +2195,73 @@ attempt to re-fix issues whose fixes are already in `main`.
   must NOT appear in selector picks.
 - Optional: also emit a warning when such a fragment is encountered, so the
   author knows to set `autonomy: n/a` on resolved entries.
+
+## #96. Chart-Presence Pivot — Multi-PR Rollout Tracking
+
+**Status**: Resolved
+**Severity**: low
+**Discovered**: 2026-04-23
+**Updated**: 2026-04-24
+**PR refs**: #147, #150, #151, #154, #158
+
+### Problem
+
+The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` emission with image-level metric-presence records on `v2_image_assets.detected_metrics`, adjudicated via `v2_image_metric_confirmations` (accept / reject / correct / add). Shipped as a five-PR sequence (originally four; PR 4 split into 4a + 4b after scope overran) to bound scope, unblock parallel review, and isolate the planned prod drain from the code + docs cleanup.
+
+### Rollout
+
+| PR | Scope | Status |
+|---|---|---|
+| [#147](https://github.com/RGMjr/filings_reviewer/pull/147) | `ChartFactBridgeStage` rewrite (emit presence on `v2_image_assets.detected_metrics`, no facts). `sql/42` adds the JSONB column. `_scan_chart` gated off. | Merged 2026-04-23 |
+| [#150](https://github.com/RGMjr/filings_reviewer/pull/150) | Gold-standard validator: presence P/R/F1; baseline schema extended; chart-row `Raw value` forced advisory. | Merged 2026-04-23 |
+| [#151](https://github.com/RGMjr/filings_reviewer/pull/151) | `sql/43_create_v2_image_metric_confirmations`; `DatabaseAdapter.insert/get_image_metric_confirmations`; `GET /api/v2/metrics/list`; `POST /api/v2/image-metric-confirmations`; Chart Evidence block + `_resolve_chart_image_status` deleted. | Merged 2026-04-23 |
+| [#154](https://github.com/RGMjr/filings_reviewer/pull/154) | Detected metrics card in `unified_review.html`; `review_images_v2.js` module (A/R/C/N focus-scoped keyboard); Playwright spec. | Merged 2026-04-23 |
+| [#158](https://github.com/RGMjr/filings_reviewer/pull/158) | PR 4a — code + docs cleanup: delete `CohortParser`, rewrite `.claude/rules/v2-pipeline.md`, update `docs/architecture/data-model.md`, `CLAUDE.md` §4, close legacy-086/035 known-issues. | Merged 2026-04-24 |
+| PR 4b (this) | Post-pivot baseline refresh; **drain deferred** after pre-flight safety audit. Overall F1 0.544 → 0.618 (+7.4pp) via PR #150's chart-row presence bypass. | This PR |
+
+### Drain deferral — why
+
+PR 4b's plan called for `DELETE FROM v2_metric_facts WHERE source_type='chart'` against prod. Pre-flight queries on 2026-04-24 found:
+
+| Metric | Count |
+|---|---|
+| Residual chart facts | 30 |
+| Filings affected | 10 |
+| Reviewer decisions on chart facts | **18** |
+
+The 18 decisions break down as: 9 rejects, 5 accepts, 4 corrects (17 by reviewer `RGM`, 1 bulk-system entry). `v2_review_decisions.fact_id ON DELETE CASCADE` means the DELETE would silently destroy that reviewer work.
+
+Options weighed:
+
+- **B1 — defer drain** (chosen): leave 30 residual chart facts in `v2_metric_facts` as dead data. Correctness-wise fine — the new UI doesn't surface chart facts (Chart Evidence block deleted in PR #151), the validator treats chart gold rows via presence (PR #150), and analytics views that filter on `source_type='chart'` are the only surface area affected. Zero reviewer-work loss.
+- B2 — export decisions to JSON archive, then DELETE. Reviewer work archived but not queryable live. Not chosen because the residual-fact presence is low-impact; no urgent need to delete.
+- B3 — migrate the 9 accepts/corrects to `v2_image_metric_confirmations`. Requires mapping code; complex because `corrected_value` has no presence-schema equivalent and some source_locators may lack img_id.
+- B4 — proceed with DELETE anyway. Counter to reviewed-filing-guard design intent.
+
+### Post-pivot baseline
+
+Refreshed 2026-04-24 via `python3 -m src.gold_standard.v2_validator --update-baseline`:
+
+| | Before | After | Δ |
+|---|---|---|---|
+| Precision | 0.668 | 0.659 | −0.9pp |
+| Recall | 0.459 | 0.581 | +12.2pp |
+| F1 | 0.544 | 0.618 | +7.4pp |
+
+The recall jump is the measurement-methodology shift from PR #150 landing: 82 `segment_type='chart'` gold rows stop counting as value-level FNs and instead route through presence P/R. `presence_f1` is still `None` in the baseline — the validator's in-memory pipeline run does not yet populate `v2_context.images[*].detected_metrics` end-to-end (the field is defined on the dataclass but not populated by the validator's `pipeline.process()` call path). Tracked separately.
+
+### Residual work (out of scope for PR 4b)
+
+- **30 residual chart facts + 18 reviewer decisions** on prod. Filed as a new known-issue fragment (`legacy-097`) for possible future handling.
+- **Validator presence_f1 measurement gap.** `detected_metrics` is populated at persistence time but not in the validator's in-memory pipeline result. Baseline presence-F1 stays `None` until this wiring lands. Filed separately.
+
+### Cross-References
+
+- Parent plan: `~/.claude/plans/pick-up-issue-86-tranquil-piglet.md`
+- PR 4a plan: `~/.claude/plans/let-s-move-on-to-snoopy-flamingo.md`
+- Dissolved issues: legacy-086 (dedup collapse), legacy-035 (chart-fact backfill).
+- Reduced-severity reference: legacy-053 (chart call limit — now affects presence coverage only).
+- Residual work: legacy-097 (residual chart facts + reviewer decisions).
 
 
 ## Change Log

--- a/docs/known-issues/legacy-096-chart-presence-pivot-rollout.md
+++ b/docs/known-issues/legacy-096-chart-presence-pivot-rollout.md
@@ -3,26 +3,28 @@ autonomy: n/a
 discovered: '2026-04-23'
 estimated: L
 id: 96
-note: 'Tracking issue for the four-PR chart-presence pivot rollout. Closes when PR 4b
-  (prod drain + baseline refresh) merges. Serves as the anchor for anyone later
-  auditing the pivot''s surface area.'
+note: 'Rollout complete. PR 4b landed the baseline refresh; prod drain was deferred
+  after the pre-flight audit found 18 reviewer decisions on the 30 residual chart
+  facts (DELETE would CASCADE-destroy reviewer work via v2_review_decisions.fact_id
+  ON DELETE CASCADE). Residual facts tracked separately for possible future drain.'
 pr_refs:
 - 147
 - 150
 - 151
 - 154
+- 158
 severity: low
 slug: chart-presence-pivot-rollout
 source: legacy
-status: open
+status: resolved
 title: Chart-Presence Pivot — Multi-PR Rollout Tracking
 touches: []
-updated: '2026-04-23'
+updated: '2026-04-24'
 ---
 
 ### Problem
 
-The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` emission with image-level metric-presence records on `v2_image_assets.detected_metrics`, adjudicated via `v2_image_metric_confirmations` (accept / reject / correct / add). Shipped as a four-PR sequence to bound scope, unblock parallel review, and isolate the prod drain from the code + docs cleanup.
+The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` emission with image-level metric-presence records on `v2_image_assets.detected_metrics`, adjudicated via `v2_image_metric_confirmations` (accept / reject / correct / add). Shipped as a five-PR sequence (originally four; PR 4 split into 4a + 4b after scope overran) to bound scope, unblock parallel review, and isolate the planned prod drain from the code + docs cleanup.
 
 ### Rollout
 
@@ -32,15 +34,44 @@ The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` e
 | [#150](https://github.com/RGMjr/filings_reviewer/pull/150) | Gold-standard validator: presence P/R/F1; baseline schema extended; chart-row `Raw value` forced advisory. | Merged 2026-04-23 |
 | [#151](https://github.com/RGMjr/filings_reviewer/pull/151) | `sql/43_create_v2_image_metric_confirmations`; `DatabaseAdapter.insert/get_image_metric_confirmations`; `GET /api/v2/metrics/list`; `POST /api/v2/image-metric-confirmations`; Chart Evidence block + `_resolve_chart_image_status` deleted. | Merged 2026-04-23 |
 | [#154](https://github.com/RGMjr/filings_reviewer/pull/154) | Detected metrics card in `unified_review.html`; `review_images_v2.js` module (A/R/C/N focus-scoped keyboard); Playwright spec. | Merged 2026-04-23 |
-| PR 4a | Code + docs cleanup: delete `CohortParser`, rewrite `.claude/rules/v2-pipeline.md`, update `docs/architecture/data-model.md`, `CLAUDE.md` §4, `docs/development/metric-lifecycle-process.md`, close legacy-086/035 known-issues. | Open (this PR) |
-| PR 4b | Prod drain (`DELETE FROM v2_metric_facts WHERE source_type='chart'` — Option B per user decision, or `scripts/batch_v2_extraction.py --chart-only` — Option A), `pg_dump` snapshot pre-drain, baseline refresh. | Pending |
+| [#158](https://github.com/RGMjr/filings_reviewer/pull/158) | PR 4a — code + docs cleanup: delete `CohortParser`, rewrite `.claude/rules/v2-pipeline.md`, update `docs/architecture/data-model.md`, `CLAUDE.md` §4, close legacy-086/035 known-issues. | Merged 2026-04-24 |
+| PR 4b (this) | Post-pivot baseline refresh; **drain deferred** after pre-flight safety audit. Overall F1 0.544 → 0.618 (+7.4pp) via PR #150's chart-row presence bypass. | This PR |
 
-### Next Steps
+### Drain deferral — why
 
-1. Land PR 4a (this PR).
-2. Ask user for drain method (Option A re-extract vs Option B SQL DELETE).
-3. Cut PR 4b worktree; execute the drain with approval gates at each step; refresh baseline.
-4. Close this fragment (`status: resolved`) in PR 4b.
+PR 4b's plan called for `DELETE FROM v2_metric_facts WHERE source_type='chart'` against prod. Pre-flight queries on 2026-04-24 found:
+
+| Metric | Count |
+|---|---|
+| Residual chart facts | 30 |
+| Filings affected | 10 |
+| Reviewer decisions on chart facts | **18** |
+
+The 18 decisions break down as: 9 rejects, 5 accepts, 4 corrects (17 by reviewer `RGM`, 1 bulk-system entry). `v2_review_decisions.fact_id ON DELETE CASCADE` means the DELETE would silently destroy that reviewer work.
+
+Options weighed:
+
+- **B1 — defer drain** (chosen): leave 30 residual chart facts in `v2_metric_facts` as dead data. Correctness-wise fine — the new UI doesn't surface chart facts (Chart Evidence block deleted in PR #151), the validator treats chart gold rows via presence (PR #150), and analytics views that filter on `source_type='chart'` are the only surface area affected. Zero reviewer-work loss.
+- B2 — export decisions to JSON archive, then DELETE. Reviewer work archived but not queryable live. Not chosen because the residual-fact presence is low-impact; no urgent need to delete.
+- B3 — migrate the 9 accepts/corrects to `v2_image_metric_confirmations`. Requires mapping code; complex because `corrected_value` has no presence-schema equivalent and some source_locators may lack img_id.
+- B4 — proceed with DELETE anyway. Counter to reviewed-filing-guard design intent.
+
+### Post-pivot baseline
+
+Refreshed 2026-04-24 via `python3 -m src.gold_standard.v2_validator --update-baseline`:
+
+| | Before | After | Δ |
+|---|---|---|---|
+| Precision | 0.668 | 0.659 | −0.9pp |
+| Recall | 0.459 | 0.581 | +12.2pp |
+| F1 | 0.544 | 0.618 | +7.4pp |
+
+The recall jump is the measurement-methodology shift from PR #150 landing: 82 `segment_type='chart'` gold rows stop counting as value-level FNs and instead route through presence P/R. `presence_f1` is still `None` in the baseline — the validator's in-memory pipeline run does not yet populate `v2_context.images[*].detected_metrics` end-to-end (the field is defined on the dataclass but not populated by the validator's `pipeline.process()` call path). Tracked separately.
+
+### Residual work (out of scope for PR 4b)
+
+- **30 residual chart facts + 18 reviewer decisions** on prod. Filed as a new known-issue fragment (`legacy-097`) for possible future handling.
+- **Validator presence_f1 measurement gap.** `detected_metrics` is populated at persistence time but not in the validator's in-memory pipeline result. Baseline presence-F1 stays `None` until this wiring lands. Filed separately.
 
 ### Cross-References
 
@@ -48,3 +79,4 @@ The chart-stage pivot for Issue #86 replaces per-value chart `v2_metric_facts` e
 - PR 4a plan: `~/.claude/plans/let-s-move-on-to-snoopy-flamingo.md`
 - Dissolved issues: legacy-086 (dedup collapse), legacy-035 (chart-fact backfill).
 - Reduced-severity reference: legacy-053 (chart call limit — now affects presence coverage only).
+- Residual work: legacy-097 (residual chart facts + reviewer decisions).

--- a/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
+++ b/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
@@ -1,0 +1,63 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: M
+id: 97
+note: 'Residual pre-pivot chart facts (30 rows across 10 filings) remain in
+  v2_metric_facts post-#86 because 18 reviewer decisions on those facts would
+  CASCADE-destroy on DELETE. Low blast radius — new UI does not read them,
+  validator bypasses them — but analytics views filtering on source_type=chart
+  still see them.'
+severity: low
+slug: residual-chart-facts-after-presence-pivot
+source: legacy
+status: open
+title: Residual Chart Facts Remain After Chart-Presence Pivot (Drain Deferred)
+touches: []
+updated: '2026-04-24'
+---
+
+### Problem
+
+The chart-presence pivot (Issue #86, merged across PRs #147/#150/#151/#154/#158) stops new chart-fact emission but PR 4b deliberately **did not drain** the existing rows. Pre-flight audit on 2026-04-24:
+
+| Metric | Count |
+|---|---|
+| Rows: `v2_metric_facts WHERE source_type='chart'` | 30 |
+| Distinct filings | 10 |
+| Reviewer decisions (`v2_review_decisions`) on chart facts | 18 |
+
+The 18 decisions break down as:
+
+| Decision | Count | Metrics |
+|---|---|---|
+| reject | 9 | cm_new_customers_acquired, cm_customers_period_end (bulk), cm_customers_period_end_by_tenure, cm_active_customers_total, cm_ltv_to_cac_ratio, cm_purchase_transactions_overall, cm_lifetime_value_per_customer, cm_customer_acquisition_cost |
+| accept | 5 | cm_revenue_by_cohort (×3), cm_large_customers_period_end, cm_customers_period_end |
+| correct | 4 | cm_average_order_value (×2), cm_monthly_active_users, cm_new_customers_acquired |
+
+17 are by reviewer `RGM`, 1 is a bulk-system entry (`bulk:superseded_slack_s1a_2019-05-20`).
+
+`v2_review_decisions.fact_id ON DELETE CASCADE` means a plain `DELETE FROM v2_metric_facts WHERE source_type='chart'` would silently destroy reviewer work. User chose to defer the drain (option B1 in the PR 4b exchange) to preserve those 18 pieces of work.
+
+### Impact (low)
+
+- **Review UI:** Chart Evidence block deleted in PR #151; detected-metrics card reads from `v2_image_assets.detected_metrics`, not `v2_metric_facts`. **No user-visible impact.**
+- **Validator:** PR #150 routes `segment_type='chart'` gold rows through presence P/R, not value-level P/R. Chart facts in `v2_metric_facts` are not considered when evaluating chart gold expectations. **No measurement impact.**
+- **Analytics views:** `v_analytics_*` views (sql/38, …) may include `source_type='chart'` rows in fact aggregates. If downstream reporting filters on source_type, the 30 residual rows will appear. Typical fix: add `AND source_type != 'chart'` at view level if unwanted. **Low impact, shimmable.**
+- **DB footprint:** 30 rows. Negligible.
+
+### Next Steps (if drain becomes needed later)
+
+Three paths, pick at triage time:
+
+1. **Archive decisions + DELETE.** Export the 18 `v2_review_decisions` rows (plus the 30 facts) to `data/audit/chart_fact_decisions_predrain_<ts>.json` for historical reference, then `DELETE FROM v2_metric_facts WHERE source_type='chart'` in a transaction. Reviewer work preserved as JSON, not queryable live.
+2. **Migrate accepts + corrects to `v2_image_metric_confirmations`.** For each chart fact with `source_locator.img_id` not null: derive a `(img_id, detected_metric_id=canonical_metric_id, decision)` row. Rejects have no natural img-level equivalent (the "this value is wrong" signal doesn't map cleanly to "this metric is not present"), so rejects would still be lost. Complex but preserves the most work as live signal.
+3. **Keep deferred.** No action; residual 30 rows are inert. Revisit only if analytics downstream actually needs them gone.
+
+### Cross-References
+
+- Parent rollout: legacy-096 (chart-presence pivot rollout, resolved).
+- Dissolved root cause: legacy-086 (dedup stage collapse).
+- Dissolved consequence: legacy-035 (pre-2026-04-17 chart-fact backfill).
+- Reviewed-filing guard: `src/extraction_v2/persistence.py::_persist_facts_in_tx`, `ReviewedFilingError`.
+- Cascade path: `v2_review_decisions.fact_id ON DELETE CASCADE` (sql/05 originally; `chart_only=True` guard in `persist_pipeline_result` refuses when decisions exist).

--- a/docs/known-issues/legacy-098-validator-presence-f1-not-populated.md
+++ b/docs/known-issues/legacy-098-validator-presence-f1-not-populated.md
@@ -1,0 +1,56 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: S
+id: 98
+note: 'PR #150 added the presence P/R/F1 infrastructure to the validator + baseline,
+  but presence_f1 is emitted as None because v2_context.images[*].detected_metrics
+  is not populated during the validator''s in-memory pipeline run. Baseline refresh
+  in PR 4b (2026-04-24) has presence_f1=null as a result.'
+severity: low
+slug: validator-presence-f1-not-populated
+source: legacy
+status: open
+title: Validator presence_f1 Stays Null — detected_metrics Not Populated in-Memory
+touches:
+  - src/gold_standard/v2_validator.py
+  - src/extraction_v2/stages/chart_fact_bridge.py
+updated: '2026-04-24'
+---
+
+### Problem
+
+The chart-presence pivot landed presence P/R/F1 infrastructure in PR #150:
+
+- `FilingResult.presence_tp / presence_fp / presence_fn` fields (`src/gold_standard/v2_validator.py`).
+- `BaselineMetrics.presence_f1` field (`src/gold_standard/baseline.py`).
+- `to_dict()` emits `presence_f1` only when `has_presence = (total_presence_tp + total_presence_fp + total_presence_fn) > 0` (`src/gold_standard/v2_validator.py:374`).
+
+After the PR 4b baseline refresh on 2026-04-24, `v2_baseline.json` has `presence_f1` **absent at all scopes** (overall and per-company). The pre-PR-4a baseline (2026-04-23) also lacked it. That means the validator has been silently computing zero presence TP/FP/FN for every run since PR #150 landed.
+
+Root cause (likely): the validator calls `V2Pipeline(...).process(..., document_date=...)` with `filing_id=0` (no persistence). The pipeline's chart bridge stage writes `image.detected_metrics` in-memory. But either:
+
+1. The chart bridge stage isn't firing because chart images aren't reaching it — e.g., vision calls skipped under test harness, `chart_data` never populated → classifier runs on empty input → no presence emitted.
+2. The validator accesses `v2_context.images` via a getter that doesn't surface the in-memory `detected_metrics` populated by the bridge.
+3. Something else in the `filing_id=0` mode skips the full image pipeline.
+
+Confirmed via grep: `_chart_presence_set_from_context` (`v2_validator.py` around the presence block) reads `v2_context.images[*].detected_metrics`. The validator does walk through that code path. But `presence_tp/fp/fn` stay 0.
+
+### Impact
+
+- Presence-F1 is unmeasurable via the GS pipeline right now. Chart-native metric improvements can't be quantified — the baseline has no floor to regress against.
+- The 30% cross-source confirmation gate (`_derive_chart_native_metrics`) still works (it's CSV-driven, not pipeline-driven), so metric-aware classification isn't affected.
+- Not a correctness issue; it's a measurement gap.
+
+### Next Steps
+
+1. Instrument `_chart_presence_set_from_context` to log `len(v2_context.images)` and how many have non-empty `detected_metrics`. Run against one filing with a known chart (e.g., Robinhood S-1 has chart images).
+2. If images reach the validator but `detected_metrics` is empty → inspect `ChartFactBridgeStage.process()` — did vision OCR fire? Did `classify_all` return anything? Check `chart_presence_min_score` threshold.
+3. If the images list is empty → the validator's pipeline run is skipping image-processing stages. Check `PipelineConfig` defaults used by the validator vs. the prod config.
+4. Fix whichever gap is real, re-run the baseline refresh, confirm `presence_f1` field appears.
+
+### Cross-References
+
+- Parent rollout: legacy-096.
+- Introducing PR: #150.
+- Baseline refresh PR (where this was surfaced): PR 4b.


### PR DESCRIPTION
## Summary

Completes the chart-presence pivot rollout for Issue #86. Ships the post-pivot gold-standard baseline. The planned prod drain was **deferred** after a pre-flight safety audit found 18 reviewer decisions on the 30 residual chart facts — CASCADE semantics would have silently destroyed that work.

## Baseline refresh

Ran \`python3 -m src.gold_standard.v2_validator --update-baseline --description "post-pivot presence-F1 baseline (#86 PR 4b); drain deferred due to 18 reviewer decisions on chart facts"\`.

| | Before (2026-04-23) | After (2026-04-24) | Δ |
|---|---|---|---|
| Precision | 0.668 | 0.659 | −0.9pp |
| Recall | 0.459 | **0.581** | **+12.2pp** |
| F1 | 0.544 | **0.618** | **+7.4pp** |
| presence_f1 | null | null | (unchanged) |

The recall jump is the measurement-methodology shift from PR #150: 82 \`segment_type='chart'\` gold rows stop counting as value-level FNs and instead route through presence P/R. \`presence_f1\` remains \`null\` — see legacy-098 for the wiring gap.

## Drain deferral (B1 — user decision)

Pre-flight queries on prod (read-only, authorized):

| Metric | Count |
|---|---|
| Chart facts (\`source_type='chart'\`) | 30 |
| Filings affected | 10 |
| **Reviewer decisions on chart facts** | **18** (9 reject / 5 accept / 4 correct) |

17 of 18 decisions are by reviewer \`RGM\`; 1 is a bulk-system entry. \`v2_review_decisions.fact_id ON DELETE CASCADE\` means a plain \`DELETE WHERE source_type='chart'\` would silently destroy that work.

User chose **B1 — defer drain**. Residual 30 rows are inert:
- Review UI doesn't surface them (Chart Evidence block deleted in PR #151).
- Validator bypasses them for chart gold (PR #150).
- Only impact: analytics views that filter on \`source_type='chart'\` still see them. Shim with \`AND source_type != 'chart'\` at the view level if needed.

## Known-issues

- \`legacy-096\` (chart-presence-pivot rollout tracking) — \`status: resolved\` with the full rollout summary, drain-deferral explanation, and baseline delta numbers. Closes the pivot program.
- \`legacy-097\` (new) — residual chart facts + 18 reviewer decisions. \`severity: low\`, \`status: open\`. Enumerates three future-drain paths (archive JSON + DELETE; migrate accepts/corrects to \`v2_image_metric_confirmations\`; keep deferred).
- \`legacy-098\` (new) — validator \`presence_f1\` measurement gap. PR #150 landed the infra but \`v2_context.images[*].detected_metrics\` isn't populated during the validator's in-memory pipeline run, so the field is always null. \`severity: low\`.

## Test plan

- [x] \`pytest -q tests/unit/scripts/test_known_issues_selector.py\` → 23 passed (validates the fragment frontmatter)
- [x] No code-file changes → lint + full test suite skipped per \`/commit\` rules
- [x] Pre-commit hooks (ruff/format/extraction guard/fragment frontmatter/rollup regen) all green

## Dependencies

- Depends on PR #158 (PR 4a — code + docs cleanup) — **merged 2026-04-24 at 01:58Z**.

## Follow-up

Neither follow-up is urgent:

- **legacy-097 drain:** reconsider if analytics downstream actually needs chart rows gone. Current low-impact assessment suggests "keep deferred" is fine indefinitely.
- **legacy-098 presence_f1 wiring:** needed to actually measure chart-presence recall improvements going forward. Would be a good next small task when chart-recall work resumes.

Parent plan: \`~/.claude/plans/pick-up-issue-86-tranquil-piglet.md\`
PR 4a/4b plan: \`~/.claude/plans/let-s-move-on-to-snoopy-flamingo.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)