### PR TITLE
feat(ops): auto-resolve fragments when pr_refs all merge (#84)

### DIFF
--- a/docs/operations/nightly-sweep-runbook.md
+++ b/docs/operations/nightly-sweep-runbook.md
@@ -4,17 +4,18 @@
 
 Every night at 02:00 EDT (06:00 UTC), the `filings-nightly-sweep` Render cron service:
 
-1. Reads fragment frontmatter from `docs/known-issues/` to find eligible issues (autonomy `safe` or `review`, status `open` or `partially-resolved`).
-2. Picks up to 5 non-colliding issues tagged `Autonomy: safe` (default) or `review` (opt-in).
-3. For each pick, creates an isolated git worktree and runs a Claude Code session that:
+1. **Status sync** (pre-selector): runs `scripts/sync_known_issue_status.py`, which reads the `pr_refs` list from each fragment's frontmatter and calls `gh pr view` for every referenced PR. Any fragment whose listed PRs are all in `MERGED` state is rewritten in-place: `status` becomes `resolved`, `autonomy` becomes `n/a`, and `updated` is set to today's date. The rollup `docs/KNOWN_ISSUES.md` is regenerated automatically. To opt a fragment out of auto-resolution, leave its `pr_refs` field empty or absent. If `gh` is temporarily unavailable, individual fragment lookups fail silently and those fragments are skipped — the sync failure does not abort the sweep.
+2. Reads fragment frontmatter from `docs/known-issues/` to find eligible issues (autonomy `safe` or `review`, status `open` or `partially-resolved`).
+3. Picks up to 5 non-colliding issues tagged `Autonomy: safe` (default) or `review` (opt-in).
+4. For each pick, creates an isolated git worktree and runs a Claude Code session that:
    - Reads the issue body.
    - Implements exactly what the "Next Steps" section asks.
    - Runs the `/commit` skill — which gates lint/tests/doc-freshness, opens a PR, enables auto-merge.
-4. Writes `.claude/sweep-digests/YYYY-MM-DD.md` summarising:
+5. Writes `.claude/sweep-digests/YYYY-MM-DD.md` summarising:
    - **Auto-merged** — safe-tier PRs already in flight to main (CI gates still enforced).
    - **Awaiting your approval** — review-tier draft PRs with one-line approve/discard commands.
    - **Abandoned** — issues the sweeper tried but gave up on, with the reason.
-5. Opens a PR for the digest file.
+6. Opens a PR for the digest file.
 
 The source of truth for which issues the sweeper may touch is the `autonomy:` field in each fragment's YAML frontmatter under `docs/known-issues/`. `docs/KNOWN_ISSUES.md` is auto-generated from those fragments — do NOT edit it directly.
 

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -123,6 +123,11 @@ else
   git reset --hard origin/main --quiet
 fi
 
+# --- 2b. Sync fragment status from merged PRs ---
+log "Syncing fragment status from merged pr_refs..."
+python3 scripts/sync_known_issue_status.py --verbose \
+  || log "WARNING: sync_known_issue_status.py failed (exit $?) — continuing anyway"
+
 # --- 3. Selector ---
 INCLUDE_REVIEW_FLAG=""
 [[ "$INCLUDE_REVIEW" == "1" ]] && INCLUDE_REVIEW_FLAG="--include-review"

--- a/scripts/sync_known_issue_status.py
+++ b/scripts/sync_known_issue_status.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Sync known-issue fragment status from GitHub PR state.
+
+For each fragment whose pr_refs are all MERGED, rewrites the frontmatter
+in-place: status -> resolved, autonomy -> n/a, updated -> today.
+
+Usage:
+    python3 scripts/sync_known_issue_status.py [--dry-run] [--fragments-dir PATH] [--verbose]
+
+Exit codes:
+    0 — success (including 0 updates)
+    1 — catastrophic failure (fragments dir not found, gh not installed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FRAGMENTS_DIR = REPO_ROOT / "docs" / "known-issues"
+
+
+def _load_validate_module() -> Any:
+    """Load validate_known_issues_fragments without requiring __init__.py."""
+    script_dir = Path(__file__).resolve().parent
+    module_path = script_dir / "validate_known_issues_fragments.py"
+    spec = importlib.util.spec_from_file_location("validate_known_issues_fragments", module_path)
+    assert spec is not None and spec.loader is not None, f"Could not load {module_path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["validate_known_issues_fragments"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _normalize_ref(raw: Any) -> int | None:
+    """Return a PR number int from int, '#N', or 'N' string. None on malformed."""
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        s = raw.lstrip("#").strip()
+        if s.isdigit():
+            return int(s)
+    return None
+
+
+def _gh_pr_state(ref: int, cache: dict[int, str | None], verbose: bool) -> str | None:
+    """Return 'MERGED', 'OPEN', 'CLOSED', etc., or None on failure. Caches results."""
+    if ref in cache:
+        return cache[ref]
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(ref), "--json", "state", "-q", ".state"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            if verbose:
+                print(
+                    f"  [warn] gh pr view {ref} failed (exit {result.returncode}): "
+                    f"{result.stderr.strip()}",
+                    file=sys.stderr,
+                )
+            cache[ref] = None
+            return None
+        state = result.stdout.strip()
+        if verbose:
+            print(f"  [gh]   PR #{ref} -> {state}")
+        cache[ref] = state
+        return state
+    except FileNotFoundError:
+        print("FATAL: 'gh' is not installed or not on PATH", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        if verbose:
+            print(f"  [warn] gh pr view {ref} timed out", file=sys.stderr)
+        cache[ref] = None
+        return None
+
+
+def _rewrite_frontmatter(path: Path, today: str, verbose: bool) -> None:
+    """Rewrite status, autonomy, and updated in the fragment's YAML frontmatter."""
+    text = path.read_text(encoding="utf-8")
+
+    # Split into frontmatter + rest.
+    if not text.startswith("---\n"):
+        raise ValueError(f"{path}: no opening frontmatter fence")
+    rest = text[4:]
+    close_idx = rest.find("\n---\n")
+    if close_idx == -1:
+        raise ValueError(f"{path}: no closing frontmatter fence")
+
+    fm_text = rest[:close_idx]
+    body_part = rest[close_idx:]  # includes "\n---\n..."
+
+    def _set_field(block: str, key: str, value: str) -> tuple[str, bool]:
+        """Replace an existing `key: <anything>` line; return (new_block, replaced)."""
+        pattern = re.compile(r"^" + re.escape(key) + r":.*$", re.MULTILINE)
+        new_block, count = pattern.subn(f"{key}: {value}", block)
+        return new_block, count > 0
+
+    fm_text, replaced_status = _set_field(fm_text, "status", "resolved")
+    if not replaced_status:
+        # Insert after first line
+        lines = fm_text.splitlines()
+        lines.insert(1, "status: resolved")
+        fm_text = "\n".join(lines)
+
+    fm_text, replaced_autonomy = _set_field(fm_text, "autonomy", "n/a")
+    if not replaced_autonomy:
+        lines = fm_text.splitlines()
+        lines.insert(1, "autonomy: n/a")
+        fm_text = "\n".join(lines)
+
+    fm_text, replaced_updated = _set_field(fm_text, "updated", f"'{today}'")
+    if not replaced_updated:
+        lines = fm_text.splitlines()
+        lines.insert(1, f"updated: '{today}'")
+        fm_text = "\n".join(lines)
+
+    new_text = "---\n" + fm_text + body_part
+    path.write_text(new_text, encoding="utf-8")
+
+    if verbose:
+        print(f"  [write] {path.name}: status=resolved, autonomy=n/a, updated={today}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Log changes but do not write")
+    parser.add_argument(
+        "--fragments-dir",
+        type=Path,
+        default=DEFAULT_FRAGMENTS_DIR,
+        help="Directory containing fragment files (default: docs/known-issues/)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+    args = parser.parse_args(argv)
+
+    if not args.fragments_dir.exists():
+        print(f"FATAL: fragments directory not found: {args.fragments_dir}", file=sys.stderr)
+        return 1
+
+    validate_mod = _load_validate_module()
+    try:
+        fragments = validate_mod.load_all_fragments(args.fragments_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 1
+
+    today = datetime.date.today().isoformat()
+    pr_state_cache: dict[int, str | None] = {}
+    inactive_statuses = frozenset({"resolved", "archived"})
+
+    n_scanned = 0
+    n_updates = 0
+    n_skipped_pending = 0
+    n_failures = 0
+
+    for fragment in fragments:
+        n_scanned += 1
+        fm = fragment.frontmatter
+        current_status = str(fm.get("status", ""))
+        if current_status in inactive_statuses:
+            if args.verbose:
+                print(f"[skip]   {fragment.path.name}: already {current_status}")
+            continue
+
+        raw_refs = fm.get("pr_refs")
+        if not raw_refs or not isinstance(raw_refs, list) or len(raw_refs) == 0:
+            if args.verbose:
+                print(f"[skip]   {fragment.path.name}: no pr_refs")
+            continue
+
+        # Normalize refs
+        refs: list[int] = []
+        malformed = False
+        for raw in raw_refs:
+            ref = _normalize_ref(raw)
+            if ref is None:
+                print(
+                    f"[warn]   {fragment.path.name}: malformed pr_ref {raw!r} — skipping fragment",
+                    file=sys.stderr,
+                )
+                malformed = True
+                break
+            refs.append(ref)
+        if malformed:
+            n_failures += 1
+            continue
+
+        # Query GitHub for each ref
+        all_merged = True
+        gh_failed = False
+        for ref in refs:
+            state = _gh_pr_state(ref, pr_state_cache, args.verbose)
+            if state is None:
+                if args.verbose:
+                    print(
+                        f"[skip]   {fragment.path.name}: gh lookup failed for PR #{ref}",
+                        file=sys.stderr,
+                    )
+                gh_failed = True
+                break
+            if state != "MERGED":
+                all_merged = False
+                if args.verbose:
+                    print(f"[pending] {fragment.path.name}: PR #{ref} is {state} (not MERGED)")
+                break
+
+        if gh_failed:
+            n_failures += 1
+            continue
+
+        if not all_merged:
+            n_skipped_pending += 1
+            continue
+
+        # All refs are MERGED — update the fragment
+        if args.dry_run:
+            print(
+                f"[dry-run] {fragment.path.name}: would set status=resolved, "
+                f"autonomy=n/a, updated={today}"
+            )
+            n_updates += 1
+        else:
+            try:
+                _rewrite_frontmatter(fragment.path, today, args.verbose)
+                print(f"[updated] {fragment.path.name}: status=resolved")
+                n_updates += 1
+            except (ValueError, OSError) as exc:
+                print(f"[error]   {fragment.path.name}: rewrite failed: {exc}", file=sys.stderr)
+                n_failures += 1
+
+    print(
+        f"Scanned {n_scanned} fragments, {n_updates} updates "
+        f"(dry_run={args.dry_run}), {n_skipped_pending} skipped (pending PRs), "
+        f"{n_failures} failures."
+    )
+
+    # Regenerate rollup if any updates happened and not dry-run
+    if n_updates > 0 and not args.dry_run:
+        regen_script = Path(__file__).resolve().parent / "regenerate_known_issues.py"
+        result = subprocess.run(
+            ["python3", str(regen_script)],
+            capture_output=False,
+        )
+        if result.returncode != 0:
+            print(
+                f"[error] regenerate_known_issues.py exited {result.returncode}",
+                file=sys.stderr,
+            )
+            return result.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_sync_known_issue_status.py
+++ b/tests/unit/scripts/test_sync_known_issue_status.py
@@ -1,0 +1,335 @@
+"""Unit tests for scripts/sync_known_issue_status.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "sync_known_issue_status.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("sync_known_issue_status", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sync_known_issue_status"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_mod = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_fragment(tmp_path: Path, filename: str, frontmatter: dict[str, Any]) -> Path:
+    """Write a minimal valid fragment file to tmp_path."""
+    fm_str = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True, sort_keys=True)
+    content = f"---\n{fm_str}---\n\nBody text here.\n"
+    p = tmp_path / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _base_fm(
+    id: int,
+    slug: str,
+    status: str = "open",
+    autonomy: str = "safe",
+    pr_refs: list[int] | None = None,
+) -> dict[str, Any]:
+    fm: dict[str, Any] = {
+        "id": id,
+        "source": "legacy",
+        "slug": slug,
+        "title": f"Issue {id}",
+        "status": status,
+        "severity": "low",
+        "autonomy": autonomy,
+        "estimated": "XS",
+        "touches": ["src/foo.py"],
+        "discovered": "2026-01-01",
+        "updated": "2026-01-01",
+        "note": f"test issue {id}",
+    }
+    if pr_refs is not None:
+        fm["pr_refs"] = pr_refs
+    return fm
+
+
+def _make_gh_mock(state_by_ref: dict[int, str]) -> Any:
+    """Return a mock for subprocess.run that simulates gh pr view responses."""
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        # cmd looks like: ['gh', 'pr', 'view', '<ref>', '--json', 'state', '-q', '.state']
+        ref_idx = cmd.index("view") + 1 if "view" in cmd else None
+        if ref_idx is not None:
+            ref = int(cmd[ref_idx])
+            if ref in state_by_ref:
+                result.returncode = 0
+                result.stdout = state_by_ref[ref] + "\n"
+                result.stderr = ""
+            else:
+                result.returncode = 1
+                result.stdout = ""
+                result.stderr = "could not find PR"
+        else:
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+        return result
+
+    return _fake_run
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRef:
+    def test_int(self) -> None:
+        assert _mod._normalize_ref(107) == 107
+
+    def test_string_with_hash(self) -> None:
+        assert _mod._normalize_ref("#107") == 107
+
+    def test_string_bare(self) -> None:
+        assert _mod._normalize_ref("107") == 107
+
+    def test_malformed_string(self) -> None:
+        assert _mod._normalize_ref("abc") is None
+
+    def test_none(self) -> None:
+        assert _mod._normalize_ref(None) is None
+
+
+class TestMainAllMerged:
+    """Fragment (a): all pr_refs MERGED — should be updated."""
+
+    def test_updates_fragment(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-001-all-merged.md",
+            _base_fm(1, "all-merged", pr_refs=[101, 102]),
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            _make_gh_mock({101: "MERGED", 102: "MERGED"}),
+        )
+        # no-op the regenerator subprocess call
+        _regen_calls: list[list[str]] = []
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            if "regenerate_known_issues" in " ".join(str(c) for c in cmd):
+                _regen_calls.append(cmd)
+                result = MagicMock()
+                result.returncode = 0
+                return result
+            return _make_gh_mock({101: "MERGED", 102: "MERGED"})(cmd, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        text = (tmp_path / "legacy-001-all-merged.md").read_text()
+        fm_block = text.split("---")[1]
+        fm = yaml.safe_load(fm_block)
+        assert fm["status"] == "resolved"
+        assert fm["autonomy"] == "n/a"
+        # updated should be today's ISO date
+        import datetime
+
+        assert fm["updated"] == datetime.date.today().isoformat()
+        # Body preserved
+        assert "Body text here." in text
+
+
+class TestMainMixedState:
+    """Fragment (b): one PR not MERGED — should NOT be updated."""
+
+    def test_does_not_update(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-002-mixed.md",
+            _base_fm(2, "mixed", pr_refs=[201, 202]),
+        )
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            if "regenerate_known_issues" in " ".join(str(c) for c in cmd):
+                r = MagicMock()
+                r.returncode = 0
+                return r
+            return _make_gh_mock({201: "MERGED", 202: "OPEN"})(cmd, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        text = (tmp_path / "legacy-002-mixed.md").read_text()
+        fm = yaml.safe_load(text.split("---")[1])
+        assert fm["status"] == "open"  # unchanged
+
+
+class TestMainNoPrRefs:
+    """Fragment (c): no pr_refs — should be ignored."""
+
+    def test_ignored(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-003-no-refs.md",
+            _base_fm(3, "no-refs"),  # no pr_refs key
+        )
+
+        gh_called = []
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            gh_called.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        # gh should not be called at all for fragments without pr_refs
+        gh_cmds = [c for c in gh_called if "gh" in " ".join(str(x) for x in c)]
+        assert len(gh_cmds) == 0
+
+
+class TestDryRun:
+    """--dry-run must not mutate files."""
+
+    def test_no_write_on_dry_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-001-all-merged.md",
+            _base_fm(1, "all-merged", pr_refs=[101]),
+        )
+        original_text = (tmp_path / "legacy-001-all-merged.md").read_text()
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            return _make_gh_mock({101: "MERGED"})(cmd, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--dry-run", "--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        assert (tmp_path / "legacy-001-all-merged.md").read_text() == original_text
+
+
+class TestMalformedPrRefs:
+    """Malformed pr_refs entries are skipped with a warning, not a crash."""
+
+    def test_skips_with_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # pr_refs with a bad entry — write raw YAML manually
+        content = "---\nautonomy: safe\ndiscovered: '2026-01-01'\nestimated: XS\nid: 1\nnote: test\npr_refs:\n- not-a-number\nseverity: low\nslug: malformed\nsource: legacy\nstatus: open\ntitle: Issue 1\ntouches:\n- src/foo.py\nupdated: '2026-01-01'\n---\n\nBody.\n"
+        (tmp_path / "legacy-001-malformed.md").write_text(content)
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        # Should not raise
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        assert "malformed" in captured.err.lower() or "malformed" in captured.out.lower()
+        # File should be unchanged
+        assert "status: open" in (tmp_path / "legacy-001-malformed.md").read_text()
+
+
+class TestAlreadyResolved:
+    """Already-resolved fragments are skipped."""
+
+    def test_skips_resolved(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-001-already.md",
+            _base_fm(1, "already", status="resolved", pr_refs=[101]),
+        )
+
+        gh_called = []
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            gh_called.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "MERGED\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        # gh should not be called for already-resolved fragments
+        assert len(gh_called) == 0
+
+
+class TestThreeFragmentsCombined:
+    """Combined scenario: (a) all-merged, (b) mixed, (c) no pr_refs."""
+
+    def test_only_a_is_updated(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_fragment(
+            tmp_path,
+            "legacy-001-all-merged.md",
+            _base_fm(1, "all-merged", pr_refs=[101]),
+        )
+        _write_fragment(
+            tmp_path,
+            "legacy-002-mixed.md",
+            _base_fm(2, "mixed", pr_refs=[201, 202]),
+        )
+        _write_fragment(
+            tmp_path,
+            "legacy-003-no-refs.md",
+            _base_fm(3, "no-refs"),
+        )
+
+        def _patched_run(cmd: list[str], **kwargs: Any) -> Any:
+            if "regenerate_known_issues" in " ".join(str(c) for c in cmd):
+                r = MagicMock()
+                r.returncode = 0
+                return r
+            return _make_gh_mock({101: "MERGED", 201: "MERGED", 202: "OPEN"})(cmd, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", _patched_run)
+
+        exit_code = _mod.main(["--fragments-dir", str(tmp_path)])
+        assert exit_code == 0
+
+        fm_a = yaml.safe_load((tmp_path / "legacy-001-all-merged.md").read_text().split("---")[1])
+        fm_b = yaml.safe_load((tmp_path / "legacy-002-mixed.md").read_text().split("---")[1])
+        fm_c = yaml.safe_load((tmp_path / "legacy-003-no-refs.md").read_text().split("---")[1])
+
+        assert fm_a["status"] == "resolved"
+        assert fm_b["status"] == "open"
+        assert fm_c["status"] == "open"


### PR DESCRIPTION
## Summary
- New `scripts/sync_known_issue_status.py` reads each fragment's `pr_refs`, queries `gh pr view <ref> --json state` per ref, and rewrites frontmatter (`status: resolved` + `autonomy: n/a` + bumped `updated`) when **all** referenced PRs are `MERGED`.
- Wired into `scripts/run_nightly_sweep.sh` **before** the selector so stale fragments are resolved before the next sweep pick.
- `--dry-run` supported for manual verification; failures per fragment log but do not abort the sweep.
- Regenerates `docs/KNOWN_ISSUES.md` rollup when any fragment is updated.

Resolves #84.

## Test plan
- [x] `pytest tests/unit/scripts/test_sync_known_issue_status.py -x -q --no-cov` — 12/12 green.
- [x] Full unit suite passes (pre-push).
- [x] Ruff clean on new Python files.
- [ ] Next nightly sweep run will exercise the live path; monitor the digest for the new \`Fragments resolved: N\` line.