### PR TITLE
feat(known-issues): phase 4 — GH-issue-number fragment IDs

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -86,13 +86,13 @@
 
    **9e. Act.** "approve"/"all"/silent → file all `TO FILE`. "none"/"skip" → file nothing. Anything else → apply user edits, confirm revised list, file.
 
-   **9f. Write fragment files.** For each item:
-   - Find the highest existing id: `{ ls docs/known-issues/legacy-*.md docs/known-issues/gh-*.md 2>/dev/null; git ls-tree --name-only origin/main docs/known-issues/ 2>/dev/null; } | grep -oE '(legacy|gh)-[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1`. Next id = that + 1. (Union of local files and `origin/main` prevents collisions when multiple branches are in flight.)
-   - Create `docs/known-issues/legacy-NNN-<kebab-slug>.md` with this exact structure:
+   **9f. Create a GitHub issue and write the fragment file.** For each item, GitHub assigns the id (no local allocation, no collisions):
+   - Create the issue first: `gh issue create --title "<Title>" --body "$(printf '%s\n\n%s\n' '<Problem: 1–3 sentences>' '## Next Steps\n\n- <1–3 bullets>')"`. Capture the returned issue number `N` from the URL (`gh` prints something like `https://github.com/<org>/<repo>/issues/N`).
+   - Name the fragment `docs/known-issues/gh-N-<kebab-slug>.md` with this structure:
      ```yaml
      ---
-     id: NNN
-     source: legacy
+     id: N
+     source: gh
      slug: <kebab-case-slug>
      title: <Title>
      status: open
@@ -102,6 +102,7 @@
      touches: []     # list of globs; required before sweeper will pick it up
      discovered: <today's date YYYY-MM-DD>
      updated: <today's date YYYY-MM-DD>
+     gh_issue: N
      note: <short one-line actionable summary>
      ---
 
@@ -115,6 +116,8 @@
      ```
    - Do NOT stage the fragment yet — it's a separate follow-up commit (step 13).
    - Note: `docs/KNOWN_ISSUES.md` is no longer tracked in git. CI regenerates it as a build artifact. Do not create or stage that file.
+   - Existing `legacy-NNN-*.md` fragments are frozen in place; do not rename or renumber them. All new fragments use the `gh-N-*` naming above.
+   - Prerequisite: `gh auth status` must return authenticated. In sweeper / CI contexts this is provided by `GITHUB_TOKEN`; for local interactive use, run `gh auth login` first if needed.
 
 10. **Show staged diff.** Run `git diff --cached --stat`.
 
@@ -128,7 +131,7 @@
 12. **Restore pre-existing staging.** Re-stage files that were unstaged in step 4.
 
 13. **Known-issues follow-up commit.** Only if step 9 produced new fragment files under `docs/known-issues/`:
-    - `git add docs/known-issues/legacy-NNN-<slug>.md` (fragment only — the rollup `docs/KNOWN_ISSUES.md` is not tracked in git; CI regenerates it as a build artifact).
+    - `git add docs/known-issues/gh-N-<slug>.md` (fragment only — the rollup `docs/KNOWN_ISSUES.md` is not tracked in git; CI regenerates it as a build artifact).
     - Commit: `docs(known-issues): log issue(s) #N[, #M] — [descriptor]` (matches commits `87b54f7`, `e96b6fb`).
     - Do NOT push yet — step 14 pushes both commits together.
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -152,6 +152,6 @@ specific files by name.
 
 ## Known-issues triage
 
-New issues surfaced during contribution go into a new `docs/known-issues/legacy-NNN-<slug>.md` fragment file (see the frontmatter template in the `/commit` skill or existing fragments for the expected shape). Fragments are the source of truth.
+New issues surfaced during contribution go into a new `docs/known-issues/gh-N-<slug>.md` fragment file, where `N` is the GitHub issue number returned by `gh issue create`. The `/commit` skill step 9 automates this — see the frontmatter template there. Existing `legacy-NNN-*.md` fragments (pre-2026-04-24) are frozen in place; do not rename them. Fragments are the source of truth.
 
 The rollup `docs/KNOWN_ISSUES.md` is not tracked in git — CI regenerates it as a build artifact on every run (`.github/workflows/ci.yml` job `known-issues-artifact`). Download the latest rendered rollup from the Actions tab of any `main` build. To regenerate locally for preview: `python3 scripts/regenerate_known_issues.py --output /tmp/KNOWN_ISSUES.md`.

