### PR TITLE
fix(ci): ignore pip CVE-2026-3219 until upstream fix ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,11 @@ jobs:
         run: uv sync --extra dev
 
       - name: Audit dependencies
-        run: uv run pip-audit
+        # Temporarily ignoring CVE-2026-3219 (pip 26.0.1). No fix version
+        # published by upstream yet; pip-audit would block every PR on a
+        # vulnerability we cannot remediate. Remove this ignore once a
+        # patched pip is released.
+        run: uv run pip-audit --ignore-vuln CVE-2026-3219
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
## Summary

A new CVE (`CVE-2026-3219`) was published against `pip 26.0.1` with **no fix version available yet**. `pip-audit` fails hard on this, blocking every PR's Vulnerability Scan despite no code change on our side.

This adds `--ignore-vuln CVE-2026-3219` as a temporary workaround. Remove the ignore once upstream ships a patched pip.

## Context

- Discovered on PR #185 (Phase 1 of known-issues rethink), which had only CI/docs changes yet failed vuln-scan.
- Affects every PR on main until patched.
- pip-audit `--ignore-vuln` is a stable, documented flag; verified locally ("No known vulnerabilities found, 1 ignored", exit 0).

## Test plan

- [x] Local verification: `uv run pip-audit --ignore-vuln CVE-2026-3219` exits 0.
- [x] YAML validated.
- [ ] Vulnerability Scan job goes green on this PR.

## Follow-up

Once this lands, PR #185 can re-run and merge. A future cleanup PR should remove the ignore when upstream publishes a fixed pip.