### PR TITLE
feat(extraction-v2): PR1 — text-presence pivot (schema + stage + persistence)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ Instructions for setting up, running, and maintaining the system.
 | **[image-model-training-runbook.md](operations/image-model-training-runbook.md)** | Image relevance model: export → train → score pipeline | Developers |
 | **[analytics-ui-runbook.md](operations/analytics-ui-runbook.md)** | Read-only BI role, `v_analytics_*` views, Metabase deployment plan | Developers, Analysts |
 | **[github-org-transfer.md](operations/github-org-transfer.md)** | Decision record + runbook: when/how to migrate from user repo to GitHub org (unlocks merge queue, teams, org rulesets) | DevOps |
+| **[text-pipeline-presence-pivot-plan.md](operations/text-pipeline-presence-pivot-plan.md)** | Text-extraction pivot to per-(doc, metric) presence: rollout plan + PR1 landed-interface contract for downstream PRs | Developers |
 
 ### Human Review System (✅ COMPLETE - Production Ready)
 

--- a/docs/architecture/extraction-pipeline.md
+++ b/docs/architecture/extraction-pipeline.md
@@ -24,7 +24,7 @@ This document specifies the architecture and implementation of the metric extrac
 
 ## V2 Pipeline Overview
 
-The V2 pipeline (`src/extraction_v2/`) implements a 14-stage extraction workflow. It is the production pipeline for all SEC filing, transcript, and presentation extraction.
+The V2 pipeline (`src/extraction_v2/`) implements a 15-stage extraction workflow. It is the production pipeline for all SEC filing, transcript, and presentation extraction.
 
 **Module:** `src/extraction_v2/pipeline.py`
 **Class:** `V2Pipeline`
