### PR TITLE
test(extraction-v2): regression guard for chart cohort dedup collapse (#86)

### DIFF
--- a/tests/unit/extraction_v2/test_deduplication.py
+++ b/tests/unit/extraction_v2/test_deduplication.py
@@ -1005,10 +1005,18 @@ class TestGroupingPerformance:
 
         facts = [
             make_fact(fact_id="f1", metric_id="cm_average_order_value", value=100.0),
-            make_fact(fact_id="f2", metric_id="cm_average_order_value", value=101.0),  # Within tolerance
-            make_fact(fact_id="f3", metric_id="cm_average_order_value", value=200.0),  # Different value
-            make_fact(fact_id="f4", metric_id="cm_lifetime_value_per_customer", value=100.0),  # Different metric
-            make_fact(fact_id="f5", metric_id="cm_lifetime_value_per_customer", value=100.0),  # Duplicate of f4
+            make_fact(
+                fact_id="f2", metric_id="cm_average_order_value", value=101.0
+            ),  # Within tolerance
+            make_fact(
+                fact_id="f3", metric_id="cm_average_order_value", value=200.0
+            ),  # Different value
+            make_fact(
+                fact_id="f4", metric_id="cm_lifetime_value_per_customer", value=100.0
+            ),  # Different metric
+            make_fact(
+                fact_id="f5", metric_id="cm_lifetime_value_per_customer", value=100.0
+            ),  # Duplicate of f4
         ]
 
         groups = stage._group_duplicates(facts, tolerance=0.02)
@@ -1426,3 +1434,31 @@ class TestAnnotateCrossSourceConfirmation:
         assert sorted(table_fact.confirming_source_types) == ["chart", "text"]
         assert sorted(text_fact.confirming_source_types) == ["chart", "html_table"]
         assert sorted(chart_fact.confirming_source_types) == ["html_table", "text"]
+
+
+class TestChartCohortCollapseRegression:
+    """Guard: chart cohort bars with distinct cohort_def must all survive dedup (#86)."""
+
+    def test_chart_cohort_bars_all_survive(self) -> None:
+        stage = DeduplicationStage()
+
+        bar_values = [17.0, 62.0, 44.0, 56.0, 87.0, 45.0, 130.0, 186.0, 175.0]
+        facts = [
+            make_fact(
+                fact_id=f"bar-{i}",
+                metric_id="cm_revenue_by_cohort",
+                value=bar_values[i],
+                unit=Unit.CURRENCY,
+                source_type=SourceType.CHART,
+                period_start=date(2020, 1, 1),
+                period_end=date(2020, 12, 31),
+                scope=Scope.COMPANY,
+                cohort_def=f"bar/{i}",
+            )
+            for i in range(9)
+        ]
+
+        context = MockPipelineContext(facts=facts)
+        stage.process(context)
+
+        assert len(context.deduplicated_facts) == 9


### PR DESCRIPTION
## Summary

- Adds `TestChartCohortCollapseRegression` to `tests/unit/extraction_v2/test_deduplication.py`
- Guards the dedup stage contract: 9 chart-sourced `cm_revenue_by_cohort` facts with distinct `cohort_def` values must all survive all three dedup passes as separate facts
- Uses the exact HOOD bar values (17, 62, 44, 56, 87, 45, 130, 186, 175) that were previously collapsed as `DEDUP_COLLISION` false negatives

## Background

Issue #86 (dedup stage collapsing chart cohort bars) was resolved by the chart-presence pivot (PRs #147/#150/#151/#154/#158/#160, 2026-04-23) — the pipeline no longer emits per-value chart facts. This test locks the dedup stage's behavior for the case where cohort facts with distinct `cohort_def` values reach it, ensuring the stage contract doesn't regress if chart value emission is ever re-introduced.

## Test plan

- [x] `pytest tests/unit/extraction_v2/test_deduplication.py -x -q` — 58 passed
- [x] `pytest -x -q --ignore=tests/integration` — 3932 passed, 11 skipped
- [x] `ruff check` + `ruff format` — clean
- [x] Pre-push hook (unit tests) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)