### PR TITLE
feat(sweep): raise nightly cap to 5 issues and email full digest via PR body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Local guards (`.claude/settings.json`): `git push origin main`, `git push --forc
 
 See `docs/development/CONTRIBUTING.md` for the full flow.
 
-**Nightly autonomous sweeper:** `filings-nightly-sweep` cron runs 06:00 UTC daily, picks up to 3 eligible issues (autonomy `safe`, status `open` or `partially-resolved`) from `docs/known-issues/` fragment frontmatter (rollup `docs/KNOWN_ISSUES.md` is auto-generated — do NOT edit directly), auto-merges on green CI, and writes a morning-review digest to `.claude/sweep-digests/`. Ships paused via `.claude/sweep.pause`. See `docs/operations/nightly-sweep-runbook.md` and the `/sweep` skill for manual runs.
+**Nightly autonomous sweeper:** `filings-nightly-sweep` cron runs 06:00 UTC daily, picks up to 5 eligible issues (autonomy `safe`, status `open` or `partially-resolved`) from `docs/known-issues/` fragment frontmatter (rollup `docs/KNOWN_ISSUES.md` is auto-generated — do NOT edit directly), auto-merges on green CI, and writes a morning-review digest to `.claude/sweep-digests/`. Ships paused via `.claude/sweep.pause`. See `docs/operations/nightly-sweep-runbook.md` and the `/sweep` skill for manual runs.
 
 ## Key Commands
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,7 +7,7 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 31 |
+| Open | 32 |
 | Partially Resolved | 1 |
 | Archived | 46 |
 | Resolved | 16 |
@@ -51,6 +51,7 @@
 | #88 | skip | S | `scripts/apply_all_migrations.py` `.pre-commit-config.yaml` | Add a pre-commit hook that fails if any sql/NN_*.sql on disk lacks an entry in MIGRATION_ORDER or EXCLUDED_FILES. |
 | #94 | safe | S | `sql/31_drop_v1_review_tables.sql` `sql/` `src/web/middleware.py` |  |
 | #95 | review | M | `scripts/apply_migrations.py` `render.yaml` `src/web/app.py` `sql/` |  |
+| #97 | review | S | `scripts/run_nightly_sweep.sh` `scripts/write_sweep_digest.py` |  |
 
 
 ## Open Issues
@@ -428,6 +429,38 @@ Not reproducing on any other provider in `PROVIDER_CONFIGS`.
 - Until resolved, omit `gemini-pro` from the classify bake-off order
   (`BAKEOFF_PROVIDER_ORDER_METRIC_CLASSIFY`) — current ordering
   already excludes `two-stage` for a similar reason.
+
+## #97. Sweep digest labels safe-tier PRs "merged" before CI has actually merged them
+
+**Status**: Open
+**Severity**: medium
+**Discovered**: 2026-04-23
+**Updated**: 2026-04-23
+
+### Problem
+
+`scripts/run_nightly_sweep.sh:224-225` writes `outcome: "merged"` to the
+run-outcomes JSON the moment a safe-tier PR URL is captured from the Claude
+session log — *before* `gh pr merge --auto --squash` has actually landed the
+PR. Auto-merge then waits for CI; if any required check fails, the PR stays
+open indefinitely.
+
+The digest (`scripts/write_sweep_digest.py`) renders those entries under
+"Auto-merged", which the runbook describes as "safe-tier PRs already in
+flight to main (CI gates still enforced)". So the daily notification
+email (now containing the full digest body, per the 2026-04-23 change)
+can show "5 merged" when only 3 actually merged and 2 are stuck on red
+CI. The user has to cross-check with `gh pr list` to discover the gap.
+
+### Next Steps
+
+1. Before writing the digest, poll `gh pr view <num> --json state,mergeStateStatus`
+   for each "merged"-labeled outcome and re-classify any that are still `OPEN`.
+2. Decide whether to keep "merged" for true merges only and introduce a new
+   `awaiting_ci` / `stuck` outcome for PRs that opened but didn't land, or to
+   rename the existing category to `opened` and derive "merged" at digest time.
+3. Update the digest writer's section headers to match whichever taxonomy is
+   chosen so the morning email is accurate.
 
 ## #4. Spelled-Out Number Parsing Limitations
 

--- a/docs/known-issues/legacy-097-sweep-digest-merged-label-before-ci.md
+++ b/docs/known-issues/legacy-097-sweep-digest-merged-label-before-ci.md
@@ -1,0 +1,40 @@
+---
+autonomy: review
+discovered: '2026-04-23'
+estimated: S
+id: 97
+severity: medium
+slug: sweep-digest-merged-label-before-ci
+source: legacy
+status: open
+title: Sweep digest labels safe-tier PRs "merged" before CI has actually merged them
+touches:
+  - scripts/run_nightly_sweep.sh
+  - scripts/write_sweep_digest.py
+updated: '2026-04-23'
+---
+
+### Problem
+
+`scripts/run_nightly_sweep.sh:224-225` writes `outcome: "merged"` to the
+run-outcomes JSON the moment a safe-tier PR URL is captured from the Claude
+session log — *before* `gh pr merge --auto --squash` has actually landed the
+PR. Auto-merge then waits for CI; if any required check fails, the PR stays
+open indefinitely.
+
+The digest (`scripts/write_sweep_digest.py`) renders those entries under
+"Auto-merged", which the runbook describes as "safe-tier PRs already in
+flight to main (CI gates still enforced)". So the daily notification
+email (now containing the full digest body, per the 2026-04-23 change)
+can show "5 merged" when only 3 actually merged and 2 are stuck on red
+CI. The user has to cross-check with `gh pr list` to discover the gap.
+
+### Next Steps
+
+1. Before writing the digest, poll `gh pr view <num> --json state,mergeStateStatus`
+   for each "merged"-labeled outcome and re-classify any that are still `OPEN`.
+2. Decide whether to keep "merged" for true merges only and introduce a new
+   `awaiting_ci` / `stuck` outcome for PRs that opened but didn't land, or to
+   rename the existing category to `opened` and derive "merged" at digest time.
+3. Update the digest writer's section headers to match whichever taxonomy is
+   chosen so the morning email is accurate.

--- a/docs/operations/nightly-sweep-runbook.md
+++ b/docs/operations/nightly-sweep-runbook.md
@@ -5,7 +5,7 @@
 Every night at 02:00 EDT (06:00 UTC), the `filings-nightly-sweep` Render cron service:
 
 1. Reads fragment frontmatter from `docs/known-issues/` to find eligible issues (autonomy `safe` or `review`, status `open` or `partially-resolved`).
-2. Picks up to 3 non-colliding issues tagged `Autonomy: safe` (default) or `review` (opt-in).
+2. Picks up to 5 non-colliding issues tagged `Autonomy: safe` (default) or `review` (opt-in).
 3. For each pick, creates an isolated git worktree and runs a Claude Code session that:
    - Reads the issue body.
    - Implements exactly what the "Next Steps" section asks.
@@ -77,9 +77,9 @@ Configurable via Render env vars on the `filings-nightly-sweep` service (default
 
 | Env var | Default | Meaning |
 |---|---|---|
-| `SWEEP_MAX` | `3` | Max issues per run |
+| `SWEEP_MAX` | `5` | Max issues per run |
 | `SWEEP_INCLUDE_REVIEW` | `0` | If `1`, include `review` issues in selection |
-| `SWEEP_WALL_BUDGET` | `2700` s | Total wall-clock cap for a run (45 min) |
+| `SWEEP_WALL_BUDGET` | `4500` s | Total wall-clock cap for a run (75 min — 5 issues × 15 min) |
 | `SWEEP_PER_ISSUE` | `900` s | Per-issue wall-clock cap (15 min) |
 
 ## Guardrails

--- a/render.yaml
+++ b/render.yaml
@@ -83,11 +83,11 @@ services:
       - fromGroup: filings-claude-secrets
       # Sweeper budgets (override defaults from run_nightly_sweep.sh).
       - key: SWEEP_MAX
-        value: "3"
+        value: "5"
       - key: SWEEP_INCLUDE_REVIEW
         value: "0"  # safe-only by default; flip to 1 to allow review-tier holds
       - key: SWEEP_WALL_BUDGET
-        value: "2700"  # 45 minutes total
+        value: "4500"  # 75 minutes total (5 issues x 15 min each)
       - key: SWEEP_PER_ISSUE
         value: "900"   # 15 minutes per issue
 

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -283,7 +283,13 @@ if [[ -f "$DIGEST_PATH" ]]; then
     git add "$DIGEST_PATH"
     git commit -m "docs(sweep-digest): nightly digest for $DATE" --quiet || true
     if git push -u origin "$DIGEST_BRANCH" --quiet; then
-      gh pr create --fill >/dev/null || log "digest PR create failed (may already exist)"
+      # Put the full digest in the PR body so GitHub's "PR opened" notification
+      # email carries the merged / awaiting / abandoned summary directly.
+      # Requires repo notification setting "All Activity" (not @mentions only).
+      gh pr create \
+        --title "docs(sweep-digest): nightly digest for $DATE" \
+        --body-file "$DIGEST_PATH" >/dev/null \
+        || log "digest PR create failed (may already exist)"
       gh pr merge --auto --squash >/dev/null || log "digest auto-merge enable failed"
     else
       log "digest push failed — leaving branch local"


### PR DESCRIPTION
## Summary
- `SWEEP_MAX` 3 → 5 on the `filings-nightly-sweep` Render cron; `SWEEP_WALL_BUDGET` 2700 → 4500s so the 5 × 15-min per-issue math stays intact.
- `scripts/run_nightly_sweep.sh` opens the digest PR with `--body-file "$DIGEST_PATH"` instead of `--fill`, so GitHub's "PR opened" notification email carries the merged / awaiting / abandoned summary as the body.
- Runbook + `CLAUDE.md` sweeper paragraph updated to match new defaults.
- Logs follow-up #97 (`docs/known-issues/legacy-097-*`): digest currently labels safe-tier PRs "merged" the moment the PR URL is captured, *before* auto-merge + CI have actually landed them. Needs a post-hoc `gh pr view` re-check before writing the digest — tracked separately because it's a cross-script judgment call about outcome taxonomy.

## Test plan
- [ ] Confirm GitHub notification settings for this repo are "All Activity" (otherwise the PR-body email never arrives).
- [ ] On the next nightly run, verify the PR opened by `claude/sweep-digest/<date>` has the full digest body (not just the commit subject) and that the notification email carries it.
- [ ] Verify `SWEEP_WALL_BUDGET=4500` is applied on the Render `filings-nightly-sweep` service after blueprint sync.
- [ ] Spot-check that a 5-issue run doesn't abandon picks 4 or 5 with "wall budget exceeded before start".

🤖 Generated with [Claude Code](https://claude.com/claude-code)