### PR TITLE
fix(image_classify): remove stale comment — cost_usd already plumbed from VisionClient

### DIFF
--- a/docs/known-issues/legacy-100-classify-cost-usd-not-plumbed-from-vision-client.md
+++ b/docs/known-issues/legacy-100-classify-cost-usd-not-plumbed-from-vision-client.md
@@ -6,7 +6,7 @@ id: 100
 severity: low
 slug: classify-cost-usd-not-plumbed-from-vision-client
 source: legacy
-status: open
+status: resolved
 title: v2_image_classifications.cost_usd Persists as 0 — VisionClient Helper Doesn't Surface Cost
 touches:
   - src/llm/vision_client.py

--- a/src/extraction_v2/stages/image_classify.py
+++ b/src/extraction_v2/stages/image_classify.py
@@ -124,8 +124,6 @@ class ImageClassifyStage:
         if parsed is None:
             return None
 
-        # `analyze_image_for_metric_classification` currently returns parse output
-        # only. Cost isn't plumbed back; record as 0 until VisionClient surfaces it.
         cost_usd = float(parsed.pop("_cost_usd", 0.0))
 
         predicted_metrics = [


### PR DESCRIPTION
`vision_client.py` already sets `parsed["_cost_usd"] = response.cost_usd` in
`analyze_image_for_metric_classification`, and `_classify_one` already reads it
via `parsed.pop("_cost_usd", 0.0)`. The comment claiming cost is not plumbed
was written in anticipation of the fix but never removed when the fix landed.

Remove the stale/contradictory comment and mark issue #100 resolved.

Closes #100

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
