### PR TITLE
fix(extraction-v2): metric-classify wiring gaps (persistence FK + CLI env vars)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -7,7 +7,7 @@
 
 | Status | Count |
 |--------|-------|
-| Open | 25 |
+| Open | 27 |
 | Partially Resolved | 1 |
 | Archived | 51 |
 | Resolved | 22 |
@@ -57,6 +57,8 @@
 | #100 | safe | S | `src/llm/vision_client.py` `src/extraction_v2/stages/image_classify.py` |  |
 | #101 | safe | S | `scripts/batch_v2_extraction.py` |  |
 | #102 | safe | XS | `docs/known-issues/` |  |
+| #103 | review | M | `src/extraction_v2/persistence.py` `src/extraction_v2/stages/ocr_extraction.py` `src/infra/image_storage.py` |  |
+| #104 | safe | M | `src/infra/sec_client.py` `src/extraction_v2/stages/ocr_extraction.py` `src/web/url_builders.py` |  |
 
 
 ## Open Issues
@@ -158,6 +160,37 @@ omission caused every run to silently extract nothing.
 - Consider adding a minimum-facts guard: if a filing has content and the pipeline
   returns 0 facts, treat it as a soft failure and log at `ERROR` level.
 - Add a test that injects a stage exception and asserts the batch exits non-zero.
+
+## #103. v2_image_assets.file_path Overwritten to NULL When SEC Download Fails During Force-Reextract
+
+**Status**: Open
+**Severity**: high
+**Discovered**: 2026-04-24
+**Updated**: 2026-04-24
+
+### Problem
+
+When `--force-reextract` runs on a filing whose images cannot be downloaded
+from SEC (e.g., malformed accession URLs — see #104), the OCR/chart stage
+emits in-memory `ImageAsset` records with `file_path=None`.
+`_persist_images_in_tx` then upserts these via `ON CONFLICT (doc_id, filename)
+DO UPDATE`, **overwriting any pre-existing R2 storage key with NULL**. Net
+effect: R2 cache references are orphaned, chart review UI breaks for those
+images, and the damage is not recoverable without a DB backup.
+
+Observed on 2026-04-24 during a test re-extraction of 20 PayPal 8-K filings
+(filing_ids 1599–1603, 1745–1759). Every chart image for the older presentations
+now has `file_path=NULL` despite having been previously cached in R2.
+
+### Next Steps
+
+- Modify `_persist_images_in_tx` to preserve an existing non-NULL `file_path`
+  when the inbound record's `file_path` is NULL (`COALESCE(EXCLUDED.file_path,
+  v2_image_assets.file_path)` on the upsert).
+- Or: skip the upsert entirely for records with `file_path=None` when a row
+  already exists (prefer the "don't touch it" over "partial overwrite").
+- Audit R2 bucket vs `v2_image_assets.file_path` to identify orphaned keys
+  from today's PayPal re-extraction so they can be either re-linked or purged.
 
 ## #58. 8-K Fetcher Returns Only Primary Doc; Earnings Content Lives in Exhibit 99.1
 
@@ -385,6 +418,40 @@ CI. The user has to cross-check with `gh pr list` to discover the gap.
    rename the existing category to `opened` and derive "merged" at digest time.
 3. Update the digest writer's section headers to match whichever taxonomy is
    chosen so the morning email is accurate.
+
+## #104. "presentation:" / "transcript:" Accession Prefix Blocks V2 Image Fetcher
+
+**Status**: Open
+**Severity**: medium
+**Discovered**: 2026-04-24
+**Updated**: 2026-04-24
+
+### Problem
+
+Filings ingested via `ingest_presentations.py` store `accession_number` in a
+synthetic format (`presentation:0001633917/0001633917-23-000070/q123file.htm`)
+rather than the bare `NNNNNNNNNN-NN-NNNNNN` SEC token. When the V2 OCR stage
+calls `SECClient.fetch_image(cik, accession, filename)`, the accession string
+is inserted into the EDGAR URL path verbatim, producing malformed URLs like
+`https://www.sec.gov/Archives/edgar/data/CIK/presentation:0001633917/...` →
+every request 404s.
+
+Observed today: all 13 chart-bearing PayPal 8-K presentations (filing_ids
+1747–1759) failed every image fetch, so the new `ImageClassifyStage` had
+zero candidates after the `file_path IS NOT NULL` filter. The V2 image
+pipeline effectively cannot run on any filing ingested through the
+presentation or transcript paths.
+
+### Next Steps
+
+- Extract the bare accession token (`re.search(r'\d{10}-\d{2}-\d{6}',
+  accession_number)`) in the image-URL construction paths, matching the
+  pattern sql/41 applies to the `filings.accession_number` backfill.
+- Or: store the synthetic key in a new column (`synthetic_accession` or
+  `source_id`) and keep `accession_number` strictly the bare SEC token.
+- Add an integration test that runs a presentation-ingested filing through
+  the V2 pipeline with `enable_metric_classify=True` and asserts chart
+  downloads succeed.
 
 ## #16. Farfetch Precision Drag — Table-Scale + Period Attribution
 