--- a/docs/operations/known-issues-system-rethink-plan.md
+++ b/docs/operations/known-issues-system-rethink-plan.md
@@ -290,8 +290,8 @@ All four resolved 2026-04-24 with rationale:
 
 - Phase 1 — ✅ shipped in PR #185 (2026-04-24)
 - Phase 2 — ✅ shipped in PR #187 (2026-04-24); in-flight PRs #169, #173, #175 cleaned up + merged same day
-- Phase 3 — 🚧 this PR
-- Phase 4 — ⏳ queued (3 ID collisions hit during #173/#175 cleanup underscored the need)
+- Phase 3 — ✅ shipped in PR #188 (2026-04-24)
+- Phase 4 — 🚧 this PR
 - Phase 5 — ⏳ queued
 
 ---

--- a/docs/operations/nightly-sweep-runbook.md
+++ b/docs/operations/nightly-sweep-runbook.md
@@ -47,7 +47,7 @@ The cron still fires on schedule — it just exits `0` with a log line on the Re
 
 ## Classifying issues
 
-When you open a new issue via `/commit`'s step 9, the fragment defaults to `autonomy: skip`. To reclassify, edit the `autonomy:` field in the fragment file (`docs/known-issues/legacy-NNN-<slug>.md`) and commit:
+When you open a new issue via `/commit`'s step 9, the fragment defaults to `autonomy: skip`. To reclassify, edit the `autonomy:` field in the fragment file (`docs/known-issues/gh-N-<slug>.md` for new fragments, or `legacy-NNN-<slug>.md` for frozen pre-2026-04-24 fragments) and commit:
 
 - `safe` — single file or disjoint files; no schema/migration; no infra/credential change; existing test coverage. Sweeper auto-merges on green CI.
 - `review` — cross-module edits, judgment calls, new feature logic. Sweeper opens draft PR for morning approval.


### PR DESCRIPTION
## Summary

Phase 4 of the known-issues system rethink. When `/commit` files a new known-issue, it now creates a GitHub issue via `gh issue create` first, then uses that issue's number as the fragment ID and filename. **Fragment ID collisions are impossible by construction — GitHub assigns numbers centrally.**

## What changed

- **`.claude/commands/commit.md` step 9f**: replaced local-max ID allocation (`ls ... | grep ... | sort -n | tail -1`) with `gh issue create` + number capture. Fragment naming: `gh-N-<slug>.md`. Frontmatter: `source: gh`, `gh_issue: N`.
- **`.claude/commands/commit.md` step 13**: updated `git add` path from `legacy-NNN-*` to `gh-N-*`.
- **`docs/operations/nightly-sweep-runbook.md`**: classifying-issues section reflects new `gh-N-*` naming for new fragments; legacy naming noted as frozen.
- **`docs/development/CONTRIBUTING.md`**: known-issues-triage paragraph updated.
- **`docs/operations/known-issues-system-rethink-plan.md`**: Phase 3 marked shipped (#188); Phase 4 marked in-flight.

**No code changes.** The validator, generator, and selector already support both `legacy-*` and `gh-*` prefixes:
- `scripts/validate_known_issues_fragments.py:55` — `FILENAME_RE = ^(legacy|gh)-<id>-<slug>\.md$`
- `scripts/validate_known_issues_fragments.py:48` — `VALID_SOURCE = {"legacy", "gh"}`
- Existing test: `tests/unit/scripts/test_regenerate_known_issues.py::test_gh_source_gets_gh_suffix`

## Why this is the right fix

Motivation proven live during Phase 2 cleanup (2026-04-24): in-flight PRs #173 and #175 both picked `legacy-101` / `legacy-102` IDs that main had independently claimed. Three separate collisions had to be hand-resolved with renumber commits because those PRs were opened before PR #167's `origin/main` ID-scan landed — and PR #167 itself was only a partial fix (only covered the `/commit` path; any other caller reintroduces the bug).

Phase 4 eliminates the class entirely. No allocation step exists for the fragment ID; GitHub is the authority.

## Preservation guarantees

- Existing `legacy-NNN-*.md` fragments (104 files at time of writing) are frozen in place. Not renamed, not renumbered. Validator / generator / selector keep rendering them.
- The plan's Q4 decision ("freeze legacy-* forever; opportunistic migration only") is preserved.

## Prerequisites

- `gh auth status` must return authenticated. Sweeper / CI contexts use `GITHUB_TOKEN` (already wired); local interactive use needs `gh auth login`.

## Test plan

- [x] `python3 scripts/regenerate_known_issues.py --validate` — 104 fragments pass
- [x] Pre-commit hooks green
- [ ] CI green on this PR
- [ ] First fragment-touching PR after this lands validates the new flow end-to-end (and also validates Phase 3's PR-comment bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)