### PR TITLE
fix(known-issues): check origin/main for highest fragment ID to prevent collisions

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -87,7 +87,7 @@
    **9e. Act.** "approve"/"all"/silent → file all `TO FILE`. "none"/"skip" → file nothing. Anything else → apply user edits, confirm revised list, file.
 
    **9f. Write fragment files.** For each item:
-   - Find the highest existing id: `ls docs/known-issues/legacy-*.md docs/known-issues/gh-*.md 2>/dev/null | grep -oE '(legacy|gh)-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1`. Next id = that + 1.
+   - Find the highest existing id: `{ ls docs/known-issues/legacy-*.md docs/known-issues/gh-*.md 2>/dev/null; git ls-tree --name-only origin/main docs/known-issues/ 2>/dev/null; } | grep -oE '(legacy|gh)-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1`. Next id = that + 1. (Union of local files and `origin/main` prevents collisions when multiple branches are in flight.)
    - Create `docs/known-issues/legacy-NNN-<kebab-slug>.md` with this exact structure:
      ```yaml
      ---


### PR DESCRIPTION
## Summary

- The `/commit` skill's step 9f computed the next known-issue ID by scanning only local worktree files. When multiple branches were created from the same `main` tip (max id `#96`), each independently assigned `#97`, causing merge conflicts on every PR.
- Fix: union local files with `git ls-tree --name-only origin/main docs/known-issues/` so the ID scan always sees what's already taken on `main`, even from a fresh worktree.

## Test plan

- [ ] CI green
- [ ] Next PR that files a known-issue picks an ID higher than the current `origin/main` max

🤖 Generated with [Claude Code](https://claude.com/claude-code)