--- a/docs/known-issues/legacy-103-image-file-path-nulled-on-failed-sec-download.md
+++ b/docs/known-issues/legacy-103-image-file-path-nulled-on-failed-sec-download.md
@@ -1,0 +1,40 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: M
+id: 103
+severity: high
+slug: image-file-path-nulled-on-failed-sec-download
+source: legacy
+status: open
+title: v2_image_assets.file_path Overwritten to NULL When SEC Download Fails During Force-Reextract
+touches:
+  - src/extraction_v2/persistence.py
+  - src/extraction_v2/stages/ocr_extraction.py
+  - src/infra/image_storage.py
+updated: '2026-04-24'
+---
+
+### Problem
+
+When `--force-reextract` runs on a filing whose images cannot be downloaded
+from SEC (e.g., malformed accession URLs — see #104), the OCR/chart stage
+emits in-memory `ImageAsset` records with `file_path=None`.
+`_persist_images_in_tx` then upserts these via `ON CONFLICT (doc_id, filename)
+DO UPDATE`, **overwriting any pre-existing R2 storage key with NULL**. Net
+effect: R2 cache references are orphaned, chart review UI breaks for those
+images, and the damage is not recoverable without a DB backup.
+
+Observed on 2026-04-24 during a test re-extraction of 20 PayPal 8-K filings
+(filing_ids 1599–1603, 1745–1759). Every chart image for the older presentations
+now has `file_path=NULL` despite having been previously cached in R2.
+
+### Next Steps
+
+- Modify `_persist_images_in_tx` to preserve an existing non-NULL `file_path`
+  when the inbound record's `file_path` is NULL (`COALESCE(EXCLUDED.file_path,
+  v2_image_assets.file_path)` on the upsert).
+- Or: skip the upsert entirely for records with `file_path=None` when a row
+  already exists (prefer the "don't touch it" over "partial overwrite").
+- Audit R2 bucket vs `v2_image_assets.file_path` to identify orphaned keys
+  from today's PayPal re-extraction so they can be either re-linked or purged.

--- a/docs/known-issues/legacy-104-presentation-accession-prefix-breaks-v2-image-urls.md
+++ b/docs/known-issues/legacy-104-presentation-accession-prefix-breaks-v2-image-urls.md
@@ -1,0 +1,43 @@
+---
+autonomy: safe
+discovered: '2026-04-24'
+estimated: M
+id: 104
+severity: medium
+slug: presentation-accession-prefix-breaks-v2-image-urls
+source: legacy
+status: open
+title: '"presentation:" / "transcript:" Accession Prefix Blocks V2 Image Fetcher'
+touches:
+  - src/infra/sec_client.py
+  - src/extraction_v2/stages/ocr_extraction.py
+  - src/web/url_builders.py
+updated: '2026-04-24'
+---
+
+### Problem
+
+Filings ingested via `ingest_presentations.py` store `accession_number` in a
+synthetic format (`presentation:0001633917/0001633917-23-000070/q123file.htm`)
+rather than the bare `NNNNNNNNNN-NN-NNNNNN` SEC token. When the V2 OCR stage
+calls `SECClient.fetch_image(cik, accession, filename)`, the accession string
+is inserted into the EDGAR URL path verbatim, producing malformed URLs like
+`https://www.sec.gov/Archives/edgar/data/CIK/presentation:0001633917/...` →
+every request 404s.
+
+Observed today: all 13 chart-bearing PayPal 8-K presentations (filing_ids
+1747–1759) failed every image fetch, so the new `ImageClassifyStage` had
+zero candidates after the `file_path IS NOT NULL` filter. The V2 image
+pipeline effectively cannot run on any filing ingested through the
+presentation or transcript paths.
+
+### Next Steps
+
+- Extract the bare accession token (`re.search(r'\d{10}-\d{2}-\d{6}',
+  accession_number)`) in the image-URL construction paths, matching the
+  pattern sql/41 applies to the `filings.accession_number` backfill.
+- Or: store the synthetic key in a new column (`synthetic_accession` or
+  `source_id`) and keep `accession_number` strictly the bare SEC token.
+- Add an integration test that runs a presentation-ingested filing through
+  the V2 pipeline with `enable_metric_classify=True` and asserts chart
+  downloads succeed.

