### PR TITLE
fix(known-issues): set autonomy: n/a on all resolved/archived fragments (issue #102)

### DIFF
--- a/docs/known-issues/legacy-002-low-farfetch-recall.md
+++ b/docs/known-issues/legacy-002-low-farfetch-recall.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-01-01'
 estimated: L
 id: 2

--- a/docs/known-issues/legacy-004-spelled-out-number-parsing-limitations.md
+++ b/docs/known-issues/legacy-004-spelled-out-number-parsing-limitations.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: —
 id: 4

--- a/docs/known-issues/legacy-005-revenue-synonym-context-gating.md
+++ b/docs/known-issues/legacy-005-revenue-synonym-context-gating.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: —
 id: 5

--- a/docs/known-issues/legacy-009-snap-filing-id-32-33-mislabeled-data.md
+++ b/docs/known-issues/legacy-009-snap-filing-id-32-33-mislabeled-data.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: M
 id: 9

--- a/docs/known-issues/legacy-011-gold-standard-coverage-tests.md
+++ b/docs/known-issues/legacy-011-gold-standard-coverage-tests.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: XS
 id: 11

--- a/docs/known-issues/legacy-027-images-tab-playwright-assertions-fail.md
+++ b/docs/known-issues/legacy-027-images-tab-playwright-assertions-fail.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: S
 id: 27

--- a/docs/known-issues/legacy-028-mock-server-template-contract-coupling.md
+++ b/docs/known-issues/legacy-028-mock-server-template-contract-coupling.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-17'
 estimated: L
 id: 28

--- a/docs/known-issues/legacy-034-v2-image-assets-file-path-rooted-in-tmpdir-purged-by-os.md
+++ b/docs/known-issues/legacy-034-v2-image-assets-file-path-rooted-in-tmpdir-purged-by-os.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-19'
 estimated: —
 id: 34

--- a/docs/known-issues/legacy-035-pre-2026-04-17-filings-missing-chart-sourced-facts.md
+++ b/docs/known-issues/legacy-035-pre-2026-04-17-filings-missing-chart-sourced-facts.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-19'
 estimated: L
 id: 35

--- a/docs/known-issues/legacy-039-is-in-scope-phase1-is-a-misnomer-post-issue-7.md
+++ b/docs/known-issues/legacy-039-is-in-scope-phase1-is-a-misnomer-post-issue-7.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-19'
 estimated: M
 id: 39

--- a/docs/known-issues/legacy-043-spectrum-brands-co-registrant-filings-still-have-uber-html-c.md
+++ b/docs/known-issues/legacy-043-spectrum-brands-co-registrant-filings-still-have-uber-html-c.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-19'
 estimated: —
 id: 43

--- a/docs/known-issues/legacy-049-integration-test-db-flakiness-under-full-suite-pytest-x.md
+++ b/docs/known-issues/legacy-049-integration-test-db-flakiness-under-full-suite-pytest-x.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-20'
 estimated: M
 id: 49

--- a/docs/known-issues/legacy-055-28-stuck-8-k-filings-in-class-e-from-form-filter-bypass.md
+++ b/docs/known-issues/legacy-055-28-stuck-8-k-filings-in-class-e-from-form-filter-bypass.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-21'
 estimated: S
 id: 55

--- a/docs/known-issues/legacy-060-detect-universe-gaps-ignores-sic-filter.md
+++ b/docs/known-issues/legacy-060-detect-universe-gaps-ignores-sic-filter.md
@@ -1,5 +1,5 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: XS
 id: 60

--- a/docs/known-issues/legacy-079-sweeper-picks-resolved-and-archived-issues.md
+++ b/docs/known-issues/legacy-079-sweeper-picks-resolved-and-archived-issues.md
@@ -1,5 +1,5 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: 2026-04-22
 estimated: XS
 id: 79

--- a/docs/known-issues/legacy-085-apply-all-migrations-stale-at-40.md
+++ b/docs/known-issues/legacy-085-apply-all-migrations-stale-at-40.md
@@ -1,5 +1,5 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: XS
 id: 85

--- a/docs/known-issues/legacy-086-dedup-stage-collapses-same-metric-different-value-cohort-facts.md
+++ b/docs/known-issues/legacy-086-dedup-stage-collapses-same-metric-different-value-cohort-facts.md
@@ -1,5 +1,5 @@
 ---
-autonomy: review
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: M
 id: 86

--- a/docs/known-issues/legacy-088-migration-order-drift-no-precommit-guard.md
+++ b/docs/known-issues/legacy-088-migration-order-drift-no-precommit-guard.md
@@ -5,7 +5,7 @@ slug: migration-order-drift-no-precommit-guard
 title: No pre-commit guard catches sql/ files missing from MIGRATION_ORDER
 status: resolved
 severity: medium
-autonomy: skip
+autonomy: n/a
 estimated: S
 touches:
   - scripts/apply_all_migrations.py

--- a/docs/known-issues/legacy-094-v2-audit-log-check-constraint-rejects-head-options.md
+++ b/docs/known-issues/legacy-094-v2-audit-log-check-constraint-rejects-head-options.md
@@ -1,5 +1,5 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-23'
 estimated: S
 id: 94

--- a/docs/known-issues/legacy-102-sweep-autonomy-cleanup-resolved-archived.md
+++ b/docs/known-issues/legacy-102-sweep-autonomy-cleanup-resolved-archived.md
@@ -1,12 +1,12 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-24'
 estimated: XS
 id: 102
 severity: low
 slug: sweep-autonomy-cleanup-resolved-archived
 source: legacy
-status: open
+status: resolved
 title: Resolved/Archived Issues Retain Non-`n/a` Autonomy — Sweep Logs Noisy
 touches:
   - docs/known-issues/


### PR DESCRIPTION
19 fragments had status=resolved/archived but non-n/a autonomy (skip/safe/review),
causing the nightly sweep selector to emit noisy warnings. Sets autonomy: n/a on
all 19 affected fragments and marks #102 as resolved. Selector now runs warning-free.
