### PR TITLE
docs(known-issues): archive #16, scope-reduce #24 — dissolved by presence pivot

### DIFF
--- a/docs/known-issues/legacy-016-farfetch-precision-drag-table-scale-period-attribution.md
+++ b/docs/known-issues/legacy-016-farfetch-precision-drag-table-scale-period-attribution.md
@@ -1,16 +1,19 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-18'
 estimated: M
 id: 16
-note: Precision tuning; data-driven, needs judgment
+note: 'Dissolved by presence-first pivot (2026-04-24). Issue is purely value-level
+  precision (table-scale inference, period attribution); facts are advisory under
+  the pivot and the Tier 1 gate no longer counts these FPs. See
+  docs/operations/text-pipeline-presence-pivot-plan.md.'
 severity: low
 slug: farfetch-precision-drag-table-scale-period-attribution
 source: legacy
-status: open
+status: archived
 title: Farfetch Precision Drag — Table-Scale + Period Attribution
 touches: []
-updated: '2026-04-18'
+updated: '2026-04-24'
 ---
 
 ### Problem

--- a/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
+++ b/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
@@ -3,14 +3,17 @@ autonomy: skip
 discovered: '2026-04-18'
 estimated: M
 id: 24
-note: Data audit + FK migration; needs cleanup decision
+note: 'Scope reduced to historical advisory-fact hygiene after 2026-04-24
+  presence-first pivot: presence rows (v2_text_metric_presence,
+  v2_image_metric_presence) do not rely on source_locator.img_id; orphans live only
+  in legacy advisory v2_metric_facts. Not on the presence-pivot critical path.'
 severity: low
 slug: v2-metric-facts-source-locator-img-id-has-no-referential-int
 source: legacy
 status: open
 title: '`v2_metric_facts.source_locator.img_id` Has No Referential Integrity'
 touches: []
-updated: '2026-04-18'
+updated: '2026-04-24'
 ---
 
 ### Problem


### PR DESCRIPTION
#16 (Farfetch precision drag — table-scale + period attribution) is purely
value-level; chart/text presence-first pivots make facts advisory and drop
these FPs from the Tier 1 gate.

#24 (source_locator.img_id referential integrity) reduced to historical
advisory-fact hygiene — presence rows track evidence via segment IDs, not
img_id.