--- a/scripts/batch_v2_extraction.py
+++ b/scripts/batch_v2_extraction.py
@@ -40,6 +40,7 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -61,6 +62,28 @@ CHECKPOINT_FILE = LOGS_DIR / "batch_v2_progress.json"
 
 # Global shutdown flag (set by SIGINT handler)
 _shutdown_requested = False
+
+
+def _apply_classify_env_overrides(config: Any) -> None:
+    """Lift ENABLE_METRIC_CLASSIFY + VISION_CLASSIFY_* env vars onto an
+    explicit PipelineConfig. Mirrors V2Pipeline._apply_env_feature_flags,
+    which is skipped when an explicit config is passed."""
+    if os.environ.get("ENABLE_METRIC_CLASSIFY", "").strip().lower() in {"1", "true", "yes", "on"}:
+        config.enable_metric_classify = True
+    if os.environ.get("VISION_CLASSIFY_PROVIDER"):
+        config.vision_classify_provider = os.environ["VISION_CLASSIFY_PROVIDER"]
+    if os.environ.get("VISION_CLASSIFY_MODEL"):
+        config.vision_classify_model = os.environ["VISION_CLASSIFY_MODEL"]
+    threshold_raw = os.environ.get("VISION_CLASSIFY_THRESHOLD")
+    if threshold_raw:
+        try:
+            config.vision_classify_threshold = float(threshold_raw)
+        except ValueError:
+            logger.warning(
+                "Invalid VISION_CLASSIFY_THRESHOLD=%r; keeping default %s",
+                threshold_raw,
+                config.vision_classify_threshold,
+            )
 
 
 def _handle_sigint(signum: int, frame: object) -> None:
@@ -241,6 +264,10 @@ def _process_filing_worker(
             enable_chart_extraction=not config_dict.get("no_images", False),
             min_confidence_auto_accept=config_dict.get("min_confidence", 0.90),
         )
+        # Honor metric-classify env vars (V2Pipeline._apply_env_feature_flags
+        # skips lifting when an explicit config is passed; CLI callers need the
+        # same env-driven behavior the Render nightly cron enjoys).
+        _apply_classify_env_overrides(pipeline_config)
 
         # Run pipeline
         pipeline = V2Pipeline(config=pipeline_config)

--- a/scripts/run_v2_extraction.py
+++ b/scripts/run_v2_extraction.py
@@ -55,6 +55,28 @@ def _sigalrm_handler(signum: int, frame: object) -> None:
     raise PipelineTimeoutError("pipeline timed out")
 
 
+def _apply_classify_env_overrides(config: PipelineConfig) -> None:
+    """Lift ENABLE_METRIC_CLASSIFY + VISION_CLASSIFY_* env vars onto an
+    explicit PipelineConfig. Mirrors V2Pipeline._apply_env_feature_flags,
+    which is skipped when an explicit config is passed."""
+    if os.environ.get("ENABLE_METRIC_CLASSIFY", "").strip().lower() in {"1", "true", "yes", "on"}:
+        config.enable_metric_classify = True
+    if os.environ.get("VISION_CLASSIFY_PROVIDER"):
+        config.vision_classify_provider = os.environ["VISION_CLASSIFY_PROVIDER"]
+    if os.environ.get("VISION_CLASSIFY_MODEL"):
+        config.vision_classify_model = os.environ["VISION_CLASSIFY_MODEL"]
+    threshold_raw = os.environ.get("VISION_CLASSIFY_THRESHOLD")
+    if threshold_raw:
+        try:
+            config.vision_classify_threshold = float(threshold_raw)
+        except ValueError:
+            logger.warning(
+                "Invalid VISION_CLASSIFY_THRESHOLD=%r; keeping default %s",
+                threshold_raw,
+                config.vision_classify_threshold,
+            )
+
+
 def lookup_filing(db: DatabaseAdapter, filing_id: int | None, accession: str | None) -> dict:
     """Look up filing metadata from database."""
     if filing_id:
@@ -237,6 +259,10 @@ def main():
         enable_chart_extraction=not args.no_images,
         min_confidence_auto_accept=args.min_confidence,
     )
+    # Honor metric-classify env vars (V2Pipeline._apply_env_feature_flags
+    # skips lifting when an explicit config is passed; CLI callers need the
+    # same env-driven behavior the Render nightly cron enjoys).
+    _apply_classify_env_overrides(config)
 
     # Run pipeline (with optional SIGALRM-based timeout)
     pipeline = V2Pipeline(config=config)

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -372,6 +372,9 @@ class V2PersistenceAdapter:
                             locator = fact.source_locator
                             if locator is not None and locator.img_id in img_id_map:
                                 locator.img_id = img_id_map[locator.img_id]
+                        for record in result.image_classifications:
+                            if record.img_id in img_id_map:
+                                record.img_id = img_id_map[record.img_id]
 
                     # 4. Persist segments — after images so the
                     # v2_segments.source_img_id FK (added by sql/40 for OCR'd

--- a/tests/unit/extraction_v2/test_persistence_image_classifications.py
+++ b/tests/unit/extraction_v2/test_persistence_image_classifications.py
@@ -106,3 +106,99 @@ class TestPersistImageClassifications:
         # take one, so a caller passing it gets a TypeError early.
         sig = inspect.signature(V2PersistenceAdapter._persist_image_classifications_in_tx)
         assert "filing_id" not in sig.parameters
+
+
+class TestPersistPipelineResultImgIdRemap:
+    """Regression guard: persist_pipeline_result must remap
+    ImageClassificationRecord.img_id via the img_id_map returned by
+    _persist_images_in_tx. Without this, FK violations occur when the DB
+    preserves a different img_id on ON CONFLICT upsert."""
+
+    def _build_result(self, classifications):
+        from src.extraction_v2.pipeline import PipelineResult
+
+        return PipelineResult(
+            document=MagicMock(),
+            facts=[],
+            tables=[],
+            images=[],
+            segments=[],
+            stage_results=[],
+            total_duration_ms=0,
+            success=True,
+            image_classifications=classifications,
+        )
+
+    def test_classification_img_ids_rewritten_via_map(self):
+        old_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        old_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        stable_a = "11111111-1111-1111-1111-111111111111"
+        stable_b = "22222222-2222-2222-2222-222222222222"
+        img_id_map = {old_a: stable_a, old_b: stable_b}
+
+        recs = [_record(img_id=old_a), _record(img_id=old_b)]
+        result = self._build_result(recs)
+
+        adapter = _make_adapter()
+
+        # Stub every _persist_*_in_tx + the DB transaction plumbing so we
+        # can drive persist_pipeline_result without touching a real cursor.
+        adapter._db.transaction = MagicMock()
+        txn_cm = adapter._db.transaction.return_value
+        conn = MagicMock()
+        txn_cm.__enter__ = MagicMock(return_value=conn)
+        txn_cm.__exit__ = MagicMock(return_value=None)
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=None)
+        conn.pipeline.return_value.__enter__ = MagicMock(return_value=None)
+        conn.pipeline.return_value.__exit__ = MagicMock(return_value=None)
+
+        adapter._persist_document_in_tx = MagicMock(return_value=1)
+        adapter._persist_tables_in_tx = MagicMock(return_value=(0, 0))
+        adapter._persist_images_in_tx = MagicMock(return_value=(2, img_id_map))
+        adapter._persist_segments_in_tx = MagicMock(return_value=0)
+        adapter._persist_facts_in_tx = MagicMock(return_value=0)
+        adapter._persist_definitions_in_tx = MagicMock(return_value=0)
+        adapter._persist_image_classifications_in_tx = MagicMock(return_value=2)
+
+        adapter.persist_pipeline_result(result, filing_id=42)
+
+        # The classifications list must have had its img_ids remapped BEFORE
+        # being passed to _persist_image_classifications_in_tx.
+        call_args = adapter._persist_image_classifications_in_tx.call_args
+        passed_recs = call_args[0][1]
+        assert [r.img_id for r in passed_recs] == [stable_a, stable_b]
+
+    def test_unmapped_img_ids_unchanged(self):
+        mapped_old = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        mapped_new = "11111111-1111-1111-1111-111111111111"
+        untouched = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        img_id_map = {mapped_old: mapped_new}
+
+        recs = [_record(img_id=mapped_old), _record(img_id=untouched)]
+        result = self._build_result(recs)
+
+        adapter = _make_adapter()
+        adapter._db.transaction = MagicMock()
+        txn_cm = adapter._db.transaction.return_value
+        conn = MagicMock()
+        txn_cm.__enter__ = MagicMock(return_value=conn)
+        txn_cm.__exit__ = MagicMock(return_value=None)
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=None)
+        conn.pipeline.return_value.__enter__ = MagicMock(return_value=None)
+        conn.pipeline.return_value.__exit__ = MagicMock(return_value=None)
+
+        adapter._persist_document_in_tx = MagicMock(return_value=1)
+        adapter._persist_tables_in_tx = MagicMock(return_value=(0, 0))
+        adapter._persist_images_in_tx = MagicMock(return_value=(2, img_id_map))
+        adapter._persist_segments_in_tx = MagicMock(return_value=0)
+        adapter._persist_facts_in_tx = MagicMock(return_value=0)
+        adapter._persist_definitions_in_tx = MagicMock(return_value=0)
+        adapter._persist_image_classifications_in_tx = MagicMock(return_value=2)
+
+        adapter.persist_pipeline_result(result, filing_id=42)
+
+        passed_recs = adapter._persist_image_classifications_in_tx.call_args[0][1]
+        assert [r.img_id for r in passed_recs] == [mapped_new, untouched]


