### PR TITLE
fix(sweep): auto-resolve DIRTY PR branches after enabling auto-merge

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -143,7 +143,14 @@
 
 16. **Enable auto-merge.** `gh pr merge --auto --squash` (idempotent — no-op if already enabled). `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
 
-17. **Report.** Final one-line summary to the user:
+17. **Conflict guard.** After enabling auto-merge, wait 5 seconds for GitHub to compute merge status, then check:
+    ```
+    gh pr view --json mergeable,mergeStateStatus
+    ```
+    - If `mergeStateStatus` is `DIRTY`: run `gh pr update-branch` (merges `main` into the PR branch). If it exits non-zero (real content conflict), warn: "Branch is DIRTY and update-branch failed — manual conflict resolution required."
+    - Any other status (`BLOCKED`, `CLEAN`, `UNKNOWN`): no action.
+
+18. **Report.** Final one-line summary to the user:
     ```
     PR #<n> opened/updated: <url>. Auto-merge enabled (squash). Waits on: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright). Run /ci-fix if checks go red.
     ```

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -291,6 +291,18 @@ if [[ -f "$DIGEST_PATH" ]]; then
         --body-file "$DIGEST_PATH" >/dev/null \
         || log "digest PR create failed (may already exist)"
       gh pr merge --auto --squash >/dev/null || log "digest auto-merge enable failed"
+      # If main advanced while the sweep was running, the digest branch may be
+      # DIRTY before CI even starts. Poll once and merge main in to unblock.
+      sleep 5
+      _DIGEST_PR_NUM="$(gh pr view --head "$DIGEST_BRANCH" --json number --jq '.number' 2>/dev/null || echo "")"
+      if [[ -n "$_DIGEST_PR_NUM" ]]; then
+        _DIGEST_MERGE_STATUS="$(gh pr view "$_DIGEST_PR_NUM" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "UNKNOWN")"
+        if [[ "$_DIGEST_MERGE_STATUS" == "DIRTY" ]]; then
+          log "Digest PR #$_DIGEST_PR_NUM is DIRTY — merging main in via update-branch."
+          gh pr update-branch "$_DIGEST_PR_NUM" >/dev/null 2>&1 \
+            || log "digest PR update-branch failed — manual resolution required"
+        fi
+      fi
     else
       log "digest push failed — leaving branch local"
     fi


### PR DESCRIPTION
## Summary

- After `gh pr merge --auto --squash`, poll GitHub for `mergeStateStatus` and call `gh pr update-branch` if `DIRTY`. Covers two call sites:
  - `/commit` skill step 17 (new) — for all issue PRs opened by the sweep or manually
  - Digest PR block in `scripts/run_nightly_sweep.sh` — for the nightly digest PR
- Handles the common case where `main` advances between branch push and CI start (another PR lands in that window). Logs a warning if `update-branch` fails due to a real content conflict (requires human resolution).

Fixes the recurring pattern where CI is green but auto-merge stalls because the branch is behind `main`.

## Test plan

- [ ] Verify `/commit` skill step numbering is correct (old 17→18, new 17 added between 16 and 18)
- [ ] Verify sweep script bash syntax: `bash -n scripts/run_nightly_sweep.sh`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)