### PR TITLE
chore: retire required_context gating infrastructure

### DIFF
--- a/config/metric_keywords.yaml
+++ b/config/metric_keywords.yaml
@@ -23,37 +23,6 @@
 
 ---
 # =============================================================================
-# Shared Context Requirements (YAML Anchors)
-# =============================================================================
-# Revenue synonym metrics require cohort or per-customer context to generate
-# review candidates. Without this context, they are just revenue measures,
-# not customer metrics. This anchor defines the shared context patterns.
-
-_revenue_synonym_context: &revenue_synonym_context
-  required_context:
-    patterns:
-      # Cohort keywords (from cohort_chart_detector.py)
-      - '\bcohort\b'
-      - '\bby\s+vintage\b'
-      - '\bacquisition\s+year\b'
-      - '\brevenue\s+(?:by|per)\s+cohort\b'
-      - '\bretention\s+(?:by|per)\s+cohort\b'
-      - '\bARR\s+(?:by|of\s+each)\s+cohort\b'
-      - '\bLTV[/ ]CAC\b'
-      # Per-customer keywords
-      - '\bper\s+customer\b'
-      - '\bper\s+user\b'
-      - '\bper\s+account\b'
-      - '\bper\s+subscriber\b'
-      - '\bper\s+client\b'
-      - '\baverage\s+per\b'
-      - '\bby\s+customer\b'
-      - '\bby\s+account\b'
-      - '\bcustomer[- ]level\b'
-      - '\baccount[- ]level\b'
-    proximity_chars: 1500
-
-# =============================================================================
 # Core Metrics
 # =============================================================================
 # SEMANTIC DISTINCTIONS - Customer Count Metrics:
@@ -677,7 +646,6 @@ cm_gmv:
   # DEPRECATED 2026-01-07: Financial metric, not customer metric unless cohort-specific
   status: deprecated
   deprecation_reason: "Financial platform metric, not customer-specific. Generated FPs for Farfetch (inventory value, subsidiary revenue, share-based expense)."
-  <<: *revenue_synonym_context
   patterns:
     - '\bgmv\b'
     - '\bgross\s+merchandise\s+value\b'

--- a/docs/architecture/extraction-decisions.md
+++ b/docs/architecture/extraction-decisions.md
@@ -36,7 +36,7 @@ Comprehensive false positive filters eliminate years (1990-2100) and date compon
 
 Metric keywords moved to `config/metric_keywords.yaml`:
 - Add/modify keyword patterns without code changes
-- YAML structure: patterns, exclusions, specific_patterns, required_context per metric
+- YAML structure: patterns, exclusions, specific_patterns per metric
 - YAML is the authoritative source of truth (no hardcoded fallback)
 - Environment override: `METRIC_KEYWORDS_CONFIG=/path/to/custom.yaml`
 - Fails fast with clear error if YAML cannot be loaded
@@ -59,17 +59,9 @@ Automated detection of cohort analysis charts in filings:
 
 ---
 
-### 10. Context-Gated Revenue Synonym Metrics (2025-12-30)
+### 10. Context-Gated Revenue Synonym Metrics (2025-12-30; retired 2026-04-24)
 
-Revenue synonyms require cohort/per-customer context:
-- GMV, TCV, ACV, Bookings, Billings only generate review candidates when context is present
-- Context keywords: cohort, vintage, per customer, per user, by account, customer-level, etc.
-- Proximity: context must appear within 1500 chars of keyword match
-- ARR/MRR NOT context-gated (inherently customer-related: "recurring" implies subscriptions)
-- Classification preserved: revenue synonyms still contribute to segment enrichment/richness scoring
-- Configuration: `required_context` in `config/metric_keywords.yaml` with YAML anchor sharing
-
-**Implementation**: `src/review/candidate_generator.py`, `config/metric_keywords.yaml`
+Revenue synonyms (GMV, TCV, ACV, Bookings, Billings) used to require cohort/per-customer context within 1500 chars of the keyword match (`required_context` in `config/metric_keywords.yaml`). The mechanism was retired when all five metrics were deprecated outright (2026-01-07) — the gate had no remaining active subscribers. ARR/MRR were also deprecated in the same wave. See known-issue #5 (archived) and the retirement PR for history.
 
 ---
 

--- a/docs/development/metric-lifecycle-process.md
+++ b/docs/development/metric-lifecycle-process.md
@@ -40,7 +40,7 @@ Follow these steps in order. Each step includes the file path and example code.
 
 **File:** `config/metric_keywords.yaml`
 
-Add a new metric block with patterns, exclusions (optional), specific_patterns (optional), required_context (optional), and aliases (optional).
+Add a new metric block with patterns, exclusions (optional), specific_patterns (optional), and aliases (optional).
 
 ```yaml
 cm_new_metric_name:
@@ -59,14 +59,6 @@ cm_new_metric_name:
   # Optional: multi-word patterns that get confidence bonus
   specific_patterns:
     - 'new\s+metric\s+pattern'
-
-  # Optional: require context keywords nearby (for revenue synonyms)
-  # Use YAML anchor <<: *revenue_synonym_context for standard context
-  required_context:
-    patterns:
-      - '\bper\s+customer\b'
-      - '\bcohort\b'
-    proximity_chars: 1500
 ```
 
 **Key considerations:**
@@ -419,8 +411,9 @@ When adding a new metric, choose a sort order value within the appropriate categ
 
 2. **YAML** - Add deprecation comments but keep patterns:
    ```yaml
-   # DEPRECATED 2026-01-07: Revenue synonym - use required_context for customer metrics
+   # DEPRECATED 2026-01-07: Revenue synonym, not a customer metric
    cm_gmv:
+     status: deprecated
      patterns:
        - '\bgross\s+merchandise\s+value\b'
    ```
@@ -434,8 +427,7 @@ When adding a new metric, choose a sort order value within the appropriate categ
    ### 4.X GMV (DEPRECATED)
 
    > **Deprecated:** 2026-01-07
-   > **Reason:** Revenue synonym without inherent customer context. Use `required_context`
-   > in YAML for metrics that need cohort/per-customer context.
+   > **Reason:** Revenue synonym without inherent customer context.
 
    **ID:** `cm_gmv`
    ...

--- a/docs/known-issues/legacy-108-gs-validator-baseline-drift-farfetch.md
+++ b/docs/known-issues/legacy-108-gs-validator-baseline-drift-farfetch.md
@@ -1,0 +1,35 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: S
+id: 108
+severity: medium
+slug: gs-validator-baseline-drift-farfetch
+source: legacy
+status: open
+title: GS Validator Baseline Drift — Farfetch Reports has_regression=True on Unmodified Main
+touches:
+  - src/gold_standard/v2_validator.py
+  - data/gold_standard/Farfetch_Limited
+updated: '2026-04-24'
+---
+
+### Problem
+
+Running `python3 -m src.gold_standard.v2_validator --companies "Farfetch Limited" --workers 1 --fail-on-regression` on a clean checkout of `origin/main` (commit `74f0d32`) reports:
+
+```
+ComparisonResult(precision_delta=-0.0668, recall_delta=+0.4192, f1_delta=+0.1266,
+                 has_regression=True, regressed_metrics=['precision'])
+```
+
+Surfaced while running the GS smoke test for the `required_context` retirement PR. Identical numbers on the unmodified main and on the modified branch — confirming the drift is pre-existing, not caused by recent extraction changes. The +0.42 recall delta is too large for any single recent commit; the saved baseline appears materially stale.
+
+Blast radius: any PR that runs the validator with `--fail-on-regression` against Farfetch is blocked at commit time even when the change is metric-neutral. This silently reduces the value of the GS gate.
+
+### Next Steps
+
+- Inspect the Farfetch baseline file to confirm staleness (date, last `--update-baseline` description).
+- Compare current TP/FP/FN counts (16/11/0) against the recorded baseline to identify which metrics moved.
+- Either (a) update the baseline with `--update-baseline --description "calibration after [...]"` if the new numbers reflect intended improvements, or (b) bisect to find the unintended regression in precision.
+- Repeat on at least one other company to determine whether the drift is Farfetch-specific or cross-corpus.