### PR DESCRIPTION
## Summary

Two independent bugs discovered while smoke-testing the metric-classify pipeline end-to-end against the Farfetch F-1 (filing_id=1540). Both must be fixed before prod can flip `ENABLE_METRIC_CLASSIFY=true`.

- **persistence remap gap** — `ImageClassificationRecord.img_id` values weren't being rewritten via the `img_id_map` that `_persist_images_in_tx` returns. Re-extracting a filing that already had `v2_image_assets` rows produced a hard FK violation (`v2_image_classifications_img_id_fkey`) because the in-memory classifications referenced the fresh uuid4, not the stable DB img_id. Fixed by adding 3 lines mirroring the existing fact/segment remap at `persistence.py:362-374`.
- **CLI env-var gap** — `run_v2_extraction.py` and `batch_v2_extraction.py` both pass an explicit `PipelineConfig`. `V2Pipeline._apply_env_feature_flags` intentionally skips env-var lifting when a caller supplies a config, so `ENABLE_METRIC_CLASSIFY` + `VISION_CLASSIFY_*` env vars had zero effect from the CLI. Only the Render nightly-cron path (which uses `config=None`) ever honored them. Added a local `_apply_classify_env_overrides` helper in each script that lifts the same four env vars onto the explicit config.

## Verification

- End-to-end re-extraction of Farfetch F-1 after both fixes: **22 classifications persisted, 28 facts re-extracted, 0 FK errors.**
- 6 existing `test_persistence_image_classifications` tests + 2 new regression guards for the remap (`test_classification_img_ids_rewritten_via_map`, `test_unmapped_img_ids_unchanged`).
- Full suite: 4221 passed / 67 skipped.

## Known issues opened

- **#103** — `v2_image_assets.file_path` overwritten to NULL when SEC download fails during force-reextract (High, `autonomy: review`). Related orphaned-R2-keys audit needed on PayPal 8-Ks re-extracted earlier today.
- **#104** — `presentation:` / `transcript:` accession prefix blocks V2 image URL construction (Medium, `autonomy: safe`). Blocks the image pipeline on any filing ingested via `ingest_presentations.py` or `ingest_transcripts.py`.

## Test plan

- [x] New unit tests pass locally
- [x] Full `pytest -x -q` green
- [x] Ruff clean
- [ ] CI green on this branch
- [ ] Manual: kick off one filing through `run_v2_extraction.py --filing-id X --force-reextract` with `ENABLE_METRIC_CLASSIFY=true` in shell; confirm `v2_image_classifications` rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)