### PR TITLE
feat(scripts): port image-triage training feed to read v2_image_metric_confirmations (#196)

### DIFF
--- a/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
+++ b/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
@@ -1,0 +1,60 @@
+---
+autonomy: review
+discovered: '2026-04-24'
+estimated: M
+gh_issue: 196
+id: 196
+severity: medium
+slug: ml-triage-feed-from-legacy-image-decisions
+source: gh
+status: partially-resolved
+title: ML image-triage training pipeline reads legacy v2_image_review_decisions
+touches:
+  - scripts/export_image_training_data.py
+  - scripts/retrain_image_triage.py
+  - scripts/benchmark_vision.py
+  - src/llm/vision_client.py
+  - src/gold_standard/image_eval.py
+updated: '2026-04-24'
+pr_refs:
+  - 197
+---
+
+### Problem
+
+After PR #192 (per-metric A/R/C/Add/Skip via `v2_image_metric_confirmations`)
+and PR #151 (the original confirmations schema), reviewer image-review work no
+longer lands in `v2_image_review_decisions`. The ML triage training/scoring/
+benchmarking pipeline still reads only from the legacy table.
+
+### Resolution status (this PR)
+
+`scripts/export_image_training_data.py` now UNIONs both reviewer surfaces.
+Per-metric confirmations aggregate to image-level using:
+
+- `relevant`     — any confirmation in `{accept, correct, add}`
+- `not_relevant` — at least one confirmation, all rejects
+- excluded       — only `skip` decisions, or zero confirmations
+
+Legacy rows take precedence when the same `img_id` appears in both surfaces.
+Smoke against Neon prod: 851 legacy rows + 1 confirmation-derived row.
+
+### Still open
+
+- **`scripts/benchmark_vision.py`** — its corpus query reads `chart_type`
+  heavily for tier-1 / hard-OCR stratification. `chart_type` is not captured
+  in `v2_image_metric_confirmations`, so a clean port requires a product
+  decision: (a) extend the confirmations schema to capture `chart_type`, or
+  (b) accept the feature loss and rework stratification. Deferred until the
+  bake-off harness next runs against new reviewer data.
+- **Triage model `chart_type` feature** — confirmation-derived rows emit
+  `chart_type=NULL`. The model treats it as missing; retraining quality
+  will degrade if confirmations become the dominant surface and `chart_type`
+  is not recovered.
+
+### Next steps
+
+- After ML team retrains with the unified feed, decide whether to capture
+  `chart_type` in `v2_image_metric_confirmations` (schema change) or
+  formalize stratification without it.
+- Port `benchmark_vision.py` once the `chart_type` decision lands.

--- a/scripts/export_image_training_data.py
+++ b/scripts/export_image_training_data.py
@@ -77,9 +77,19 @@ OUTPUT_COLUMNS = [
 # SEC export (database-backed)
 # ---------------------------------------------------------------------------
 
-SEC_QUERY = """
+_IMAGE_URL_FRAGMENT = (
+    "'https://www.sec.gov/Archives/edgar/data/'\n"
+    "        || COALESCE(NULLIF(REGEXP_REPLACE(c.cik, '^0+', ''), ''), '0')\n"
+    "        || '/' || REPLACE(f.accession_number, '-', '')\n"
+    "        || '/' || v.filename AS image_url"
+)
+
+# Legacy reviewer decisions (image-level relevant / not_relevant).
+# Stops accumulating new rows after PR #192 (per-metric confirmations
+# took over the reviewer surface), but historical rows remain valid
+# training data.
+LEGACY_SEC_QUERY = f"""
     SELECT
-        d.image_decision_id,
         v.img_id,
         d.decision,
         d.chart_type,
@@ -93,10 +103,7 @@ SEC_QUERY = """
         v.relevance_score,
         f.accession_number,
         c.company_name,
-        'https://www.sec.gov/Archives/edgar/data/'
-            || COALESCE(NULLIF(REGEXP_REPLACE(c.cik, '^0+', ''), ''), '0')
-            || '/' || REPLACE(f.accession_number, '-', '')
-            || '/' || v.filename AS image_url
+        {_IMAGE_URL_FRAGMENT}
     FROM v2_image_review_decisions d
     JOIN v2_image_assets v ON v.img_id = d.img_id
     JOIN filings f ON v.doc_id = f.filing_id
@@ -104,10 +111,67 @@ SEC_QUERY = """
     ORDER BY c.company_name, v.img_id
 """
 
+# Per-metric confirmations aggregated to image-level relevant / not_relevant.
+# Mapping (sql/47):
+#   relevant     — any confirmation in {accept, correct, add}
+#   not_relevant — at least one confirmation, all rejects (no accept/correct/add)
+#   excluded     — only skips, or zero confirmations (filtered by HAVING)
+# `chart_type` is not captured in v2_image_metric_confirmations and is
+# emitted as NULL — downstream training treats it as a missing feature.
+# `rejection_reason` is taken from any reject confirmation deterministically
+# (earliest by created_at).
+CONFIRMATIONS_SEC_QUERY = f"""
+    SELECT
+        v.img_id,
+        CASE
+            WHEN bool_or(imc.decision IN ('accept','correct','add'))
+                 THEN 'relevant'
+            ELSE 'not_relevant'
+        END                                          AS decision,
+        NULL::text                                   AS chart_type,
+        (
+            SELECT imc2.rejection_reason
+              FROM v2_image_metric_confirmations imc2
+             WHERE imc2.img_id = v.img_id
+               AND imc2.decision = 'reject'
+               AND imc2.rejection_reason IS NOT NULL
+             ORDER BY imc2.created_at
+             LIMIT 1
+        )                                            AS rejection_reason,
+        v.filename,
+        v.width,
+        v.height,
+        v.nearby_text,
+        v.classification,
+        v.section_type,
+        v.relevance_score,
+        f.accession_number,
+        c.company_name,
+        {_IMAGE_URL_FRAGMENT}
+    FROM v2_image_metric_confirmations imc
+    JOIN v2_image_assets v ON v.img_id = imc.img_id
+    JOIN filings f ON v.doc_id = f.filing_id
+    JOIN companies c ON f.company_id = c.company_id
+    GROUP BY v.img_id, v.filename, v.width, v.height, v.nearby_text,
+             v.classification, v.section_type, v.relevance_score,
+             f.accession_number, c.company_name, c.cik
+    HAVING bool_or(imc.decision IN ('accept','correct','add','reject'))
+    ORDER BY c.company_name, v.img_id
+"""
+
 
 def export_sec_rows(db) -> list[dict]:
     """
     Export V2 SEC image decisions for training.
+
+    Pulls from both reviewer surfaces:
+      - v2_image_review_decisions (legacy, image-level relevant/not_relevant)
+      - v2_image_metric_confirmations (per-metric A/R/C/Add/Skip, sql/47),
+        aggregated to image-level using the mapping in
+        ``CONFIRMATIONS_SEC_QUERY``
+
+    Legacy rows take precedence when the same `img_id` appears in both
+    surfaces — historical reviewer intent on existing rows is authoritative.
 
     V2 does not persist V1's `detected_keywords[]` or `cohort_keyword_nearby`.
     Synthesize both from nearby_text using the same COHORT_KEYWORDS set used by
@@ -118,7 +182,12 @@ def export_sec_rows(db) -> list[dict]:
     """
     from src.shared.image_features import derive_detection_tier
 
-    rows = db.query(SEC_QUERY)
+    legacy_rows = db.query(LEGACY_SEC_QUERY)
+    confirmation_rows = db.query(CONFIRMATIONS_SEC_QUERY)
+    legacy_img_ids = {str(r["img_id"]) for r in legacy_rows}
+    rows = list(legacy_rows) + [
+        r for r in confirmation_rows if str(r["img_id"]) not in legacy_img_ids
+    ]
     out = []
     for r in rows:
         w = r.get("width")

--- a/scripts/retrain_image_triage.py
+++ b/scripts/retrain_image_triage.py
@@ -14,7 +14,9 @@ Usage:
 
 Operator notes:
     - Run monthly after a batch of new human image review decisions have been
-      collected in v2_image_review_decisions.
+      collected. Both reviewer surfaces feed the export: v2_image_review_decisions
+      (legacy, image-level relevant/not_relevant) and v2_image_metric_confirmations
+      (per-metric A/R/C/Add/Skip, sql/47) aggregated to image-level.
     - Defaults to $TEST_DATABASE_URL (local Docker) so you must pass
       --database-url explicitly for production Neon (or set DATABASE_URL to the
       prod URL and pass --use-env-database-url).

--- a/tests/unit/scripts/test_export_image_training_data.py
+++ b/tests/unit/scripts/test_export_image_training_data.py
@@ -202,3 +202,57 @@ def test_pres_export_uses_same_cohort_keywords_constant() -> None:
     assert "cohort_keywords = {" not in src, (
         "export_pres_rows must not re-define cohort_keywords locally; use COHORT_KEYWORDS"
     )
+
+
+# ---------------------------------------------------------------------------
+# export_sec_rows: legacy + confirmations UNION + dedup (gh-196)
+# ---------------------------------------------------------------------------
+
+
+def _make_two_query_mock_db(legacy: list[dict], confirmations: list[dict]) -> MagicMock:
+    """Mock that returns `legacy` on the first .query() call and `confirmations` on the second."""
+    mock_db = MagicMock()
+    mock_db.query.side_effect = [legacy, confirmations]
+    return mock_db
+
+
+def test_sec_rows_emits_legacy_and_confirmation_rows() -> None:
+    mod = _load_module()
+    legacy_row = _base_sec_row(img_id="11111111-1111-1111-1111-111111111111")
+    confirmation_row = _base_sec_row(
+        img_id="22222222-2222-2222-2222-222222222222",
+        chart_type=None,
+        decision="not_relevant",
+        rejection_reason="not_present",
+    )
+    result = mod.export_sec_rows(_make_two_query_mock_db([legacy_row], [confirmation_row]))
+    assert len(result) == 2
+    by_img = {r["image_id"]: r for r in result}
+    assert "sec:11111111-1111-1111-1111-111111111111" in by_img
+    assert "sec:22222222-2222-2222-2222-222222222222" in by_img
+
+
+def test_sec_rows_legacy_takes_precedence_on_duplicate_img_id() -> None:
+    """If an img_id appears in both surfaces, the legacy row wins."""
+    mod = _load_module()
+    legacy_row = _base_sec_row(decision="relevant", chart_type="cohort_table")
+    # Same img_id, different decision shape
+    confirmation_row = _base_sec_row(decision="not_relevant", chart_type=None)
+    result = mod.export_sec_rows(_make_two_query_mock_db([legacy_row], [confirmation_row]))
+    assert len(result) == 1
+    assert result[0]["decision"] == "relevant"
+    assert result[0]["chart_type"] == "cohort_table"
+
+
+def test_sec_rows_handles_null_chart_type_from_confirmations() -> None:
+    """Confirmation-derived rows have chart_type=None; downstream emits ''."""
+    mod = _load_module()
+    confirmation_row = _base_sec_row(
+        img_id="33333333-3333-3333-3333-333333333333",
+        chart_type=None,
+        decision="relevant",
+    )
+    result = mod.export_sec_rows(_make_two_query_mock_db([], [confirmation_row]))
+    assert len(result) == 1
+    # The transform path coerces None to '' for CSV emission
+    assert result[0]["chart_type"] == ""


### PR DESCRIPTION
Closes #196 (partially — see "Still open" in the fragment).

## Summary

After PR #192 stopped writing `v2_image_review_decisions` (per-metric A/R/C/Add/Skip moved to `v2_image_metric_confirmations`), the ML triage training pipeline's feed quietly went stale. This PR ports the primary training export to read both reviewer surfaces.

- **`scripts/export_image_training_data.py`** — splits `SEC_QUERY` into `LEGACY_SEC_QUERY` + `CONFIRMATIONS_SEC_QUERY`. The latter aggregates per-metric decisions to image-level using the mapping in gh-196:
  - `relevant`     — any confirmation in `{accept, correct, add}`
  - `not_relevant` — at least one confirmation, all rejects
  - excluded       — only skips, or zero confirmations
- **Legacy precedence** on duplicate `img_id`: when the same image has rows in both tables, the legacy `decision`/`chart_type`/`rejection_reason` win — historical reviewer intent stays authoritative.
- **`chart_type` is null** for confirmation-derived rows (the new schema doesn't capture it). Treated as a missing feature by the model.
- **`scripts/retrain_image_triage.py`** — operator-note updated to mention both surfaces.
- **`docs/known-issues/gh-196-*.md`** — partially-resolved fragment opened. `benchmark_vision.py` port deferred (chart_type is load-bearing for stratification — needs a product decision before that script can be ported).

## Test plan

- [x] 16 unit tests in `tests/unit/scripts/test_export_image_training_data.py` pass (3 new: union, dedup precedence, null chart_type).
- [x] Read-only smoke against Neon prod (after applying sql/46 + sql/47): **851 legacy rows + 1 confirmation-derived row** (the Farfetch accept) aggregate cleanly.
- [x] Ruff clean.
- [ ] CI: Lint / Unit Tests / Integration Tests / UI E2E / Vulnerability Scan.

## Out of scope (still open in gh-196)

- `scripts/benchmark_vision.py` corpus query — `chart_type` is heavily used for tier-1 / hard-OCR stratification. Needs either a schema extension to capture chart_type in confirmations or a stratification rework.
- Triage-model `chart_type` feature handling on retrain — punt until ML team has data on whether the missing-feature regression matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)