--- a/docs/known-issues/legacy-109-v1-keyword-matching-module-orphaned.md
+++ b/docs/known-issues/legacy-109-v1-keyword-matching-module-orphaned.md
@@ -1,0 +1,28 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: S
+id: 109
+severity: low
+slug: v1-keyword-matching-module-orphaned
+source: legacy
+status: open
+title: V1 src/review/keyword_matching.py Has No Live Callers — Module Deletable
+touches:
+  - src/review/keyword_matching.py
+  - tests/unit/review/test_keyword_matching.py
+updated: '2026-04-24'
+---
+
+### Problem
+
+`src/review/keyword_matching.py` is imported only by its own unit test file (`tests/unit/review/test_keyword_matching.py`). No production code path in `src/`, `scripts/`, or the V2 pipeline imports it. V1 review tables and the V1 candidate generator that wrapped this module have been retired (per CLAUDE.md and `sql/31_drop_v1_review_tables.sql`).
+
+Surfaced while retiring the `required_context` gating: the V1 `_has_required_context` was removed in that PR, but the broader question of whether the entire module is dead-code was deliberately scoped out to keep the cleanup tight. The module still ships, runs at import time (eagerly loads YAML), and counts toward `mypy --strict` coverage — pure overhead.
+
+### Next Steps
+
+- Re-confirm zero live callers across `src/`, `scripts/`, `tests/integration/`, and any cron / runner entrypoints.
+- Delete `src/review/keyword_matching.py` and its dedicated test file.
+- Run `pytest -x -q` and `mypy --strict src/review/` to verify no fallout.
+- Sweep `docs/` for stale references to the module (likely a few in `docs/architecture/` and `docs/development/`).

