### PR TITLE
claude/sweep/issue 105 2026 04 25

### DIFF
--- a/docs/known-issues/gh-204-46-extend-audit-missing-from-apply-migrations.md
+++ b/docs/known-issues/gh-204-46-extend-audit-missing-from-apply-migrations.md
@@ -1,0 +1,34 @@
+---
+id: 204
+source: gh
+slug: 46-extend-audit-missing-from-apply-migrations
+title: 46_extend_audit_http_method_constraint.sql missing from apply_migrations.py MIGRATIONS list
+status: open
+severity: low
+autonomy: safe
+estimated: XS
+touches:
+  - scripts/apply_migrations.py
+discovered: '2026-04-25'
+updated: '2026-04-25'
+gh_issue: 204
+note: Add 46_extend_audit_http_method_constraint.sql after 46_v2_text_metric_presence.sql in MIGRATIONS
+---
+
+### Problem
+
+`sql/46_extend_audit_http_method_constraint.sql` (which extends the `v2_audit_log`
+http_method constraint to include HEAD and OPTIONS) is present in
+`scripts/apply_all_migrations.py` MIGRATION_ORDER but absent from
+`scripts/apply_migrations.py` MIGRATIONS. The latter is the deploy-time runner
+(`preDeployCommand`) and the source for the integration test conftest. If any test
+sends a HEAD/OPTIONS request through the audit-log middleware, the DB constraint
+would reject it with a check violation.
+
+### Next Steps
+
+- Add `"46_extend_audit_http_method_constraint.sql"` to MIGRATIONS in
+  `scripts/apply_migrations.py` after `"46_v2_text_metric_presence.sql"` (matching
+  the order in `apply_all_migrations.py`).
+- Verify the migration is idempotent for test DBs that already have the constraint
+  applied (`DROP CONSTRAINT IF EXISTS` before `ADD CONSTRAINT`).

--- a/docs/known-issues/gh-205-dead-v1-conftest-helpers.md
+++ b/docs/known-issues/gh-205-dead-v1-conftest-helpers.md
@@ -1,0 +1,31 @@
+---
+id: 205
+source: gh
+slug: dead-v1-conftest-helpers
+title: Dead V1 helper functions in tests/integration/conftest.py
+status: open
+severity: low
+autonomy: safe
+estimated: XS
+touches:
+  - tests/integration/conftest.py
+discovered: '2026-04-25'
+updated: '2026-04-25'
+gh_issue: 205
+note: Remove create_test_candidate and create_test_decision — call non-existent db methods
+---
+
+### Problem
+
+`tests/integration/conftest.py` defines `create_test_candidate()` and
+`create_test_decision()` which call `db.insert_review_candidate()` and
+`db.insert_review_decision()`. These methods no longer exist in `DatabaseAdapter`
+(V1 tables were retired via `sql/31`). No test in `tests/integration/` calls these
+helpers, making them dead code. If someone adds a test using them it will fail with
+`AttributeError` at runtime.
+
+### Next Steps
+
+- Confirm no integration test calls `create_test_candidate` or `create_test_decision`
+  (`grep -r "create_test_candidate\|create_test_decision" tests/`).
+- Remove both helper functions from `tests/integration/conftest.py`.

--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -65,15 +65,11 @@ MIGRATIONS = [
     "28_extend_v2_image_assets_review.sql",
     "29_create_v2_image_review_decisions.sql",
     "30_drop_v1_image_review.sql",
-    # NOTE: 31_drop_v1_review_tables.sql and 33_fix_identity_index.sql are
-    # intentionally not registered here — both were already applied to Neon
-    # prod out-of-band (sql/31 via commit 03a8a20 V1 retirement batch; sql/33
-    # via the identity-index rollout; see docs/KNOWN_ISSUES.md Issue #13).
-    # `apply_migrations.py --test` does not apply them to fresh test DBs, but
-    # CI's integration-tests job does not depend on V1 tables existing, and
-    # the V2 code path does not require the sql/33 index fix to run.
-    # 32 below must NOT depend on any schema object 31 drops (it only ALTERs
-    # v2_image_assets, untouched by sql/31).
+    "31_drop_v1_review_tables.sql",
+    # NOTE: 33_fix_identity_index.sql was applied to Neon prod out-of-band
+    # (identity-index rollout; see docs/KNOWN_ISSUES.md Issue #13) and is not
+    # required for CI integration tests to pass — it is a pure index fix with
+    # no schema objects the V2 code path depends on.
     "32_add_detected_keywords_to_v2_image_assets.sql",
     "34_dedup_v2_image_assets.sql",
     "35_drop_v2_image_assets_segment_id.sql",


### PR DESCRIPTION
- **fix(migrations): register sql/31 in apply_migrations.py so v2_audit_log exists in test DBs**
- **docs(known-issues): log issues #204, #205 — apply_migrations gaps and dead conftest helpers**
