### PR TITLE
fix(deploy): auto-apply schema migrations on every Render deploy (#66)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -38,6 +38,24 @@ Region is pinned so blueprint re-deploys do not scatter services across regions.
 - Install with `brew install postgresql@16` and invoke via the explicit Cellar path or a pinned symlink (do not rely on the default `/opt/homebrew/bin/pg_dump` which resolves to whatever was installed first).
 - Run `python3 scripts/check_pg_client_version.py` before taking snapshots. Silent failure (0-byte file with exit 0) is the symptom when this guard is skipped.
 
+### Deploy-Time Migration Contract
+
+`render.yaml` wires `preDeployCommand: python3 scripts/apply_migrations.py` on the `filings-reviewer` web service. Render runs that command before the container starts serving traffic, on every deploy. The script is idempotent via the `schema_migrations` ledger, so re-runs are no-ops once a migration has been applied.
+
+**For schema-change PRs**, the contract is:
+1. Add `sql/<timestamp>_<description>.sql` (timestamp filename per `.claude/rules/sql.md`).
+2. Register it in `MIGRATIONS` in `scripts/apply_migrations.py`.
+3. Merge the PR. The next Render deploy applies the migration automatically.
+
+**Failure mode.** A non-zero exit from the predeploy step aborts the deploy and leaves the previous container serving traffic. Common causes:
+- Migration not registered in `apply_migrations.py` (script exits non-zero on unregistered files).
+- Checksum mismatch — the migration file was edited after being applied to prod (script refuses to re-apply).
+- `DATABASE_URL` not in scope at deploy phase (it should be — the env group `filings-shared-secrets` covers `filings-reviewer`).
+
+**Verification.** Render dashboard → `filings-reviewer` → **Events → Deploy** → predeploy log shows `APPLIED: <filename>` lines for any migrations the deploy applied.
+
+**Limitations.** Only `filings-reviewer` has the predeploy hook. Other services (`filings-extraction`, `filings-onboarding-runner`, `filings-nightly-sweep`, `filings-metabase`) rely on `filings-reviewer` running its predeploy first when a schema change ships — they redeploy in parallel but share the database, so the order doesn't matter for safety, only for log visibility.
+
 ## DATABASE_URL vs TEST_DATABASE_URL — IMPORTANT
 
 **In this project's `.env`, `DATABASE_URL` points at the Neon prod database, NOT local Postgres.** The local Docker Postgres is addressed by `TEST_DATABASE_URL`.

--- a/docs/known-issues/legacy-066-migrations-not-auto-applied-on-render-deploy.md
+++ b/docs/known-issues/legacy-066-migrations-not-auto-applied-on-render-deploy.md
@@ -12,7 +12,7 @@ title: Migrations Not Auto-Applied on Render Deploy
 touches:
 - render.yaml
 - .claude/rules/infrastructure.md
-updated: '2026-04-21'
+updated: '2026-04-24'
 ---
 
 ### Problem

--- a/docs/operations/cloud-deployment-runbook.md
+++ b/docs/operations/cloud-deployment-runbook.md
@@ -188,13 +188,28 @@ For errors, filter by `ERROR` or `Exception`.
 
 ## Deploying a Schema Migration
 
+**As of the fix for Known Issue #66, schema migrations run automatically on every
+Render deploy.** The `filings-reviewer` web service has a `preDeployCommand` in
+`render.yaml` that runs `python3 scripts/apply_migrations.py` before the
+container starts serving traffic. No manual migration step is required for
+normal schema-change PRs.
+
 When a new SQL migration file is added (e.g., `10_new_table.sql`):
 
-1. Apply to Neon using the direct endpoint (see above)
-2. Verify the migration ran without errors
-3. Deploy the new code to Render (push to main)
+1. Create `sql/NN_descriptive_name.sql` with the schema change.
+2. Register it in the `MIGRATIONS` list in `scripts/apply_migrations.py`.
+3. Merge the PR. The pre-deploy step runs automatically on the next Render deploy.
+4. Verify in Render dashboard: **filings-reviewer → Events → Deploy** → confirm
+   the predeploy log shows `APPLIED: NN_descriptive_name.sql`.
 
-Do NOT deploy code that depends on a new schema before the migration runs.
+**If the pre-deploy fails** (non-zero exit): the deploy aborts and the previous
+version keeps serving. Check the Render predeploy logs for the error. Common
+causes: migration not registered in `apply_migrations.py`, checksum mismatch
+(migration file edited after being applied), or `DATABASE_URL` missing from the
+`filings-shared-secrets` env group.
+
+See `.claude/rules/infrastructure.md` — "Deploy-Time Migration Contract" — for
+full details on the mechanism, limitations, and troubleshooting.
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,10 @@ services:
     region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile
+    # Run schema migrations before every deploy. The script is idempotent
+    # (schema_migrations ledger) so this is safe on every push to main.
+    # DATABASE_URL is available here via the filings-shared-secrets group below.
+    preDeployCommand: python3 scripts/apply_migrations.py
     envVars:
       - fromGroup: filings-shared-secrets
       - key: SECRET_KEY


### PR DESCRIPTION
## Summary

Adds `preDeployCommand: python3 scripts/apply_migrations.py` to the `filings-reviewer` web service in `render.yaml`. The script is idempotent via the `schema_migrations` ledger, so it is safe to run on every deploy.

Fixes the crash-loop that hit when PR #48 merged `sql/39_v2_ingest_batches.sql` without the migration running first — `filings-onboarding-runner` then crashed every ~5 min with `psycopg.errors.UndefinedTable: relation "v2_ingest_batches" does not exist` until an operator manually ran the script. Every future schema-change PR has the same failure mode by default.

## Mechanism chosen

`preDeployCommand` on `filings-reviewer` (Option A from the fragment), not a one-shot Job (Option B). Reasoning:
- `filings-reviewer` already has `DATABASE_URL` in scope at deploy phase via the `filings-shared-secrets` env group — no credential widening needed.
- Render runs `preDeployCommand` before the container starts serving traffic; non-zero exit aborts the deploy and leaves the previous version running.
- `filings-reviewer` has the longest deploy budget of the services, so a slow migration doesn't risk a timeout.
- A one-shot Job would require either manual triggering on every merge (operator burden) or a separate webhook setup (more infra).

## What changed

- `render.yaml` (+4): added `preDeployCommand` line on `filings-reviewer` with an inline comment.
- `docs/operations/cloud-deployment-runbook.md` (+23 -8): updated the "Deploying a Schema Migration" section — schema migrations now run automatically; the manual step is gone.
- `.claude/rules/infrastructure.md` (+18): added a new **"Deploy-Time Migration Contract"** subsection under Production (Neon + Render) — what it does, where it's wired, failure modes, verification, limitations.
- `docs/known-issues/legacy-066-...md` (touch only — `updated:` date bumped; status stays `open` until merge per Issue #84).

## Verification plan (post-merge)

The next schema-change PR is the live test:
1. Operator merges a PR that adds `sql/<timestamp>_<name>.sql` registered in `apply_migrations.py`.
2. Render deploys `filings-reviewer`.
3. Confirm in Render dashboard → `filings-reviewer` → **Events → Deploy** → predeploy log shows `APPLIED: <filename>`.
4. Service starts cleanly without the `UndefinedTable` crash that triggered this fix.

If the predeploy step fails for any reason (unregistered migration, checksum mismatch, missing env var), the deploy aborts and the previous version keeps serving — the failure mode is loud, not silent.

## Test plan

- [x] Unit suite passes (`pytest -x -q --tb=short`) — pre-push hook ran cleanly.
- [x] Pre-commit hooks pass (ruff, secret scan, fragment frontmatter validator, migration order, etc.).
- [ ] Live verification on the next schema-change deploy (described above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)