@@ -218,7 +218,7 @@ The per-value value-emission path — `CohortParser` regime dispatch, `unit_infe
 ## Key Files
 
 - **`src/extraction_v2/models.py`** — Core data models (MetricFact, EvidencePack, Table, Cell, ImageAsset, Segment)
-- **`src/extraction_v2/pipeline.py`** — Pipeline orchestrator with 14-stage workflow and configuration
+- **`src/extraction_v2/pipeline.py`** — Pipeline orchestrator with 15-stage workflow and configuration
 - **`src/extraction_v2/persistence.py`** — Database write layer (V2PersistenceAdapter)
 - **`src/extraction_v2/table_reconstructor.py`** — Table reconstruction with colspan/rowspan resolution
 - **`src/extraction_v2/stages/ingestion.py`** — HTML parsing with XPath locators and segment extraction

--- a/docs/operations/text-pipeline-presence-pivot-plan.md
+++ b/docs/operations/text-pipeline-presence-pivot-plan.md
@@ -1,0 +1,124 @@
+# Text-pipeline presence-first pivot
+
+Rollout doc for the text-extraction pivot that mirrors the chart-presence pivot (PR #147). Under this pivot, extraction's primary scoring surface shifts from per-fact accuracy to per-(document, metric) presence detection, plus reviewer confirmation. Fact emission continues as an advisory evidence layer — not deleted, not migrated.
+
+Strategic direction memo: `~/.claude/projects/.../memory/project_presence_first_extraction_direction.md`.
+
+## Program status
+
+| PR | Scope | Status |
+|---|---|---|
+| PR1 | Schema + presence emission + `presence_only` persistence mode | **Landed** (this PR) |
+| PR2 | Gold-standard presence derivation + validator + Tier 1 gate flip | Pending |
+| PR3 | Reviewer UI surfaces presence (`v2_text_presence_confirmations`) | Pending |
+| PR4 | Tier-1 definition/methodology LLM classifier | Pending |
+
+Full plan files live under `~/.claude/plans/text-presence-pr*.md` and `~/.claude/plans/text-presence-pivot-index.md`.
+
+---
+
+## Landed in PR1 — interface contract for downstream PRs
+
+PR2/PR3/PR4 must read this section instead of the PR1 plan file. Names below match the landed code; they are authoritative.
+
+### Migration
+
+`sql/46_v2_text_metric_presence.sql` creates table `v2_text_metric_presence`:
+
+| Column | Type | Notes |
+|---|---|---|
+| `presence_id` | `UUID PRIMARY KEY` | `DEFAULT gen_random_uuid()` |
+| `doc_id` | `BIGINT NOT NULL` | FK → `filings(filing_id)` ON DELETE CASCADE |
+| `canonical_metric_id` | `TEXT NOT NULL` | Metric taxonomy ID |
+| `score` | `DOUBLE PRECISION NOT NULL` | Max across contributing signals; `CHECK (0 ≤ score ≤ 1)` |
+| `detected_at_stage` | `TEXT NOT NULL` | Stage name that first surfaced the metric |
+| `evidence_segment_ids` | `JSONB NOT NULL DEFAULT '[]'` | Sorted list of segment IDs |
+| `advisory_value_count` | `INTEGER NOT NULL DEFAULT 0` | Count of contributing facts |
+| `advisory_fact_ids` | `JSONB NOT NULL DEFAULT '[]'` | Contributing fact_ids (no FK; facts may be deleted independently) |
+| `pipeline_version` | `TEXT NOT NULL` | Currently `"2.0.0"` |
+| `created_at`, `updated_at` | `TIMESTAMPTZ` | `DEFAULT NOW()` |
+
+Uniqueness: `UNIQUE (doc_id, canonical_metric_id)` (one row per metric per filing).
+Indexes: `(doc_id)`, `(canonical_metric_id)`.
+
+### Dataclass
+
+`src.extraction_v2.models.MetricPresence`:
+
+```python
+@dataclass
+class MetricPresence:
+    canonical_metric_id: str
+    score: float
+    detected_at_stage: str
+    evidence_segment_ids: list[str] = field(default_factory=list)
+    advisory_value_count: int = 0
+    advisory_fact_ids: list[str] = field(default_factory=list)
+```
+
+Field names match SQL column names 1:1 except for the DB-managed columns (`presence_id`, `doc_id`, `pipeline_version`, `created_at`, `updated_at`) which are attached at persist time.
+
+### Stage
+
+`src.extraction_v2.stages.metric_presence.MetricPresenceStage` runs as the **final stage** in `V2Pipeline._setup_stages`, after `ValidationStage`. Enum: `PipelineStage.METRIC_PRESENCE = "metric_presence"`.
+
+The stage reads:
+
+- `context.deduplicated_facts` (falls back to `context.facts` when dedup didn't run)
+- `context.images` (contributes `image.detected_metrics`)
+- `context.definitions` (contributes at floor score `_DEFINITION_ONLY_PRESENCE_SCORE = 0.5`)
+
+And writes `context.presences: list[MetricPresence]`.
+
+Scoring: max across contributing signals. Evidence: union of segment IDs from facts + definitions (chart-only presences have empty `evidence_segment_ids`). `advisory_fact_ids` lists contributing fact IDs (empty when presence comes solely from charts or definitions).
+
+### PipelineResult field
+
+`PipelineResult.presences: list[MetricPresence]` is populated from `context.presences` at pipeline completion.
+
+### Persistence
+
+`V2PersistenceAdapter._persist_presence_in_tx(cur, presences, filing_id) -> int` upserts on `(doc_id, canonical_metric_id)`. Called from `persist_pipeline_result` as step 8 (after facts, definitions, and image classifications). Idempotent; never touches `v2_metric_facts` or `v2_review_decisions`.
+
+`persist_pipeline_result` signature:
+
+```python
+def persist_pipeline_result(
+    self,
+    result: PipelineResult,
+    filing_id: int,
+    document_type: str = "sec_filing",
+    ticker: str | None = None,
+    document_date: date | None = None,
+    transcript_source: str | None = None,
+    *,
+    force: bool = False,
+    chart_only: bool = False,
+    presence_only: bool = False,
+) -> PersistenceResult
+```
+
+New kwarg `presence_only=False`. When `True`:
+
+- Step 5 (`_persist_facts_in_tx`) is skipped entirely — no DELETE, no INSERT on `v2_metric_facts`, no `ReviewedFilingError` possible.
+- All other idempotent steps (document, tables, images, segments, definitions, image classifications, presence) run as normal.
+- Mutually exclusive with `chart_only`; combining raises `ValueError`.
+
+`PersistenceResult` gains `presences_upserted: int = 0`; `total_upserted` property includes it.
+
+### Interface invariants
+
+- Presence rows are never deleted by the persistence layer — only the CASCADE on `filings.filing_id` removes them.
+- `_persist_presence_in_tx` is pure upsert; re-running extraction overwrites `score`, `evidence_segment_ids`, `advisory_*`, `pipeline_version`, and `updated_at`.
+- `advisory_fact_ids` is an advisory JSONB list, **not** a FK. Facts may be deleted by `force=True` re-extraction without cascading to presence rows — presence is a document-level claim, independent of which specific fact rows currently back it.
+- `presence_only=True` does NOT bypass the image-re-classification guard inside `_persist_images_in_tx`; that guard is orthogonal and still fires on hidden-class transitions.
+
+### How downstream PRs reference this contract
+
+Each of PR2/PR3/PR4 has a plan file in `~/.claude/plans/text-presence-pr*.md` that points fresh sessions here. Read this section first; the PR plan file then describes the incremental changes the PR makes.
+
+---
+
+## Known pre-PR1 gap closed alongside
+
+`scripts/apply_migrations.py` and `scripts/apply_all_migrations.py` were missing `44_extend_image_rejection_reason_enum.sql` and `45_create_v2_image_classifications.sql` in their ordered lists (landed in PR #162 without registration). The pre-commit `migration-order-check` guard was blocking PR1 until these were registered; PR1 registered all three (44, 45, 46) to unblock. If this gap reappears on other branches created from pre-#162 heads, they will hit the same guard.

--- a/scripts/apply_all_migrations.py
+++ b/scripts/apply_all_migrations.py
@@ -97,6 +97,9 @@ MIGRATION_ORDER = [
     "41_normalize_accession_numbers.sql",
     "42_add_detected_metrics_to_v2_image_assets.sql",
     "43_create_v2_image_metric_confirmations.sql",
+    "44_extend_image_rejection_reason_enum.sql",
+    "45_create_v2_image_classifications.sql",
+    "46_v2_text_metric_presence.sql",
 ]
 
 # Non-migration SQL files that live in sql/ but are not schema migrations.

--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -86,6 +86,7 @@ MIGRATIONS = [
     "43_create_v2_image_metric_confirmations.sql",
     "44_extend_image_rejection_reason_enum.sql",
     "45_create_v2_image_classifications.sql",
+    "46_v2_text_metric_presence.sql",
 ]
 
 BOOTSTRAP_DDL = """

--- a/sql/46_v2_text_metric_presence.sql
+++ b/sql/46_v2_text_metric_presence.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- Migration 46: Create v2_text_metric_presence
+-- Purpose: Per-(doc, metric) presence records emitted by MetricPresenceStage.
+--
+-- Part of the text-presence pivot — see docs/operations/text-pipeline-presence-pivot-plan.md.
+-- Mirrors the chart-presence pivot (#147, sql/42) but on a dedicated table
+-- rather than a JSONB column: text presence needs FK-reachable evidence
+-- segment IDs + advisory fact back-refs + reviewer confirmation joins
+-- (PR3 adds v2_text_presence_confirmations → presence_id).
+--
+-- Upsert keyed on (doc_id, canonical_metric_id); re-extraction overwrites
+-- the row rather than appending history. No DELETE path; persistence uses
+-- INSERT ... ON CONFLICT DO UPDATE and never touches v2_metric_facts, so
+-- this table is safe to populate on reviewed filings (PR2 backfill runs
+-- with presence_only=True, which short-circuits _persist_facts_in_tx).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS v2_text_metric_presence (
+    presence_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    doc_id BIGINT NOT NULL
+        REFERENCES filings(filing_id) ON DELETE CASCADE,
+    canonical_metric_id TEXT NOT NULL,
+
+    score DOUBLE PRECISION NOT NULL,
+    detected_at_stage TEXT NOT NULL,
+
+    evidence_segment_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    advisory_value_count INTEGER NOT NULL DEFAULT 0,
+    advisory_fact_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+    pipeline_version TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_v2_text_metric_presence_doc_metric
+        UNIQUE (doc_id, canonical_metric_id),
+    CONSTRAINT check_v2_text_metric_presence_score
+        CHECK (score >= 0 AND score <= 1),
+    CONSTRAINT check_v2_text_metric_presence_advisory_count
+        CHECK (advisory_value_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_v2_text_metric_presence_doc
+    ON v2_text_metric_presence(doc_id);
+
+CREATE INDEX IF NOT EXISTS idx_v2_text_metric_presence_metric
+    ON v2_text_metric_presence(canonical_metric_id);
+
+COMMENT ON TABLE v2_text_metric_presence IS
+    'Per-(doc, metric) presence records emitted by MetricPresenceStage. Primary scoring surface for Tier 1 regression gate under the presence-first pivot. See docs/operations/text-pipeline-presence-pivot-plan.md.';

--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -671,6 +671,27 @@ class DetectedMetric:
 
 
 @dataclass
+class MetricPresence:
+    """Per-(doc, metric) presence signal emitted by MetricPresenceStage.
+
+    Persisted to `v2_text_metric_presence` (sql/46). Aggregates signals
+    across the text pipeline (facts from html_table / text / ocr_table
+    sources) and the chart pipeline (`ImageAsset.detected_metrics`) into
+    one record per `(doc_id, canonical_metric_id)` pair.
+
+    Primary scoring surface for the Tier 1 regression gate under the
+    presence-first pivot — see `docs/operations/text-pipeline-presence-pivot-plan.md`.
+    """
+
+    canonical_metric_id: str
+    score: float
+    detected_at_stage: str
+    evidence_segment_ids: list[str] = field(default_factory=list)
+    advisory_value_count: int = 0
+    advisory_fact_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
 class ImageClassificationRecord:
     """Vision API metric-classify output for one image.
 

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -28,6 +28,7 @@ from src.extraction_v2.models import (
     ImageClassificationRecord,
     MetricDefinition,
     MetricFact,
+    MetricPresence,
     Segment,
     SourceType,
     Table,
@@ -53,6 +54,7 @@ class PersistenceResult:
     images_upserted: int = 0
     facts_upserted: int = 0
     definitions_upserted: int = 0
+    presences_upserted: int = 0
     errors: list[str] | None = None
 
     @property
@@ -66,6 +68,7 @@ class PersistenceResult:
             + self.images_upserted
             + self.facts_upserted
             + self.definitions_upserted
+            + self.presences_upserted
         )
 
 
@@ -294,6 +297,7 @@ class V2PersistenceAdapter:
         *,
         force: bool = False,
         chart_only: bool = False,
+        presence_only: bool = False,
     ) -> PersistenceResult:
         """
         Persist a complete pipeline result in a single transaction.
@@ -311,10 +315,22 @@ class V2PersistenceAdapter:
                 images, definitions) run normally — they are idempotent
                 via ON CONFLICT and do not touch reviewer decisions.
                 Used for Issue #35 chart-fact backfills.
+            presence_only: If True, skip fact persistence entirely and
+                only write ``v2_text_metric_presence`` rows. Used by the
+                PR2 gold-standard backfill to populate presence for
+                reviewed filings without tripping the fact-level
+                ``ReviewedFilingError`` guard. Other idempotent writes
+                (documents, segments, tables, images, definitions,
+                image classifications) still run — presence records
+                reference segment IDs via ``evidence_segment_ids``, so
+                segment persistence must complete. Mutually exclusive
+                with ``chart_only``; combining raises ``ValueError``.
 
         Returns:
             PersistenceResult with counts and any errors
         """
+        if presence_only and chart_only:
+            raise ValueError("presence_only and chart_only are mutually exclusive")
         errors: list[str] = []
 
         try:
@@ -378,10 +394,19 @@ class V2PersistenceAdapter:
                     # segments) has a valid target row.
                     seg_count = self._persist_segments_in_tx(cur, result.segments, filing_id)
 
-                    # 5. Persist facts
-                    fact_count = self._persist_facts_in_tx(
-                        cur, result.facts, filing_id, force=force, chart_only=chart_only
-                    )
+                    # 5. Persist facts (skipped when presence_only=True —
+                    #    the whole point of that mode is to populate presence
+                    #    for reviewed filings without touching facts).
+                    if presence_only:
+                        fact_count = 0
+                    else:
+                        fact_count = self._persist_facts_in_tx(
+                            cur,
+                            result.facts,
+                            filing_id,
+                            force=force,
+                            chart_only=chart_only,
+                        )
 
                     # 6. Persist definitions
                     def_count = self._persist_definitions_in_tx(cur, result.definitions, filing_id)
@@ -392,11 +417,17 @@ class V2PersistenceAdapter:
                         cur, result.image_classifications
                     )
 
+                    # 8. Persist per-(doc, metric) presence records.
+                    #    Upsert-only; does not touch facts or reviewer
+                    #    decisions, so safe on reviewed filings regardless
+                    #    of presence_only / force.
+                    presence_count = self._persist_presence_in_tx(cur, result.presences, filing_id)
+
             logger.info(
                 f"Persisted pipeline result for filing_id={filing_id}: "
                 f"{seg_count} segments, {table_count} tables, {cell_count} cells, "
                 f"{img_count} images, {fact_count} facts, {def_count} definitions, "
-                f"{classify_count} image classifications"
+                f"{classify_count} image classifications, {presence_count} presences"
             )
 
             return PersistenceResult(
@@ -408,6 +439,7 @@ class V2PersistenceAdapter:
                 images_upserted=img_count,
                 facts_upserted=fact_count,
                 definitions_upserted=def_count,
+                presences_upserted=presence_count,
             )
 
         except ReviewedFilingError:
@@ -686,6 +718,78 @@ class V2PersistenceAdapter:
             ],
         )
         return len(records)
+
+    def _persist_presence_in_tx(
+        self,
+        cur: Any,
+        presences: list[MetricPresence],
+        filing_id: int,
+    ) -> int:
+        """Persist per-(doc, metric) presence records to v2_text_metric_presence.
+
+        Idempotent upsert on ``(doc_id, canonical_metric_id)``. Never
+        deletes from ``v2_metric_facts`` and never triggers
+        ``ReviewedFilingError`` — safe on reviewed filings regardless of
+        ``force`` / ``presence_only`` / ``chart_only`` flags. The
+        ``advisory_fact_ids`` column references facts that contributed to
+        the presence record but carries no FK constraint: facts may be
+        deleted (via ``force=True`` re-extraction) without cascading to
+        presence rows, which is the correct behavior — presence is
+        a document-level claim about metric disclosure, independent of
+        which specific fact rows currently back it.
+        """
+        if not presences:
+            return 0
+
+        cur.executemany(
+            """
+            INSERT INTO v2_text_metric_presence (
+                doc_id,
+                canonical_metric_id,
+                score,
+                detected_at_stage,
+                evidence_segment_ids,
+                advisory_value_count,
+                advisory_fact_ids,
+                pipeline_version,
+                created_at,
+                updated_at
+            ) VALUES (
+                %(doc_id)s,
+                %(canonical_metric_id)s,
+                %(score)s,
+                %(detected_at_stage)s,
+                %(evidence_segment_ids)s,
+                %(advisory_value_count)s,
+                %(advisory_fact_ids)s,
+                %(pipeline_version)s,
+                NOW(),
+                NOW()
+            )
+            ON CONFLICT (doc_id, canonical_metric_id) DO UPDATE SET
+                score = EXCLUDED.score,
+                detected_at_stage = EXCLUDED.detected_at_stage,
+                evidence_segment_ids = EXCLUDED.evidence_segment_ids,
+                advisory_value_count = EXCLUDED.advisory_value_count,
+                advisory_fact_ids = EXCLUDED.advisory_fact_ids,
+                pipeline_version = EXCLUDED.pipeline_version,
+                updated_at = NOW()
+            """,
+            [
+                {
+                    "doc_id": filing_id,
+                    "canonical_metric_id": p.canonical_metric_id,
+                    "score": p.score,
+                    "detected_at_stage": p.detected_at_stage,
+                    "evidence_segment_ids": json.dumps(p.evidence_segment_ids),
+                    "advisory_value_count": p.advisory_value_count,
+                    "advisory_fact_ids": json.dumps(p.advisory_fact_ids),
+                    "pipeline_version": "2.0.0",
+                }
+                for p in presences
+            ],
+        )
+        return len(presences)
 
     def _persist_images_in_tx(
         self,

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -1,7 +1,7 @@
 """
 V2 Extraction Pipeline Orchestrator.
 
-This module orchestrates the 12-stage extraction pipeline, plus an optional
+This module orchestrates the 15-stage extraction pipeline, plus an optional
 Chart Fact Bridge that runs after validation when enable_chart_fact_bridge=True:
 
 1. Ingestion & Parsing         → Segments with XPath locators
@@ -46,6 +46,7 @@ from src.extraction_v2.models import (
     MetricCandidate,
     MetricDefinition,
     MetricFact,
+    MetricPresence,
     Segment,
     Table,
 )
@@ -58,6 +59,7 @@ from src.extraction_v2.stages.false_positive_filter import FalsePositiveFilterSt
 from src.extraction_v2.stages.image_classify import ImageClassifyStage
 from src.extraction_v2.stages.image_triage import ImageTriageStage
 from src.extraction_v2.stages.ingestion import IngestionStage
+from src.extraction_v2.stages.metric_presence import MetricPresenceStage
 from src.extraction_v2.stages.ocr_extraction import OCRExtractionStage
 from src.extraction_v2.stages.period_inference import PeriodInferenceStage
 from src.extraction_v2.stages.section_classification import SectionClassificationStage
@@ -97,6 +99,7 @@ class PipelineStage(str, Enum):
     DEFINITION_EXTRACTION = "definition_extraction"
     DEDUPLICATION = "deduplication"
     VALIDATION = "validation"
+    METRIC_PRESENCE = "metric_presence"
 
 
 @dataclass
@@ -250,6 +253,7 @@ class PipelineResult:
     success: bool
     definitions: list[MetricDefinition] = field(default_factory=list)
     image_classifications: list[ImageClassificationRecord] = field(default_factory=list)
+    presences: list[MetricPresence] = field(default_factory=list)
     error_message: str | None = None
     context: Any | None = None  # PipelineContext — only set when retain_context=True
 
@@ -339,6 +343,9 @@ class PipelineContext:
     image_classifications: list[ImageClassificationRecord] = field(
         default_factory=list
     )  # Populated by ImageClassifyStage when enabled
+    presences: list[MetricPresence] = field(
+        default_factory=list
+    )  # Populated by MetricPresenceStage (final stage)
 
     # Diagnostics (only populated when config.retain_context=True)
     _pre_filter_bound_values: list[BoundValue] = field(default_factory=list)  # Before FP filter
@@ -378,7 +385,7 @@ class V2Pipeline:
     """
     V2 Extraction Pipeline Orchestrator.
 
-    Coordinates the 12-stage extraction process for a single filing.
+    Coordinates the 15-stage extraction process for a single filing.
     """
 
     def __init__(
@@ -511,6 +518,12 @@ class V2Pipeline:
         # Stage 11: Validation & Review Routing
         self._stages.append((PipelineStage.VALIDATION, ValidationStage()))
 
+        # Stage 12: Metric Presence — final stage. Aggregates dedup'd facts,
+        # chart detected_metrics, and definitions into per-(doc, metric)
+        # presence records. Primary scoring surface under the text-presence
+        # pivot (see docs/operations/text-pipeline-presence-pivot-plan.md).
+        self._stages.append((PipelineStage.METRIC_PRESENCE, MetricPresenceStage()))
+
     def process(
         self,
         html_path: Path | str,
@@ -637,6 +650,7 @@ class V2Pipeline:
             success=True,
             definitions=context.definitions,
             image_classifications=context.image_classifications,
+            presences=context.presences,
             context=context if self.config.retain_context else None,
         )
 
@@ -660,6 +674,7 @@ class V2Pipeline:
             total_duration_ms=total_ms,
             success=False,
             definitions=[],
+            presences=[],
             error_message=error_message,
         )
 

--- a/src/extraction_v2/stages/metric_presence.py
+++ b/src/extraction_v2/stages/metric_presence.py
@@ -1,0 +1,160 @@
+"""
+Stage 12: Metric Presence Aggregation.
+
+Final stage of the V2 pipeline. Aggregates extraction signals across all
+surfaces — deduplicated facts (text / html_table / ocr_table / chart),
+chart-image `detected_metrics`, and definitions — into one
+``MetricPresence`` record per ``(doc, canonical_metric_id)`` pair.
+
+Primary scoring surface for the Tier 1 regression gate under the
+text-presence pivot. See ``docs/operations/text-pipeline-presence-pivot-plan.md``.
+
+Design invariants (must hold; downstream PRs depend on them):
+
+- One record per ``(doc_id, canonical_metric_id)``. Duplicates are an error
+  upstream; ``_persist_presence_in_tx`` upsert would otherwise collapse
+  them silently.
+- ``score`` is the MAX confidence across all contributing signals.
+- ``evidence_segment_ids`` is the union of segment IDs from contributing
+  facts (via ``fact.source_locator.segment_id``) and from definitions
+  (``definition_segment_id`` / ``methodology_segment_id``). Chart-only
+  presences have no segment IDs — evidence lives on the image row.
+- ``advisory_fact_ids`` lists the fact IDs that contributed. Empty when
+  presence comes solely from chart ``detected_metrics`` or definitions.
+- ``advisory_value_count`` is the count of contributing facts (not unique
+  values). Rough disclosure-depth signal for downstream UI.
+
+The stage never mutates ``context.facts`` / ``context.images`` / etc. — it
+only reads them and writes ``context.presences``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from src.extraction_v2.models import MetricPresence
+
+if TYPE_CHECKING:
+    from src.extraction_v2.pipeline import PipelineContext, StageResult
+
+logger = logging.getLogger(__name__)
+
+
+# Scores assigned to presence signals when no explicit confidence exists.
+# Facts always carry ``confidence``; charts carry ``DetectedMetric.score``.
+# Definition-only presence is weaker than a value-bearing fact, so we floor
+# it at 0.5 — same threshold the chart pipeline uses for minimum presence
+# emission (``chart_presence_min_score``).
+_DEFINITION_ONLY_PRESENCE_SCORE = 0.5
+
+
+class MetricPresenceStage:
+    """Aggregate per-(doc, metric) presence records from all surfaces."""
+
+    def process(self, context: PipelineContext) -> StageResult:
+        from src.extraction_v2.pipeline import PipelineStage, StageResult
+
+        start_time = datetime.now(UTC)
+
+        # Per-metric accumulator.
+        # Keys are canonical_metric_id; values carry aggregated score,
+        # segment-ID set, fact-ID list, fact count, and the stage that first
+        # surfaced the metric (for downstream diagnostics).
+        accumulator: dict[str, _Accumulator] = {}
+
+        # Source 1: deduplicated facts (falls back to raw facts if dedup
+        # hasn't populated yet — mirrors pipeline.process() output_facts logic).
+        facts = (
+            context.deduplicated_facts if context.deduplicated_facts is not None else context.facts
+        )
+        for fact in facts:
+            if not fact.canonical_metric_id:
+                continue
+            acc = accumulator.setdefault(
+                fact.canonical_metric_id,
+                _Accumulator(first_stage=PipelineStage.FACT_CONSTRUCTION.value),
+            )
+            acc.score = max(acc.score, float(fact.confidence))
+            acc.advisory_value_count += 1
+            acc.fact_ids.append(fact.fact_id)
+            seg_id = fact.source_locator.segment_id if fact.source_locator else None
+            if seg_id:
+                acc.segment_ids.add(seg_id)
+
+        # Source 2: chart detected_metrics from ChartFactBridgeStage.
+        for image in context.images:
+            for detected in image.detected_metrics:
+                if not detected.metric_id:
+                    continue
+                acc = accumulator.setdefault(
+                    detected.metric_id,
+                    _Accumulator(first_stage=PipelineStage.CHART_FACT_BRIDGE.value),
+                )
+                acc.score = max(acc.score, float(detected.score))
+
+        # Source 3: definitions (weaker signal; contributes only when
+        # no stronger signal exists, but always adds evidence segment IDs).
+        for definition in context.definitions:
+            if not definition.canonical_metric_id:
+                continue
+            acc = accumulator.setdefault(
+                definition.canonical_metric_id,
+                _Accumulator(first_stage=PipelineStage.DEFINITION_EXTRACTION.value),
+            )
+            acc.score = max(acc.score, _DEFINITION_ONLY_PRESENCE_SCORE)
+            if definition.definition_segment_id:
+                acc.segment_ids.add(definition.definition_segment_id)
+            if definition.methodology_segment_id:
+                acc.segment_ids.add(definition.methodology_segment_id)
+
+        context.presences = [
+            MetricPresence(
+                canonical_metric_id=metric_id,
+                score=acc.score,
+                detected_at_stage=acc.first_stage,
+                evidence_segment_ids=sorted(acc.segment_ids),
+                advisory_value_count=acc.advisory_value_count,
+                advisory_fact_ids=list(acc.fact_ids),
+            )
+            for metric_id, acc in sorted(accumulator.items())
+        ]
+
+        duration_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
+        logger.info(
+            "MetricPresenceStage: doc_id=%s metrics_present=%s fact_contributors=%s",
+            context.filing_id,
+            len(context.presences),
+            sum(p.advisory_value_count for p in context.presences),
+        )
+
+        return StageResult(
+            stage=PipelineStage.METRIC_PRESENCE,
+            success=True,
+            duration_ms=duration_ms,
+            items_processed=len(facts) + len(context.images) + len(context.definitions),
+            items_output=len(context.presences),
+            metadata={
+                "metrics_present": len(context.presences),
+                "fact_contributors": sum(p.advisory_value_count for p in context.presences),
+                "chart_only_presences": sum(
+                    1
+                    for p in context.presences
+                    if p.advisory_value_count == 0 and not p.evidence_segment_ids
+                ),
+            },
+        )
+
+
+class _Accumulator:
+    """Mutable per-metric aggregator used only within ``MetricPresenceStage``."""
+
+    __slots__ = ("score", "first_stage", "segment_ids", "fact_ids", "advisory_value_count")
+
+    def __init__(self, first_stage: str) -> None:
+        self.score: float = 0.0
+        self.first_stage: str = first_stage
+        self.segment_ids: set[str] = set()
+        self.fact_ids: list[str] = []
+        self.advisory_value_count: int = 0

--- a/tests/integration/extraction_v2/test_e2e_pipeline.py
+++ b/tests/integration/extraction_v2/test_e2e_pipeline.py
@@ -149,8 +149,8 @@ class TestE2ESlackFiling:
         assert slack_result.document is not None
         assert slack_result.total_duration_ms > 0
 
-    def test_e2e_slack_all_14_stages_executed(self, slack_result: PipelineResult):
-        """Test that all 14 pipeline stages were executed."""
+    def test_e2e_slack_all_15_stages_executed(self, slack_result: PipelineResult):
+        """Test that all 15 pipeline stages were executed."""
         executed_stages = {result.stage for result in slack_result.stage_results}
 
         expected_stages = {
@@ -168,6 +168,7 @@ class TestE2ESlackFiling:
             PipelineStage.DEFINITION_EXTRACTION,
             PipelineStage.DEDUPLICATION,
             PipelineStage.VALIDATION,
+            PipelineStage.METRIC_PRESENCE,
         }
 
         # Image stages are skipped when OPENAI_API_KEY is not set (e.g. in CI)

--- a/tests/integration/extraction_v2/test_persistence_guard.py
+++ b/tests/integration/extraction_v2/test_persistence_guard.py
@@ -24,6 +24,7 @@ from src.extraction_v2.models import (
     ImageAsset,
     ImageClassification,
     MetricFact,
+    MetricPresence,
     PeriodType,
     ReviewStatus,
     SourceLocator,
@@ -661,3 +662,161 @@ class TestChartOnlyMode:
                 (test_filing_id,),
             )
             assert int(cur.fetchone()["n"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Presence-only mode: gold-standard backfill safety
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline_result_with_presence(
+    facts: list[MetricFact],
+    presences: list[MetricPresence],
+) -> PipelineResult:
+    """PipelineResult carrying facts AND presence records. Used by the
+    presence_only tests below to prove that presence is written even when
+    facts are short-circuited."""
+    doc = Document(
+        doc_id=str(uuid.uuid4()),
+        accession="9999999998-99-999998",
+        cik="9999999998",
+        company="Guard Test Company",
+        parse_version="2.0.0",
+    )
+    return PipelineResult(
+        document=doc,
+        segments=[],
+        tables=[],
+        images=[],
+        facts=facts,
+        definitions=[],
+        presences=presences,
+        stage_results=[
+            StageResult(
+                stage=PipelineStage.METRIC_PRESENCE,
+                success=True,
+                duration_ms=1,
+                items_processed=len(facts) + len(presences),
+                items_output=len(presences),
+            )
+        ],
+        total_duration_ms=1,
+        success=True,
+    )
+
+
+def _presence_count(db: DatabaseAdapter, filing_id: int) -> int:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS n FROM v2_text_metric_presence WHERE doc_id = %s",
+                (filing_id,),
+            )
+            return int(cur.fetchone()["n"])
+
+
+def _fact_count(db: DatabaseAdapter, filing_id: int) -> int:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS n FROM v2_metric_facts WHERE doc_id = %s",
+                (filing_id,),
+            )
+            return int(cur.fetchone()["n"])
+
+
+class TestPresenceOnlyMode:
+    """Verify presence_only=True is safe on reviewed filings: no
+    ReviewedFilingError, no fact mutation, presence populated. This is the
+    mode the PR2 gold-standard backfill will use."""
+
+    @pytest.fixture(autouse=True)
+    def _purge_presence(self, db_adapter: DatabaseAdapter, test_filing_id: int):
+        with db_adapter.get_connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                (test_filing_id,),
+            )
+        yield
+        with db_adapter.get_connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                (test_filing_id,),
+            )
+
+    def test_presence_only_does_not_raise_on_reviewed_filing(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        # Seed a reviewed filing — fact with a decision.
+        seeded = _make_fact(test_filing_id)
+        persistence_adapter.persist_facts([seeded], test_filing_id)
+        _insert_decision(db_adapter, seeded.fact_id, reviewer_id="alice@example.com")
+        assert _decision_count(db_adapter, test_filing_id) == 1
+
+        # Same filing, new pipeline run — facts would normally raise, but
+        # presence_only=True short-circuits fact persistence entirely.
+        fresh_fact = _make_fact(test_filing_id, value=999.0)
+        presence = MetricPresence(
+            canonical_metric_id="cm_net_revenue_retention",
+            score=0.9,
+            detected_at_stage="fact_construction",
+            advisory_fact_ids=[fresh_fact.fact_id],
+        )
+        result = _make_pipeline_result_with_presence([fresh_fact], [presence])
+
+        persist_result = persistence_adapter.persist_pipeline_result(
+            result, test_filing_id, presence_only=True
+        )
+
+        assert persist_result.success
+        assert persist_result.facts_upserted == 0  # fact path skipped
+        assert persist_result.presences_upserted == 1
+
+        # Existing fact + decision untouched; new fact NOT persisted.
+        assert _fact_count(db_adapter, test_filing_id) == 1  # only the seeded fact
+        assert _decision_count(db_adapter, test_filing_id) == 1
+        assert _presence_count(db_adapter, test_filing_id) == 1
+
+    def test_presence_only_upserts_presence_without_force(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        # No reviewer decisions; plain presence_only write should succeed.
+        p1 = MetricPresence(
+            canonical_metric_id="cm_a", score=0.5, detected_at_stage="fact_construction"
+        )
+        result = _make_pipeline_result_with_presence([], [p1])
+        r1 = persistence_adapter.persist_pipeline_result(result, test_filing_id, presence_only=True)
+        assert r1.success and r1.presences_upserted == 1
+
+        # Re-run with updated score — upsert on (doc_id, metric_id).
+        p2 = MetricPresence(
+            canonical_metric_id="cm_a", score=0.8, detected_at_stage="fact_construction"
+        )
+        result = _make_pipeline_result_with_presence([], [p2])
+        r2 = persistence_adapter.persist_pipeline_result(result, test_filing_id, presence_only=True)
+        assert r2.success
+        assert _presence_count(db_adapter, test_filing_id) == 1  # still one row
+
+        with db_adapter.get_connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT score FROM v2_text_metric_presence WHERE doc_id = %s",
+                (test_filing_id,),
+            )
+            assert cur.fetchone()["score"] == 0.8
+
+    def test_presence_only_and_chart_only_are_mutually_exclusive(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        test_filing_id: int,
+    ):
+        result = _make_pipeline_result_with_presence([], [])
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            persistence_adapter.persist_pipeline_result(
+                result, test_filing_id, presence_only=True, chart_only=True
+            )

--- a/tests/integration/extraction_v2/test_presence_persistence.py
+++ b/tests/integration/extraction_v2/test_presence_persistence.py
@@ -1,0 +1,231 @@
+"""
+Integration test: round-trip MetricPresence through v2_text_metric_presence.
+
+Verifies _persist_presence_in_tx writes rows via the pipeline-result path,
+re-runs are idempotent (UPSERT on (doc_id, canonical_metric_id)), and the
+upsert never touches v2_metric_facts or v2_review_decisions. The
+presence_only=True mode is exercised in test_persistence_guard.py alongside
+the existing fact/image guard suite.
+
+Requires TEST_DATABASE_URL; skips otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from src.extraction_v2.models import Document, MetricPresence
+from src.extraction_v2.persistence import V2PersistenceAdapter
+from src.extraction_v2.pipeline import PipelineResult, PipelineStage, StageResult
+from src.infra.db import DatabaseAdapter
+
+pytestmark = pytest.mark.integration
+
+
+def _test_db_url() -> str | None:
+    return os.environ.get("TEST_DATABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def db_adapter() -> DatabaseAdapter:
+    url = _test_db_url()
+    if not url:
+        pytest.skip("TEST_DATABASE_URL not set")
+    return DatabaseAdapter(url)
+
+
+@pytest.fixture(scope="module")
+def persistence_adapter(db_adapter: DatabaseAdapter) -> V2PersistenceAdapter:
+    return V2PersistenceAdapter(db_adapter)
+
+
+@pytest.fixture
+def test_filing_id(db_adapter: DatabaseAdapter) -> int:
+    with db_adapter.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO companies (cik, company_name, ticker)
+                VALUES ('9999999997', 'Presence Round-Trip Co', 'PRESRT')
+                ON CONFLICT (cik) DO UPDATE SET company_name = EXCLUDED.company_name
+                RETURNING company_id
+                """
+            )
+            company_id = cur.fetchone()["company_id"]
+            cur.execute(
+                """
+                INSERT INTO filings (
+                    company_id, cik, accession_number, form_type, filing_date, sec_html_url
+                )
+                VALUES (
+                    %(company_id)s, '9999999997', '9999999997-99-999997',
+                    'S-1', '2026-01-01', 'https://www.sec.gov/presence-rt/filing.htm'
+                )
+                ON CONFLICT (company_id, accession_number) DO UPDATE SET
+                    form_type = EXCLUDED.form_type
+                RETURNING filing_id
+                """,
+                {"company_id": company_id},
+            )
+            return cur.fetchone()["filing_id"]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_adapter: DatabaseAdapter, test_filing_id: int):
+    def _purge() -> None:
+        with db_adapter.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                    (test_filing_id,),
+                )
+
+    _purge()
+    yield
+    _purge()
+
+
+def _make_pipeline_result(presences: list[MetricPresence]) -> PipelineResult:
+    doc = Document(
+        doc_id=str(uuid.uuid4()),
+        accession="9999999997-99-999997",
+        cik="9999999997",
+        company="Presence Round-Trip Co",
+        parse_version="2.0.0",
+    )
+    return PipelineResult(
+        document=doc,
+        segments=[],
+        tables=[],
+        images=[],
+        facts=[],
+        definitions=[],
+        presences=presences,
+        stage_results=[
+            StageResult(
+                stage=PipelineStage.METRIC_PRESENCE,
+                success=True,
+                duration_ms=1,
+                items_processed=len(presences),
+                items_output=len(presences),
+            )
+        ],
+        total_duration_ms=1,
+        success=True,
+    )
+
+
+def _read_presences(db: DatabaseAdapter, doc_id: int) -> list[dict]:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT canonical_metric_id, score, detected_at_stage,
+                       evidence_segment_ids, advisory_value_count, advisory_fact_ids,
+                       pipeline_version
+                  FROM v2_text_metric_presence
+                 WHERE doc_id = %s
+                 ORDER BY canonical_metric_id
+                """,
+                (doc_id,),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+
+class TestPresenceRoundTrip:
+    def test_persist_writes_rows(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        result = _make_pipeline_result(
+            [
+                MetricPresence(
+                    canonical_metric_id="cm_net_revenue_retention",
+                    score=0.85,
+                    detected_at_stage="fact_construction",
+                    evidence_segment_ids=["seg-1", "seg-2"],
+                    advisory_value_count=2,
+                    advisory_fact_ids=[str(uuid.uuid4())],
+                ),
+                MetricPresence(
+                    canonical_metric_id="cm_revenue_by_cohort",
+                    score=0.7,
+                    detected_at_stage="chart_fact_bridge",
+                    evidence_segment_ids=[],
+                    advisory_value_count=0,
+                    advisory_fact_ids=[],
+                ),
+            ]
+        )
+
+        persist_result = persistence_adapter.persist_pipeline_result(result, test_filing_id)
+
+        assert persist_result.success
+        assert persist_result.presences_upserted == 2
+
+        rows = _read_presences(db_adapter, test_filing_id)
+        assert [r["canonical_metric_id"] for r in rows] == [
+            "cm_net_revenue_retention",
+            "cm_revenue_by_cohort",
+        ]
+        nrr = rows[0]
+        assert nrr["score"] == 0.85
+        assert nrr["detected_at_stage"] == "fact_construction"
+        # JSONB deserializes to list for evidence_segment_ids / advisory_fact_ids
+        assert nrr["evidence_segment_ids"] == ["seg-1", "seg-2"]
+        assert nrr["advisory_value_count"] == 2
+        assert len(nrr["advisory_fact_ids"]) == 1
+        assert nrr["pipeline_version"] == "2.0.0"
+
+    def test_re_run_is_idempotent_and_updates(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        # First run
+        r1 = _make_pipeline_result(
+            [
+                MetricPresence(
+                    canonical_metric_id="cm_a",
+                    score=0.6,
+                    detected_at_stage="fact_construction",
+                )
+            ]
+        )
+        persistence_adapter.persist_pipeline_result(r1, test_filing_id)
+
+        # Second run with higher score — should UPDATE, not INSERT a second row
+        r2 = _make_pipeline_result(
+            [
+                MetricPresence(
+                    canonical_metric_id="cm_a",
+                    score=0.9,
+                    detected_at_stage="fact_construction",
+                    evidence_segment_ids=["seg-new"],
+                )
+            ]
+        )
+        persistence_adapter.persist_pipeline_result(r2, test_filing_id)
+
+        rows = _read_presences(db_adapter, test_filing_id)
+        assert len(rows) == 1
+        assert rows[0]["score"] == 0.9
+        assert rows[0]["evidence_segment_ids"] == ["seg-new"]
+
+    def test_empty_presences_is_noop(
+        self,
+        persistence_adapter: V2PersistenceAdapter,
+        db_adapter: DatabaseAdapter,
+        test_filing_id: int,
+    ):
+        result = _make_pipeline_result([])
+        persist_result = persistence_adapter.persist_pipeline_result(result, test_filing_id)
+        assert persist_result.success
+        assert persist_result.presences_upserted == 0
+        assert _read_presences(db_adapter, test_filing_id) == []

--- a/tests/unit/extraction_v2/test_metric_presence_stage.py
+++ b/tests/unit/extraction_v2/test_metric_presence_stage.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for MetricPresenceStage.
+
+Contract under the text-presence pivot: produce one MetricPresence record
+per (doc, metric_id) with max score across contributing signals, union of
+evidence segment IDs, and fact_id list for facts that contributed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from pathlib import Path
+
+from src.extraction_v2.models import (
+    ChartData,
+    ChartSeries,
+    ChartType,
+    DataPoint,
+    DetectedMetric,
+    EvidencePack,
+    ExtractionMethod,
+    ImageAsset,
+    ImageClassification,
+    MetricDefinition,
+    MetricFact,
+    PeriodType,
+    ReviewStatus,
+    SourceLocator,
+    SourceType,
+    Unit,
+)
+from src.extraction_v2.pipeline import PipelineConfig, PipelineContext, PipelineStage
+from src.extraction_v2.stages.metric_presence import MetricPresenceStage
+
+
+def _make_context(
+    *,
+    facts: list[MetricFact] | None = None,
+    dedup: list[MetricFact] | None = None,
+    images: list[ImageAsset] | None = None,
+    definitions: list[MetricDefinition] | None = None,
+) -> PipelineContext:
+    ctx = PipelineContext(
+        html_path=Path("/test/filing.html"),
+        filing_id=42,
+        config=PipelineConfig(),
+        document_date=date(2025, 1, 1),
+    )
+    ctx.facts = facts or []
+    ctx.deduplicated_facts = dedup
+    ctx.images = images or []
+    ctx.definitions = definitions or []
+    return ctx
+
+
+def _fact(
+    metric_id: str,
+    *,
+    confidence: float = 0.8,
+    segment_id: str | None = None,
+    fact_id: str | None = None,
+) -> MetricFact:
+    return MetricFact(
+        fact_id=fact_id or str(uuid.uuid4()),
+        doc_id="42",
+        canonical_metric_id=metric_id,
+        value=100.0,
+        value_raw="100",
+        unit=Unit.COUNT,
+        period_type=PeriodType.ANNUAL,
+        period_start=date(2024, 1, 1),
+        period_end=date(2024, 12, 31),
+        source_type=SourceType.TEXT,
+        source_locator=SourceLocator(segment_id=segment_id),
+        evidence_pack=EvidencePack(snippet_html="<p>100</p>"),
+        confidence=confidence,
+        extraction_method=ExtractionMethod.EXACT_MATCH,
+        review_status=ReviewStatus.PENDING_REVIEW,
+    )
+
+
+def _chart_image(metrics: list[tuple[str, float]]) -> ImageAsset:
+    return ImageAsset(
+        img_id=str(uuid.uuid4()),
+        classification=ImageClassification.CHART,
+        chart_data=ChartData(
+            chart_type=ChartType.BAR,
+            series=[ChartSeries(name="x", points=[DataPoint(x="a", y=1.0)])],
+        ),
+        processed=True,
+        confidence=0.9,
+        relevance_score=0.9,
+        detected_metrics=[DetectedMetric(metric_id=m, score=s) for m, s in metrics],
+    )
+
+
+class TestMetricPresenceStage:
+    def test_empty_context_emits_zero_presences(self) -> None:
+        ctx = _make_context()
+        MetricPresenceStage().process(ctx)
+        assert ctx.presences == []
+
+    def test_facts_aggregated_one_row_per_metric(self) -> None:
+        # Two facts for same metric, different segments and confidences.
+        f1 = _fact("cm_new_customers_acquired", confidence=0.6, segment_id="seg-1")
+        f2 = _fact("cm_new_customers_acquired", confidence=0.9, segment_id="seg-2")
+        ctx = _make_context(dedup=[f1, f2])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        p = ctx.presences[0]
+        assert p.canonical_metric_id == "cm_new_customers_acquired"
+        assert p.score == 0.9  # max
+        assert p.advisory_value_count == 2
+        assert set(p.advisory_fact_ids) == {f1.fact_id, f2.fact_id}
+        assert set(p.evidence_segment_ids) == {"seg-1", "seg-2"}
+        assert p.detected_at_stage == PipelineStage.FACT_CONSTRUCTION.value
+
+    def test_prefers_deduplicated_facts_when_populated(self) -> None:
+        raw = _fact("cm_a", confidence=0.5, segment_id="seg-raw")
+        dedup = _fact("cm_a", confidence=0.7, segment_id="seg-dedup")
+        ctx = _make_context(facts=[raw], dedup=[dedup])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        # Dedup fact used, not raw
+        assert ctx.presences[0].score == 0.7
+        assert ctx.presences[0].evidence_segment_ids == ["seg-dedup"]
+
+    def test_falls_back_to_raw_facts_when_dedup_not_run(self) -> None:
+        raw = _fact("cm_a", confidence=0.5, segment_id="seg-raw")
+        ctx = _make_context(facts=[raw], dedup=None)
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        assert ctx.presences[0].score == 0.5
+
+    def test_chart_detected_metrics_contribute(self) -> None:
+        img = _chart_image([("cm_revenue_by_cohort", 0.85)])
+        ctx = _make_context(images=[img])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        p = ctx.presences[0]
+        assert p.canonical_metric_id == "cm_revenue_by_cohort"
+        assert p.score == 0.85
+        assert p.advisory_value_count == 0  # chart-only, no text facts
+        assert p.advisory_fact_ids == []
+        assert p.evidence_segment_ids == []  # chart evidence lives on image
+        assert p.detected_at_stage == PipelineStage.CHART_FACT_BRIDGE.value
+
+    def test_fact_and_chart_merge_into_single_presence(self) -> None:
+        # Chart detects metric at 0.7; text fact independently binds at 0.9.
+        fact = _fact("cm_revenue_by_cohort", confidence=0.9, segment_id="seg-1")
+        img = _chart_image([("cm_revenue_by_cohort", 0.7)])
+        ctx = _make_context(dedup=[fact], images=[img])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        p = ctx.presences[0]
+        assert p.score == 0.9  # max of fact + chart
+        assert p.advisory_value_count == 1
+        assert p.advisory_fact_ids == [fact.fact_id]
+        assert p.evidence_segment_ids == ["seg-1"]
+        # detected_at_stage comes from whoever seeded the accumulator first
+        assert p.detected_at_stage == PipelineStage.FACT_CONSTRUCTION.value
+
+    def test_definition_alone_emits_presence_at_floor_score(self) -> None:
+        defn = MetricDefinition(
+            canonical_metric_id="cm_net_revenue_retention",
+            doc_id="42",
+            definition_text="Net revenue retention measures...",
+            definition_segment_id="seg-def",
+        )
+        ctx = _make_context(definitions=[defn])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        p = ctx.presences[0]
+        assert p.canonical_metric_id == "cm_net_revenue_retention"
+        assert p.score == 0.5  # _DEFINITION_ONLY_PRESENCE_SCORE
+        assert p.evidence_segment_ids == ["seg-def"]
+        assert p.advisory_value_count == 0
+
+    def test_definition_does_not_downgrade_stronger_fact_score(self) -> None:
+        fact = _fact("cm_a", confidence=0.95, segment_id="seg-f")
+        defn = MetricDefinition(
+            canonical_metric_id="cm_a",
+            doc_id="42",
+            definition_text="cm_a is...",
+            definition_segment_id="seg-d",
+        )
+        ctx = _make_context(dedup=[fact], definitions=[defn])
+
+        MetricPresenceStage().process(ctx)
+
+        assert len(ctx.presences) == 1
+        p = ctx.presences[0]
+        assert p.score == 0.95  # fact wins; definition floor does not lower it
+        assert set(p.evidence_segment_ids) == {"seg-f", "seg-d"}
+
+    def test_presences_sorted_by_metric_id_for_determinism(self) -> None:
+        ctx = _make_context(
+            dedup=[
+                _fact("cm_zebra", confidence=0.5, segment_id="s1"),
+                _fact("cm_alpha", confidence=0.5, segment_id="s2"),
+                _fact("cm_middle", confidence=0.5, segment_id="s3"),
+            ]
+        )
+
+        MetricPresenceStage().process(ctx)
+
+        metric_ids = [p.canonical_metric_id for p in ctx.presences]
+        assert metric_ids == sorted(metric_ids)
+
+    def test_fact_without_canonical_metric_id_is_skipped(self) -> None:
+        ctx = _make_context(
+            dedup=[
+                _fact("", confidence=0.9, segment_id="s1"),
+                _fact("cm_real", confidence=0.7, segment_id="s2"),
+            ]
+        )
+
+        MetricPresenceStage().process(ctx)
+
+        assert [p.canonical_metric_id for p in ctx.presences] == ["cm_real"]
+
+    def test_stage_result_metadata_has_counters(self) -> None:
+        fact = _fact("cm_a", confidence=0.8, segment_id="seg")
+        img = _chart_image([("cm_b", 0.6)])
+        ctx = _make_context(dedup=[fact], images=[img])
+
+        result = MetricPresenceStage().process(ctx)
+
+        assert result.success
+        assert result.stage == PipelineStage.METRIC_PRESENCE
+        assert result.items_output == 2
+        assert result.metadata["metrics_present"] == 2
+        assert result.metadata["fact_contributors"] == 1
+        assert result.metadata["chart_only_presences"] == 1


### PR DESCRIPTION
## Summary

First of four PRs for the text-extraction pivot: shifts the primary scoring surface from per-fact accuracy to per-(document, metric) **presence** detection, mirroring the chart-presence pivot (PR #147). Fact emission continues unchanged as an advisory evidence layer; this PR lands the parallel presence surface.

**Zero user-visible change in this PR** — no reviewer UI edits, no validator/gate changes, no gold-standard changes. Safe to revert by dropping the migration + stage. Downstream PR2/PR3/PR4 read this PR's landed interface from `docs/operations/text-pipeline-presence-pivot-plan.md`.

## What's in here

- **Schema** (`sql/46_v2_text_metric_presence.sql`): new table keyed on `(doc_id, canonical_metric_id)` with `score`, `evidence_segment_ids`, `advisory_value_count`, `advisory_fact_ids` (JSONB, no FK — presence survives `force=True` fact purges because presence is a document-level claim, independent of which specific fact rows back it).
- **Stage** (`src/extraction_v2/stages/metric_presence.py`): new final stage (`PipelineStage.METRIC_PRESENCE`) that aggregates dedup'd facts + chart `detected_metrics` + definitions into one `MetricPresence` per `(doc, metric)`. Max score across signals; union of segment IDs.
- **Dataclass** (`src/extraction_v2/models.py`): `MetricPresence` mirroring `DetectedMetric`.
- **Persistence** (`src/extraction_v2/persistence.py`): `_persist_presence_in_tx` upsert; new `presence_only=True` kwarg on `persist_pipeline_result` short-circuits fact persistence (for the PR2 gold-standard backfill on reviewed filings) while all other idempotent steps run as normal. Mutually exclusive with `chart_only`.
- **Interface contract** (`docs/operations/text-pipeline-presence-pivot-plan.md`): the canonical reference PR2/PR3/PR4 use to pick up the pivot from fresh sessions.

## No fact deletion, no reviewer-decision impact, gate semantics unchanged

- `v2_metric_facts` and `v2_review_decisions` untouched.
- Existing `ReviewedFilingError` guard at `persistence.py:_persist_facts_in_tx` stays active.
- `_persist_presence_in_tx` is pure upsert — never triggers the guard.
- `presence_only=True` mode skips the fact-persist path entirely, so reviewed filings can be backfilled with presence data without `force=True`.
- Tier 1 gate semantics flip only when PR2 merges.

## Side note: MIGRATION_ORDER cleanup

`sql/44` and `sql/45` (landed in PR #162) were missing from `MIGRATION_ORDER` in both `scripts/apply_migrations.py` and `scripts/apply_all_migrations.py`. The pre-commit `migration-order-check` guard blocked this PR until all three (44, 45, 46) were registered. Closed inline rather than deferred — see interface doc for the note.

## Test plan

- [x] `pytest tests/unit -x -q` — **3944 passed, 11 skipped**
- [x] `pytest tests/integration/extraction_v2/ -x -q` — **102 passed, 56 skipped, 12 deselected** (includes new `TestPresenceRoundTrip`, `TestPresenceOnlyMode`, and E2E 15-stage assertion)
- [x] `ruff check` on changed files — clean
- [x] `ruff format --check` on changed files — clean
- [x] `mypy src/review/ --strict` — clean (13 files)
- [x] `python3 scripts/check_migration_order.py` — passes
- [x] `python3 scripts/apply_migrations.py --test` — migration 46 applied successfully

## Downstream

- PR2 — gold-standard presence derivation + validator + Tier 1 gate flip
- PR3 — reviewer UI (`v2_text_presence_confirmations`)
- PR4 — Tier-1 LLM definition/methodology classifier

Full program: `~/.claude/plans/text-presence-pivot-index.md` (local). Landed-interface contract: `docs/operations/text-pipeline-presence-pivot-plan.md` (in-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)