### PR TITLE
fix(pre-commit): trigger rollup regeneration when KNOWN_ISSUES.md itself is staged

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,8 @@ repos:
         files: ^sql/.*\.sql$
 
       # Pre-commit: validate and regenerate the KNOWN_ISSUES.md rollup whenever
-      # a fragment under docs/known-issues/ is staged.  Validate runs first so
+      # a fragment under docs/known-issues/ is staged OR the rollup itself is
+      # staged (e.g. during a merge conflict resolution).  Validate runs first so
       # we never regenerate from invalid input.  The regenerator's --stage flag
       # auto-adds the rollup to the commit, so developers don't need to stage it
       # manually.  The rollup is byte-deterministic, so the hook never loops.
@@ -74,7 +75,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
-        files: '^docs/known-issues/.*\.md$'
+        files: '^(docs/known-issues/.*|docs/KNOWN_ISSUES)\.md$'
 
       - id: migration-order-check
         name: Migration order completeness

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,10 +7,10 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 31 |
+| Open | 30 |
 | Partially Resolved | 1 |
 | Archived | 45 |
-| Resolved | 20 |
+| Resolved | 21 |
 
 
 ## Nightly Sweeper Classification


### PR DESCRIPTION
## Summary

- The \`known-issues-rollup\` hook's \`files\` filter matched only \`docs/known-issues/*.md\`, so it never fired during merge conflict resolution (where only \`docs/KNOWN_ISSUES.md\` is staged, not any fragment file).
- Result: merge commits resolving a \`KNOWN_ISSUES.md\` conflict would commit the raw conflict markers, requiring a manual fixup commit.
- Fix: broaden filter to \`'^(docs/known-issues/.*|docs/KNOWN_ISSUES)\.md$'\` so the hook regenerates and re-stages a clean rollup in both cases.

## Test plan

- [ ] CI green
- [ ] Next merge that conflicts on \`KNOWN_ISSUES.md\` should commit cleanly without a fixup

🤖 Generated with [Claude Code](https://claude.com/claude-code)