### PR TITLE
fix(infra): refuse R2 put_bytes without prod-write env opt-in (#80)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -78,6 +78,7 @@ Rules for any DB-touching command in this repo:
 | `VISION_CLASSIFY_MODEL` | With `ENABLE_METRIC_CLASSIFY` | Model id (default `gemini-2.5-flash-lite`, per 2026-04-23 bake-off). |
 | `VISION_CLASSIFY_THRESHOLD` | With `ENABLE_METRIC_CLASSIFY` | Confidence floor (default `0.5`) for the downstream `predicted_relevant` signal. Records below the floor are still persisted. |
 | `GEMINI_API_KEY` | With `VISION_CLASSIFY_PROVIDER=gemini` | Google AI Studio key for Gemini vision calls. Set manually in Render. |
+| `FILINGS_REVIEWER_ALLOW_PROD_WRITES` | Required for `R2Storage.put_bytes` | Must be set to `"1"` for any process that writes image bytes to R2. Refused otherwise. Reads (`get_bytes`, `exists`) are unaffected. Set on Render services that run extraction/ingestion (`filings-reviewer`, `filings-extraction`, `filings-onboarding-runner`); leave unset on local dev to prevent accidental prod writes when prod creds are sourced for one-off CLI work. |
 
 ## Image Storage
 
@@ -93,6 +94,12 @@ Image bytes (chart/table OCR cache + ingestion-local copies) persist via
 (e.g. `pipeline/<cik>/<accession>/<filename>`), not a filesystem path. Key shape
 is validated by `validate_key()` — path-traversal sequences and absolute paths
 are rejected at every call site.
+
+### Prod-write guard
+
+`R2Storage.put_bytes` refuses to write unless `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` is in the process environment. The guard prevents accidental prod R2 mutations from local CLI tools (e.g. `python3 -m src.gold_standard.v2_validator`) when a contributor sources prod `.env` for one-off work. Reads (`get_bytes`, `exists`) remain open so diagnostics still work. `LocalFilesystemStorage` is unguarded — dev writes to `data/image_cache/` are always allowed.
+
+Render services that legitimately write images (`filings-reviewer`, `filings-extraction`, `filings-onboarding-runner`) need `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` set in their env. Services that don't write images (`filings-nightly-sweep`, `filings-metabase`) should leave it unset.
 
 ## SEC EDGAR Integration
 

--- a/docs/known-issues/legacy-080-gs-validator-has-no-safeguard-against-unintended-prod-r2-wri.md
+++ b/docs/known-issues/legacy-080-gs-validator-has-no-safeguard-against-unintended-prod-r2-wri.md
@@ -5,6 +5,7 @@ estimated: S
 id: 80
 note: Add env-scoped guard against unintended prod R2 writes from CLI tools; design
   call (storage-layer vs validator-layer) needed
+pr_refs: []
 severity: medium
 slug: gs-validator-has-no-safeguard-against-unintended-prod-r2-wri
 source: legacy
@@ -14,7 +15,7 @@ touches:
 - src/infra/image_storage.py
 - src/gold_standard/v2_validator.py
 - .claude/rules/infrastructure.md
-updated: '2026-04-22'
+updated: '2026-04-24'
 ---
 
 ### Problem

--- a/src/infra/image_storage.py
+++ b/src/infra/image_storage.py
@@ -82,6 +82,12 @@ class R2Storage:
         )
 
     def put_bytes(self, key: str, data: bytes, content_type: str = "image/jpeg") -> None:
+        if os.environ.get("FILINGS_REVIEWER_ALLOW_PROD_WRITES") != "1":
+            raise RuntimeError(
+                "Refusing R2 write — set FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 to allow. "
+                "This guard prevents accidental prod R2 mutations when running CLI tools "
+                "with prod credentials in the environment."
+            )
         validate_key(key)
         self._client.put_object(
             Bucket=self._bucket,

--- a/tests/unit/infra/test_image_storage.py
+++ b/tests/unit/infra/test_image_storage.py
@@ -104,6 +104,8 @@ class TestR2Storage:
             return original_client(service, **kwargs)
 
         monkeypatch.setattr(boto3, "client", patched_client)
+        # Allow prod writes in tests that exercise the happy path.
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
 
         with moto.mock_aws():
             original_client(
@@ -138,6 +140,71 @@ class TestR2Storage:
     def test_invalid_key_rejected(self, r2: R2Storage) -> None:
         with pytest.raises(InvalidStorageKeyError):
             r2.put_bytes("/leading.jpg", b"x")
+
+
+class TestR2StorageProdWriteGuard:
+    """Guard: put_bytes refused without FILINGS_REVIEWER_ALLOW_PROD_WRITES=1."""
+
+    @pytest.fixture
+    def r2_no_writes_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        """R2Storage instance with prod-write guard active (env var absent)."""
+        moto = pytest.importorskip("moto")
+        import boto3
+
+        original_client = boto3.client
+
+        def patched_client(service, **kwargs):
+            kwargs.pop("endpoint_url", None)
+            kwargs["region_name"] = "us-east-1"
+            return original_client(service, **kwargs)
+
+        monkeypatch.setattr(boto3, "client", patched_client)
+        monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+
+        with moto.mock_aws():
+            original_client(
+                "s3",
+                region_name="us-east-1",
+                aws_access_key_id="test",
+                aws_secret_access_key="test",
+            ).create_bucket(Bucket="test-bucket")
+
+            yield R2Storage(
+                bucket="test-bucket",
+                endpoint="https://example.com",
+                access_key="test",
+                secret_key="test",
+            )
+
+    def test_put_bytes_raises_when_env_var_unset(self, r2_no_writes_allowed: R2Storage) -> None:
+        with pytest.raises(RuntimeError, match="FILINGS_REVIEWER_ALLOW_PROD_WRITES"):
+            r2_no_writes_allowed.put_bytes("pipeline/cik/acc/g001.jpg", b"data")
+
+    def test_put_bytes_raises_when_env_var_not_1(
+        self, r2_no_writes_allowed: R2Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "true")
+        with pytest.raises(RuntimeError, match="FILINGS_REVIEWER_ALLOW_PROD_WRITES"):
+            r2_no_writes_allowed.put_bytes("pipeline/cik/acc/g001.jpg", b"data")
+
+    def test_get_bytes_allowed_without_env_var(
+        self, r2_no_writes_allowed: R2Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reads must remain open regardless of the guard."""
+        # put first via allowed env var, then read without it
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+        r2_no_writes_allowed.put_bytes("pipeline/cik/acc/read_test.jpg", b"readable")
+        monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+        assert r2_no_writes_allowed.get_bytes("pipeline/cik/acc/read_test.jpg") == b"readable"
+
+    def test_exists_allowed_without_env_var(
+        self, r2_no_writes_allowed: R2Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """exists() must remain open regardless of the guard."""
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+        r2_no_writes_allowed.put_bytes("pipeline/cik/acc/exists_test.jpg", b"x")
+        monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+        assert r2_no_writes_allowed.exists("pipeline/cik/acc/exists_test.jpg") is True
 
 
 class TestGetImageStorageFactory:


### PR DESCRIPTION
## Summary

`R2Storage.put_bytes` now raises `RuntimeError` unless `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` is set in the process environment. Prevents silent prod R2 mutations from local CLI tools (e.g. `python3 -m src.gold_standard.v2_validator`) when a contributor sources prod `.env` for one-off work — the scenario described in Known Issue #80.

Reads (`get_bytes`, `exists`) remain open so diagnostics still work. `LocalFilesystemStorage` is unaffected (dev writes always allowed).

## Mechanism chosen

Storage-layer guard (Option A from the fragment), not validator-only startup check (Option B). Reasoning:
- Solves the problem class for every `put_bytes` caller — `OCRExtractionStage._download_missing_images` (`src/extraction_v2/stages/ocr_extraction.py:346`) and `IngestionStage._extract_image_assets` (`src/extraction_v2/stages/ingestion.py:964`) — plus any future write paths.
- Failure is loud and immediate at the call site, with a message naming the exact env var to set.
- One narrow change in one file rather than scattered startup checks across CLIs.

## What changed

- `src/infra/image_storage.py` (+6): guard at top of `R2Storage.put_bytes` before `validate_key()` and the `boto3` call.
- `tests/unit/infra/test_image_storage.py` (+67 -1): new `TestR2StorageProdWriteGuard` class — 4 tests covering env-var-unset (refused), env-var-truthy-but-not-"1" (refused), reads-without-env-var (allowed), exists-without-env-var (allowed). Existing happy-path `TestR2Storage` fixture had `monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")` added so its puts still work.
- `.claude/rules/infrastructure.md` (+8): new env-var row in the Environment Variables table; new "Prod-write guard" subsection under Image Storage.
- `docs/known-issues/legacy-080-...md` (touch): added empty `pr_refs: []`, bumped `updated:` date. Status stays `open` until merge.

## Operator action (post-merge, NOT in this PR)

Add `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` to the env of the Render services that legitimately write images:
- `filings-reviewer` — web service; ingestion endpoints write via `IngestionStage`.
- `filings-extraction` — cron; both `OCRExtractionStage._download_missing_images` and `IngestionStage._extract_image_assets` write.
- `filings-onboarding-runner` — background worker; same extraction pipeline.

`filings-nightly-sweep` and `filings-metabase` don't call `put_bytes`; leave the env var unset on those.

## Test plan

- [x] Unit suite passes (`pytest -x -q --tb=short`) — pre-push hook ran cleanly (3933 tests).
- [x] Pre-commit hooks pass (ruff, ruff format, secret scan, fragment frontmatter validator).
- [x] New tests cover the guard (env unset / "true" / reads OK / exists OK).
- [ ] Live verification: after merge + env var set on the services, run `R2_BUCKET=<prod-bucket> R2_ENDPOINT_URL=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... python3 -c "from src.infra.image_storage import get_image_storage; get_image_storage().put_bytes('test/x.jpg', b'x')"` from a local shell **without** the env var set — must raise `RuntimeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)