--- a/src/extraction_v2/stages/candidate_generation.py
+++ b/src/extraction_v2/stages/candidate_generation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from src.extraction_v2.exceptions import V2FatalError
 from src.extraction_v2.models import (
@@ -31,7 +31,6 @@ from src.shared.keyword_config import (
     KeywordConfigError,
     get_exclusion_patterns,
     get_metric_keywords,
-    get_required_context,
     get_specific_patterns,
     is_metric_deprecated,
 )
@@ -76,18 +75,12 @@ class CandidateGenerationStage:
         """Initialize stage with compiled regex patterns from V1 config."""
         self._keywords: dict[str, list[str]] = {}
         self._exclusions: dict[str, list[str]] = {}
-        self._required_context: dict[str, dict[str, Any]] = {}
         self._specific_patterns: list[str] = []
 
         # Compiled patterns for performance
         self._compiled_patterns: dict[str, list[re.Pattern[str]]] = {}
         self._compiled_exclusions: dict[str, list[re.Pattern[str]]] = {}
-        # Tuple of (compiled_patterns, proximity_chars)
-        self._compiled_context: dict[str, tuple[list[re.Pattern[str]], int]] = {}
         self._compiled_specific: list[re.Pattern[str]] = []
-
-        # Default proximity for required context (chars)
-        self._default_proximity_chars: int = 1500
 
         self._initialized = False
 
@@ -109,10 +102,6 @@ class CandidateGenerationStage:
             all_exclusions = get_exclusion_patterns()
             self._exclusions = {
                 mid: p for mid, p in all_exclusions.items() if not is_metric_deprecated(mid)
-            }
-            all_context = get_required_context()
-            self._required_context = {
-                mid: c for mid, c in all_context.items() if not is_metric_deprecated(mid)
             }
             self._specific_patterns = get_specific_patterns()
             self._compile_patterns()
@@ -148,17 +137,6 @@ class CandidateGenerationStage:
                 except re.error as e:
                     logger.warning(f"Invalid exclusion pattern for {metric_id}: {pattern!r} - {e}")
             self._compiled_exclusions[metric_id] = compiled
-
-        # Compile required context patterns with proximity
-        for metric_id, config in self._required_context.items():
-            compiled = []
-            for pattern in config.get("patterns", []):
-                try:
-                    compiled.append(re.compile(pattern, re.IGNORECASE))
-                except re.error as e:
-                    logger.warning(f"Invalid context pattern for {metric_id}: {pattern!r} - {e}")
-            proximity = config.get("proximity_chars", self._default_proximity_chars)
-            self._compiled_context[metric_id] = (compiled, proximity)
 
         # Compile specific patterns
         for pattern in self._specific_patterns:
@@ -272,10 +250,6 @@ class CandidateGenerationStage:
                     if self._is_excluded(metric_id, text, match):
                         continue
 
-                    # Check required context (proximity-based)
-                    if not self._has_required_context(metric_id, text, match.start()):
-                        continue
-
                     # Extract context
                     context_text = self._extract_context(text, match.start(), match.end())
 
@@ -342,10 +316,6 @@ class CandidateGenerationStage:
                     for match in pattern.finditer(combined_text):
                         # Check exclusions
                         if self._is_excluded(metric_id, combined_text, match):
-                            continue
-
-                        # Check required context (proximity-based)
-                        if not self._has_required_context(metric_id, combined_text, match.start()):
                             continue
 
                         # Determine if match is in cell text or only in header/stub
@@ -435,8 +405,6 @@ class CandidateGenerationStage:
                     for match in pattern.finditer(combined_text):
                         if self._is_excluded(metric_id, combined_text, match):
                             continue
-                        if not self._has_required_context(metric_id, combined_text, match.start()):
-                            continue
 
                         confidence = self._compute_confidence(
                             metric_id=metric_id,
@@ -468,8 +436,6 @@ class CandidateGenerationStage:
                 for pattern in patterns:
                     for match in pattern.finditer(nearby_text):
                         if self._is_excluded(metric_id, nearby_text, match):
-                            continue
-                        if not self._has_required_context(metric_id, nearby_text, match.start()):
                             continue
 
                         confidence = self._compute_confidence(
@@ -705,41 +671,6 @@ class CandidateGenerationStage:
 
         for exclusion in exclusions:
             if exclusion.search(window_text):
-                return True
-
-        return False
-
-    def _has_required_context(self, metric_id: str, text: str, match_position: int) -> bool:
-        """
-        Check if required context patterns are present within proximity.
-
-        Some metrics (e.g., revenue synonyms) require specific context
-        like cohort or per-customer keywords to be considered candidates.
-        Uses proximity-based checking to ensure context is near the match.
-
-        Args:
-            metric_id: The metric being checked
-            text: Full text to check for context
-            match_position: Position of the keyword match in text
-
-        Returns:
-            True if no required context OR required context is present within proximity
-        """
-        context_data = self._compiled_context.get(metric_id)
-        if not context_data:
-            # No required context for this metric
-            return True
-
-        patterns, proximity_chars = context_data
-
-        # Extract text within proximity window of the match
-        context_start = max(0, match_position - proximity_chars)
-        context_end = min(len(text), match_position + proximity_chars)
-        proximity_text = text[context_start:context_end]
-
-        # At least one context pattern must match within the proximity window
-        for pattern in patterns:
-            if pattern.search(proximity_text):
                 return True
 
         return False

--- a/src/review/keyword_matching.py
+++ b/src/review/keyword_matching.py
@@ -81,7 +81,7 @@ See Also:
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from src.review.number_parsing import NumberMatch
 
@@ -96,6 +96,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Keyword Loading Functions
 # =============================================================================
+
 
 def _load_metric_keywords() -> dict[str, list[str]]:
     """Load metric keywords from YAML config, excluding deprecated metrics.
@@ -149,31 +150,8 @@ def _load_specific_patterns() -> list[str]:
         KeywordConfigError: If YAML config cannot be loaded.
     """
     from src.shared.keyword_config import get_specific_patterns
+
     return get_specific_patterns()
-
-
-def _load_required_context() -> dict[str, dict[str, Any]]:
-    """Load required context patterns from YAML config, excluding deprecated metrics.
-
-    Required context patterns gate which metrics generate review candidates.
-    Metrics with required_context only generate candidates when at least one
-    of the context patterns appears within proximity of the keyword match.
-
-    Raises:
-        KeywordConfigError: If YAML config cannot be loaded.
-    """
-    from src.shared.keyword_config import get_required_context, is_metric_deprecated
-
-    all_context = get_required_context()
-
-    # Filter out deprecated metrics
-    active_context = {
-        metric_id: context
-        for metric_id, context in all_context.items()
-        if not is_metric_deprecated(metric_id)
-    }
-
-    return active_context
 
 
 # =============================================================================
@@ -184,7 +162,6 @@ def _load_required_context() -> dict[str, dict[str, Any]]:
 METRIC_KEYWORDS: dict[str, list[str]] = _load_metric_keywords()
 METRIC_EXCLUSION_PATTERNS: dict[str, list[str]] = _load_exclusion_patterns()
 SPECIFIC_KEYWORD_PATTERNS: list[str] = _load_specific_patterns()
-METRIC_REQUIRED_CONTEXT: dict[str, dict[str, Any]] = _load_required_context()
 
 
 # =============================================================================
@@ -299,30 +276,9 @@ class KeywordMatcher:
                     compiled_list.append(re.compile(pattern, re.IGNORECASE))
                 except re.error as e:
                     # Log and skip invalid patterns - don't crash
-                    logger.warning(
-                        f"Invalid exclusion pattern for {metric_id}: {pattern!r} - {e}"
-                    )
+                    logger.warning(f"Invalid exclusion pattern for {metric_id}: {pattern!r} - {e}")
             if compiled_list:
                 self._compiled_exclusions[metric_id] = compiled_list
-
-        # Pre-compile required context patterns for revenue synonym filtering
-        # tuple of (compiled_patterns, proximity_chars)
-        self._compiled_required_context: dict[str, tuple[list[re.Pattern[str]], int]] = {}
-        for metric_id, ctx_config in METRIC_REQUIRED_CONTEXT.items():
-            compiled_ctx_patterns: list[re.Pattern[str]] = []
-            for pattern in ctx_config.get("patterns", []):
-                try:
-                    compiled_ctx_patterns.append(re.compile(pattern, re.IGNORECASE))
-                except re.error as e:
-                    logger.warning(
-                        f"Invalid required_context pattern for {metric_id}: {pattern!r} - {e}"
-                    )
-            if compiled_ctx_patterns:
-                proximity = ctx_config.get("proximity_chars", 1500)
-                self._compiled_required_context[metric_id] = (
-                    compiled_ctx_patterns,
-                    proximity,
-                )
 
     def _is_excluded(self, metric_id: str, context: str) -> bool:
         """
@@ -416,56 +372,6 @@ class KeywordMatcher:
 
         return False, None
 
-    def _has_required_context(
-        self, metric_id: str, match_position: int, full_text: str
-    ) -> bool:
-        """
-        Check if required context is present for a context-gated metric.
-
-        For metrics with required_context configuration (e.g., cm_gmv, cm_tcv),
-        this checks if at least one of the required context patterns (cohort,
-        per customer, etc.) appears within the specified proximity of the
-        keyword match.
-
-        Revenue synonym metrics (GMV, TCV, ACV, Bookings, Billings) require
-        cohort or per-customer context to be meaningful as customer metrics.
-        Without this context, they are just aggregate revenue measures.
-
-        Args:
-            metric_id: The metric ID to check required context for
-            match_position: The character position of the keyword match
-            full_text: The full text to search for context
-
-        Returns:
-            True if no required context is configured for this metric, OR
-            True if required context IS configured AND at least one pattern is found.
-            False if required context IS configured but NO patterns are found.
-        """
-        if metric_id not in self._compiled_required_context:
-            return True  # No required context for this metric - always matches
-
-        patterns, proximity_chars = self._compiled_required_context[metric_id]
-
-        # Define the search window around the match position
-        context_start = max(0, match_position - proximity_chars)
-        context_end = min(len(full_text), match_position + proximity_chars)
-        context = full_text[context_start:context_end]
-
-        # Check if ANY required context pattern matches
-        for pattern in patterns:
-            if pattern.search(context):
-                logger.debug(
-                    f"Required context found for {metric_id} at position {match_position}: "
-                    f"pattern '{pattern.pattern}' matched within {proximity_chars} chars"
-                )
-                return True
-
-        logger.debug(
-            f"Required context NOT found for {metric_id} at position {match_position}: "
-            f"no cohort/per-customer patterns within {proximity_chars} chars"
-        )
-        return False
-
     def find_all_keywords(self, text: str) -> list[KeywordMatch]:
         """
         Find all metric keywords in text.
@@ -529,7 +435,6 @@ class KeywordMatcher:
         text: str = "",
         segment_type: str | None = None,
         table_row_parser: Optional["TableRowParser"] = None,
-        check_required_context: bool = True,
     ) -> list[KeywordMatch]:
         """
         Find metric keywords within max_keyword_distance of a number.
@@ -564,9 +469,6 @@ class KeywordMatcher:
             text: Optional full text for context detection (L4 Option C)
             segment_type: Optional segment type for context detection (L4 Option C)
             table_row_parser: Optional TableRowParser for table row filtering
-            check_required_context: If True (default), filter out revenue synonym
-                metrics (GMV, TCV, etc.) that lack cohort or per-customer context.
-                Set to False to include all matches regardless of context.
 
         Returns:
             List of KeywordMatch objects within range (one per metric,
@@ -574,7 +476,6 @@ class KeywordMatcher:
         """
         # Phase 1: Collect all keywords within distance with their distances and directions
         # Store as (keyword, raw_distance, direction) for L4 multiplier application
-        # Also filter by required context for revenue synonym metrics
         #
         # FIX-5: For tables with row/cell structure, skip distance filter in Phase 1
         # and rely on Phase 2.75 (table row filtering) instead. This prevents
@@ -595,15 +496,6 @@ class KeywordMatcher:
             if not has_table_structure and dist > self.max_keyword_distance:
                 continue
 
-            # Check required context for context-gated metrics (GMV, TCV, etc.)
-            if check_required_context and not self._has_required_context(
-                kw.metric_id, kw.start, text
-            ):
-                logger.debug(
-                    f"Filtered keyword '{kw.keyword}' ({kw.metric_id}): "
-                    f"required cohort/per-customer context not present"
-                )
-                continue
             candidates_with_distance.append((kw, dist))
 
         if not candidates_with_distance:
@@ -633,18 +525,14 @@ class KeywordMatcher:
         # Phase 2.5: Apply sentence boundary constraints (P1.5 enhancement)
         if sentence_boundaries and self.respect_sentence_boundaries:
             # Find the sentence containing the number
-            number_sentence = self._get_boundary_at_position(
-                number.start, sentence_boundaries
-            )
+            number_sentence = self._get_boundary_at_position(number.start, sentence_boundaries)
 
             if number_sentence is not None:
                 # Filter to keywords in the same sentence as the number
                 same_sentence = [
                     (kw, dist)
                     for kw, dist in candidates_with_distance
-                    if self._is_in_same_boundary(
-                        kw.start, number_sentence, sentence_boundaries
-                    )
+                    if self._is_in_same_boundary(kw.start, number_sentence, sentence_boundaries)
                 ]
 
                 # Only filter if we have same-sentence candidates
@@ -721,14 +609,10 @@ class KeywordMatcher:
                             f"reduced {raw_distance:.1f} → {effective_distance:.1f}"
                         )
 
-                candidates_with_effective_distance.append(
-                    (kw, raw_distance, effective_distance)
-                )
+                candidates_with_effective_distance.append((kw, raw_distance, effective_distance))
 
             # Sort by (effective_distance, -length): closest first, then longest
-            candidates_with_effective_distance.sort(
-                key=lambda x: (x[2], -len(x[0].keyword))
-            )
+            candidates_with_effective_distance.sort(key=lambda x: (x[2], -len(x[0].keyword)))
         else:
             # Original behavior: sort by length only (longest first)
             # Still need to create tuples with effective distance for consistency
@@ -772,9 +656,7 @@ class KeywordMatcher:
             replace_index: int | None = None
 
             for i, accepted in enumerate(matches):
-                if self._keywords_overlap(kw, accepted) and self._is_substring_match(
-                    kw, accepted
-                ):
+                if self._keywords_overlap(kw, accepted) and self._is_substring_match(kw, accepted):
                     # Overlapping substring match found - compare lengths
                     if len(kw.keyword) > len(accepted.keyword):
                         # New keyword is longer (more specific) - replace accepted
@@ -892,9 +774,7 @@ class KeywordMatcher:
             # Overlapping
             return 0
 
-    def calculate_keyword_direction(
-        self, keyword_start: int, number_start: int
-    ) -> str:
+    def calculate_keyword_direction(self, keyword_start: int, number_start: int) -> str:
         """
         Calculate whether keyword appears before or after the number.
 
@@ -945,28 +825,30 @@ class KeywordMatcher:
 
         # Priority 1: Table context (strongest signal)
         if segment_type == "table" or self._is_in_table(number_position, boundaries):
-            return 'table'
+            return "table"
 
         # Priority 2: Parenthetical text (strong signal for clarifications)
         if self._is_in_parentheses(number_position, text):
-            return 'parenthetical'
+            return "parenthetical"
 
         # Priority 3: Bullet points (strong signal for structured lists)
         if self._is_in_bullet_point(number_position, boundaries):
-            return 'bullet'
+            return "bullet"
 
         # Priority 4: Copula verb pattern (moderate signal)
         if self._has_copula_verb_between(
             text, min(keyword_position, number_position), max(keyword_position, number_position)
         ):
-            return 'copula'
+            return "copula"
 
         # Priority 5: Prepositional phrase (moderate signal)
-        if keyword_direction == "after" and self._has_preposition_after(text, number_position, keyword_position):
-            return 'preposition'
+        if keyword_direction == "after" and self._has_preposition_after(
+            text, number_position, keyword_position
+        ):
+            return "preposition"
 
         # Default: no special context
-        return 'default'
+        return "default"
 
     def get_context_multiplier(
         self,
@@ -1012,12 +894,12 @@ class KeywordMatcher:
 
         # Map context type to multiplier
         context_multipliers = {
-            'table': self.multiplier_tables,
-            'parenthetical': self.multiplier_parenthetical,
-            'bullet': self.multiplier_bullet_points,
-            'copula': self.multiplier_copula_verb,
-            'preposition': self.multiplier_preposition,
-            'default': self.multiplier_default,
+            "table": self.multiplier_tables,
+            "parenthetical": self.multiplier_parenthetical,
+            "bullet": self.multiplier_bullet_points,
+            "copula": self.multiplier_copula_verb,
+            "preposition": self.multiplier_preposition,
+            "default": self.multiplier_default,
         }
 
         return context_multipliers.get(context_type, self.multiplier_default)
@@ -1040,9 +922,7 @@ class KeywordMatcher:
         # If more open than close, we're inside parentheses
         return open_count > 0
 
-    def _is_in_table(
-        self, position: int, boundaries: list["TextBoundary"] | None
-    ) -> bool:
+    def _is_in_table(self, position: int, boundaries: list["TextBoundary"] | None) -> bool:
         """
         Check if a position is in a table boundary.
 
@@ -1064,9 +944,7 @@ class KeywordMatcher:
         # Note: boundary_type might be "table" or have other indicators
         return getattr(boundary, "boundary_type", None) == "table"
 
-    def _is_in_bullet_point(
-        self, position: int, boundaries: list["TextBoundary"] | None
-    ) -> bool:
+    def _is_in_bullet_point(self, position: int, boundaries: list["TextBoundary"] | None) -> bool:
         """
         Check if a position is in a bullet point boundary.
 

--- a/src/shared/keyword_config.py
+++ b/src/shared/keyword_config.py
@@ -137,35 +137,6 @@ def _validate_config(config: dict[str, Any]) -> None:
                     f"Invalid 'specific_patterns' for {metric_id}: expected list"
                 )
 
-        # Validate required_context if present
-        if "required_context" in metric_config:
-            req_ctx = metric_config["required_context"]
-            if not isinstance(req_ctx, dict):
-                raise KeywordConfigError(
-                    f"Invalid 'required_context' for {metric_id}: expected dict"
-                )
-            if "patterns" not in req_ctx:
-                raise KeywordConfigError(f"Missing 'patterns' in required_context for {metric_id}")
-            ctx_patterns = req_ctx["patterns"]
-            if not isinstance(ctx_patterns, list) or not ctx_patterns:
-                raise KeywordConfigError(
-                    f"Invalid 'patterns' in required_context for {metric_id}: "
-                    "expected non-empty list"
-                )
-            for j, ctx_pattern in enumerate(ctx_patterns):
-                if not isinstance(ctx_pattern, str):
-                    raise KeywordConfigError(
-                        f"Invalid required_context pattern {j} for {metric_id}: expected string"
-                    )
-            # Validate proximity_chars if present
-            if "proximity_chars" in req_ctx:
-                prox = req_ctx["proximity_chars"]
-                if not isinstance(prox, int) or prox <= 0:
-                    raise KeywordConfigError(
-                        f"Invalid 'proximity_chars' in required_context for {metric_id}: "
-                        "expected positive int"
-                    )
-
         # Validate aliases if present
         if "aliases" in metric_config:
             aliases_list = metric_config["aliases"]
@@ -361,36 +332,6 @@ def get_specific_patterns_by_metric(config_path: str | None = None) -> dict[str,
         for metric_id, metric_config in config.items()
         if _is_metric_key(metric_id)
         and "specific_patterns" in metric_config
-        and metric_config.get("status") != "deprecated"
-    }
-
-
-def get_required_context(config_path: str | None = None) -> dict[str, dict[str, Any]]:
-    """
-    Get required context patterns for metrics.
-
-    Metrics with required_context only generate review candidates when
-    at least one of the context patterns appears within proximity of the
-    keyword match. This filters out revenue synonyms (GMV, TCV, etc.)
-    that appear without cohort or per-customer context.
-
-    Args:
-        config_path: Optional path to config file.
-
-    Returns:
-        Dictionary mapping metric_id to required context configuration.
-        Only includes metrics that have required_context defined.
-        Each config contains:
-        - 'patterns': list of regex patterns (at least one must match)
-        - 'proximity_chars': max distance for context check (default: 1500)
-        Excludes YAML anchor keys (starting with underscore).
-    """
-    config = _load_config(config_path)
-    return {
-        metric_id: metric_config["required_context"]
-        for metric_id, metric_config in config.items()
-        if _is_metric_key(metric_id)
-        and "required_context" in metric_config
         and metric_config.get("status") != "deprecated"
     }
 

--- a/tests/unit/extraction_v2/test_candidate_generation.py
+++ b/tests/unit/extraction_v2/test_candidate_generation.py
@@ -324,36 +324,6 @@ class TestFiltering:
                     or "cost" not in segment.text.lower()
                 )
 
-    def test_excludes_without_required_context(
-        self, stage: CandidateGenerationStage, mock_context: MockPipelineContext
-    ) -> None:
-        """Revenue synonym metrics require cohort/per-customer context."""
-        # GMV without cohort context should not generate candidate
-        segment = make_segment("Our GMV was $500 million this year.")
-        mock_context.segments.append(segment)
-
-        stage.process(mock_context)
-
-        # cm_gmv (if it exists and has required_context) should not match
-        # without cohort keywords
-        # Note: This depends on actual YAML config having required_context
-        # The test validates the mechanism works
-        assert result_does_not_contain_revenue_synonym_without_context(mock_context.candidates)
-
-    def test_includes_with_required_context(
-        self, stage: CandidateGenerationStage, mock_context: MockPipelineContext
-    ) -> None:
-        """Metrics with required context pass when context is present."""
-        # Include cohort keyword to satisfy required_context
-        segment = make_segment("The GMV per customer cohort showed strong retention patterns.")
-        mock_context.segments.append(segment)
-
-        stage.process(mock_context)
-
-        # With cohort context, revenue synonyms should be allowed
-        # (if they match patterns in the config)
-        assert True  # Validates no exception and stage completes
-
     def test_passes_valid_matches(
         self, stage: CandidateGenerationStage, mock_context: MockPipelineContext
     ) -> None:
@@ -378,24 +348,6 @@ class TestFiltering:
 
         assert result.success
         assert len(mock_context.candidates) == 0
-
-
-def result_does_not_contain_revenue_synonym_without_context(
-    candidates: list[MetricCandidate],
-) -> bool:
-    """Helper to check revenue synonyms have context."""
-    # Revenue synonym metrics from the YAML that have required_context
-    revenue_synonyms = {"cm_gmv", "cm_tcv", "cm_acv", "cm_bookings"}
-    for c in candidates:
-        if c.metric_id in revenue_synonyms:
-            # If found, there should be cohort/per-customer context
-            context_lower = c.context_text.lower()
-            has_context = any(
-                kw in context_lower for kw in ["cohort", "per customer", "per user", "by customer"]
-            )
-            if not has_context:
-                return False
-    return True
 
 
 # =============================================================================
@@ -652,7 +604,6 @@ class TestEdgeCases:
         stage._initialized = False
         stage._keywords = {"test_metric": ["[invalid regex"]}  # Unclosed bracket
         stage._exclusions = {}
-        stage._required_context = {}
         stage._specific_patterns = []
 
         # Compile should log warning but not raise
@@ -669,7 +620,6 @@ class TestEdgeCases:
         stage._initialized = False
         stage._keywords = {"test_metric": [r"\btest\b"]}
         stage._exclusions = {"test_metric": ["[unclosed"]}  # Invalid
-        stage._required_context = {}
         stage._specific_patterns = []
 
         stage._compile_patterns()
@@ -679,25 +629,6 @@ class TestEdgeCases:
         # Invalid exclusion should be skipped
         assert len(stage._compiled_exclusions.get("test_metric", [])) == 0
 
-    def test_invalid_context_pattern_handled(self, mock_context: MockPipelineContext) -> None:
-        """Invalid required_context patterns are skipped gracefully."""
-        stage = CandidateGenerationStage()
-
-        stage._initialized = False
-        stage._keywords = {"test_metric": [r"\btest\b"]}
-        stage._exclusions = {}
-        stage._required_context = {"test_metric": {"patterns": ["[unclosed", r"\bvalid\b"]}}
-        stage._specific_patterns = []
-
-        stage._compile_patterns()
-
-        # One pattern is valid, one is invalid
-        # _compiled_context stores (patterns, proximity_chars) tuple
-        context_data = stage._compiled_context.get("test_metric")
-        assert context_data is not None
-        patterns, proximity = context_data
-        assert len(patterns) == 1  # Only valid pattern compiled
-
     def test_invalid_specific_pattern_handled(self, mock_context: MockPipelineContext) -> None:
         """Invalid specific patterns are skipped gracefully."""
         stage = CandidateGenerationStage()
@@ -705,7 +636,6 @@ class TestEdgeCases:
         stage._initialized = False
         stage._keywords = {}
         stage._exclusions = {}
-        stage._required_context = {}
         stage._specific_patterns = ["[invalid", r"\bvalid pattern\b"]
 
         stage._compile_patterns()
@@ -771,81 +701,6 @@ class TestEdgeCases:
             assert result2  # Still True
 
 
-class TestProximityBasedContext:
-    """Tests for proximity-based required context checking."""
-
-    def test_context_within_proximity_passes(self, mock_context: MockPipelineContext) -> None:
-        """Required context within proximity window is accepted."""
-        stage = CandidateGenerationStage()
-        stage._initialized = True
-        stage._compiled_patterns = {"test_metric": [re.compile(r"\bGMV\b", re.IGNORECASE)]}
-        stage._compiled_exclusions = {}
-        # Context must be within 100 chars
-        stage._compiled_context = {
-            "test_metric": ([re.compile(r"\bper\s+customer\b", re.IGNORECASE)], 100)
-        }
-        stage._compiled_specific = []
-
-        # "GMV" at position ~50, "per customer" within 100 chars
-        # Use spaces to ensure word boundaries
-        text = "some text " * 5 + "GMV metric " + "per customer revenue " * 2
-        segment = make_segment(text)
-        candidates = stage._scan_segment(segment)
-
-        assert len(candidates) == 1, "Should match when context is within proximity"
-
-    def test_context_beyond_proximity_fails(self, mock_context: MockPipelineContext) -> None:
-        """Required context beyond proximity window is rejected."""
-        stage = CandidateGenerationStage()
-        stage._initialized = True
-        stage._compiled_patterns = {"test_metric": [re.compile(r"\bGMV\b", re.IGNORECASE)]}
-        stage._compiled_exclusions = {}
-        # Context must be within 50 chars (small window)
-        stage._compiled_context = {
-            "test_metric": ([re.compile(r"\bper\s+customer\b", re.IGNORECASE)], 50)
-        }
-        stage._compiled_specific = []
-
-        # "GMV" near start, "per customer" very far away (>50 chars from GMV)
-        text = "Our GMV was strong. " + "x" * 200 + " per customer revenue"
-        segment = make_segment(text)
-        candidates = stage._scan_segment(segment)
-
-        assert len(candidates) == 0, "Should NOT match when context is beyond proximity"
-
-    def test_proximity_uses_config_value(self) -> None:
-        """Proximity value from config is stored correctly."""
-        stage = CandidateGenerationStage()
-        stage._initialized = False
-        stage._keywords = {"test_metric": [r"\btest\b"]}
-        stage._exclusions = {}
-        stage._required_context = {
-            "test_metric": {"patterns": [r"\bcontext\b"], "proximity_chars": 500}
-        }
-        stage._specific_patterns = []
-
-        stage._compile_patterns()
-
-        patterns, proximity = stage._compiled_context["test_metric"]
-        assert proximity == 500
-
-    def test_proximity_uses_default_when_not_specified(self) -> None:
-        """Default proximity is used when not specified in config."""
-        stage = CandidateGenerationStage()
-        stage._initialized = False
-        stage._keywords = {"test_metric": [r"\btest\b"]}
-        stage._exclusions = {}
-        stage._required_context = {
-            "test_metric": {"patterns": [r"\bcontext\b"]}  # No proximity_chars
-        }
-        stage._specific_patterns = []
-
-        stage._compile_patterns()
-
-        patterns, proximity = stage._compiled_context["test_metric"]
-        assert proximity == stage._default_proximity_chars  # Default 1500
-
-
 class TestCandidateDeduplication:
     """Tests for candidate deduplication."""
 
@@ -863,7 +718,6 @@ class TestCandidateDeduplication:
             ]
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # "new customers" matches both patterns at overlapping positions
@@ -883,7 +737,6 @@ class TestCandidateDeduplication:
             "cm_other": [re.compile(r"\bnew customers\b", re.IGNORECASE)],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "We had 1000 new customers"
@@ -903,7 +756,6 @@ class TestCandidateDeduplication:
             "cm_customers": [re.compile(r"\bcustomers\b", re.IGNORECASE)],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # Two mentions of "customers" at different positions
@@ -925,7 +777,6 @@ class TestCandidateDeduplication:
             ]
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # Cell with text that matches both patterns
@@ -948,7 +799,6 @@ class TestCandidateDeduplication:
             ]
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         # "paid customers" is a specific pattern that gets bonus
         stage._compiled_specific = [re.compile(r"\bpaid customers\b", re.IGNORECASE)]
 
@@ -975,7 +825,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "We had 1 million daily active users"
@@ -1001,7 +850,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "We had 1 million daily active users"
@@ -1028,7 +876,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "Our customer retention rate was 95% in Q4"
@@ -1055,7 +902,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "We had 5000 paid customers and 3000 active users"
@@ -1080,7 +926,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         text = "We had 3000 active users"
@@ -1107,7 +952,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         cell = make_cell(0, 0, "Daily Active Users")
@@ -1133,7 +977,6 @@ class TestCandidateDeduplication:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         cell = make_cell(0, 0, "Daily Active Users")
@@ -1253,7 +1096,6 @@ class TestExactSpanDedup:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # Both have same match text length, so both should be kept
@@ -1351,7 +1193,6 @@ class TestHeaderColumnBroadcastDedup:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # 5 cells in column 1, all with "Customers" in header_path but not in cell text
@@ -1375,7 +1216,6 @@ class TestHeaderColumnBroadcastDedup:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # Cells where "customers" appears in cell text too
@@ -1405,7 +1245,6 @@ class TestHeaderColumnBroadcastDedup:
             ],
         }
         stage._compiled_exclusions = {}
-        stage._compiled_context = {}
         stage._compiled_specific = []
 
         # Two columns, each with "Customers" in header but not cell text

--- a/tests/unit/review/test_keyword_matching.py
+++ b/tests/unit/review/test_keyword_matching.py
@@ -10,13 +10,11 @@ import pytest
 
 from src.review.keyword_matching import (
     METRIC_KEYWORDS,
-    METRIC_REQUIRED_CONTEXT,
     SPECIFIC_KEYWORD_PATTERNS,
     KeywordMatch,
     KeywordMatcher,
 )
 from src.review.number_parsing import NumberMatch
-from src.shared.keyword_config import is_metric_deprecated
 
 # =============================================================================
 # KeywordMatcher.find_all_keywords Tests
@@ -179,7 +177,9 @@ class TestCalculateDistance:
     def test_keyword_before_number(self, matcher):
         """Distance when keyword is before number."""
         number = NumberMatch(start=50, end=55, raw_text="1000", value=Decimal(1000), unit="count")
-        keyword = KeywordMatch(start=10, end=25, keyword="customers", metric_id="cm_active", pattern="")
+        keyword = KeywordMatch(
+            start=10, end=25, keyword="customers", metric_id="cm_active", pattern=""
+        )
 
         distance = matcher.calculate_distance(number, keyword)
         assert distance == 25  # 50 - 25 = 25
@@ -187,7 +187,9 @@ class TestCalculateDistance:
     def test_keyword_after_number(self, matcher):
         """Distance when keyword is after number."""
         number = NumberMatch(start=10, end=15, raw_text="1000", value=Decimal(1000), unit="count")
-        keyword = KeywordMatch(start=30, end=45, keyword="customers", metric_id="cm_active", pattern="")
+        keyword = KeywordMatch(
+            start=30, end=45, keyword="customers", metric_id="cm_active", pattern=""
+        )
 
         distance = matcher.calculate_distance(number, keyword)
         assert distance == 15  # 30 - 15 = 15
@@ -195,7 +197,9 @@ class TestCalculateDistance:
     def test_overlapping_spans(self, matcher):
         """Distance is 0 when spans overlap."""
         number = NumberMatch(start=20, end=30, raw_text="1000", value=Decimal(1000), unit="count")
-        keyword = KeywordMatch(start=25, end=35, keyword="customers", metric_id="cm_active", pattern="")
+        keyword = KeywordMatch(
+            start=25, end=35, keyword="customers", metric_id="cm_active", pattern=""
+        )
 
         distance = matcher.calculate_distance(number, keyword)
         assert distance == 0
@@ -258,7 +262,9 @@ class TestSubstringDeduplication:
 
         # Should have only LTV/CAC ratio (the most specific/longest match)
         matched_keywords = [kw.keyword for kw in keywords_near_number]
-        assert len(matched_keywords) == 1, f"Expected 1 keyword (LTV/CAC), got {len(matched_keywords)}: {matched_keywords}"
+        assert len(matched_keywords) == 1, (
+            f"Expected 1 keyword (LTV/CAC), got {len(matched_keywords)}: {matched_keywords}"
+        )
 
         # Should be the LTV/CAC ratio metric
         assert any("LTV/CAC" in kw or "ltv/cac" in kw.lower() for kw in matched_keywords)
@@ -267,7 +273,9 @@ class TestSubstringDeduplication:
         """Compound metrics should prevent substring matches at overlapping positions."""
         matcher = KeywordMatcher(max_keyword_distance=100)
         text = "Net Revenue Retention was 120% for the year."
-        number = NumberMatch(start=26, end=30, raw_text="120%", value=Decimal("120"), unit="percent")
+        number = NumberMatch(
+            start=26, end=30, raw_text="120%", value=Decimal("120"), unit="percent"
+        )
 
         all_keywords = matcher.find_all_keywords(text)
         keywords_near_number = matcher.find_keywords_near_number(number, all_keywords)
@@ -314,9 +322,7 @@ class TestCrossMetricSubstringSuppression:
         matcher = KeywordMatcher(max_keyword_distance=100)
         # The keyword pattern for cm_large_customers matches "Paid Customers > $1"
         text = "We have 500 Paid Customers > $100,000 in ARR"
-        number = NumberMatch(
-            start=8, end=11, raw_text="500", value=Decimal("500"), unit="count"
-        )
+        number = NumberMatch(start=8, end=11, raw_text="500", value=Decimal("500"), unit="count")
 
         all_keywords = matcher.find_all_keywords(text)
         keywords_near_number = matcher.find_keywords_near_number(number, all_keywords)
@@ -325,23 +331,21 @@ class TestCrossMetricSubstringSuppression:
         metric_ids = [kw.metric_id for kw in keywords_near_number]
 
         # The longer pattern should win
-        assert (
-            "cm_large_customers_period_end" in metric_ids
-        ), f"Expected cm_large_customers_period_end, got {metric_ids}"
+        assert "cm_large_customers_period_end" in metric_ids, (
+            f"Expected cm_large_customers_period_end, got {metric_ids}"
+        )
 
         # cm_customers_period_end should be suppressed as substring
-        assert (
-            "cm_customers_period_end" not in metric_ids
-        ), f"cm_customers_period_end should be suppressed, got {metric_ids}"
+        assert "cm_customers_period_end" not in metric_ids, (
+            f"cm_customers_period_end should be suppressed, got {metric_ids}"
+        )
 
     def test_cross_metric_non_overlapping_both_kept(self):
         """Non-overlapping keywords from different metrics should both be kept."""
         matcher = KeywordMatcher(max_keyword_distance=150)
         # "customers" at one position, "retention" at another (different metrics)
         text = "We had 1000 paying customers and our net dollar retention was strong"
-        number = NumberMatch(
-            start=8, end=12, raw_text="1000", value=Decimal("1000"), unit="count"
-        )
+        number = NumberMatch(start=8, end=12, raw_text="1000", value=Decimal("1000"), unit="count")
 
         all_keywords = matcher.find_all_keywords(text)
         keywords_near_number = matcher.find_keywords_near_number(number, all_keywords)
@@ -356,9 +360,7 @@ class TestCrossMetricSubstringSuppression:
         # Create a scenario where keywords might overlap but neither is substring
         # This tests that we only suppress when there's actual substring relationship
         text = "Our 95% customer retention rate was strong"
-        number = NumberMatch(
-            start=4, end=7, raw_text="95%", value=Decimal("95"), unit="percent"
-        )
+        number = NumberMatch(start=4, end=7, raw_text="95%", value=Decimal("95"), unit="percent")
 
         all_keywords = matcher.find_all_keywords(text)
         keywords_near_number = matcher.find_keywords_near_number(number, all_keywords)
@@ -437,7 +439,7 @@ class TestP1DistanceFirstSorting:
         # When sorted by (distance, -length), closest comes first
         if len(distances) >= 2:
             first_dist = distances[0][1]
-            second_dist = distances[1][1] if len(distances) > 1 else float('inf')
+            second_dist = distances[1][1] if len(distances) > 1 else float("inf")
             # First keyword should have smaller or equal distance
             assert first_dist <= second_dist, (
                 f"Expected first keyword to be closest, "
@@ -619,7 +621,9 @@ class TestP1AmbiguityLogging:
         matcher.find_keywords_near_number(number, all_keywords)
 
         # Should not log ambiguity messages
-        ambiguity_logs = [record for record in caplog.records if "Ambiguous match" in record.message]
+        ambiguity_logs = [
+            record for record in caplog.records if "Ambiguous match" in record.message
+        ]
         assert len(ambiguity_logs) == 0
 
 
@@ -724,7 +728,9 @@ class TestP15SentenceAwareMatching:
         )
 
         # WITHOUT sentence filtering
-        matcher_no_sent = KeywordMatcher(respect_sentence_boundaries=False, max_keyword_distance=150)
+        matcher_no_sent = KeywordMatcher(
+            respect_sentence_boundaries=False, max_keyword_distance=150
+        )
         keywords_no_filter = matcher_no_sent.find_keywords_near_number(
             number, all_keywords, sentence_boundaries=sentences
         )
@@ -777,10 +783,12 @@ class TestP15SentenceAwareMatching:
         all_keywords = matcher.find_all_keywords(text)
 
         # Verify we found keywords in both sentences
-        assert any("customer" in kw.keyword.lower() for kw in all_keywords), \
+        assert any("customer" in kw.keyword.lower() for kw in all_keywords), (
             "Should find 'active customers' keyword"
-        assert any("retention" in kw.keyword.lower() for kw in all_keywords), \
+        )
+        assert any("retention" in kw.keyword.lower() for kw in all_keywords), (
             "Should find 'net revenue retention' keyword"
+        )
 
         # 50000 should only match keywords in sentence 1
         keywords1 = matcher.find_keywords_near_number(
@@ -794,23 +802,27 @@ class TestP15SentenceAwareMatching:
 
         # Keywords for 50000 should be "active customers" (sentence 1)
         for kw in keywords1:
-            assert sentences[0].contains_position(kw.start), \
+            assert sentences[0].contains_position(kw.start), (
                 f"Keyword '{kw.keyword}' at pos {kw.start} should be in sentence 1 ({sentences[0].start}-{sentences[0].end})"
+            )
 
         # Keywords for 120% should be "net revenue retention" (sentence 2)
         for kw in keywords2:
-            assert sentences[1].contains_position(kw.start), \
+            assert sentences[1].contains_position(kw.start), (
                 f"Keyword '{kw.keyword}' at pos {kw.start} should be in sentence 2 ({sentences[1].start}-{sentences[1].end})"
+            )
 
         # Verify the key behavior: 50000 should NOT match "net revenue retention"
         keywords1_ids = {kw.metric_id for kw in keywords1}
-        assert "cm_net_revenue_retention" not in keywords1_ids, \
+        assert "cm_net_revenue_retention" not in keywords1_ids, (
             "50000 should not match net revenue retention (different sentence)"
+        )
 
         # Verify the key behavior: 120% should NOT match "active customers"
         keywords2_ids = {kw.metric_id for kw in keywords2}
-        assert "cm_active_customers_total" not in keywords2_ids, \
+        assert "cm_active_customers_total" not in keywords2_ids, (
             "120% should not match active customers (different sentence)"
+        )
 
     def test_fallback_when_no_same_sentence_keywords(self):
         """If no keywords in same sentence, should keep all candidates."""
@@ -925,9 +937,7 @@ class TestP15SentenceAwareMatching:
         all_keywords = matcher.find_all_keywords(text)
 
         # Pass None for sentence_boundaries
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, sentence_boundaries=None
-        )
+        keywords = matcher.find_keywords_near_number(number, all_keywords, sentence_boundaries=None)
 
         # Should return keywords without sentence filtering (behaves like P1)
         assert len(keywords) >= 1
@@ -948,9 +958,7 @@ class TestP15SentenceAwareMatching:
         all_keywords = matcher.find_all_keywords(text)
 
         # Pass empty list for sentence_boundaries
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, sentence_boundaries=[]
-        )
+        keywords = matcher.find_keywords_near_number(number, all_keywords, sentence_boundaries=[])
 
         # Should return keywords without filtering
         assert len(keywords) >= 1
@@ -1180,8 +1188,7 @@ class TestKeywordDirection:
         )
 
         matcher_with_boundaries = KeywordMatcher(
-            respect_bullet_boundaries=True,
-            max_keyword_distance=100
+            respect_bullet_boundaries=True, max_keyword_distance=100
         )
         all_keywords = matcher_with_boundaries.find_all_keywords(text)
         keywords = matcher_with_boundaries.find_keywords_near_number(
@@ -1227,9 +1234,7 @@ class TestPostValueMultiplier:
         all_keywords = matcher.find_all_keywords(text)
 
         # Create number match for "100" (starts at position 17)
-        number = NumberMatch(
-            start=17, end=20, raw_text="100", value=Decimal("100"), unit="count"
-        )
+        number = NumberMatch(start=17, end=20, raw_text="100", value=Decimal("100"), unit="count")
 
         # Find keywords near number
         keywords = matcher.find_keywords_near_number(number, all_keywords)
@@ -1249,9 +1254,7 @@ class TestPostValueMultiplier:
 
         all_keywords = matcher.find_all_keywords(text)
 
-        number = NumberMatch(
-            start=44, end=47, raw_text="100", value=Decimal("100"), unit="count"
-        )
+        number = NumberMatch(start=44, end=47, raw_text="100", value=Decimal("100"), unit="count")
 
         keywords = matcher.find_keywords_near_number(number, all_keywords)
 
@@ -1283,9 +1286,7 @@ class TestPostValueMultiplier:
         all_keywords_strict = matcher_strict.find_all_keywords(text)
         all_keywords_neutral = matcher_neutral.find_all_keywords(text)
 
-        number = NumberMatch(
-            start=22, end=25, raw_text="100", value=Decimal("100"), unit="count"
-        )
+        number = NumberMatch(start=22, end=25, raw_text="100", value=Decimal("100"), unit="count")
 
         # With strict multiplier, post-value penalty is higher
         keywords_strict = matcher_strict.find_keywords_near_number(number, all_keywords_strict)
@@ -1309,9 +1310,7 @@ class TestPostValueMultiplier:
         text = "active customers 100 revenue"
         all_keywords = matcher_longest.find_all_keywords(text)
 
-        number = NumberMatch(
-            start=17, end=20, raw_text="100", value=Decimal("100"), unit="count"
-        )
+        number = NumberMatch(start=17, end=20, raw_text="100", value=Decimal("100"), unit="count")
 
         keywords = matcher_longest.find_keywords_near_number(number, all_keywords)
 
@@ -1332,9 +1331,7 @@ class TestPostValueMultiplier:
         text = "revenue100margin"
         all_keywords = matcher.find_all_keywords(text)
 
-        number = NumberMatch(
-            start=7, end=10, raw_text="100", value=Decimal("100"), unit="count"
-        )
+        number = NumberMatch(start=7, end=10, raw_text="100", value=Decimal("100"), unit="count")
 
         keywords = matcher.find_keywords_near_number(number, all_keywords)
 
@@ -1365,9 +1362,7 @@ class TestL4ContextDependentMultipliers:
         text = "We achieved 5% (churn rate) improvement"
         all_keywords = matcher.find_all_keywords(text)
 
-        number = NumberMatch(
-            start=12, end=14, raw_text="5%", value=Decimal("5"), unit="percent"
-        )
+        number = NumberMatch(start=12, end=14, raw_text="5%", value=Decimal("5"), unit="percent")
 
         keywords = matcher.find_keywords_near_number(number, all_keywords, text=text)
 
@@ -1651,344 +1646,6 @@ class TestL4MultipleKeywords:
 
 
 # =============================================================================
-# Required Context Tests (Revenue Synonym Filtering)
-# =============================================================================
-
-
-class TestRequiredContext:
-    """Tests for required context filtering on revenue synonym metrics.
-
-    Revenue synonyms (GMV, TCV, ACV, Bookings, Billings) are not inherently
-    customer metrics - they're revenue/value measures. They only become
-    customer metrics when associated with cohort analysis or per-customer context.
-
-    ARR and MRR are NOT context-gated because "recurring revenue" inherently
-    implies ongoing customer relationships.
-    """
-
-    REVENUE_SYNONYM_METRICS = [
-        "cm_gmv",
-        "cm_tcv",
-        "cm_acv",
-        "cm_bookings",
-        "cm_billings",
-    ]
-
-    @pytest.fixture
-    def matcher(self):
-        """Create a KeywordMatcher instance."""
-        return KeywordMatcher(max_keyword_distance=200)
-
-    def test_required_context_constant_exists(self):
-        """METRIC_REQUIRED_CONTEXT constant should be loaded."""
-        assert METRIC_REQUIRED_CONTEXT is not None
-        assert isinstance(METRIC_REQUIRED_CONTEXT, dict)
-
-    def test_revenue_synonyms_have_required_context(self):
-        """All active revenue synonym metrics should have required context."""
-        for metric_id in self.REVENUE_SYNONYM_METRICS:
-            # Skip deprecated metrics (FIX-A: cm_billings was deprecated)
-            if is_metric_deprecated(metric_id):
-                continue
-            assert metric_id in METRIC_REQUIRED_CONTEXT, \
-                f"{metric_id} should have required_context defined"
-            assert "patterns" in METRIC_REQUIRED_CONTEXT[metric_id]
-            assert "proximity_chars" in METRIC_REQUIRED_CONTEXT[metric_id]
-
-    def test_arr_mrr_not_context_gated(self):
-        """ARR and MRR should NOT have required context (inherently customer-related)."""
-        assert "cm_arr" not in METRIC_REQUIRED_CONTEXT
-        assert "cm_mrr" not in METRIC_REQUIRED_CONTEXT
-
-    @pytest.mark.parametrize("metric_id", [m for m in REVENUE_SYNONYM_METRICS if not is_metric_deprecated(m)])
-    def test_revenue_synonym_without_context_no_match(self, matcher, metric_id):
-        """Revenue synonyms without cohort/per-customer context should not generate matches."""
-        # Build text with the metric keyword but NO cohort/per-customer context
-        metric_texts = {
-            "cm_gmv": "Our GMV reached $1 billion in the quarter",
-            "cm_tcv": "Total contract value was $500 million this year",
-            "cm_acv": "Average contract value increased to $50,000",
-            "cm_bookings": "We achieved $200 million in bookings",
-            "cm_billings": "Calculated billings were $300 million",
-        }
-        text = metric_texts[metric_id]
-
-        # Find all keywords (this should find the metric)
-        all_keywords = matcher.find_all_keywords(text)
-
-        # Create a number match for the dollar value
-        # Find the first number-like pattern
-        import re
-        num_match = re.search(r'\$[\d,]+', text)
-        assert num_match is not None
-
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("1000000"),
-            unit="currency",
-        )
-
-        # With required context check enabled (default), should NOT find matches
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should NOT find the revenue synonym metric
-        metric_matches = [kw for kw in keywords if kw.metric_id == metric_id]
-        assert len(metric_matches) == 0, \
-            f"{metric_id} should not match without cohort/per-customer context"
-
-    @pytest.mark.parametrize("metric_id", [m for m in REVENUE_SYNONYM_METRICS if not is_metric_deprecated(m)])
-    def test_revenue_synonym_with_cohort_context_generates_match(self, matcher, metric_id):
-        """Revenue synonyms with cohort context should generate matches."""
-        # Build text with the metric keyword AND cohort context
-        metric_texts = {
-            "cm_gmv": "Cohort retention was strong; GMV reached $1 billion overall",
-            "cm_tcv": "TCV by cohort reached $500 million for the 2020 vintage",
-            "cm_acv": "ACV per cohort increased to $50,000 on average",
-            "cm_bookings": "Cohort bookings were $200 million in 2020",
-            "cm_billings": "Billings by vintage show $300 million for cohort 2019",
-        }
-        text = metric_texts[metric_id]
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        # Create a number match
-        import re
-        num_match = re.search(r'\$[\d,]+', text)
-        assert num_match is not None
-
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("1000000"),
-            unit="currency",
-        )
-
-        # With required context check enabled, should find matches (cohort context present)
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should find the revenue synonym metric
-        metric_matches = [kw for kw in keywords if kw.metric_id == metric_id]
-        assert len(metric_matches) >= 1, \
-            f"{metric_id} should match when cohort context is present"
-
-    @pytest.mark.parametrize("metric_id", [m for m in REVENUE_SYNONYM_METRICS if not is_metric_deprecated(m)])
-    def test_revenue_synonym_with_per_customer_context_generates_match(self, matcher, metric_id):
-        """Revenue synonyms with per-customer context should generate matches."""
-        # Build text with the metric keyword AND per-customer context
-        metric_texts = {
-            "cm_gmv": "GMV per customer averaged $1 billion across our user base",
-            "cm_tcv": "Average TCV per account was $500,000 this year",
-            "cm_acv": "ACV by customer segment reached $50,000 average",
-            "cm_bookings": "Bookings per user increased to $200 million",
-            "cm_billings": "Customer-level billings averaged $300,000",
-        }
-        text = metric_texts[metric_id]
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        # Create a number match
-        import re
-        num_match = re.search(r'\$[\d,]+', text)
-        assert num_match is not None
-
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("1000000"),
-            unit="currency",
-        )
-
-        # Should find matches with per-customer context
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should find the revenue synonym metric
-        metric_matches = [kw for kw in keywords if kw.metric_id == metric_id]
-        assert len(metric_matches) >= 1, \
-            f"{metric_id} should match when per-customer context is present"
-
-    @pytest.mark.skip(reason="cm_gmv deprecated on this branch (patterns removed); no matches expected")
-    def test_context_check_disabled_always_matches(self, matcher):
-        """When check_required_context=False, revenue synonyms should always match."""
-        # Bookings without cohort/per-customer context (cm_gmv is deprecated; use cm_bookings)
-        text = "Our bookings reached $1 billion in the quarter"
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        import re
-        num_match = re.search(r'\$[\d,]+', text)
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("1000000000"),
-            unit="currency",
-        )
-
-        # With required context check DISABLED
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=False, text=text
-        )
-
-        # Should find bookings even without context
-        bookings_matches = [kw for kw in keywords if kw.metric_id == "cm_bookings"]
-        assert len(bookings_matches) >= 1, \
-            "Bookings should match when check_required_context=False"
-
-    def test_context_too_far_no_match(self, matcher):
-        """Context beyond proximity_chars should not satisfy requirement."""
-        # Bookings with cohort context, but very far apart (more than 1500 chars)
-        # cm_gmv is deprecated; use cm_bookings which also has *revenue_synonym_context
-        padding = "x" * 2000  # 2000 chars of padding
-        text = f"Bookings were $1 billion for the quarter. {padding} The cohort analysis shows growth."
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        import re
-        num_match = re.search(r'\$[\d,]+', text)
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("1000000000"),
-            unit="currency",
-        )
-
-        # Context is too far away
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should NOT find bookings because cohort context is too far
-        bookings_matches = [kw for kw in keywords if kw.metric_id == "cm_bookings"]
-        assert len(bookings_matches) == 0, \
-            "Bookings should not match when context is beyond proximity_chars"
-
-    def test_nrr_matches_without_context(self, matcher):
-        """NRR should match even without cohort/per-customer context."""
-        # NRR without any cohort/per-customer context
-        text = "Our net revenue retention grew to 120% this year"
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        import re
-        num_match = re.search(r'\d+%', text)
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("120"),
-            unit="percent",
-        )
-
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should find NRR (not context-gated)
-        nrr_matches = [kw for kw in keywords if kw.metric_id == "cm_net_revenue_retention"]
-        assert len(nrr_matches) >= 1, \
-            "NRR should match without cohort context (inherently customer-related)"
-
-    def test_customer_retention_matches_without_context(self, matcher):
-        """Customer retention rate should match without cohort/per-customer context."""
-        text = "Our customer retention rate reached 95% last quarter"
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        import re
-        num_match = re.search(r'\d+%', text)
-        number = NumberMatch(
-            start=num_match.start(),
-            end=num_match.end(),
-            raw_text=num_match.group(),
-            value=Decimal("95"),
-            unit="percent",
-        )
-
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should find customer retention rate (not context-gated)
-        crr_matches = [kw for kw in keywords if kw.metric_id == "cm_customer_retention_rate"]
-        assert len(crr_matches) >= 1, \
-            "Customer retention rate should match without cohort context"
-
-    def test_non_revenue_metrics_unaffected(self, matcher):
-        """Non-revenue synonym metrics should not be affected by context check."""
-        # Active customers - not a revenue synonym, should always match
-        text = "We have 50000 active customers globally"
-
-        all_keywords = matcher.find_all_keywords(text)
-
-        number = NumberMatch(
-            start=text.index("50000"),
-            end=text.index("50000") + 5,
-            raw_text="50000",
-            value=Decimal("50000"),
-            unit="count",
-        )
-
-        keywords = matcher.find_keywords_near_number(
-            number, all_keywords, check_required_context=True, text=text
-        )
-
-        # Should find active customers
-        customer_matches = [kw for kw in keywords if kw.metric_id == "cm_active_customers_total"]
-        assert len(customer_matches) >= 1, \
-            "Non-revenue metrics should match without context requirement"
-
-    @pytest.mark.skip(reason="cm_gmv deprecated on this branch (patterns removed); not found by find_all_keywords")
-    def test_revenue_synonyms_still_in_find_all_keywords(self, matcher):
-        """Revenue synonyms should still be found by find_all_keywords (classification preserved)."""
-        # Bookings without cohort context (cm_gmv is deprecated; use cm_bookings)
-        text = "Our bookings reached $1 billion in the quarter"
-
-        # find_all_keywords should still find bookings
-        all_keywords = matcher.find_all_keywords(text)
-
-        bookings_matches = [kw for kw in all_keywords if kw.metric_id == "cm_bookings"]
-        assert len(bookings_matches) >= 1, \
-            "find_all_keywords should find bookings (for classification/enrichment purposes)"
-
-    def test_has_required_context_method_exists(self, matcher):
-        """KeywordMatcher should have _has_required_context method."""
-        assert hasattr(matcher, "_has_required_context")
-
-    def test_has_required_context_true_for_non_gated_metrics(self, matcher):
-        """_has_required_context returns True for metrics without required_context."""
-        text = "We have 50000 active customers"
-        # Non-revenue metric should always return True
-        result = matcher._has_required_context("cm_active_customers_total", 10, text)
-        assert result is True
-
-    @pytest.mark.skip(reason="cm_gmv deprecated on this branch (no required_context entry); returns True by default")
-    def test_has_required_context_false_without_context(self, matcher):
-        """_has_required_context returns False for bookings without context."""
-        # cm_gmv is deprecated; use cm_bookings which also has *revenue_synonym_context
-        text = "Our bookings reached $1 billion"
-        result = matcher._has_required_context("cm_bookings", 4, text)
-        assert result is False
-
-    def test_has_required_context_true_with_cohort(self, matcher):
-        """_has_required_context returns True for bookings with cohort context."""
-        # cm_gmv is deprecated; use cm_bookings which also has *revenue_synonym_context
-        text = "Our cohort bookings reached $1 billion"
-        result = matcher._has_required_context("cm_bookings", 11, text)
-        assert result is True
-
-
-# =============================================================================
 # should_exclude_for_number_context with Table Row Awareness (EXT-FN-1)
 # =============================================================================
 
@@ -2066,7 +1723,9 @@ class TestShouldExcludeWithMarkerRowParser:
             number_position=32,  # position of "135"
             table_row_parser=parser,
         )
-        assert should_exclude is False, f"Value should NOT be excluded - 'retention rate' is in different row. Got: {reason}"
+        assert should_exclude is False, (
+            f"Value should NOT be excluded - 'retention rate' is in different row. Got: {reason}"
+        )
 
     def test_exclusion_triggers_when_pattern_in_same_row(self, matcher):
         """Exclusion pattern IN the same row SHOULD trigger exclusion."""
@@ -2131,7 +1790,9 @@ class TestShouldExcludeWithMarkerRowParser:
                 number_position=actual_pos,
                 table_row_parser=parser,
             )
-            assert should_exclude is False, f"Value '{raw_text}' should NOT be excluded - retention rate in different row. Got: {reason}"
+            assert should_exclude is False, (
+                f"Value '{raw_text}' should NOT be excluded - retention rate in different row. Got: {reason}"
+            )
 
     def test_value_in_retention_row_is_excluded(self, matcher):
         """Value in retention rate row SHOULD be excluded from large customers metric."""
@@ -2208,7 +1869,9 @@ class TestShouldExcludeWithTableRowParser:
             number_position=value_pos,
             table_row_parser=parser,
         )
-        assert should_exclude is False, f"Value should NOT be excluded with HTML parser. Got: {reason}"
+        assert should_exclude is False, (
+            f"Value should NOT be excluded with HTML parser. Got: {reason}"
+        )
 
     def test_html_parser_same_row_exclusion(self, matcher):
         """HTML parser should exclude when pattern IS in same row."""


### PR DESCRIPTION
## Summary

- Retires the `required_context` gating mechanism that was last used by `cm_gmv` (deprecated 2026-01-07).
- Known-issue #5 ("Revenue Synonym Context Gating") was archived by PR #180 earlier today; this PR removes the now-orphaned implementation.
- Touches: YAML anchor + sole `<<:` reference, V1 `src/review/keyword_matching.py`, V2 `src/extraction_v2/stages/candidate_generation.py` (4 call sites), `src/shared/keyword_config.py` validator + loader, two test files, two docs.

Net change: **+96 / -892 lines** across 8 files.

## Why

- The mechanism was a no-op at runtime: the V2 candidate generator filters deprecated metrics out before reaching the gating check, and `cm_gmv` was the only metric carrying `required_context`. Every call to `_has_required_context()` returned `True`.
- With the chart-presence pivot underway (#86 / PR #150) and V1 review tables retired, dead branches in the keyword/classifier path are pure drag.

## Verification

- 4234 unit tests pass; ruff clean; `mypy --strict src/review/` clean; YAML parses; all three modules import cleanly.
- Gold-standard validator on Farfetch shows **zero metric-level delta** (TP=16, FP=11, FN=0). Same numbers on origin/main and on this branch — the `--fail-on-regression` flag fires from a pre-existing baseline drift filed as #108, not from this PR.

## Out of scope (filed as separate fragments)

- **#108** — GS validator baseline drift on Farfetch (precision -0.067, recall +0.42 vs saved baseline) reproduces on unmodified main. Not caused by this change.
- **#109** — `src/review/keyword_matching.py` is now imported only by its own test file; the whole module is deletable. Deferred to a separate cleanup PR.

## Test plan

- [x] `pytest -x -q` (4234 passed, 5 skipped)
- [x] `ruff check src/ tests/` clean
- [x] `mypy --strict src/review/` clean
- [x] `python3 -m src.gold_standard.v2_validator --companies "Farfetch Limited"` — same numbers as origin/main
- [x] Final grep sweep finds no live `required_context` references (one historical mention in `extraction-decisions.md` decision-log entry is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)