### PR TITLE
docs(presence-pivot): align top-of-funnel index docs (PR 1 of doc audit)

### DIFF
--- a/MANUAL_TESTING_GUIDE.md
+++ b/MANUAL_TESTING_GUIDE.md
@@ -1,8 +1,21 @@
-# Manual Testing Guide
+# Manual Testing Guide — DEPRECATED
 
-Quick guide for manually testing the human review system.
+> **DEPRECATED 2026-04-25.** The flow described below (`scripts/setup_manual_test.py`,
+> `review.candidates` / `review.decisions` tables, `/review/filings` and
+> `/api/decisions` endpoints, `sql/07_create_review_schema.sql`) belongs to the
+> retired V1 review system. The script no longer exists; the schema has been
+> dropped (see `sql/31_drop_v1_review_tables.sql`). The active system is the V2
+> unified review UI at `/v2/review/<filing_id>`, which surfaces text facts
+> (advisory under the presence pivot), image presence detections from
+> `v2_image_assets.detected_metrics`, and reviewer confirmations via
+> `v2_image_metric_confirmations`. Manual value entry uses
+> `POST /api/v2/missed-metric`.
+>
+> For current QA flows, see `docs/operations/text-pipeline-presence-pivot-plan.md`
+> and `docs/architecture/system-overview.md`. This file is preserved for
+> historical context and will be archived in a follow-up PR.
 
-## Quick Start
+## Quick Start (HISTORICAL — does not work)
 
 **Single command to set up everything:**
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # CMASB Disclosures Review
 
-**Version:** 2.3
-**Status:** In process
-**Last Updated:** 2026-04-18
+**Version:** 2.8
+**Status:** In process (presence-pivot mid-rollout)
+**Last Updated:** 2026-04-25
 
-A system for systematically analyzing SEC filings to assess how companies disclose customer-related metrics.
+A system for systematically analyzing SEC filings to assess how companies disclose customer-related metrics. As of 2026-04, the system's primary output is **metric presence** — a per-(filing, metric) signal aggregated from text, charts, and metric definitions, with full provenance back to source segments and images. Per-value extraction continues as advisory evidence; CMASB-required values are entered manually via `POST /api/v2/missed-metric`.
+
+> **Pivot status (2026-04-25):** Chart-presence pivot is **live** (#86, 2026-04-23). Text-presence PR1 **landed** (#182, 2026-04-16). PR2 (gold-standard derivation + Tier-1 gate flip), PR3 (reviewer UI for text presence), PR4–PR5 are pending. Known gaps: legacy-097 (residual chart facts), legacy-098 (validator `presence_f1` not yet populated). See [`docs/operations/text-pipeline-presence-pivot-plan.md`](docs/operations/text-pipeline-presence-pivot-plan.md) for the rollout plan and authoritative interface contract.
 
 ## Project Overview
 
 This project supports the Customer Metrics Accounting Standards Board (CMASB) initiative by:
 - Discovering and classifying S-1/F-1 IPO filings from SEC EDGAR
-- Extracting customer metrics, definitions, and methodologies
+- **Detecting metric presence** in filings (text + charts + definitions) and tracking provenance from each presence claim back to source evidence
+- Capturing values as advisory evidence and supporting manual value entry where CMASB needs them
+- Extracting metric definitions and methodologies
 - Assessing disclosure quality and comparability
-- Providing human-in-the-loop review for quality assurance
+- Providing human-in-the-loop review (image presence confirmations; text-fact decisions; per-metric skip/undo)
 - Demonstrating the need for standardized customer metrics disclosure
 
 ## Current Status
@@ -21,10 +25,14 @@ This project supports the Customer Metrics Accounting Standards Board (CMASB) in
 |-----------|--------|
 | Universe Builder | Complete |
 | Filing Fetcher | Complete |
-| V2 Extraction Pipeline | Complete |
+| V2 Extraction Pipeline (incl. `MetricPresenceStage`) | Complete |
+| Text-presence persistence (`v2_text_metric_presence`) | PR1 landed (#182); PR2–PR5 pending |
+| Chart-presence pivot (`v2_image_assets.detected_metrics`, `v2_image_metric_confirmations`) | Live (#86, 2026-04-23) |
+| Vision metric-classifier (`ENABLE_METRIC_CLASSIFY`, `v2_image_classifications`) | Live |
 | LLM & Vision Integration | Complete |
-| Gold Standard Validation | Complete |
-| Human Review System | Complete |
+| Gold Standard Validation (presence-F1) | In progress (legacy-098 open) |
+| Unified Review UI (`/v2/review/<filing_id>`) | Complete; text-presence reviewer surface lands in PR3 |
+| Manual value entry (`POST /api/v2/missed-metric`) | Live |
 | Transcripts & Presentations | Complete (beyond SEC) |
 
 **Coverage target:** 80% overall minimum (enforced per CLAUDE.md).
@@ -97,7 +105,7 @@ src/
 UniverseBuilder → FilingFetcher → V2Pipeline → V2PersistenceAdapter → Database
 ```
 
-**V2 pipeline stages** (in `src/extraction_v2/stages/`): ingestion, section_classification, table_reconstruction, image_triage, ocr_extraction, `CandidateGenerationStage`, `ValueBindingStage`, false_positive_filter, period_inference, fact_construction, `DefinitionExtractionStage`, deduplication, validation, and chart_fact_bridge.
+**V2 pipeline stages** (in `src/extraction_v2/stages/`): ingestion, section_classification, table_reconstruction, image_triage, ocr_extraction, image_classify (Vision metric-classifier, gated by `ENABLE_METRIC_CLASSIFY`), `CandidateGenerationStage`, `ValueBindingStage`, false_positive_filter, period_inference, fact_construction, `DefinitionExtractionStage`, deduplication, validation, chart_fact_bridge (chart **presence** signals to `v2_image_assets.detected_metrics`, no per-value chart facts), and **`MetricPresenceStage`** (final stage; aggregates text facts, chart detections, and definitions into per-`(doc_id, canonical_metric_id)` rows in `v2_text_metric_presence`).
 
 ## Documentation
 
@@ -106,15 +114,16 @@ Comprehensive documentation is available in the `docs/` directory:
 | Category | Document | Description |
 |----------|----------|-------------|
 | **Start Here** | [docs/README.md](docs/README.md) | Documentation index and quick links |
+| **Pivot plan** | [docs/operations/text-pipeline-presence-pivot-plan.md](docs/operations/text-pipeline-presence-pivot-plan.md) | Authoritative rollout plan + PR1 interface contract for downstream PRs |
 | **Architecture** | [docs/architecture/system-overview.md](docs/architecture/system-overview.md) | System architecture and components |
-| | [docs/architecture/extraction-pipeline.md](docs/architecture/extraction-pipeline.md) | Extraction pipeline details |
-| | [docs/architecture/data-model.md](docs/architecture/data-model.md) | Database schema and tables |
-| | [docs/architecture/llm-integration.md](docs/architecture/llm-integration.md) | OpenAI integration |
+| | [docs/architecture/extraction-pipeline.md](docs/architecture/extraction-pipeline.md) | Extraction pipeline details (incl. `MetricPresenceStage`) |
+| | [docs/architecture/data-model.md](docs/architecture/data-model.md) | Database schema and tables (incl. `v2_text_metric_presence`, `v2_image_metric_confirmations`, `v2_image_classifications`) |
+| | [docs/architecture/llm-integration.md](docs/architecture/llm-integration.md) | OpenAI + Vision metric-classifier integration |
 | **Development** | [docs/development/metrics-taxonomy.md](docs/development/metrics-taxonomy.md) | Canonical metric definitions |
-| | [docs/development/quality-model.md](docs/development/quality-model.md) | Quality scoring (0-3 scale) |
+| | [docs/development/quality-model.md](docs/development/quality-model.md) | Quality scoring (presence-F1 primary; value-correctness advisory under the pivot) |
 | | [docs/development/testing.md](docs/development/testing.md) | Test strategy and coverage |
 | **Operations** | [docs/operations/setup-guide.md](docs/operations/setup-guide.md) | Environment setup |
-| **Review System** | [docs/HUMAN_REVIEW_SYSTEM.md](docs/HUMAN_REVIEW_SYSTEM.md) | Human review implementation |
+| **Review System** | [docs/HUMAN_REVIEW_SYSTEM.md](docs/HUMAN_REVIEW_SYSTEM.md) | DEPRECATED — V1 review system; see pivot plan for the active V2 unified review UI and image-presence confirmations |
 
 ## Project Structure
 
@@ -141,7 +150,7 @@ filings_reviewer/
 │   ├── operations/        # Operations guides
 │   ├── requirements/      # Business requirements
 │   └── archive/           # Historical documents
-├── sql/                    # Database schema (00-30)
+├── sql/                    # Database schema — legacy integer-prefix range 00-47 frozen; new migrations use timestamp filenames (see `.claude/rules/sql.md`)
 ├── scripts/               # Utility scripts
 ├── CLAUDE.md              # Claude Code instructions
 └── docker-compose.yml     # Docker configuration
@@ -149,11 +158,12 @@ filings_reviewer/
 
 ## Key Design Decisions
 
-1. **Rule-based first, LLM second**: Keyword matching before expensive LLM calls
-2. **Provenance tracking**: Every extracted value links to its source segment
-3. **Idempotent operations**: Re-running any stage is safe (upserts)
-4. **Conservative classification**: "Require BOTH" signals to minimize false positives
-5. **Human-in-the-loop**: Review system for quality validation and pattern learning
+1. **Presence-first, values advisory**: The primary scoring surface is per-`(doc_id, canonical_metric_id)` presence — aggregated from text facts, chart detections, the Vision metric-classifier, and metric definitions. Per-value extraction continues as advisory evidence; CMASB-required values are entered manually via `POST /api/v2/missed-metric`. See [`docs/operations/text-pipeline-presence-pivot-plan.md`](docs/operations/text-pipeline-presence-pivot-plan.md).
+2. **Rule-based first, LLM second**: Keyword matching before expensive LLM calls
+3. **Provenance tracking**: Every presence row points back to its evidence — `evidence_segment_ids` and `advisory_fact_ids` (JSONB arrays on `v2_text_metric_presence`) for text; `v2_image_metric_confirmations` joined to `v2_image_assets` for charts; `v2_image_classifications` for the Vision-API audit trail. The `advisory_*` columns are non-FK pointers, allowing facts to be re-extracted (`force=True`) without cascading to presence.
+4. **Idempotent operations**: Re-running any stage is safe (upserts). Presence rows are upserted on `(doc_id, canonical_metric_id)`; `updated_at` advances on re-extraction. Reviewer-decision tables are append-only/decision-only; the audit trail lives in `v2_audit_log` + the decision tables, not in presence-row history.
+5. **Conservative classification**: "Require BOTH" signals to minimize false positives. Chart signals are presence-only — no per-value chart facts emitted at extraction time.
+6. **Human-in-the-loop**: Unified review UI at `/v2/review/<filing_id>` surfaces text facts (advisory) and per-image presence detections; reviewers confirm via `v2_image_metric_confirmations` (accept / reject / correct / add / skip). Reviewed-filing guard prevents silent CASCADE-destruction of reviewer work.
 
 ## Development
 

--- a/docs/HUMAN_REVIEW_SYSTEM.md
+++ b/docs/HUMAN_REVIEW_SYSTEM.md
@@ -1,288 +1,60 @@
-# Human-in-the-Loop Metric Extraction Review System — DEPRECATED
+# Human Review System
 
-> **DEPRECATED 2026-04-18.** The V1 human-review system described below (candidate
+**Status:** V2 unified review (presence-pivot mid-rollout)
+**Last Updated:** 2026-04-25
+
+> **This is a pointer document.** The original V1 design doc (candidate
 > generator, pattern analyzer, rule applicator, `review_candidates` /
-> `review_decisions` tables, `/api/decisions` endpoints, `review.js`) has been
-> retired. The V2 unified review interface (`src/web/routes/review_unified.py`
-> at `/v2/review`, writing to `v2_review_decisions` and
-> `v2_image_review_decisions`) is the active system.
->
-> This document is preserved for historical context and design-intent reference.
-> Do not rely on the commands, module layout, or database schema below — they
-> describe a retired system. See `docs/architecture/v1-table-deprecation-plan.md`
-> for the retirement record and `docs/architecture/system-overview.md` for the
-> current V2 review data flow.
-
-**Status (historical):** Production Ready (2026-03-30)
-**Core System:** Complete (Streams A-E)
-**Interface Improvements:** 11/12 Complete (HRI-12 blocked)
-
----
-
-## Overview
-
-Human-in-the-loop system for reviewing and improving automated metric extraction from SEC S-1/F-1 filings.
-
-### Problem Solved
-
-Automated extraction had ~0% precision on initial samples:
-- Samsara: 0 correct out of 55 extractions
-- Farfetch: 0 correct out of 48 extractions
-- Root cause: LLM extracted numbers near keywords without understanding context
-
-### Solution
-
-Iterative learning loop:
-1. Generate candidate metrics with high recall
-2. Human reviews candidates (accept/reject/reclassify)
-3. System analyzes decisions to find patterns
-4. Generate improved filtering rules
-5. Apply rules to reduce false positives
-
----
-
-## Architecture
-
-### Database Schema
-
-```sql
--- sql/07_create_review_schema.sql
-review_candidates     -- Candidate metrics awaiting review
-review_decisions      -- Human review decisions
-learned_patterns      -- Discovered acceptance/rejection patterns
-review_audit_log      -- Audit trail for compliance
-```
-
-### Module Structure
-
-```
-src/review/
-├── models.py                # ReviewCandidate, ReviewDecision, CandidateFeatures
-├── number_parsing.py        # Number extraction and normalization
-├── false_positive_filter.py # Date/year filtering
-├── context_extraction.py    # Context window extraction
-├── boundary_detection.py    # Paragraph/section boundary detection
-├── table_structure.py       # Table row parsing and filtering
-├── marker_row_parser.py     # Marker/heading row detection in tables
-├── respectively_parser.py   # "X, Y and Z, respectively" value extraction
-├── feature_extractor.py     # Feature extraction for pattern learning (B2)
-├── confidence_scoring.py    # Candidate confidence score calculation
-├── deduplicator.py          # Cross-candidate deduplication
-├── pattern_analyzer.py      # Analyze decisions for patterns (E1)
-├── rule_applicator.py       # Apply learned patterns (E2)
-├── statistical_tests.py     # Chi-squared, t-test helpers for pattern discovery
-├── helpers.py               # Shared utilities
-├── exceptions.py            # Review-specific exception types
-└── config.py                # CandidateGenerationConfig
-
-src/web/
-├── app.py                 # Flask factory with health check
-├── pres_image_store.py    # File-based presentation image state
-├── routes/
-│   ├── review.py          # Text candidate review (filing list + review UI)
-│   ├── api.py             # REST API for text review decisions
-│   ├── review_images.py   # DB-backed image review (SEC filing images)
-│   ├── api_images.py      # REST API for image review decisions
-│   ├── review_unified.py  # Unified V2 extraction review interface
-│   ├── api_unified.py     # REST API for unified V2 review
-│   └── review_pres_images.py # Presentation image review (file-based)
-├── templates/
-│   ├── base.html                  # Bootstrap base
-│   ├── filing_list.html           # Filing selection (text review)
-│   ├── review.html                # Text candidate review interface
-│   ├── image_filing_list.html     # Filing selection (image review)
-│   ├── review_images.html         # Image review interface
-│   ├── image_stats.html           # Image review statistics dashboard
-│   ├── pres_image_filing_list.html # Filing selection (presentation images)
-│   ├── review_pres_images.html    # Presentation image review interface
-│   ├── unified_filing_list.html   # Filing selection (unified V2)
-│   ├── unified_review.html        # Unified V2 review interface
-│   ├── unified_stats.html         # Unified V2 statistics dashboard
-│   ├── v2_filing_list.html        # Filing selection (V2 legacy)
-│   ├── v2_review.html             # V2 review interface
-│   ├── v2_review_transcript.html  # V2 transcript review interface
-│   ├── v2_stats.html              # V2 statistics dashboard
-│   └── stats.html                 # General stats
-└── static/
-    ├── css/review.css
-    └── js/review.js       # Keyboard shortcuts, AJAX
-```
-
----
-
-## Usage
-
-### 1. Generate Candidates
-
-```bash
-python scripts/generate_review_candidates.py --filing-ids 1,2,3,4,5
-```
-
-Options: `--limit`, `--batch-id`, `--dry-run`, `--no-progress`
-
-### 2. Start Review Server
-
-```bash
-export DATABASE_URL="postgresql://user:pass@localhost/filings_analysis"
-export SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
-export APP_ENV=production
-python scripts/run_review_server.py
-```
-
-Review at: http://localhost:8000/filings
-
-### 3. Analyze Patterns (E1)
-
-After 5-10 filings reviewed:
-
-```bash
-python scripts/analyze_review_patterns.py \
-    --min-precision 0.75 \
-    --save-patterns \
-    --verbose
-```
-
-Options: `--filing-id`, `--metric-id`, `--pattern-type`, `--min-precision` (default: 0.75), `--min-support` (default: 5), `--auto-approve`, `--save-patterns`, `--verbose`
-
-### 4. Approve Patterns
-
-```sql
--- View candidate patterns
-SELECT pattern_id, pattern_name, precision_score, recall_score, sample_count
-FROM learned_patterns
-WHERE status = 'candidate'
-ORDER BY precision_score DESC, sample_count DESC;
-
--- Approve pattern
-UPDATE learned_patterns
-SET status = 'approved', approved_at = now(), approved_by = 'your_name'
-WHERE pattern_id = 123;
-```
-
-### 5. Evaluate Improvement (E2)
-
-Run gold standard validation to measure extraction improvement after rules are applied:
-
-```bash
-python3 -m src.gold_standard.v2_validator
-```
-
-To export review decisions for offline analysis:
-
-```bash
-python scripts/export_review_decisions.py
-```
-
----
-
-## Key Features
-
-### Candidate Generation
-- High-recall number detection with metric keyword matching
-- Table row filtering prevents cross-row keyword matches
-- Row heading priority (0.25x distance multiplier)
-- Date/year false positive filtering
-- Same-sentence deduplication preference
-
-### Review Interface
-- Keyboard shortcuts:
-  - Shared: `F`=Next filing, `Esc`=Cancel form
-  - Text tab: `A`=Accept, `R`=Reject, `C`=Correct, `N`/`→`=Next fact, `P`/`←`=Previous fact, `Enter`=Submit reject/correct form
-  - Images tab: `Y`=Relevant (chart type picker), `N`=Not relevant (reason picker), `S`=Skip, `U`=Undo, `←`/`→`=Prev/next image, `1`–`7`=Quick-select in open picker, `?`/`H`=Toggle hints
-- Confidence score badges (color-coded)
-- Filtering by status, metric type, confidence level
-- Sorting by document order, confidence, value
-- Bulk accept/reject (up to 20 candidates)
-- Decision history with undo
-- Context expansion and SEC filing links
-- Session persistence (resume where left off)
-
-### Pattern Learning (E1)
-- Feature importance analysis (chi-squared, t-test)
-- Cross-validation with stratified k-fold
-- Pattern conflict detection
-- Multi-feature conjunctive patterns
-- Natural language explanations
-
-### Rule Application (E2)
-- Automatic filtering during candidate generation
-- Cached pattern loading (5-minute reload)
-- Metric-specific and global patterns
-- Statistics tracking for filtered candidates
-
----
-
-## Configuration
-
-See `src/review/config.py`:
-
-```python
-from src.review.config import get_high_precision_config, get_high_recall_config
-
-# High precision (fewer, more accurate candidates)
-config = get_high_precision_config()
-
-# High recall (more candidates, may include false positives)
-config = get_high_recall_config()
-```
-
----
-
-## Post-Implementation Enhancements
-
-### Table Row Filtering (2025-12-17)
-- `TableRowParser` class maps character positions to table rows
-- Prevents cross-row keyword matches
-- Row headings get priority (0.25x distance multiplier)
-
-### Keyword Exclusions (2025-12-17)
-- `METRIC_EXCLUSION_PATTERNS` prevent common misclassifications
-- Example: "contribution margin" excluded from CAC
-- 34 tests covering exclusion patterns
-
-### Cohort Chart Image Detection (2025-12-29)
-- Automated detection of cohort analysis charts in filings
-- Segment-level detection via `segment_enricher._detect_cohort_chart_images()`
-- Filing-level detection via `cohort_chart_detector.py`
-- Results stored in `extra_metadata["cohort_chart_candidates"]`
-- Enables human review of high-value visualizations (ARR by cohort, LTV/CAC, retention curves)
-
-### Presentation Image Review (file-based)
-
-A separate review workflow for presentation images (e.g., investor day slides) under `/review/pres-images/`. Unlike the SEC filing image review (which is DB-backed), this workflow is file-based:
-
-- State is persisted per-directory via `src/web/pres_image_store.py`: presentation GS uses `data/presentation_gold_standard/_image_decisions.json` (8-K filings), filing GS uses `data/filing_gold_standard/_image_decisions.json` (S-1/F-1/10-K filings)
-- Route: `src/web/routes/review_pres_images.py`
-- Filing selection: `pres_image_filing_list.html`; review UI: `review_pres_images.html`
-
-### Image Review Stats Dashboard and Export (2026-03-30)
-- `/review/images/stats` route: overall decision statistics, daily counts, chart type distribution, rejection reason breakdown
-- `scripts/export_image_decisions.py`: exports reviewed decisions to CSV
-- New DB methods: `get_image_overall_decision_statistics`, `get_image_daily_decision_counts`, `get_image_chart_type_distribution`, `get_image_rejection_reason_stats`
-
----
-
-## Remaining Work
-
-### HRI-12: Inter-Rater Agreement (Future)
-- Multiple reviewers per candidate
-- Cohen's Kappa calculation
-- Arbitration workflow
-- **Blocked:** Requires multi-user authentication
-
----
-
-## Success Criteria
-
-Target metrics for production use:
-- Precision: >= 80% (up from ~0%)
-- Recall degradation: < 10%
-- Candidate volume reduction: >= 50%
-
----
-
-## Related Documentation
-
-- `docs/architecture/extraction-pipeline.md` - Full extraction pipeline
-- `docs/development/metrics-taxonomy.md` - Metric definitions
-- `CLAUDE.md` - Quick reference for Claude Code
+> `review_decisions` tables, `/api/decisions` endpoints, `review.js`) was
+> retired and archived at
+> [`archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md`](archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md).
+
+## Active review surfaces
+
+The V2 unified review UI is at `/v2/review/<filing_id>` and serves three
+surfaces against a single filing:
+
+1. **Text facts (advisory under the pivot).** Per-fact accept / reject /
+   correct decisions persist to `v2_review_decisions`. The
+   `v2_review_decision_updates_fact` trigger promotes
+   `v2_metric_facts.review_status` accordingly. PR3 of the text-presence
+   pivot will add a parallel **presence confirmation** surface
+   (`v2_text_presence_confirmations`, sql/48) so reviewers can confirm or
+   override per-(doc, metric) presence directly. Until then, presence is
+   computed from facts + chart detections + definitions.
+2. **Image presence (primary post-#86).** Per-image, per-metric reviewer
+   adjudications for chart-presence detections — accept / reject / correct
+   / add / skip — persist to `v2_image_metric_confirmations`
+   (sql/43, sql/47). The reviewer UI surfaces both rule-based detections
+   from `v2_image_assets.detected_metrics` and Vision-classifier
+   predictions from `v2_image_classifications`. An accept / correct / add
+   promotes a value-less chart `v2_metric_facts` row
+   (one per `(doc_id, metric_id)`, `review_status='accepted'`); reject /
+   skip / undo roll it back when no other accepting confirmation remains.
+3. **Manual value entry.** When CMASB needs a numeric value the pipeline
+   did not capture (typical for chart-native metrics under the pivot),
+   reviewers use the "Add Missed Metric" modal which posts to
+   `POST /api/v2/missed-metric` (`src/web/routes/api_unified.py`). The
+   resulting `MetricFact` carries `extraction_method='manual'` and feeds
+   into `MetricPresenceStage` on the next re-extraction.
+
+## Reviewer-work protection
+
+Re-extraction of a filing with human review decisions requires explicit
+`force=True` / `--force-reextract`. Three guards in
+`V2PersistenceAdapter` raise `ReviewedFilingError` otherwise: text-fact
+guard on `v2_review_decisions`, image-confirmation guard on
+`v2_image_metric_confirmations`, and a hidden-class transition guard in
+`_persist_images_in_tx`. See Core Design Principle #6 in `CLAUDE.md`.
+
+## Where to look for details
+
+| Topic | Source |
+|---|---|
+| Pivot rollout (PR1–PR5) and interface contract | [`operations/text-pipeline-presence-pivot-plan.md`](operations/text-pipeline-presence-pivot-plan.md) |
+| Schema for presence + confirmations + classifications | [`architecture/data-model.md`](architecture/data-model.md) |
+| MetricPresenceStage and pipeline flow | [`architecture/extraction-pipeline.md`](architecture/extraction-pipeline.md) |
+| Vision metric-classifier | [`architecture/llm-integration.md`](architecture/llm-integration.md) |
+| V2 review routes (HTML + API) | `src/web/routes/review_unified.py`, `src/web/routes/api_unified.py` |
+| Reviewer-UI tests (Playwright) | `tests/e2e/` |
+| Historical V1 design (archived) | [`archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md`](archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,28 @@
 # Customer Metrics Filings Analysis - Documentation
 
 **Project:** SEC Filings Customer Metrics Extraction System
-**Version:** 2.6
-**Status:** Production Ready
-**Last Updated:** 2026-04-21
+**Version:** 2.8
+**Status:** Production Ready (presence-pivot mid-rollout)
+**Last Updated:** 2026-04-25
 
 ---
 
+> **Pivot status (2026-04-25):** The system is mid-pivot from value-extraction-as-primary to **presence-as-primary** — the canonical scoring surface is now per-`(doc_id, canonical_metric_id)` detection, with values demoted to advisory evidence and a manual-entry path (`POST /api/v2/missed-metric`) when CMASB needs them. Chart-presence pivot is **live** (#86, 2026-04-23). Text-presence PR1 **landed** (#182, 2026-04-16). PR2 (gold-standard derivation + Tier-1 gate flip), PR3 (reviewer UI for text presence), PR4–PR5 are pending. Known gaps: legacy-097 (residual chart facts), legacy-098 (validator `presence_f1` not yet populated). See [`operations/text-pipeline-presence-pivot-plan.md`](operations/text-pipeline-presence-pivot-plan.md) for the rollout plan and authoritative interface contract.
+
 ## Overview
 
-This system analyzes SEC S-1/F-1 filings to assess how companies disclose customer-related metrics, supporting the Customer Metrics Accounting Standards Board (CMASB) initiative to establish standardized customer metrics disclosure practices.
+This system analyzes SEC S-1/F-1 filings to assess how companies disclose customer-related metrics, supporting the Customer Metrics Accounting Standards Board (CMASB) initiative to establish standardized customer metrics disclosure practices. The primary output of the V2 pipeline is **presence**: a per-(filing, metric) signal aggregated from text facts, chart detections, and metric definitions, with full provenance back to source segments and images.
 
 ### Quick Links
 
 | For... | Start Here |
 |--------|------------|
-| **New developers** | [System Architecture](architecture/system-overview.md) |
+| **New developers** | [System Architecture](architecture/system-overview.md) → [Presence-pivot plan](operations/text-pipeline-presence-pivot-plan.md) |
 | **Analysts/Researchers** | [Analytic Requirements](requirements/analytic-requirements.md) |
 | **Project managers** | [System Architecture](architecture/system-overview.md) → Success Criteria |
 | **Quality assurance** | [Testing Strategy](development/testing.md) → [Quality Model](development/quality-model.md) |
 | **Data users** | [Data Model](architecture/data-model.md) → Analysis Views |
+| **Anyone tracing a presence claim back to source** | [Presence-pivot plan](operations/text-pipeline-presence-pivot-plan.md) → [Data Model](architecture/data-model.md) provenance section |
 
 ---
 
@@ -158,6 +161,8 @@ Worker prompt templates are archived at `archive/historical/process/`. Use the A
 
 **Overall Status:** ✅ **Production Ready** (87% test coverage, 4,500+ tests)
 
+> **Pivot note (2026-04-25):** The component table above is structurally correct, but the `Value Extractor` entry should now be read as **advisory evidence**, not the headline output. The headline output is the **MetricPresenceStage** (final V2 stage; aggregates facts/charts/definitions into per-`(doc_id, metric_id)` presence rows in `v2_text_metric_presence`). See [`extraction-pipeline.md`](architecture/extraction-pipeline.md) and the [presence-pivot plan](operations/text-pipeline-presence-pivot-plan.md).
+
 ---
 
 ## Getting Started
@@ -227,8 +232,36 @@ python scripts/build_universe_real.py --start-date 2015-01-01 --end-date 2025-12
 
 ### Querying Results
 
+Presence-first (current; recommended):
+
 ```sql
--- Filing-level incidence by year
+-- Per-filing presence with provenance for one Tier-1 metric
+SELECT
+    p.doc_id,
+    p.canonical_metric_id,
+    p.score,
+    p.detected_at_stage,
+    p.evidence_segment_ids,
+    p.advisory_fact_ids,
+    p.advisory_value_count
+FROM v2_text_metric_presence p
+WHERE p.canonical_metric_id = 'cm_net_revenue_retention'
+ORDER BY p.score DESC;
+
+-- Reverse-trace from a presence row to source segment text
+SELECT s.segment_id, s.section_name, s.text
+FROM v2_segments s
+WHERE s.segment_id = ANY (
+    SELECT jsonb_array_elements_text(p.evidence_segment_ids)::int
+    FROM v2_text_metric_presence p
+    WHERE p.doc_id = $1 AND p.canonical_metric_id = $2
+);
+```
+
+Legacy V1 incidence (retained for backwards compatibility):
+
+```sql
+-- Filing-level incidence by year (V1 view, value-extraction era)
 SELECT
     EXTRACT(YEAR FROM filing_date) AS year,
     metric_id,
@@ -248,17 +281,25 @@ ORDER BY year, metric_id;
 
 Standardized customer-related measurements (e.g., new customers acquired, revenue by cohort). See [Metrics Taxonomy](development/metrics-taxonomy.md).
 
+### Presence
+
+Per-`(doc_id, canonical_metric_id)` detection signal — the **primary scoring surface** under the 2026-04 pivot. Aggregated from text facts (`v2_metric_facts`), chart detections (`v2_image_assets.detected_metrics`), Vision classifier output (`v2_image_classifications`), and metric definitions. Persisted to `v2_text_metric_presence` (text grain) and `v2_image_metric_presence` (image grain, lands with image-review Wave 2); union-readable via `v_doc_metric_presence`. See [Presence-pivot plan](operations/text-pipeline-presence-pivot-plan.md) and [`MetricPresenceStage`](architecture/extraction-pipeline.md).
+
+### Provenance / Audit Trail
+
+Every presence row points back to its evidence: `evidence_segment_ids` and `advisory_fact_ids` (JSONB arrays on `v2_text_metric_presence`) for text; `v2_image_metric_confirmations` joined to `v2_image_assets` for charts. Reviewer decisions are captured in `v2_image_metric_confirmations` (accept / reject / correct / add / skip) and `v2_review_decisions` (text facts; until PR3 lands `v2_text_presence_confirmations`). The `advisory_*` columns are JSONB pointers, **not** foreign keys — facts may be deleted on `force=True` re-extraction without cascading to presence rows, since presence is a doc-level claim independent of which specific fact rows currently back it.
+
 ### Segments
 
 Atomic units of filing content (paragraphs, tables, footnotes) from which metrics are extracted. See [Extraction Pipeline](architecture/extraction-pipeline.md).
 
 ### Incidence
 
-Whether a metric is disclosed in a filing (binary: yes/no). See [Analytic Requirements](requirements/analytic-requirements.md).
+Whether a metric is disclosed in a filing (binary: yes/no). Operationalized as **presence** in V2; `v_filing_metric_incidence` is a legacy V1 view kept for backwards compatibility. See [Analytic Requirements](requirements/analytic-requirements.md).
 
 ### Quality Score
 
-0-3 scale assessment of disclosure quality. See [Quality Model](development/quality-model.md).
+0-3 scale assessment of disclosure quality. See [Quality Model](development/quality-model.md). **Note:** under the presence pivot, value-correctness has been demoted to advisory; the primary quality dimension for chart-native metrics is now **presence-F1**.
 
 ### Alignment
 
@@ -380,6 +421,14 @@ Specialized sub-agents invoked via the Claude Code Agent tool for targeted tasks
 ---
 
 ## Version History
+
+### v2.8 — 2026-04-25 — Documentation aligned with presence pivot
+
+- Top-of-funnel docs (this file, root `README.md`, `MANUAL_TESTING_GUIDE.md`) updated to lead with **presence** as the primary scoring surface.
+- New Key Concepts: **Presence**, **Provenance / Audit Trail**.
+- `Querying Results` example now leads with a presence-with-provenance query against `v2_text_metric_presence`; the legacy `v_filing_metric_incidence` query retained for backwards compatibility.
+- Implementation Status table annotated to clarify that `Value Extractor` outputs are advisory under the pivot; the headline V2 output is `MetricPresenceStage`.
+- Architecture, operations, and development docs updates land in follow-on PRs (PR 2, PR 3 of the doc-audit series).
 
 ### v2.7 — 2026-04-16 — Tier 1 Recall — Text Pipeline Concluded
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,14 +1,16 @@
 # Data Model Specification
 
-**Version:** 3.0
-**Last Updated:** 2026-04-18
-**Status:** Production Schema (V2)
+**Version:** 3.1
+**Last Updated:** 2026-04-25
+**Status:** Production Schema (V2, presence-pivot mid-rollout)
 
 ---
 
+> **Pivot status (2026-04-25):** The primary scoring surface is **presence**, persisted to `v2_text_metric_presence` (sql/46) and surfaced jointly with image-presence via the `v_doc_metric_presence` UNION view (image-grain table lands with image-review Wave 2). Per-value `v2_metric_facts` rows continue as advisory evidence; the chart pipeline writes presence-only signals to `v2_image_assets.detected_metrics` (sql/42) and the Vision classifier appends to `v2_image_classifications` (sql/45). Reviewer adjudications for image-presence live in `v2_image_metric_confirmations` (sql/43, sql/47). See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md) for the rollout plan and authoritative interface contract.
+
 ## Overview
 
-This document defines the live PostgreSQL schema for the CMASB filings review system as of 2026-04-18, following the V1→V2 cutover (migrations `26_drop_filing_metric_incidence.sql`, `27_drop_v1_metric_tables.sql`, `30_drop_v1_image_review.sql`).
+This document defines the live PostgreSQL schema for the CMASB filings review system as of 2026-04-25, following the V1→V2 cutover (migrations `26_drop_filing_metric_incidence.sql`, `27_drop_v1_metric_tables.sql`, `30_drop_v1_image_review.sql`) and the chart-presence + text-presence-pivot PR1 (sql/42–47).
 
 V2 tables (`v2_*`) are the authoritative extraction output for all document types: SEC filings, transcripts, and investor presentations. A small set of V1 tables remains live only to support the legacy review-candidate workflow; their retirement is tracked in `docs/architecture/v1-table-deprecation-plan.md`.
 
@@ -18,10 +20,10 @@ Table structures, keys, enums, and relationships below match the live DB. Where 
 
 ## Design Principles
 
-1. **Provenance-first.** Every `v2_metric_facts` row carries a `source_locator` JSONB pointing to an exact DOM location and an `evidence_pack` JSONB with a renderable snippet. No value without provenance.
-2. **Idempotent writes.** The persistence layer upserts against a unique identity index on `v2_metric_facts`, so re-running extraction on the same filing produces stable row counts.
-3. **Analysis-first grain.** Tables are keyed to the units of analysis: document, fact (doc × metric × period × scope × cohort × source_type), table × cell, image asset, segment.
-4. **Canonical taxonomy.** All facts reference `metrics.metric_id`; issuer-specific definitions live in `v2_metric_definitions` per (doc, metric).
+1. **Provenance-first.** Every presence row in `v2_text_metric_presence` carries `evidence_segment_ids` and `advisory_fact_ids` (JSONB pointers, **not** foreign keys) back to source segments and contributing facts. Every `v2_metric_facts` row carries a `source_locator` JSONB and an `evidence_pack` JSONB with a renderable snippet. No claim without provenance.
+2. **Idempotent writes.** The persistence layer upserts against unique identity indexes on `v2_metric_facts` (8-column tuple) and `v2_text_metric_presence` (`(doc_id, canonical_metric_id)`). Re-running extraction on the same filing produces stable row counts.
+3. **Analysis-first grain.** Tables are keyed to the units of analysis: **presence (doc × metric)** is the primary grain for scoring; advisory fact (doc × metric × period × scope × cohort × source_type) is the per-value evidence grain; document, table × cell, image asset, segment, and image-presence-confirmation are subordinate grains.
+4. **Canonical taxonomy.** All facts and presences reference `metrics.metric_id`; issuer-specific definitions live in `v2_metric_definitions` per (doc, metric).
 5. **Extensible.** Check-constraint enums on `form_type`, `section_type`, `segment_type`, etc. absorb new document types (SEC 8-K, earnings calls, investor presentations) without table changes.
 6. **PostgreSQL-oriented.** Types align to Postgres (`text`, `numeric`, `timestamptz`, `jsonb`, `uuid`, `text[]`).
 
@@ -44,14 +46,17 @@ Tables are grouped into three tiers.
 
 | Table | Purpose |
 |-------|---------|
+| `v2_text_metric_presence` (sql/46) | **Primary scoring surface.** One row per `(doc_id, canonical_metric_id)`; aggregates contributions from text facts, chart `detected_metrics`, and definitions. Upserted by `MetricPresenceStage`. |
+| `v2_image_metric_confirmations` (sql/43, sql/47) | Reviewer adjudications of image-presence detections (accept / reject / correct / add / skip). |
+| `v2_image_classifications` (sql/45) | Append-only audit trail for the Vision-API metric-classifier (Stage 5b, gated by `ENABLE_METRIC_CLASSIFY`). |
 | `v2_documents` | Filing-level V2 processing state and transcript/presentation metadata |
 | `v2_segments` | DOM-native content blocks with hierarchical `section_path` |
 | `v2_tables`, `v2_table_cells` | Reconstructed tables with resolved spans and `header_path`/`stub_path` arrays |
-| `v2_image_assets` | Extracted images with classification, OCR/chart results, and review status |
-| `v2_metric_facts` | Primary extraction output — every extracted metric with provenance and review status |
+| `v2_image_assets` | Extracted images with classification, OCR/chart results, `detected_metrics` JSONB (sql/42), and review status |
+| `v2_metric_facts` | Advisory per-value extraction output with provenance and review status. Chart sources do not auto-emit new rows post-#86. |
 | `v2_metric_definitions` | Issuer-specific definition and methodology text, one per (doc, metric) |
 | `v2_review_decisions` | Human review decisions on V2 facts (accept/reject/correct) |
-| `v2_image_review_decisions` | Human review decisions on V2 images |
+| `v2_image_review_decisions` | Legacy per-image review decisions (read-only; superseded by `v2_image_metric_confirmations`) |
 
 ### V1 residual (retirement tracked in `v1-table-deprecation-plan.md`)
 
@@ -67,9 +72,12 @@ Tables are grouped into three tiers.
 
 - `companies` 1–N `filings`
 - `filings` 1–1 `v2_documents` (via `v2_documents.filing_id`, `UNIQUE`)
-- `filings` 1–N `v2_metric_facts`, `v2_segments`, `v2_tables`, `v2_image_assets`
+- `filings` 1–N `v2_metric_facts`, `v2_segments`, `v2_tables`, `v2_image_assets`, `v2_text_metric_presence`
+- `v2_text_metric_presence` `UNIQUE (doc_id, canonical_metric_id)`; references `filings(filing_id)` ON DELETE CASCADE. `evidence_segment_ids` and `advisory_fact_ids` are **JSONB arrays, not foreign keys** — see Provenance section below.
 - `v2_metric_facts` 1–1 `v2_review_decisions` (via `v2_review_decisions.fact_id`, `UNIQUE`)
-- `v2_image_assets` 1–1 `v2_image_review_decisions` (via `UNIQUE img_id`)
+- `v2_image_assets` 1–1 `v2_image_review_decisions` (legacy; via `UNIQUE img_id`)
+- `v2_image_assets` 1–N `v2_image_metric_confirmations` (per-reviewer-per-metric adjudications; ON DELETE CASCADE from `img_id`)
+- `v2_image_assets` 1–N `v2_image_classifications` (append-only Vision-API audit trail; ON DELETE CASCADE from `img_id`)
 - `v2_segments` 0–N `v2_metric_definitions` (definition/methodology segment FKs)
 - `filings` 1–N `source_segments` (V1 residual)
 - `filings` 1–N `review_candidates` 1–1 `review_decisions` (V1 residual)
@@ -589,6 +597,74 @@ This table is the reviewer-adjudication surface for `v2_image_assets.detected_me
 
 ---
 
+#### `v2_image_classifications`
+
+**Grain:** Append-only audit row per Vision-API metric-classify call. Added in `sql/45_create_v2_image_classifications.sql` (chart-presence pivot, #86).
+
+```sql
+CREATE TABLE v2_image_classifications (
+    classification_id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    img_id              UUID NOT NULL
+                            REFERENCES v2_image_assets(img_id) ON DELETE CASCADE,
+    predicted_metrics   JSONB NOT NULL DEFAULT '[]',  -- [{metric_id, confidence, reasoning}]
+    model_version       TEXT NOT NULL,
+    prompt_version      TEXT NOT NULL,
+    cost_usd            NUMERIC(10,6),
+    latency_ms          INTEGER,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_v2_image_classifications_img_id
+    ON v2_image_classifications(img_id);
+```
+
+The Vision metric-classifier (`src/extraction_v2/stages/image_classify.py`, gated by `ENABLE_METRIC_CLASSIFY`) is **independent** from the rule-based `v2_image_assets.detected_metrics` (sql/42). Both signals can co-exist on the same image; `MetricPresenceStage` reads `detected_metrics` (the rule-based list); the Vision audit trail is consumed by reviewer UI and analytics. **No `MetricFact` rows are emitted** from this stage.
+
+---
+
+#### `v2_text_metric_presence`
+
+**Grain:** One row per `(doc_id, canonical_metric_id)`. Enforced by `UNIQUE (doc_id, canonical_metric_id)`. Added in `sql/46_v2_text_metric_presence.sql` (text-presence pivot PR1, #182).
+
+```sql
+CREATE TABLE v2_text_metric_presence (
+    presence_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    doc_id                 BIGINT NOT NULL
+                               REFERENCES filings(filing_id) ON DELETE CASCADE,
+    canonical_metric_id    TEXT NOT NULL,
+    score                  DOUBLE PRECISION NOT NULL CHECK (score >= 0 AND score <= 1),
+    detected_at_stage      TEXT NOT NULL,
+    evidence_segment_ids   JSONB NOT NULL DEFAULT '[]',  -- sorted list of segment IDs
+    advisory_value_count   INTEGER NOT NULL DEFAULT 0,
+    advisory_fact_ids      JSONB NOT NULL DEFAULT '[]',  -- contributing fact_ids (no FK)
+    pipeline_version       TEXT NOT NULL,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (doc_id, canonical_metric_id)
+);
+
+CREATE INDEX idx_v2_text_metric_presence_doc_id
+    ON v2_text_metric_presence(doc_id);
+CREATE INDEX idx_v2_text_metric_presence_metric_id
+    ON v2_text_metric_presence(canonical_metric_id);
+```
+
+**Semantics:**
+
+- **Primary scoring surface for the Tier 1 regression gate** under the presence-first pivot. PR2 (pending) flips the gate from fact-recall to presence-recall.
+- `score` = MAX confidence across all contributing signals (text facts, chart `detected_metrics`, definitions). Definition-only presence floors at `_DEFINITION_ONLY_PRESENCE_SCORE = 0.5`.
+- `detected_at_stage` ∈ `fact_construction`, `chart_fact_bridge`, `definition_extraction` — records the source that first surfaced the metric, for diagnostics.
+- `evidence_segment_ids` is a **sorted JSONB array of segment IDs** drawn from contributing facts (`fact.source_locator.segment_id`) and definitions (`definition_segment_id`, `methodology_segment_id`). **Chart-only presences have an empty array** — evidence lives on `v2_image_assets` and `v2_image_metric_confirmations`.
+- `advisory_fact_ids` is a JSONB array of contributing fact UUIDs. **Not a foreign key.** Facts may be deleted on `force=True` re-extraction without cascading to presence rows — presence is a doc-level claim independent of which specific fact rows currently back it.
+- `advisory_value_count` = count of contributing facts (not unique values). Rough disclosure-depth signal for downstream UI.
+- `pipeline_version` is currently `"2.0.0"`.
+
+**Persistence:** `V2PersistenceAdapter._persist_presence_in_tx(cur, presences, filing_id) -> int` upserts on `(doc_id, canonical_metric_id)`. Called from `persist_pipeline_result` as step 8 (after facts, definitions, and image classifications). The `presence_only=True` kwarg on `persist_pipeline_result` skips the fact-write step entirely; presence rows still upsert. Mutually exclusive with `chart_only=True`.
+
+**Cross-pivot view (image-review Wave 2 dependency):** PR2 reads `v_doc_metric_presence` (UNION view of `v2_text_metric_presence` + `v2_image_metric_presence`, the per-image grain table that lands with image-review Wave 2). See `docs/operations/text-pipeline-presence-pivot-plan.md`.
+
+---
+
 ### V1 residual
 
 These tables are live but on a retirement path. See `docs/architecture/v1-table-deprecation-plan.md` for migration roadmaps and difficulty assessments. The V2 pipeline does not read them; they support the legacy candidate-review UI and gold-standard tooling.
@@ -783,8 +859,29 @@ Authoritative DDL ordering. Applied to live DB in the order shown (see `schema_m
 | 28 | `28_extend_v2_image_assets_review.sql` | Review columns on `v2_image_assets` |
 | 29 | `29_create_v2_image_review_decisions.sql` | `v2_image_review_decisions` |
 | 30 | `30_drop_v1_image_review.sql` | **Drops V1 image-review tables** |
+| 31 | `31_drop_v1_review_tables.sql` | **Drops V1 `review_candidates`, `review_decisions`, `learned_patterns`, etc.** |
+| 32 | `32_add_detected_keywords_to_v2_image_assets.sql` | `v2_image_assets.detected_keywords` (precursor to `detected_metrics`) |
+| 33 | `33_fix_identity_index.sql` | Idempotently rebuild 9-column identity index (resolves drift; see Known Discrepancies) |
+| 34 | `34_dedup_v2_image_assets.sql` | One-time dedup of `v2_image_assets` |
+| 35 | `35_drop_v2_image_assets_segment_id.sql` | Drops legacy `segment_id` column on `v2_image_assets` |
+| 36 | `36_backfill_presentation_urls.sql` | Backfills SEC presentation URLs |
+| 37 | `37_create_analytics_role.sql` | Read-only `analytics` role |
+| 38 | `38_create_analytics_views.sql` | `v_analytics_*` BI views (canonical reporting shape) |
+| 39 | `39_v2_ingest_batches.sql` | `v2_ingest_batches`, `v2_ingest_batch_filings` |
+| 40 | `40_full_page_scan_and_ocr_provenance.sql` | Full-page OCR provenance fields |
+| 41 | `41_normalize_accession_numbers.sql` | Normalize `filings.accession_number` formatting |
+| 42 | `42_add_detected_metrics_to_v2_image_assets.sql` | `v2_image_assets.detected_metrics` JSONB (chart-presence pivot #86) |
+| 43 | `43_create_v2_image_metric_confirmations.sql` | Per-reviewer image-metric adjudications (accept/reject/correct/add) |
+| 44 | `44_extend_image_rejection_reason_enum.sql` | Extends `rejection_reason` enum on confirmations |
+| 45 | `45_create_v2_image_classifications.sql` | Vision-API metric-classifier audit trail (Stage 5b) |
+| 46 | `46_extend_audit_http_method_constraint.sql` | Loosens `v2_audit_log.http_method` CHECK |
+| 46 | `46_v2_text_metric_presence.sql` | **`v2_text_metric_presence` — primary scoring surface** (text-presence PR1 #182) |
+| 47 | `47_add_skip_to_image_metric_confirmations.sql` | Adds `skip` decision to confirmations |
 
-Note: historical duplicate migration numbers (04/08/09/10/11/12) reflect prior splits. Do not add further duplicates.
+**Notes:**
+- The legacy integer-prefix range `00-47` is **frozen**. New migrations use timestamp filenames (`YYYYMMDDHHMM_description.sql`) generated by `scripts/new_migration.py`. See `.claude/rules/sql.md`.
+- Two migrations share prefix `46` (audit constraint + text-presence) — a duplicate-prefix collision tracked alongside the migration-registration gap closed in PR1. Both are applied; see "Known pre-PR1 gap closed alongside" in `docs/operations/text-pipeline-presence-pivot-plan.md`.
+- Historical duplicate numbers (04/08/09/10/11/12) also reflect prior splits.
 
 ---
 
@@ -796,11 +893,12 @@ Note: historical duplicate migration numbers (04/08/09/10/11/12) reflect prior s
 
 ## Related Documentation
 
+- **Pivot plan (authoritative for in-flight rollout):** `docs/operations/text-pipeline-presence-pivot-plan.md`
 - **V1 retirement roadmap:** `docs/architecture/v1-table-deprecation-plan.md`
 - **Extraction decisions:** `docs/architecture/extraction-decisions.md`
 - **Metric taxonomy:** `docs/development/metrics-taxonomy.md`
-- **Human review system:** `docs/HUMAN_REVIEW_SYSTEM.md`
+- **Human review system:** `docs/HUMAN_REVIEW_SYSTEM.md` (DEPRECATED — V1 system; see pivot plan for current unified review UI)
 - **Gold standard spec:** `docs/GOLD_STANDARD_SPECIFICATION.md`
-- **V2 schema DDL (authoritative):** `sql/09_v2_schema.sql` plus migrations 10–30 listed above
-- **V2 dataclasses (code-level truth for field meanings):** `src/extraction_v2/models.py`
-- **V2 persistence (upsert SQL):** `src/extraction_v2/persistence.py`
+- **V2 schema DDL (authoritative):** `sql/09_v2_schema.sql` plus migrations 10–47 listed above
+- **V2 dataclasses (code-level truth for field meanings):** `src/extraction_v2/models.py` (incl. `MetricPresence`, `DetectedMetric`, `ImageClassificationRecord`)
+- **V2 persistence (upsert SQL):** `src/extraction_v2/persistence.py` (incl. `_persist_presence_in_tx`, `presence_only` kwarg)

--- a/docs/architecture/extraction-pipeline.md
+++ b/docs/architecture/extraction-pipeline.md
@@ -1,30 +1,32 @@
 # Metric Extraction Pipeline
 
-**Version:** 3.0
-**Last Updated:** 2026-04-07
-**Status:** Production (V2 Pipeline)
+**Version:** 3.1
+**Last Updated:** 2026-04-25
+**Status:** Production (V2 Pipeline, presence-pivot mid-rollout)
 
 ---
 
+> **Pivot status (2026-04-25):** The pipeline's primary scoring surface is **presence** — per-`(doc_id, canonical_metric_id)` records emitted by the final stage `MetricPresenceStage` and persisted to `v2_text_metric_presence`. Per-value `MetricFact` rows continue as **advisory evidence** for text/table sources; chart pipelines emit presence-only signals (`v2_image_assets.detected_metrics`) and never auto-emit per-value chart facts. Chart-presence pivot is **live** (#86, 2026-04-23). Text-presence PR1 **landed** (#182, 2026-04-16). PR2–PR5 pending. See [`docs/operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md) for the rollout plan.
+
 ## Overview
 
-This document specifies the architecture and implementation of the metric extraction pipeline. The pipeline transforms SEC filing HTML into structured, analysis-ready metrics data through a series of modular processing stages.
+This document specifies the architecture and implementation of the metric extraction pipeline. The pipeline transforms SEC filing HTML into structured, analysis-ready **presence** signals (with advisory facts as evidence) through a series of modular processing stages.
 
 **V2 is the sole production pipeline.** V1 has been retired and the `src/extraction/` package has been deleted. See the [Appendix](#appendix-v1-pipeline-retired) at the bottom of this document for V1 stage documentation.
 
 ### Pipeline Principles
 
-1. **Auditability:** Every extracted value must be traceable to its source segment
-2. **Reproducibility:** Re-running extraction on the same filing produces identical results
+1. **Auditability:** Every presence row points back to evidence — `evidence_segment_ids` and `advisory_fact_ids` (JSONB arrays on `v2_text_metric_presence`) for text; `v2_image_metric_confirmations` joined to `v2_image_assets` for charts. Every advisory `MetricFact` carries a complete `EvidencePack`.
+2. **Reproducibility:** Re-running extraction on the same filing produces identical results. Presence rows are upserted on `(doc_id, canonical_metric_id)`; facts upsert on the 8-column identity index.
 3. **Incremental Processing:** Process filings independently; support resume/retry
-4. **Quality Tracking:** Capture confidence, alignment, and quality scores throughout
+4. **Quality Tracking:** Capture confidence, alignment, and quality scores throughout. **Primary metric: presence-F1.** Value-correctness is advisory under the pivot.
 5. **Structure-first, LLM-second:** Parse DOM structure before LLM calls
 
 ---
 
 ## V2 Pipeline Overview
 
-The V2 pipeline (`src/extraction_v2/`) implements a 15-stage extraction workflow. It is the production pipeline for all SEC filing, transcript, and presentation extraction.
+The V2 pipeline (`src/extraction_v2/`) implements up to a 16-stage extraction workflow (image stages and `IMAGE_CLASSIFY` are conditional). It is the production pipeline for all SEC filing, transcript, and presentation extraction. The final stage, `MetricPresenceStage`, aggregates signals from text facts, chart `detected_metrics`, and metric definitions into per-`(doc_id, canonical_metric_id)` presence records.
 
 **Module:** `src/extraction_v2/pipeline.py`
 **Class:** `V2Pipeline`
@@ -76,6 +78,25 @@ The V2 pipeline (`src/extraction_v2/`) implements a 15-stage extraction workflow
 │  - Vision model analysis for charts (labeled values only)           │
 │  - Never interpolates from axes — explicit data labels only         │
 │  Output: ImageAsset objects with extracted values                   │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 5a: CHART FACT BRIDGE  (presence-only, no LLM, no facts)     │
+│  - ChartMetricClassifier scores chart_data + nearby_text against    │
+│    YAML keyword patterns                                            │
+│  - Emits [{metric_id, score}, ...] to v2_image_assets.detected_metrics│
+│    for scores >= chart_presence_min_score (default 0.5)             │
+│  Output: ImageAsset.detected_metrics populated; no MetricFact rows  │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 5b: IMAGE CLASSIFY  (Vision API, gated by ENABLE_METRIC_CLASSIFY)│
+│  - Sends chart images to Vision API for metric classification       │
+│  - Writes audit trail to v2_image_classifications (append-only)     │
+│  - Independent signal from rule-based detected_metrics above        │
+│  Output: ImageClassificationRecord rows; no MetricFact rows         │
 └────────────────────────────┬────────────────────────────────────────┘
                              │
                              ▼
@@ -146,7 +167,20 @@ The V2 pipeline (`src/extraction_v2/`) implements a 15-stage extraction workflow
                              │
                              ▼
 ┌─────────────────────────────────────────────────────────────────────┐
+│  STAGE 14: METRIC PRESENCE  (final; primary scoring surface)        │
+│  - Aggregates signals from deduplicated facts, chart                │
+│    detected_metrics, and definitions                                │
+│  - One row per (doc_id, canonical_metric_id);                       │
+│    score = MAX across contributing signals                          │
+│  - evidence_segment_ids = union of contributing segment IDs;        │
+│    advisory_fact_ids = JSONB list of contributing fact IDs          │
+│  Output: MetricPresence list → upserted to v2_text_metric_presence  │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
 │                    ANALYSIS-READY DATABASE                          │
+│  Presence rows (primary) + advisory facts + reviewer confirmations  │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -184,11 +218,46 @@ The per-value value-emission path — `CohortParser` regime dispatch, `unit_infe
 
 ---
 
+## Metric Presence Stage — Final Aggregation
+
+`MetricPresenceStage` (`src/extraction_v2/stages/metric_presence.py`, `PipelineStage.METRIC_PRESENCE`) runs as the final stage after `ValidationStage`. It aggregates extraction signals across all surfaces — deduplicated text/table/OCR facts, chart `detected_metrics`, and metric definitions — into one `MetricPresence` record per `(doc_id, canonical_metric_id)`.
+
+The stage is the **primary scoring surface** for the Tier 1 regression gate under the presence-first pivot. See `docs/operations/text-pipeline-presence-pivot-plan.md`.
+
+### Sources and scoring
+
+| Source | Score contribution | Evidence contribution |
+|---|---|---|
+| Deduplicated `MetricFact` (text/html_table/ocr_table/chart) | `MAX(fact.confidence)` | `evidence_segment_ids` ← `fact.source_locator.segment_id`; `advisory_fact_ids` ← `fact.fact_id`; `advisory_value_count` += 1 per fact |
+| Chart `ImageAsset.detected_metrics` (rule-based; from `ChartFactBridgeStage`) | `MAX(detected.score)` | None — chart-only presences have empty `evidence_segment_ids` (evidence lives on `v2_image_assets`) |
+| `v2_metric_definitions` rows | Floor `_DEFINITION_ONLY_PRESENCE_SCORE = 0.5` (matches `chart_presence_min_score`) | `evidence_segment_ids` ← `definition_segment_id`, `methodology_segment_id` |
+
+`detected_at_stage` records which source first surfaced the metric (`fact_construction`, `chart_fact_bridge`, or `definition_extraction`).
+
+### Persistence
+
+`V2PersistenceAdapter._persist_presence_in_tx(cur, presences, filing_id) -> int` upserts presences on `(doc_id, canonical_metric_id)`. Called from `persist_pipeline_result` as step 8 (after facts, definitions, and image classifications). Idempotent; never touches `v2_metric_facts` or `v2_review_decisions`. The `presence_only=True` kwarg on `persist_pipeline_result` skips the fact-write step entirely while still upserting presences and image-related rows.
+
+### Invariants (downstream PRs depend on these)
+
+- One record per `(doc_id, canonical_metric_id)`; duplicates from multiple sources collapse into a single row by MAX score and unioned evidence.
+- `advisory_fact_ids` is a JSONB array of fact IDs, **not** a foreign key. Facts may be deleted by `force=True` re-extraction without cascading to presence — presence is a doc-level claim independent of which specific fact rows currently back it.
+- Presence rows are upserted, never deleted by the persistence layer; only `filings.filing_id` CASCADE removes them.
+- `presence_only=True` does NOT bypass the image re-classification guard inside `_persist_images_in_tx`; that guard remains orthogonal.
+
+---
+
 ## Core Data Models
 
-**MetricFact:** Primary extraction output with full provenance
-- Combines extracted value, metric ID, period, cohort, and evidence
-- Immutable audit trail from detection to acceptance
+**MetricPresence:** Primary scoring output (per filing × metric)
+- Aggregates evidence from text facts, chart detections, and definitions
+- Persisted to `v2_text_metric_presence` (sql/46), upserted on `(doc_id, canonical_metric_id)`
+- Carries `evidence_segment_ids` and `advisory_fact_ids` JSONB pointers back to source
+
+**MetricFact:** Advisory per-value evidence with full provenance
+- Combines extracted value, metric ID, period, cohort, and evidence pack
+- Audit trail from detection to acceptance (text/html_table/ocr_table sources)
+- Under the chart-presence pivot, the chart pipeline does not auto-emit per-value chart facts; values for chart metrics enter via `POST /api/v2/missed-metric` when CMASB needs them
 - Replaces V1's separate `metric_values` and `metric_definitions` tables
 
 **EvidencePack:** Audit-grade proof for every extracted value
@@ -217,23 +286,27 @@ The per-value value-emission path — `CohortParser` regime dispatch, `unit_infe
 
 ## Key Files
 
-- **`src/extraction_v2/models.py`** — Core data models (MetricFact, EvidencePack, Table, Cell, ImageAsset, Segment)
-- **`src/extraction_v2/pipeline.py`** — Pipeline orchestrator with 15-stage workflow and configuration
-- **`src/extraction_v2/persistence.py`** — Database write layer (V2PersistenceAdapter)
+- **`src/extraction_v2/models.py`** — Core data models (MetricFact, EvidencePack, Table, Cell, ImageAsset, Segment, **MetricPresence**, ImageClassificationRecord, DetectedMetric)
+- **`src/extraction_v2/pipeline.py`** — Pipeline orchestrator with up-to-16-stage workflow and configuration
+- **`src/extraction_v2/persistence.py`** — Database write layer (V2PersistenceAdapter; `presence_only` kwarg skips fact write)
 - **`src/extraction_v2/table_reconstructor.py`** — Table reconstruction with colspan/rowspan resolution
 - **`src/extraction_v2/stages/ingestion.py`** — HTML parsing with XPath locators and segment extraction
+- **`src/extraction_v2/stages/metric_presence.py`** — Final stage; aggregates facts/charts/definitions into per-(doc, metric) presence
+- **`src/extraction_v2/stages/chart_fact_bridge.py`** — Rule-based chart-presence emission to `v2_image_assets.detected_metrics`
+- **`src/extraction_v2/stages/image_classify.py`** — Vision-API metric classifier; gated by `ENABLE_METRIC_CLASSIFY`
 - **`src/extraction_v2/stages/`** — One module per pipeline stage
 
 ---
 
 ## Design Principles
 
-1. **Structure-first, LLM-second**: Parse DOM structure before LLM calls
-2. **No value without provenance**: Every MetricFact includes complete EvidencePack
-3. **Fail closed**: Ambiguous cases route to review (never guess)
-4. **Charts only when labeled**: Extract only explicit data labels (never interpolate from axis)
-5. **Complete table reconstruction**: Full colspan/rowspan resolution before extraction
-6. **DOM-native**: XPath locators maintain exact source positions
+1. **Presence-first, values advisory**: The primary scoring surface is `MetricPresence` (per-`(doc_id, metric_id)`). Per-value `MetricFact` rows are advisory evidence; chart pipelines emit presence-only signals.
+2. **Structure-first, LLM-second**: Parse DOM structure before LLM calls
+3. **No claim without provenance**: Every presence row carries `evidence_segment_ids` + `advisory_fact_ids`. Every advisory `MetricFact` includes a complete `EvidencePack`.
+4. **Fail closed**: Ambiguous cases route to review (never guess)
+5. **Charts only when labeled**: Stage 5 extracts only explicit data labels (never interpolates from axes)
+6. **Complete table reconstruction**: Full colspan/rowspan resolution before extraction
+7. **DOM-native**: XPath locators maintain exact source positions
 
 ---
 

--- a/docs/architecture/llm-integration.md
+++ b/docs/architecture/llm-integration.md
@@ -1,10 +1,12 @@
 # LLM Integration - OpenAI GPT-4o / GPT-4o-mini
 
-**Date:** 2026-04-08
+**Date:** 2026-04-25
 **Status:** Production
 **Pipeline:** V2 (sole production pipeline)
 
 ---
+
+> **Pivot status (2026-04-25):** Under the chart-presence pivot (#86, 2026-04-23) the LLM/Vision surface produces **presence signals**, not per-value facts. The Vision metric-classifier (Stage 5b, gated by `ENABLE_METRIC_CLASSIFY`) writes to `v2_image_classifications` (audit trail). Stage 5a `ChartFactBridgeStage` writes rule-based presence pairs to `v2_image_assets.detected_metrics`. Vision OCR (Stage 5) still extracts labeled chart values into `chart_data`, but those values feed the rule-based bridge — they are not auto-emitted as `v2_metric_facts` rows. See [`docs/operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md).
 
 ## Overview
 
@@ -156,6 +158,18 @@ response = client.analyze_image(
     detail="high",
 )
 ```
+
+### 2.05 Vision Metric Classifier — Stage 5b (LLM)
+
+**Module:** `src/extraction_v2/stages/image_classify.py` (stage `PipelineStage.IMAGE_CLASSIFY`)
+
+**Gate:** `ENABLE_METRIC_CLASSIFY` env var. When `false` (default in many environments), the stage is not added to the pipeline; rule-based chart presence still flows through Stage 5a `ChartFactBridgeStage`.
+
+**Purpose:** Independently classify each chart image against the metric taxonomy via the Vision API and produce an audit-traced confidence score per `(metric_id)`. Results are appended to `v2_image_classifications` (sql/45) — append-only, capturing predicted metrics, confidence, reasoning, cost/latency. The classifier is **separate from rule-based** `v2_image_assets.detected_metrics`; both signals can co-exist on the same image and are read together by `MetricPresenceStage` and the reviewer UI.
+
+**Cost:** one Vision call per processed image, in addition to the OCR/chart-extraction call in Stage 5. Cached via the same PostgreSQL `LLMCache` when prompt content is unchanged.
+
+**Output:** `ImageClassificationRecord` rows persisted to `v2_image_classifications`. **No `MetricFact` rows are emitted** — the classifier feeds presence and reviewer adjudication only.
 
 ### 2.1 Chart Fact Bridge — metric-presence emission (post-processing, no LLM)
 
@@ -477,10 +491,12 @@ except Exception as e:
 |-----------|------|-------|---------|
 | `OpenAIClient` | `src/llm/openai_client.py` | gpt-4o-mini | Text extraction (when called explicitly) |
 | `VisionClient` | `src/llm/vision_client.py` | gpt-4o | V2 Stage 5 — OCR & Chart Extraction |
+| `ImageClassifyStage` | `src/extraction_v2/stages/image_classify.py` | gpt-4o (Vision) | V2 Stage 5b — gated by `ENABLE_METRIC_CLASSIFY`; writes audit trail to `v2_image_classifications` (no `MetricFact` rows) |
 | `LLMCache` | `src/llm/cache.py` | n/a | Transparently via `OpenAIClient.complete()` |
 | `PromptTemplates` | `src/llm/prompts.py` | n/a | Prompt construction and response parsing |
-| `ChartFactBridgeStage` | `src/extraction_v2/stages/chart_fact_bridge.py` | **none (rule-based)** | Post-processes Stage 5 `ChartData` into `v2_image_assets.detected_metrics` (metric-presence records; no `MetricFact` rows post-#86) |
+| `ChartFactBridgeStage` | `src/extraction_v2/stages/chart_fact_bridge.py` | **none (rule-based)** | Stage 5a — post-processes Stage 5 `ChartData` into `v2_image_assets.detected_metrics` (metric-presence records; no `MetricFact` rows post-#86) |
 | `ChartMetricClassifier` | `src/extraction_v2/chart/metric_classifier.py` | **none (rule-based)** | Classifies `ChartData` against YAML patterns |
+| `MetricPresenceStage` | `src/extraction_v2/stages/metric_presence.py` | **none** | Final stage — aggregates facts, chart `detected_metrics`, and definitions into `v2_text_metric_presence` rows (primary scoring surface) |
 
 ---
 
@@ -499,6 +515,7 @@ export OPENAI_API_KEY="sk-..."
 export DATABASE_URL="postgresql://..."    # Required for LLMCache
 export LLM_CACHE_ENABLED="true"          # Default: true
 export LLM_CACHE_VERSION="v1"            # Increment to invalidate cache
+export ENABLE_METRIC_CLASSIFY="false"    # Stage 5b Vision metric-classifier (writes v2_image_classifications)
 ```
 
 ---

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,20 +1,22 @@
 # System Architecture Overview
 
-**Version:** 3.0
-**Last Updated:** 2026-04-08
-**Status:** Production Ready
+**Version:** 3.1
+**Last Updated:** 2026-04-25
+**Status:** Production Ready (presence-pivot mid-rollout)
 
 ---
 
+> **Pivot status (2026-04-25):** The system's primary scoring surface is **presence** — per-`(doc_id, canonical_metric_id)` records aggregated from text facts, chart detections, the Vision metric-classifier, and metric definitions, persisted to `v2_text_metric_presence`. Per-value `MetricFact` rows continue as advisory evidence; CMASB-required values flow via manual entry (`POST /api/v2/missed-metric`). Chart-presence pivot is **live** (#86, 2026-04-23). Text-presence PR1 **landed** (#182, 2026-04-16). PR2–PR5 pending. See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md).
+
 ## Executive Summary
 
-This system extracts structured customer metrics from SEC filings (S-1/F-1, 10-K), earnings call transcripts, and investor presentations at scale to support the Customer Metrics Accounting Standards Board (CMASB) initiative. The system processes thousands of documents using a 13-stage V2 pipeline combining rule-based table reconstruction with selective LLM processing to achieve high quality at minimal cost.
+This system extracts **metric presence** (with advisory values where available) from SEC filings (S-1/F-1, 10-K), earnings call transcripts, and investor presentations at scale to support the Customer Metrics Accounting Standards Board (CMASB) initiative. The system processes thousands of documents through an up-to-16-stage V2 pipeline that combines rule-based table reconstruction, selective LLM processing, and a final `MetricPresenceStage` that aggregates signals into per-(filing, metric) presence rows with full provenance.
 
 ### Key Metrics
 - **Target Volume:** 7,304 in-scope S-1/F-1 filings (2015-2025), extensible to 10-K
 - **Target Cost:** $500-$1,000 total processing cost
-- **Target Quality:** ≥95% metric extraction accuracy
-- **Architecture:** 13-stage pipeline with immutable PipelineContext passing through typed stage processors
+- **Target Quality:** **presence-F1** is primary (Tier 1 must-not-miss); value-correctness on text/table sources remains a secondary advisory metric
+- **Architecture:** Up to 16-stage pipeline (image stages and `IMAGE_CLASSIFY` are conditional) with `PipelineContext` passing through typed stage processors; final `MetricPresenceStage` aggregates signals into `v2_text_metric_presence` rows
 
 ---
 
@@ -32,11 +34,11 @@ Phase 1 focuses on S-1/F-1 registration statements for first-time issuers of pub
 
 ## Design Principles
 
-### 1. Analysis-First
-Architecture is driven by required analytic outputs (incidence, quality, and metric values) and the data model, not by convenience of extraction.
+### 1. Analysis-First (presence as the unit of analysis)
+Architecture is driven by required analytic outputs — primarily **per-(filing, metric) presence** — and the data model, not by convenience of extraction. Per-value extraction is retained as advisory evidence and as the substrate for definition/methodology assessment, but presence is the headline output.
 
 ### 2. Provenance-First
-Every metric value, definition, and quality score must be traceable to specific segments in specific filings. No value without provenance.
+Every presence row, metric value, definition, and quality score must be traceable to specific segments or images in specific filings. Presence rows carry `evidence_segment_ids` + `advisory_fact_ids` (JSONB pointers, non-FK) back to source. Every advisory `MetricFact` carries a complete `EvidencePack`. No claim without provenance.
 
 ### 3. Investor-Grade Defensibility
 The system must support audit, replication, and quality evaluation for any published statistic.
@@ -173,7 +175,7 @@ The system is organized into six logical layers:
 
 ### 3. V2Pipeline
 **Module:** `src/extraction_v2/pipeline.py`
-**Purpose:** Orchestrate the 13-stage extraction process for a single document
+**Purpose:** Orchestrate the up-to-16-stage extraction process (image stages 4–5b and IMAGE_CLASSIFY are conditional) for a single document, ending in `MetricPresenceStage`
 **Input:** HTML path, filing ID, document type
 **Output:** `PipelineResult` containing `MetricFact` list, tables, images, segments, and per-stage diagnostics
 **Technology:** Python orchestration via `PipelineContext` passed through typed `StageProcessor` instances
@@ -192,8 +194,10 @@ The system is organized into six logical layers:
 | 1 | `IngestionStage` | lxml HTML parsing into typed `Segment` objects with DOM locators |
 | 2 | `SectionClassificationStage` | Assigns section_type (mda, risk_factors, business, financials, etc.) |
 | 3 | `TableReconstructionStage` | Resolves colspan/rowspan; computes header_path and stub_path per cell |
-| 4 | `ImageTriageStage` | Classifies images as chart, table_image, decorative, logo |
-| 5 | `OCRExtractionStage` | Vision API + OCR for labeled chart values; skips unlabeled axes |
+| 4 | `ImageTriageStage` | Classifies images as chart, table_image, decorative, logo (conditional) |
+| 5 | `OCRExtractionStage` | Vision API + OCR for labeled chart values; skips unlabeled axes (conditional) |
+| 5a | `ChartFactBridgeStage` | Rule-based `ChartMetricClassifier` writes `(metric_id, score)` pairs to `v2_image_assets.detected_metrics` — **presence-only**, no per-value chart facts (conditional) |
+| 5b | `ImageClassifyStage` | Vision API metric classifier; appends to `v2_image_classifications` audit trail (gated by `ENABLE_METRIC_CLASSIFY`) |
 | 6 | `CandidateGenerationStage` | Matches segments against `config/metric_keywords.yaml` taxonomy |
 | 7 | `ValueBindingStage` | Links numeric values to metric candidates via structural proximity |
 | 7.5 | `FalsePositiveFilterStage` | Applies 13 rule-based FP suppression rules |
@@ -202,6 +206,7 @@ The system is organized into six logical layers:
 | 9.5 | `DefinitionExtractionStage` | Extracts metric definitions from methodology/definition segments |
 | 10 | `DeduplicationStage` | Merges duplicate facts by (metric, period, unit, scope, cohort) identity tuple |
 | 11 | `ValidationStage` | Routes facts to auto_accepted or pending_review based on confidence thresholds |
+| 12 | `MetricPresenceStage` | **Final stage / primary scoring surface.** Aggregates dedup'd facts, chart `detected_metrics`, and definitions into `MetricPresence` rows (one per `(doc_id, canonical_metric_id)`); upserted to `v2_text_metric_presence` with `evidence_segment_ids` and `advisory_fact_ids` provenance |
 
 ### 5. V2PersistenceAdapter
 **Module:** `src/extraction_v2/persistence.py`
@@ -243,6 +248,72 @@ UniverseBuilder → FilingFetcher → V2Pipeline → V2PersistenceAdapter → Da
 **Stage 4: Persistence**
 - Writes all V2 artifacts to database (idempotent upserts)
 - Tracks processing status per filing in `v2_documents`
+
+---
+
+## Provenance: Reverse-Trace from Presence to Source
+
+A researcher receives a presence claim (`doc_id=42, canonical_metric_id='cm_net_revenue_retention', score=0.92`) and needs to walk it back to source evidence. The reverse-trace is one of the system's hard requirements — every presence row must be auditable.
+
+**Step 1 — read presence + provenance pointers:**
+
+```sql
+SELECT score, detected_at_stage, evidence_segment_ids,
+       advisory_fact_ids, advisory_value_count
+FROM v2_text_metric_presence
+WHERE doc_id = 42 AND canonical_metric_id = 'cm_net_revenue_retention';
+```
+
+**Step 2a — for text/table evidence, walk segment IDs back to source text:**
+
+```sql
+SELECT s.segment_id, s.section_type, s.dom_locator, s.segment_text
+FROM v2_segments s
+WHERE s.segment_id = ANY (
+    SELECT (jsonb_array_elements_text(p.evidence_segment_ids))::uuid
+    FROM v2_text_metric_presence p
+    WHERE p.doc_id = 42 AND p.canonical_metric_id = 'cm_net_revenue_retention'
+);
+```
+
+**Step 2b — for advisory fact IDs, read the EvidencePack:**
+
+```sql
+SELECT f.fact_id, f.value, f.unit, f.period_start, f.period_end,
+       f.source_type, f.evidence_pack
+FROM v2_metric_facts f
+WHERE f.fact_id = ANY (
+    SELECT (jsonb_array_elements_text(p.advisory_fact_ids))::uuid
+    FROM v2_text_metric_presence p
+    WHERE p.doc_id = 42 AND p.canonical_metric_id = 'cm_net_revenue_retention'
+);
+```
+
+**Step 3 — for chart-only presence (empty `evidence_segment_ids`), pivot to image confirmations:**
+
+```sql
+SELECT ia.img_id, ia.dom_locator, ia.detected_metrics,
+       imc.decision, imc.reviewer_id, imc.created_at
+FROM v2_image_assets ia
+LEFT JOIN v2_image_metric_confirmations imc
+    ON imc.img_id = ia.img_id
+   AND COALESCE(imc.confirmed_metric_id, imc.detected_metric_id)
+       = 'cm_net_revenue_retention'
+WHERE ia.doc_id = 42
+  AND ia.detected_metrics @> '[{"metric_id":"cm_net_revenue_retention"}]'::jsonb;
+```
+
+**Step 4 — for the Vision-classifier audit trail (independent signal), join `v2_image_classifications`:**
+
+```sql
+SELECT ic.img_id, ic.predicted_metrics, ic.cost_usd, ic.created_at
+FROM v2_image_classifications ic
+JOIN v2_image_assets ia USING (img_id)
+WHERE ia.doc_id = 42
+  AND ic.predicted_metrics @> '[{"metric_id":"cm_net_revenue_retention"}]'::jsonb;
+```
+
+**Important:** `evidence_segment_ids` and `advisory_fact_ids` are JSONB arrays, **not** foreign keys. A presence row can outlive the fact rows it cites — e.g., when `force=True` re-extraction recreates facts with new UUIDs. That's intentional: presence is a doc-level claim independent of which specific fact rows currently back it. The `v2_audit_log` table records batch-level changes; presence-row history is captured in `updated_at` only.
 
 ---
 
@@ -290,14 +361,16 @@ Filing Metadata (CIK, accession number, form type)
 
 ### Models and Roles
 
-- **GPT-4o-mini** (primary):
-  - Image classification via vision API (Stage 4-5)
-  - OCR text extraction from chart images (Stage 5)
-  - Definition/methodology summarization (Stage 9.5)
-  - PostgreSQL-backed caching by `(filing_id, source_segment_id, task_type)`
+- **GPT-4o-mini** (text):
   - Cost: $0.15/M input tokens, $0.60/M output tokens
+  - Used for any explicit text-extraction prompts via `OpenAIClient` (definition extraction is rule-based in V2 — no LLM)
+  - PostgreSQL-backed caching via `LLMCache`
 
-- **Future:** GPT-4o for complex edge cases (currently unused)
+- **GPT-4o** (vision):
+  - Stage 5 — `OCRExtractionStage` / `VisionClient`: OCR + labeled chart-value extraction (one call per processed image)
+  - Stage 5b — `ImageClassifyStage`: Vision metric-classifier; appends to `v2_image_classifications` audit trail. Gated by `ENABLE_METRIC_CLASSIFY` env var. **No `MetricFact` rows emitted** — output is a presence signal consumed by `MetricPresenceStage` and reviewer UI.
+
+Stage 5a `ChartFactBridgeStage` and `MetricPresenceStage` are **rule-based, no LLM** — they post-process Vision/text outputs into presence signals and aggregated presence rows respectively.
 
 ### Cost Control Mechanisms
 
@@ -321,7 +394,7 @@ Filing Metadata (CIK, accession number, form type)
 ### Parallelism Model
 
 - **Filing-level parallelism:** Process different filings concurrently in separate workers
-- Each worker runs the full 13-stage pipeline for its assigned filings
+- Each worker runs the full up-to-16-stage pipeline (ending in `MetricPresenceStage`) for its assigned filings
 - Database writes use short transactions with upsert semantics
 
 ### Database Considerations
@@ -375,18 +448,22 @@ Filing Metadata (CIK, accession number, form type)
 | `filings` | One row per SEC filing; classification flags, processing status |
 | `metrics` | Canonical metric registry (metric_id, display_name, etc.) |
 
-### V2 Tables (sql/09_v2_schema.sql, sql/29, sql/31)
+### V2 Tables (sql/09_v2_schema.sql, sql/29, sql/31, sql/42–47)
 
 | Table | Purpose |
 |-------|---------|
-| `v2_metric_facts` | Primary extraction output; one row per extracted value with full provenance |
+| `v2_text_metric_presence` (sql/46) | **Primary scoring surface.** One row per `(doc_id, canonical_metric_id)`; `score`, `detected_at_stage`, `evidence_segment_ids` (JSONB), `advisory_fact_ids` (JSONB), `advisory_value_count`. Upserted by `MetricPresenceStage`. |
+| `v2_image_metric_confirmations` (sql/43, sql/47) | Reviewer adjudications of image-presence detections (accept / reject / correct / add / skip). Replaces the per-value chart-fact review path. |
+| `v2_image_classifications` (sql/45) | Append-only audit trail for the Vision-API metric-classifier (Stage 5b, gated by `ENABLE_METRIC_CLASSIFY`). |
+| `v2_metric_facts` | Advisory per-value extraction output; one row per extracted value with full provenance. Chart sources do not auto-emit new rows post-#86. |
+| `v2_metric_definitions` | Issuer-specific definition and methodology text, one per `(doc_id, canonical_metric_id)`. |
 | `v2_segments` | DOM-native content blocks with section classification and XPath locators |
 | `v2_tables` | Reconstructed tables with row/col counts and section context |
 | `v2_table_cells` | Individual cells with header_path[] and stub_path[] arrays |
-| `v2_image_assets` | Extracted images with classification, OCR text, and chart data |
+| `v2_image_assets` | Extracted images with classification, OCR text, chart data, and `detected_metrics` JSONB (sql/42, presence pairs from rule-based classifier) |
 | `v2_documents` | Filing-level processing metadata and status |
 | `v2_review_decisions` | Human review decisions linked to V2 facts |
-| `v2_image_review_decisions` | Human review decisions on image assets |
+| `v2_image_review_decisions` | Legacy per-image review decisions (read-only; superseded by `v2_image_metric_confirmations`) |
 | `v2_audit_log` | HTTP audit trail for V2 review routes (replaces V1 `review_audit_log`) |
 
 ### Key V2 Fact Columns
@@ -413,6 +490,8 @@ Filing Metadata (CIK, accession number, form type)
 | TableReconstructionStage | Complete | Full colspan/rowspan resolution; header_path/stub_path |
 | ImageTriageStage | Complete | chart, table_image, decorative, logo classification |
 | OCRExtractionStage | Complete | Vision API + OCR; labeled values only |
+| ChartFactBridgeStage (Stage 5a) | Complete | Rule-based presence pairs to `v2_image_assets.detected_metrics`; no per-value chart facts |
+| ImageClassifyStage (Stage 5b) | Live (gated by `ENABLE_METRIC_CLASSIFY`) | Vision metric-classifier; audit trail in `v2_image_classifications` |
 | CandidateGenerationStage | Complete | YAML taxonomy matching (`config/metric_keywords.yaml`) |
 | ValueBindingStage | Complete | Structural binding; 1,436 lines |
 | FalsePositiveFilterStage | Complete | 13 FP suppression rules; 1,538 lines |
@@ -421,7 +500,8 @@ Filing Metadata (CIK, accession number, form type)
 | DefinitionExtractionStage | Complete | Methodology and definition segments |
 | DeduplicationStage | Complete | Identity-tuple deduplication |
 | ValidationStage | Complete | Confidence-based review routing |
-| V2PersistenceAdapter | Complete | Idempotent upserts to all V2 tables |
+| **MetricPresenceStage (final)** | **PR1 landed (#182)** | Aggregates facts/charts/definitions into `v2_text_metric_presence`; primary scoring surface (PR2 flips Tier-1 gate to presence-F1) |
+| V2PersistenceAdapter | Complete | Idempotent upserts to all V2 tables; `presence_only=True` skips fact write |
 | OpenAI Client (llm/) | Complete | PostgreSQL-backed LLM response cache |
 | Web UI (Flask) | Complete | Human review interface |
 | **Overall** | **Production Ready** | V2 is sole production pipeline |
@@ -507,16 +587,17 @@ python3 scripts/run_v2_extraction.py
 
 ## Related Documentation
 
-- **Data Model:** `docs/architecture/data-model.md` - Database schemas, relationships
-- **Extraction Details:** `docs/architecture/extraction-pipeline.md` - V2 stage interfaces and extraction logic
-- **LLM Integration:** `docs/architecture/llm-integration.md` - OpenAI integration, prompts, costs
+- **Pivot Plan (authoritative for in-flight rollout):** `docs/operations/text-pipeline-presence-pivot-plan.md`
+- **Data Model:** `docs/architecture/data-model.md` - Database schemas, relationships, presence tables
+- **Extraction Details:** `docs/architecture/extraction-pipeline.md` - V2 stage interfaces, MetricPresenceStage
+- **LLM Integration:** `docs/architecture/llm-integration.md` - OpenAI + Vision metric-classifier
 - **Requirements:** `docs/requirements/analytic-requirements.md` - Business requirements
-- **Quality Model:** `docs/development/quality-model.md` - QA scoring framework
+- **Quality Model:** `docs/development/quality-model.md` - presence-F1 primary; value-correctness advisory
 - **Testing:** `docs/development/testing.md` - Test strategy
 - **Documentation Index:** `docs/README.md`
 
 ---
 
-**Last Updated:** 2026-04-08
-**Version:** 3.0
-**Status:** Production Ready
+**Last Updated:** 2026-04-25
+**Version:** 3.1
+**Status:** Production Ready (presence-pivot mid-rollout)

--- a/docs/archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md
+++ b/docs/archive/historical/HUMAN_REVIEW_SYSTEM-pre-presence.md
@@ -1,0 +1,288 @@
+# Human-in-the-Loop Metric Extraction Review System — DEPRECATED
+
+> **DEPRECATED 2026-04-18.** The V1 human-review system described below (candidate
+> generator, pattern analyzer, rule applicator, `review_candidates` /
+> `review_decisions` tables, `/api/decisions` endpoints, `review.js`) has been
+> retired. The V2 unified review interface (`src/web/routes/review_unified.py`
+> at `/v2/review`, writing to `v2_review_decisions` and
+> `v2_image_review_decisions`) is the active system.
+>
+> This document is preserved for historical context and design-intent reference.
+> Do not rely on the commands, module layout, or database schema below — they
+> describe a retired system. See `docs/architecture/v1-table-deprecation-plan.md`
+> for the retirement record and `docs/architecture/system-overview.md` for the
+> current V2 review data flow.
+
+**Status (historical):** Production Ready (2026-03-30)
+**Core System:** Complete (Streams A-E)
+**Interface Improvements:** 11/12 Complete (HRI-12 blocked)
+
+---
+
+## Overview
+
+Human-in-the-loop system for reviewing and improving automated metric extraction from SEC S-1/F-1 filings.
+
+### Problem Solved
+
+Automated extraction had ~0% precision on initial samples:
+- Samsara: 0 correct out of 55 extractions
+- Farfetch: 0 correct out of 48 extractions
+- Root cause: LLM extracted numbers near keywords without understanding context
+
+### Solution
+
+Iterative learning loop:
+1. Generate candidate metrics with high recall
+2. Human reviews candidates (accept/reject/reclassify)
+3. System analyzes decisions to find patterns
+4. Generate improved filtering rules
+5. Apply rules to reduce false positives
+
+---
+
+## Architecture
+
+### Database Schema
+
+```sql
+-- sql/07_create_review_schema.sql
+review_candidates     -- Candidate metrics awaiting review
+review_decisions      -- Human review decisions
+learned_patterns      -- Discovered acceptance/rejection patterns
+review_audit_log      -- Audit trail for compliance
+```
+
+### Module Structure
+
+```
+src/review/
+├── models.py                # ReviewCandidate, ReviewDecision, CandidateFeatures
+├── number_parsing.py        # Number extraction and normalization
+├── false_positive_filter.py # Date/year filtering
+├── context_extraction.py    # Context window extraction
+├── boundary_detection.py    # Paragraph/section boundary detection
+├── table_structure.py       # Table row parsing and filtering
+├── marker_row_parser.py     # Marker/heading row detection in tables
+├── respectively_parser.py   # "X, Y and Z, respectively" value extraction
+├── feature_extractor.py     # Feature extraction for pattern learning (B2)
+├── confidence_scoring.py    # Candidate confidence score calculation
+├── deduplicator.py          # Cross-candidate deduplication
+├── pattern_analyzer.py      # Analyze decisions for patterns (E1)
+├── rule_applicator.py       # Apply learned patterns (E2)
+├── statistical_tests.py     # Chi-squared, t-test helpers for pattern discovery
+├── helpers.py               # Shared utilities
+├── exceptions.py            # Review-specific exception types
+└── config.py                # CandidateGenerationConfig
+
+src/web/
+├── app.py                 # Flask factory with health check
+├── pres_image_store.py    # File-based presentation image state
+├── routes/
+│   ├── review.py          # Text candidate review (filing list + review UI)
+│   ├── api.py             # REST API for text review decisions
+│   ├── review_images.py   # DB-backed image review (SEC filing images)
+│   ├── api_images.py      # REST API for image review decisions
+│   ├── review_unified.py  # Unified V2 extraction review interface
+│   ├── api_unified.py     # REST API for unified V2 review
+│   └── review_pres_images.py # Presentation image review (file-based)
+├── templates/
+│   ├── base.html                  # Bootstrap base
+│   ├── filing_list.html           # Filing selection (text review)
+│   ├── review.html                # Text candidate review interface
+│   ├── image_filing_list.html     # Filing selection (image review)
+│   ├── review_images.html         # Image review interface
+│   ├── image_stats.html           # Image review statistics dashboard
+│   ├── pres_image_filing_list.html # Filing selection (presentation images)
+│   ├── review_pres_images.html    # Presentation image review interface
+│   ├── unified_filing_list.html   # Filing selection (unified V2)
+│   ├── unified_review.html        # Unified V2 review interface
+│   ├── unified_stats.html         # Unified V2 statistics dashboard
+│   ├── v2_filing_list.html        # Filing selection (V2 legacy)
+│   ├── v2_review.html             # V2 review interface
+│   ├── v2_review_transcript.html  # V2 transcript review interface
+│   ├── v2_stats.html              # V2 statistics dashboard
+│   └── stats.html                 # General stats
+└── static/
+    ├── css/review.css
+    └── js/review.js       # Keyboard shortcuts, AJAX
+```
+
+---
+
+## Usage
+
+### 1. Generate Candidates
+
+```bash
+python scripts/generate_review_candidates.py --filing-ids 1,2,3,4,5
+```
+
+Options: `--limit`, `--batch-id`, `--dry-run`, `--no-progress`
+
+### 2. Start Review Server
+
+```bash
+export DATABASE_URL="postgresql://user:pass@localhost/filings_analysis"
+export SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
+export APP_ENV=production
+python scripts/run_review_server.py
+```
+
+Review at: http://localhost:8000/filings
+
+### 3. Analyze Patterns (E1)
+
+After 5-10 filings reviewed:
+
+```bash
+python scripts/analyze_review_patterns.py \
+    --min-precision 0.75 \
+    --save-patterns \
+    --verbose
+```
+
+Options: `--filing-id`, `--metric-id`, `--pattern-type`, `--min-precision` (default: 0.75), `--min-support` (default: 5), `--auto-approve`, `--save-patterns`, `--verbose`
+
+### 4. Approve Patterns
+
+```sql
+-- View candidate patterns
+SELECT pattern_id, pattern_name, precision_score, recall_score, sample_count
+FROM learned_patterns
+WHERE status = 'candidate'
+ORDER BY precision_score DESC, sample_count DESC;
+
+-- Approve pattern
+UPDATE learned_patterns
+SET status = 'approved', approved_at = now(), approved_by = 'your_name'
+WHERE pattern_id = 123;
+```
+
+### 5. Evaluate Improvement (E2)
+
+Run gold standard validation to measure extraction improvement after rules are applied:
+
+```bash
+python3 -m src.gold_standard.v2_validator
+```
+
+To export review decisions for offline analysis:
+
+```bash
+python scripts/export_review_decisions.py
+```
+
+---
+
+## Key Features
+
+### Candidate Generation
+- High-recall number detection with metric keyword matching
+- Table row filtering prevents cross-row keyword matches
+- Row heading priority (0.25x distance multiplier)
+- Date/year false positive filtering
+- Same-sentence deduplication preference
+
+### Review Interface
+- Keyboard shortcuts:
+  - Shared: `F`=Next filing, `Esc`=Cancel form
+  - Text tab: `A`=Accept, `R`=Reject, `C`=Correct, `N`/`→`=Next fact, `P`/`←`=Previous fact, `Enter`=Submit reject/correct form
+  - Images tab: `Y`=Relevant (chart type picker), `N`=Not relevant (reason picker), `S`=Skip, `U`=Undo, `←`/`→`=Prev/next image, `1`–`7`=Quick-select in open picker, `?`/`H`=Toggle hints
+- Confidence score badges (color-coded)
+- Filtering by status, metric type, confidence level
+- Sorting by document order, confidence, value
+- Bulk accept/reject (up to 20 candidates)
+- Decision history with undo
+- Context expansion and SEC filing links
+- Session persistence (resume where left off)
+
+### Pattern Learning (E1)
+- Feature importance analysis (chi-squared, t-test)
+- Cross-validation with stratified k-fold
+- Pattern conflict detection
+- Multi-feature conjunctive patterns
+- Natural language explanations
+
+### Rule Application (E2)
+- Automatic filtering during candidate generation
+- Cached pattern loading (5-minute reload)
+- Metric-specific and global patterns
+- Statistics tracking for filtered candidates
+
+---
+
+## Configuration
+
+See `src/review/config.py`:
+
+```python
+from src.review.config import get_high_precision_config, get_high_recall_config
+
+# High precision (fewer, more accurate candidates)
+config = get_high_precision_config()
+
+# High recall (more candidates, may include false positives)
+config = get_high_recall_config()
+```
+
+---
+
+## Post-Implementation Enhancements
+
+### Table Row Filtering (2025-12-17)
+- `TableRowParser` class maps character positions to table rows
+- Prevents cross-row keyword matches
+- Row headings get priority (0.25x distance multiplier)
+
+### Keyword Exclusions (2025-12-17)
+- `METRIC_EXCLUSION_PATTERNS` prevent common misclassifications
+- Example: "contribution margin" excluded from CAC
+- 34 tests covering exclusion patterns
+
+### Cohort Chart Image Detection (2025-12-29)
+- Automated detection of cohort analysis charts in filings
+- Segment-level detection via `segment_enricher._detect_cohort_chart_images()`
+- Filing-level detection via `cohort_chart_detector.py`
+- Results stored in `extra_metadata["cohort_chart_candidates"]`
+- Enables human review of high-value visualizations (ARR by cohort, LTV/CAC, retention curves)
+
+### Presentation Image Review (file-based)
+
+A separate review workflow for presentation images (e.g., investor day slides) under `/review/pres-images/`. Unlike the SEC filing image review (which is DB-backed), this workflow is file-based:
+
+- State is persisted per-directory via `src/web/pres_image_store.py`: presentation GS uses `data/presentation_gold_standard/_image_decisions.json` (8-K filings), filing GS uses `data/filing_gold_standard/_image_decisions.json` (S-1/F-1/10-K filings)
+- Route: `src/web/routes/review_pres_images.py`
+- Filing selection: `pres_image_filing_list.html`; review UI: `review_pres_images.html`
+
+### Image Review Stats Dashboard and Export (2026-03-30)
+- `/review/images/stats` route: overall decision statistics, daily counts, chart type distribution, rejection reason breakdown
+- `scripts/export_image_decisions.py`: exports reviewed decisions to CSV
+- New DB methods: `get_image_overall_decision_statistics`, `get_image_daily_decision_counts`, `get_image_chart_type_distribution`, `get_image_rejection_reason_stats`
+
+---
+
+## Remaining Work
+
+### HRI-12: Inter-Rater Agreement (Future)
+- Multiple reviewers per candidate
+- Cohen's Kappa calculation
+- Arbitration workflow
+- **Blocked:** Requires multi-user authentication
+
+---
+
+## Success Criteria
+
+Target metrics for production use:
+- Precision: >= 80% (up from ~0%)
+- Recall degradation: < 10%
+- Candidate volume reduction: >= 50%
+
+---
+
+## Related Documentation
+
+- `docs/architecture/extraction-pipeline.md` - Full extraction pipeline
+- `docs/development/metrics-taxonomy.md` - Metric definitions
+- `CLAUDE.md` - Quick reference for Claude Code

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> **Pivot status (2026-04-25):** Tier-1 regression on **presence-F1 / presence-recall** for chart-native metrics is a merge blocker (chart-presence pivot live #86; text-presence Tier-1 gate flip pending PR2). For text/table metrics, the gate currently still uses fact-recall but flips to presence-recall when PR2 lands. Run the validator (`python3 -m src.gold_standard.v2_validator --fail-on-regression`) before pushing extraction-related changes. See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md) and [`../operations/gold-standard-runbook.md`](../operations/gold-standard-runbook.md).
+
 ## One-time setup
 
 ```bash

--- a/docs/development/metric-lifecycle-process.md
+++ b/docs/development/metric-lifecycle-process.md
@@ -1,7 +1,9 @@
 # Metric Lifecycle Process
 
-Version: 1.0
-Date: 2026-01-07
+Version: 1.1
+Date: 2026-04-25
+
+> **Pivot status (2026-04-25):** Under the presence pivot, a metric is "present" in a filing the moment any of three signals fires: a text/table fact, a chart-presence detection (`v2_image_assets.detected_metrics`), or a definition match. **A metric exists in the analytic surface even before any value is bound** — value extraction is now advisory. When you add a new metric, ensure (1) keyword patterns in `config/metric_keywords.yaml` cover the text path, (2) chart-presence patterns cover the chart path if the metric is chart-native, and (3) gold-standard entries exercise both presence detection and (where applicable) value binding. See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md) and [`./metrics-taxonomy.md`](./metrics-taxonomy.md).
 
 ## 1. Overview
 
@@ -282,14 +284,16 @@ pytest tests/unit/web/ -v
 -- Connect to database
 psql $DATABASE_URL
 
--- Check for existing data
-SELECT COUNT(*) FROM metric_values WHERE metric_id = 'cm_xxx';
-SELECT COUNT(*) FROM review_candidates WHERE suggested_metric_id = 'cm_xxx';
-SELECT COUNT(*) FROM review_decisions WHERE assigned_metric_id = 'cm_xxx';
-SELECT COUNT(*) FROM filing_metric_incidence WHERE metric_id = 'cm_xxx';
+-- Check V2 tables for existing data
+SELECT COUNT(*) FROM v2_metric_facts          WHERE canonical_metric_id = 'cm_xxx';
+SELECT COUNT(*) FROM v2_metric_definitions    WHERE canonical_metric_id = 'cm_xxx';
+SELECT COUNT(*) FROM v2_text_metric_presence  WHERE canonical_metric_id = 'cm_xxx';
+SELECT COUNT(*) FROM v2_image_assets WHERE detected_metrics @> jsonb_build_array(jsonb_build_object('metric_id','cm_xxx'));
+SELECT COUNT(*) FROM v2_image_metric_confirmations
+  WHERE detected_metric_id = 'cm_xxx' OR confirmed_metric_id = 'cm_xxx';
 ```
 
-**If any count > 0:** STOP and deprecate instead of removing.
+**If any count > 0:** STOP and deprecate instead of removing — reviewer work and presence claims would be silently destroyed by `ON DELETE CASCADE`. The V1 tables (`metric_values`, `review_candidates`, `review_decisions`, `filing_metric_incidence`) referenced in earlier versions of this doc have been dropped (sql/26, sql/27, sql/31).
 
 ### Step 2: Remove from All Locations (Reverse Order)
 

--- a/docs/development/metrics-taxonomy.md
+++ b/docs/development/metrics-taxonomy.md
@@ -1,8 +1,10 @@
 # 02_METRIC_TAXONOMY_AND_DEFINITIONS
 
-Version: 0.1  
-Date: 2025-11-15  
-Owner: Rob Markey  
+Version: 0.2
+Date: 2026-04-25
+Owner: Rob Markey
+
+> **Pivot status (2026-04-25):** Tier assignments (Tier 1 must-not-miss / Tier 2 nice-to-have) live in `config/metric_keywords.yaml` (`tier:` field) and are loaded at validator runtime via `src/shared/keyword_config.py::get_metric_tiers()`. Under the presence pivot, **Tier 1 metrics gate on presence-recall** (gate flip pending PR2 of the text-presence pivot — see [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md)). The current authoritative Tier 1 list is in `CLAUDE.md` § Metric Priority Tiers; the V2 schema (`v2_metric_facts`, `v2_text_metric_presence`) supersedes the V1 schema referenced in some sections below.
 
 ## 1. Purpose
 

--- a/docs/development/quality-model.md
+++ b/docs/development/quality-model.md
@@ -2,9 +2,11 @@
 
 # 06_QA_AND_QUALITY_MODEL
 
-Version: 0.1  
-Date: 2025-11-15  
-Owner: Rob Markey  
+Version: 0.2
+Date: 2026-04-25
+Owner: Rob Markey
+
+> **Pivot status (2026-04-25):** Under the chart-presence pivot (#86) and text-presence PR1 (#182), the **primary quality dimension is presence detection (presence-F1, presence-recall)**, not numeric extraction accuracy. Per-value extraction is retained as advisory evidence and as the substrate for definition / methodology assessment, but is no longer the headline scoring surface for chart-native metrics. PR2 of the text-presence pivot will flip the Tier-1 gate from fact-recall to presence-recall (pending). Several sections below still describe V1 schema (`metric_values`, `metric_definitions`, `filing_metric_incidence`, `cohort_bucket_raw`, etc.) — those tables have been dropped (sql/26, sql/27); read them as historical context for the dimensions, with the V2 schema (`v2_metric_facts`, `v2_metric_definitions`, `v2_text_metric_presence`) as the current truth. See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md).
 
 ## 1. Purpose
 
@@ -40,25 +42,25 @@ Where automation is fragile, we prefer:
 
 ## 3. Quality dimensions
 
-We evaluate quality along six dimensions.
+We evaluate quality along six dimensions. The first dimension is the **headline scoring surface** post-pivot.
 
-1. **Coverage & completeness**  
+1. **Presence detection quality (PRIMARY post-pivot)**
+   Do we correctly detect that a metric is disclosed in a filing — across text, charts, and definitions, aggregated to per-`(doc_id, canonical_metric_id)` rows in `v2_text_metric_presence`? Measured as **presence-precision / presence-recall / presence-F1** by tier. Tier-1 presence-F1 regression is a **merge blocker** (gate flip pending PR2).
+
+2. **Coverage & completeness**
    Are all in-scope filings represented, and is the segment universe rich enough to find disclosures?
 
-2. **Incidence detection quality**  
-   Do we correctly detect whether a metric is disclosed in a filing?
+3. **Numeric extraction accuracy (advisory under the pivot)**
+   For values that are extracted (text/table sources, manual entry), are they correct and appropriately structured (periods, cohorts, segments)? Chart-native metrics no longer auto-emit values; CMASB-required values come through manual entry (`POST /api/v2/missed-metric`).
 
-3. **Numeric extraction accuracy**  
-   Are extracted metric values correct and appropriately structured (periods, cohorts, segments)?
-
-4. **Definition & methodology quality**  
+4. **Definition & methodology quality**
    Do we accurately capture and summarize how issuers define and calculate metrics?
 
-5. **Comparability / alignment**  
+5. **Comparability / alignment**
    Can we reliably judge how closely issuer metrics match canonical CMASB definitions?
 
-6. **Provenance & traceability**  
-   Can we always trace results back to precise locations in filings?
+6. **Provenance & traceability**
+   Can we always trace any presence claim or value back to precise locations in filings? Presence rows carry `evidence_segment_ids` + `advisory_fact_ids` JSONB pointers; per-value facts carry `EvidencePack` with `source_locator` and `header_path` / `stub_path`.
 
 Each dimension has:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,6 +1,8 @@
 # Testing
 
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-25
+
+> **Pivot status (2026-04-25):** Under the presence pivot, gold-standard regression tests target **presence-F1 / presence-recall** for chart-native metrics (chart-presence pivot live; text-presence Tier-1 gate flip pending PR2). New extraction-stage tests should populate `evidence_pack` such that any emitted fact's `fact_id` flows into `v2_text_metric_presence.advisory_fact_ids` and traces back through `MetricPresenceStage`. See [`../operations/text-pipeline-presence-pivot-plan.md`](../operations/text-pipeline-presence-pivot-plan.md).
 
 ---
 
@@ -10,8 +12,9 @@ The test suite enforces correctness across the extraction pipeline, review syste
 
 **Test philosophy:**
 1. Rule-based extraction logic is tested in isolation before integration — unit tests cover individual stages and parsers without database or LLM dependencies.
-2. Integration tests require a real PostgreSQL test database (`TEST_DATABASE_URL`). They validate database upsert idempotency, full pipeline runs on cached HTML fixtures, and API transaction integrity.
-3. Gold standard regression tests guard against precision/recall regressions on a curated set of known-good filings.
+2. Integration tests require a real PostgreSQL test database (`TEST_DATABASE_URL`). They validate database upsert idempotency (including `_persist_presence_in_tx` upsert on `(doc_id, canonical_metric_id)`), full pipeline runs on cached HTML fixtures, and API transaction integrity.
+3. Gold standard regression tests guard against presence-F1 and (advisory) precision/recall regressions on a curated set of known-good filings.
+4. **Presence-provenance test pattern:** any new fact-emitting stage MUST populate `evidence_pack` such that its `fact_id` can flow into `v2_text_metric_presence.advisory_fact_ids` and reverse-trace to `v2_segments` via `evidence_segment_ids`. Reverse-trace tests live in `tests/integration/extraction_v2/test_presence_provenance.py` (or equivalent — see PR1 #182).
 
 **Coverage requirement:** 80% minimum, enforced by `pytest-cov` (`fail_under = 80` in `pyproject.toml`). The `src/extraction/` (V1, retired) directory is excluded from coverage measurement.
 

--- a/docs/operations/analytics-ui-runbook.md
+++ b/docs/operations/analytics-ui-runbook.md
@@ -4,11 +4,20 @@
 pointed at the filings database. Covers the read-only DB role, the
 `v_analytics_*` views, and the (future) self-hosted Metabase deployment.
 
+> **Pivot status (2026-04-25):** The presence-pivot adds a new doc-grain
+> view `v_doc_metric_presence` (UNION of `v2_text_metric_presence` and the
+> per-image `v2_image_metric_presence`, the latter landing with image-review
+> Wave 2). Existing `v_analytics_fact_wide` and `v_analytics_coverage_matrix`
+> views remain valid for advisory-fact analyses; presence-aware analytics
+> views are pending PR2 of the text-presence pivot. See
+> [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md).
+
 ## What this layer is for
 
 The extraction pipeline produces structured data in Neon Postgres
-(`v2_metric_facts`, `filings`, `companies`, `metrics`, etc.). Two audiences need
-to query it:
+(presence in `v2_text_metric_presence` — primary; advisory facts in
+`v2_metric_facts`; image classifications, segments, tables, etc.). Two
+audiences need to query it:
 
 - **Researchers (you)** — want ad-hoc slice/dice exploration: "which companies
   disclosed NRR?", "what does our extraction look like per source_type?"
@@ -43,8 +52,9 @@ is deployed later via `render.yaml`.
 
 | View | Grain | Use |
 |------|-------|-----|
-| `v_analytics_fact_wide` | 1 row / primary `v2_metric_fact` | Default surface for ad-hoc exploration. Most questions (trends, QA, per-company) derive from this. |
-| `v_analytics_coverage_matrix` | 1 row / (company × active metric) | Powers "who discloses what" heatmap dashboards. Includes `has_fact` / `has_accepted_fact` flags. |
+| `v_analytics_fact_wide` | 1 row / primary `v2_metric_fact` (advisory under the pivot) | Surface for advisory-fact analysis (trends, QA, per-company values). Note: chart-native metrics no longer auto-populate facts post-#86. |
+| `v_analytics_coverage_matrix` | 1 row / (company × active metric) | Powers "who discloses what" heatmap dashboards. Includes `has_fact` / `has_accepted_fact` flags. PR2 of the text-presence pivot will switch the headline coverage flag from fact-presence to **doc-grain presence** via `v_doc_metric_presence`. |
+| `v_doc_metric_presence` (UNION view, planned) | 1 row / (filing × metric × source) | Primary presence surface — UNION of `v2_text_metric_presence` and per-image `v2_image_metric_presence`. Lands with image-review Wave 2; consumed by PR2 of the text-presence pivot for the Tier-1 gate. Pre-launch, query `v2_text_metric_presence` directly. |
 
 Both views use `CREATE OR REPLACE`, so the migration is safe to re-apply after
 editing. If a column or join changes, bump the migration number and add a new

--- a/docs/operations/extraction-runbook.md
+++ b/docs/operations/extraction-runbook.md
@@ -1,10 +1,10 @@
 # Extraction Operations Runbook
 
-**Last Updated:** 2024-12-24
+**Last Updated:** 2026-04-25
 
-> **Note:** This runbook was originally written for the V1 extraction pipeline and has been partially updated for V2. The V2 extraction pipeline (`src/extraction_v2/`) is now the sole production pipeline. V1 (`src/extraction/`) has been **deleted** from the repository. Where this document references V1 modules directly, treat those references as historical context only — the files no longer exist.
+> **Pivot status (2026-04-25):** Under the chart-presence pivot (#86, 2026-04-23) and text-presence PR1 (#182, 2026-04-16), the V2 extraction pipeline emits **presence** as the primary scoring surface (`v2_text_metric_presence`) plus advisory facts (`v2_metric_facts`). This runbook covers V2 only; V1 has been deleted from the repo (`src/extraction/`). The legacy V1 candidate / `source_segments` / `review_candidates` flow no longer exists. See [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md).
 
-This runbook documents the correct procedures for re-extracting and re-segmenting filings. **Following these procedures is critical** to avoid stale data issues.
+This runbook documents the correct procedures for re-extracting filings under the V2 pipeline. **Following these procedures is critical** to avoid stale data issues and to respect the reviewed-filing guard (`ReviewedFilingError`).
 
 ---
 
@@ -13,83 +13,81 @@ This runbook documents the correct procedures for re-extracting and re-segmentin
 | Task | Command |
 |------|---------|
 | Re-extract single filing (V2 pipeline) | `DATABASE_URL="..." python3 scripts/run_v2_extraction.py --filing-id <ID>` |
-| Batch re-extract all filings (V2 pipeline) | `DATABASE_URL="..." python3 scripts/batch_v2_extraction.py` |
-| Regenerate candidates only (keeps segments) | `DATABASE_URL="..." python3 scripts/generate_review_candidates.py --filing-ids <ID>` |
-| Diagnose extraction issues | Run `scripts/run_v2_extraction.py --filing-id <ID>` with logging enabled (see Procedure 4) |
+| Re-extract a reviewed filing (forces, requires explicit flag) | `DATABASE_URL="..." python3 scripts/run_v2_extraction.py --filing-id <ID> --force-reextract` |
+| Re-extract presence-only (skip fact write; useful for keyword/aggregator changes) | `DATABASE_URL="..." python3 scripts/run_v2_extraction.py --filing-id <ID> --presence-only` |
+| Batch re-extract | `DATABASE_URL="..." python3 scripts/batch_v2_extraction.py` |
+| Diagnose extraction issues | Run `scripts/run_v2_extraction.py --filing-id <ID>` with `LOG_LEVEL=DEBUG` (see Procedure 4) |
 
 ---
 
 ## Understanding the Data Flow
 
 ```
-HTML File → Segmenter → source_segments (DB) → Classifier → Candidate Generator → review_candidates (DB)
-                ↓
-          LLM Extraction → metric_values (DB)
+HTML File
+    ↓
+V2Pipeline (up to 16 stages; image stages 4–5b conditional)
+    ├─ v2_segments              (DOM-native content blocks)
+    ├─ v2_tables / v2_table_cells  (header_path / stub_path)
+    ├─ v2_image_assets          (incl. detected_metrics JSONB — chart-presence pairs)
+    ├─ v2_image_classifications (Vision API metric-classifier audit; Stage 5b)
+    ├─ v2_metric_facts          (advisory per-value evidence, with EvidencePack)
+    ├─ v2_metric_definitions    (issuer-specific definition / methodology text)
+    └─ v2_text_metric_presence  ★ primary scoring surface
+                                  one row per (doc_id, canonical_metric_id);
+                                  upserted by MetricPresenceStage
 ```
 
-**Key Insight**: If you modify segmentation logic or keywords, you must re-run the appropriate stage AND all downstream stages.
+**Key Insight**: If you modify segmentation logic, keywords, FP rules, or the `MetricPresenceStage` aggregator, you must re-run the V2 pipeline. Presence rows are upserted on `(doc_id, canonical_metric_id)`, so re-extraction is idempotent. The `presence_only=True` mode skips the fact-write step entirely — useful when iterating on aggregation logic or keyword rules without disturbing reviewed facts.
 
 | If you modify... | You must re-run... |
 |------------------|-------------------|
 | `src/extraction_v2/stages/ingestion.py` (V2 segmentation) | Full re-extraction (`scripts/batch_v2_extraction.py`) |
-| `config/metric_keywords.yaml` (keyword patterns) | Delete old candidates, run `generate_review_candidates.py` |
+| `config/metric_keywords.yaml` (keyword patterns) | Full re-extraction; presence rows refresh on the next run |
+| `src/extraction_v2/stages/metric_presence.py` (aggregator) | Re-extraction with `--presence-only` is sufficient — does not touch facts |
+| `src/extraction_v2/chart/metric_classifier.py` (chart presence rules) | Full re-extraction; updates `v2_image_assets.detected_metrics` |
 | LLM prompts | Full re-extraction (`scripts/batch_v2_extraction.py`) |
 
 ---
 
 ## Procedure 1: Full Re-extraction (Recommended)
 
-Use when: Segmenter logic changed, or you want to ensure fresh data.
+Use when: Segmentation, keyword, FP-filter, or LLM-prompt logic changed.
 
 ```bash
-# 1. Run V2 extraction for a single filing
 DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
     python3 scripts/run_v2_extraction.py --filing-id <FILING_ID>
-
-# 2. Regenerate review candidates
-DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
-    python3 scripts/generate_review_candidates.py --filing-ids <FILING_ID>
 ```
 
 **What this does:**
 - Runs the V2 unified extraction pipeline (`src/extraction_v2/`) on the specified filing
-- Re-runs HTML segmentation with current segmenter
-- Re-runs LLM extraction
-- You must then regenerate candidates separately
+- Upserts `v2_segments`, `v2_tables`, `v2_image_assets` (with `detected_metrics` JSONB), `v2_metric_facts` (advisory), `v2_metric_definitions`, and `v2_text_metric_presence` (primary scoring surface)
+- Idempotent — safe to re-run; presence rows are upserted on `(doc_id, canonical_metric_id)` and `updated_at` advances
+
+If the filing has reviewer decisions on facts or image confirmations, this command will raise `ReviewedFilingError`. Use `--force-reextract` only when you intentionally want to overwrite reviewed work; the reviewer-protection guards exist to prevent silent CASCADE-destruction.
 
 ---
 
-## Procedure 2: Regenerate Candidates Only
+## Procedure 2: Presence-Only Re-extraction
 
-Use when: Only keyword patterns changed, segmenter unchanged.
+Use when: You changed `MetricPresenceStage` aggregation logic, the chart-presence classifier, or want to refresh presence scores without touching reviewed facts.
 
 ```bash
-# 1. Delete existing candidates for the filing
-PGPASSWORD=dev psql -h localhost -p 5433 -U dev -d filings_analysis \
-    -c "DELETE FROM review_candidates WHERE filing_id = <FILING_ID>;"
-
-# 2. Regenerate candidates
 DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
-    python scripts/generate_review_candidates.py --filing-ids <FILING_ID>
+    python3 scripts/run_v2_extraction.py --filing-id <FILING_ID> --presence-only
 ```
 
 **What this does:**
-- Uses existing `source_segments` (does NOT re-segment)
-- Applies current keyword patterns from `config/metric_keywords.yaml`
-- Generates new `review_candidates`
+- Runs the full pipeline through the final `MetricPresenceStage`
+- Calls `V2PersistenceAdapter.persist_pipeline_result(..., presence_only=True)`, which skips the `_persist_facts_in_tx` step entirely
+- Upserts presence rows, image classifications, and image-asset `detected_metrics`
+- **Does NOT touch `v2_metric_facts`** — no `ReviewedFilingError` on text-fact decisions can fire
+- Image confirmation guard still applies to hidden-class transitions
 
 ---
 
 ## Procedure 3: Manual Re-segmentation Only — RETIRED
 
-The V1 segmenter (`src/shared/html_segmenter.py`) and the V1 `source_segments` table were retired. For the equivalent V2 workflow, use:
-
-```bash
-DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
-    python3 scripts/batch_v2_extraction.py --filing-ids <FILING_ID>
-```
-
-The V2 pipeline writes to `v2_segments` (not `source_segments`) and does not require a separate candidate-generation pass.
+The V1 segmenter and `source_segments` table are retired. The V2 pipeline writes to `v2_segments` and runs all downstream stages in one pass — there is no separate "segmentation only" mode. Use Procedure 1.
 
 ---
 
@@ -114,50 +112,44 @@ LOG_LEVEL=DEBUG DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analys
 
 ## Procedure 5: Batch Re-extraction
 
-Use when: Re-extracting multiple filings (e.g., after major segmenter changes).
+Use when: Re-extracting multiple filings (e.g., after major pipeline changes).
 
 ```bash
 # 1. Run a limited batch first to verify behavior
 DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
     python3 scripts/batch_v2_extraction.py --limit 5
 
-# 2. Verify results before full run
+# 2. Verify results before full run (V2 tables)
 PGPASSWORD=dev psql -h localhost -p 5433 -U dev -d filings_analysis \
-    -c "SELECT COUNT(*) FROM source_segments;"
+    -c "SELECT COUNT(*) AS docs FROM v2_documents;
+        SELECT COUNT(*) AS facts, COUNT(DISTINCT canonical_metric_id) AS metrics FROM v2_metric_facts;
+        SELECT COUNT(*) AS presences, COUNT(DISTINCT canonical_metric_id) AS metrics FROM v2_text_metric_presence;"
 
 # 3. Full re-extraction (can take hours)
 DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
     python3 scripts/batch_v2_extraction.py
-
-# 4. Regenerate all candidates
-DATABASE_URL="postgresql://dev:dev@localhost:5433/filings_analysis" \
-    python3 scripts/generate_review_candidates.py
 ```
 
 ---
 
 ## Common Pitfalls
 
-### Pitfall 1: Stale Segments
-**Symptom:** Gold standard values exist in HTML but not in candidates.
-**Cause:** Database has old segments from previous segmenter version.
-**Fix:** Run Procedure 1 or 3 to re-segment.
+### Pitfall 1: Stale Presence
+**Symptom:** A keyword change should have promoted a metric to "present" but didn't.
+**Cause:** `v2_text_metric_presence` was not refreshed after the keyword/aggregator change.
+**Fix:** Run Procedure 1 (full) or Procedure 2 (`--presence-only`) for affected filings.
 
 ### Pitfall 2: Missing Keywords
-**Symptom:** Values are in segments but not matched to correct metric.
+**Symptom:** Values are in segments but not matched to the correct metric.
 **Cause:** Keyword patterns in `config/metric_keywords.yaml` don't include company-specific terminology.
 **Fix:**
-1. Add keywords to `config/metric_keywords.yaml` (the authoritative keyword source)
-2. Run Procedure 2 to regenerate candidates
+1. Add keywords to `config/metric_keywords.yaml` (the authoritative keyword source).
+2. Run Procedure 1 to re-extract; presence rows refresh on next run.
 
-### Pitfall 3: Regenerating Candidates Without Deleting Old Ones
-**Symptom:** Duplicate candidates or old incorrect candidates remain.
-**Cause:** `generate_review_candidates.py` doesn't delete existing candidates by default.
-**Fix:** Always delete candidates first:
-```bash
-PGPASSWORD=dev psql -h localhost -p 5433 -U dev -d filings_analysis \
-    -c "DELETE FROM review_candidates WHERE filing_id = <ID>;"
-```
+### Pitfall 3: ReviewedFilingError on Re-extraction
+**Symptom:** `scripts/run_v2_extraction.py` raises `ReviewedFilingError` and refuses to write.
+**Cause:** The filing has reviewer decisions on facts (`v2_review_decisions`) or image-presence confirmations (`v2_image_metric_confirmations`); the guard prevents silent overwrite.
+**Fix:** Use `--presence-only` (does not touch facts) when only aggregation changed. Use `--force-reextract` only when you intentionally want to invalidate reviewer work.
 
 ### Pitfall 4: Forgetting to Set DATABASE_URL
 **Symptom:** Script runs but doesn't affect expected database.
@@ -170,46 +162,70 @@ PGPASSWORD=dev psql -h localhost -p 5433 -U dev -d filings_analysis \
 
 ### Check segment count for a filing
 ```sql
-SELECT COUNT(*) as segment_count,
-       SUM(LENGTH(raw_text)) as total_chars
-FROM source_segments
-WHERE filing_id = <FILING_ID>;
+SELECT COUNT(*) AS segment_count,
+       SUM(LENGTH(segment_text)) AS total_chars
+FROM v2_segments
+WHERE doc_id = <FILING_ID>;
 ```
 
 ### Check if specific value is in segments
 ```sql
-SELECT COUNT(*) as matches
-FROM source_segments
-WHERE filing_id = <FILING_ID>
-  AND raw_text ILIKE '%<VALUE>%';
+SELECT COUNT(*) AS matches
+FROM v2_segments
+WHERE doc_id = <FILING_ID>
+  AND segment_text ILIKE '%<VALUE>%';
 ```
 
-### Check candidate count for a filing
+### Check fact count (advisory) for a filing
 ```sql
-SELECT COUNT(*) as candidate_count
-FROM review_candidates
-WHERE filing_id = <FILING_ID>;
+SELECT canonical_metric_id, COUNT(*) AS fact_count, COUNT(*) FILTER (WHERE review_status='accepted') AS accepted
+FROM v2_metric_facts
+WHERE doc_id = <FILING_ID>
+GROUP BY canonical_metric_id
+ORDER BY fact_count DESC;
 ```
 
-### Check candidates for specific metric
+### Check presence (primary) for a filing
 ```sql
-SELECT parsed_value, triggering_keyword, suggested_metric_id
-FROM review_candidates
-WHERE filing_id = <FILING_ID>
-  AND suggested_metric_id = '<METRIC_ID>';
+SELECT canonical_metric_id, score, detected_at_stage,
+       jsonb_array_length(evidence_segment_ids) AS n_segments,
+       jsonb_array_length(advisory_fact_ids)    AS n_facts,
+       advisory_value_count
+FROM v2_text_metric_presence
+WHERE doc_id = <FILING_ID>
+ORDER BY score DESC;
+```
+
+### Check chart-presence detections + reviewer confirmations for a filing
+```sql
+SELECT ia.img_id, ia.classification, ia.detected_metrics,
+       jsonb_agg(jsonb_build_object(
+           'reviewer', imc.reviewer_id,
+           'decision', imc.decision,
+           'detected', imc.detected_metric_id,
+           'confirmed', imc.confirmed_metric_id
+       )) FILTER (WHERE imc.id IS NOT NULL) AS confirmations
+FROM v2_image_assets ia
+LEFT JOIN v2_image_metric_confirmations imc USING (img_id)
+WHERE ia.doc_id = <FILING_ID>
+  AND ia.classification = 'chart'
+GROUP BY ia.img_id, ia.classification, ia.detected_metrics;
 ```
 
 ### Compare filing stats before/after
 ```sql
 SELECT f.filing_id, c.company_name,
-       COUNT(DISTINCT ss.source_segment_id) as segments,
-       COUNT(DISTINCT rc.candidate_id) as candidates,
-       COUNT(DISTINCT mv.metric_value_id) as extracted_values
+       COUNT(DISTINCT s.segment_id)                AS segments,
+       COUNT(DISTINCT mf.fact_id)                  AS facts,
+       COUNT(DISTINCT mf.fact_id) FILTER (WHERE mf.review_status='accepted') AS accepted_facts,
+       COUNT(DISTINCT p.presence_id)               AS presences,
+       COUNT(DISTINCT ia.img_id) FILTER (WHERE ia.classification='chart') AS charts
 FROM filings f
 JOIN companies c ON f.company_id = c.company_id
-LEFT JOIN source_segments ss ON f.filing_id = ss.filing_id
-LEFT JOIN review_candidates rc ON f.filing_id = rc.filing_id
-LEFT JOIN metric_values mv ON f.filing_id = mv.filing_id
+LEFT JOIN v2_segments s            ON f.filing_id = s.doc_id
+LEFT JOIN v2_metric_facts mf       ON f.filing_id = mf.doc_id
+LEFT JOIN v2_text_metric_presence p ON f.filing_id = p.doc_id
+LEFT JOIN v2_image_assets ia       ON f.filing_id = ia.doc_id
 WHERE f.filing_id = <FILING_ID>
 GROUP BY f.filing_id, c.company_name;
 ```

--- a/docs/operations/full-page-ocr-runbook.md
+++ b/docs/operations/full-page-ocr-runbook.md
@@ -4,6 +4,14 @@ How to operate the two optional image-OCR entry points introduced in the
 full-page-OCR feature branch: `FULL_PAGE_OCR_ENABLED` (Path A) and
 `IMAGE_KEYWORD_PRESCAN_ENABLED` (Path B). Both ship default-off.
 
+> **Pivot status (2026-04-25):** Both paths feed advisory `v2_metric_facts`
+> rows (text/OCR sources). Chart-shaped output flows through
+> `ChartFactBridgeStage` and writes presence pairs to
+> `v2_image_assets.detected_metrics` rather than per-value chart facts
+> (chart-presence pivot #86). `MetricPresenceStage` aggregates whatever
+> these paths emit into `v2_text_metric_presence`. See
+> [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md).
+
 ## What each path does
 
 ### Path A — full-page-scan filing

--- a/docs/operations/gold-standard-runbook.md
+++ b/docs/operations/gold-standard-runbook.md
@@ -1,5 +1,7 @@
 # Gold Standard Baseline Update Runbook
 
+> **Pivot status (2026-04-25):** Under the chart-presence pivot (#86, 2026-04-23), chart-native metrics are scored on **presence-P/R/F1**, not value-level P/R/F1. Text-pipeline scoring will flip to **presence-recall** as the Tier-1 gate when PR2 of the text-presence pivot lands (gold-standard derivation + validator wiring; pending). Until then, the V2 validator still gates on fact-recall for text/table metrics. See [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md). Known gap: legacy-098 — `presence_f1` is not yet populated in the validator output; chart-native improvements are unmeasurable until that fixes.
+
 ## Overview
 
 Three validation pipelines maintain independent baselines:
@@ -137,9 +139,27 @@ Tier 2 recall: ...
 CHART cross-source confirmation: m/n (pct%)
 ```
 
-The `m/n` counts chart facts that were independently confirmed by a second source type (e.g., a TEXT or TABLE fact agreeing on the same metric+period+value slot). `pct%` is `m/n * 100`.
+The `m/n` counts chart facts that were independently confirmed by a second source type (e.g., a TEXT or TABLE fact agreeing on the same metric+period+value slot). `pct%` is `m/n * 100`. (Under the chart-presence pivot the chart pipeline no longer auto-emits per-value chart facts; this line currently reflects only residual pre-pivot rows. The metric will be deprecated in PR2 of the text-presence pivot in favor of a presence-derived check.)
 
 A soft `WARNING` is printed if `pct < 30%`. This warning is not a hard failure and will not block a baseline update, but it indicates that the chart bridge is producing few cross-confirmed facts — which may signal chart OCR quality issues or a gap in the text/table extraction path for those metrics. Discuss with the team before updating the baseline when this warning appears.
+
+### 7a. Presence-derived metrics (PR2-pending)
+
+PR2 of the text-presence pivot will add the following to the validator output:
+
+```
+Tier 1 presence-recall: ...
+Tier 1 presence-F1: ...     ← NEW Tier-1 gate (replaces fact-recall)
+Tier 2 presence-recall: ...
+```
+
+Mechanics under PR2 (interface contract, not yet shipped — see `text-pipeline-presence-pivot-plan.md` §3):
+
+- The validator queries `v_doc_metric_presence` (UNION view of `v2_text_metric_presence` + `v2_image_metric_presence`, the per-image grain table that lands with image-review Wave 2).
+- Tier-1 gate flips from "fact-recall on text/table" to "presence-recall on the doc grain". A regression on a Tier-1 metric blocks PR merge regardless of whether per-value facts exist.
+- Chart-native metrics (`cm_revenue_by_cohort`, `cm_balance_by_cohort`, `cm_gross_margin_by_cohort`, etc.) become measurable for the first time post-pivot — pre-PR2 their recall has been silently zero in the gate because the chart pipeline emits no facts.
+
+Until PR2 lands, do not expect chart-native presence improvements to show up in the V2 baseline; they are still tracked manually via gold-standard inspection and the `vision-bakeoff-metric-classify-2026-04-23.md` report. Known gap: legacy-098 (`presence_f1` not yet populated in the validator output).
 
 ---
 

--- a/docs/operations/setup-guide.md
+++ b/docs/operations/setup-guide.md
@@ -1,6 +1,8 @@
 # Setup Guide
 
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-25
+
+> **Pivot status (2026-04-25):** The V2 pipeline emits **presence** as the primary scoring surface (`v2_text_metric_presence`). The Vision metric-classifier (Stage 5b) is gated by the `ENABLE_METRIC_CLASSIFY` env var — see "V2 pipeline settings" below. See [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md).
 
 ---
 
@@ -83,6 +85,7 @@ The table below documents every variable. Variables marked **Required** must be 
 | `LOG_LEVEL` | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 | `V2_WORKER_COUNT` | `4` | Default number of parallel workers for batch extraction. |
 | `V2_MIN_CONFIDENCE` | `0.5` | Minimum confidence threshold for including extracted facts. |
+| `ENABLE_METRIC_CLASSIFY` | `false` | Enables Stage 5b `ImageClassifyStage` (Vision API metric classifier). When `true`, each chart image is sent to the Vision API and the predicted-metrics list is appended to `v2_image_classifications`. Independent from the rule-based `v2_image_assets.detected_metrics` (Stage 5a) — both signals can coexist. Cost: one extra Vision call per processed chart image. |
 
 ### Optional integrations
 

--- a/src/extraction_v2/__init__.py
+++ b/src/extraction_v2/__init__.py
@@ -1,44 +1,40 @@
 """
 V2 Extraction Pipeline for SEC Filings Metric Extraction.
 
-This module implements a unified extraction pipeline with:
-- Structure-first extraction (DOM parsing before LLM)
-- Full table reconstruction with colspan/rowspan resolution
-- Image/chart extraction via OCR and vision models
-- Complete provenance tracking via MetricFact and EvidencePack
+Extracts metric **presence** (with advisory values where available) from SEC
+filings. Primary output is per-(doc_id, canonical_metric_id) presence rows in
+``v2_text_metric_presence``; per-value ``MetricFact`` rows are advisory
+evidence under the chart-presence pivot (#86, 2026-04-23) and text-presence
+pivot PR1 (#182). See ``docs/operations/text-pipeline-presence-pivot-plan.md``.
 
-Architecture:
-    SEC HTML Filing
-        ↓
-    [Stage 1: Ingestion & Parsing] → Segments with XPath locators
-        ↓
-    [Stage 2: Section Classification] → MD&A, Risk Factors, etc.
-        ↓
-    [Stage 3: Table Reconstruction] → header_path, stub_path per cell
-        ↓
-    [Stage 4: Image Triage] → chart, table_image, decorative
-        ↓
-    [Stage 5: OCR & Chart Extraction] → labeled values only
-        ↓
-    [Stage 6: Metric Candidate Generation] → YAML taxonomy matching
-        ↓
-    [Stage 7: Value Binding] → structural link required
-        ↓
-    [Stage 8: Period Inference] → from header_path or context
-        ↓
-    [Stage 9: MetricFact Construction] → with evidence_pack
-        ↓
-    [Stage 10: Deduplication] → by identity tuple
-        ↓
-    [Stage 11: Validation & Review Routing] → confidence-based
+Pipeline stages (image stages and IMAGE_CLASSIFY are conditional):
+    1. Ingestion & Parsing         → Segments with XPath locators
+    2. Section Classification      → MD&A, Risk Factors, etc.
+    3. Table Reconstruction        → header_path, stub_path per cell
+    4. Image Triage                → chart, table_image, decorative
+    5. OCR & Chart Extraction      → labeled values only
+    5a. Chart Fact Bridge          → presence pairs to v2_image_assets.detected_metrics
+    5b. Image Classify             → Vision metric-classifier; appends to v2_image_classifications
+                                     (gated by ENABLE_METRIC_CLASSIFY)
+    6. Metric Candidate Generation → YAML taxonomy matching
+    7. Value Binding               → structural link required
+    7.5. False Positive Filter     → 13 rule-based suppression rules
+    8. Period Inference            → from header_path or context
+    9. MetricFact Construction     → with evidence_pack
+    9.5. Definition Extraction     → methodology / definition segments
+    10. Deduplication              → by identity tuple
+    11. Validation & Review Routing → confidence-based
+    12. MetricPresenceStage (final) → aggregate facts/charts/definitions
+                                     → v2_text_metric_presence (primary scoring surface)
 
-Design Principles (from PRD synthesis):
-    1. Structure-first, LLM-second: DOM parsing → rules → embedding → LLM fallback
-    2. No value without provenance: Every MetricFact has evidence_pack
-    3. Fail closed: Ambiguous extraction → flag for review, don't guess
-    4. Charts only when labeled: Never interpolate from axis pixels
-
-See: /Users/rgmarkey/.claude/plans/deep-conjuring-treehouse.md for full architecture
+Design Principles:
+    1. Presence-first, values advisory: presence is the headline output;
+       per-value facts are advisory evidence.
+    2. Structure-first, LLM-second: DOM parsing → rules → embedding → LLM fallback.
+    3. No claim without provenance: Every presence row carries
+       evidence_segment_ids + advisory_fact_ids; every MetricFact has evidence_pack.
+    4. Fail closed: Ambiguous extraction → flag for review, don't guess.
+    5. Charts only when labeled: Never interpolate from axis pixels.
 """
 
 __version__ = "2.0.0-rc1"

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -1,14 +1,27 @@
 """
 V2 Extraction Pipeline Persistence Layer.
 
-Provides database persistence for V2 extraction results:
+Provides idempotent database persistence for V2 extraction results:
 - Documents (v2_documents)
 - Segments (v2_segments)
 - Tables and Cells (v2_tables, v2_table_cells)
-- Image Assets (v2_image_assets)
-- Metric Facts (v2_metric_facts)
+- Image Assets (v2_image_assets, including detected_metrics JSONB)
+- Image Classifications (v2_image_classifications, append-only Vision audit trail)
+- Metric Facts (v2_metric_facts) -- advisory under the presence pivot
+- Metric Definitions (v2_metric_definitions)
+- Metric Presence (v2_text_metric_presence) -- primary scoring surface
 
-All operations are idempotent (safe to re-run).
+The ``presence_only=True`` kwarg on ``persist_pipeline_result`` skips the
+fact-write step entirely; presence rows still upsert. Mutually exclusive
+with ``chart_only=True``. See ``docs/operations/text-pipeline-presence-pivot-plan.md``
+for the rollout-PR interface contract.
+
+All operations are idempotent (safe to re-run). Re-extraction with
+``force=True`` may delete and re-emit facts; presence rows are never
+deleted by the persistence layer (only by ``filings.filing_id`` CASCADE).
+The reviewed-filing guard prevents silent CASCADE-destruction of reviewer
+work via ``v2_review_decisions.fact_id ON DELETE CASCADE`` and a parallel
+check on ``v2_image_metric_confirmations``.
 """
 
 from __future__ import annotations

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -1,26 +1,37 @@
 """
 V2 Extraction Pipeline Orchestrator.
 
-This module orchestrates the 15-stage extraction pipeline, plus an optional
-Chart Fact Bridge that runs after validation when enable_chart_fact_bridge=True:
+Orchestrates the V2 extraction stages and emits **presence** as the primary
+output (advisory facts as evidence). See
+``docs/operations/text-pipeline-presence-pivot-plan.md``.
 
-1. Ingestion & Parsing         → Segments with XPath locators
-2. Section Classification      → MD&A, Risk Factors, etc.
-3. Table Reconstruction        → header_path, stub_path per cell
-4. Image Triage                → chart, table_image, decorative
-5. OCR & Chart Extraction      → labeled values only
-6. Metric Candidate Generation → YAML taxonomy matching
-7. Value Binding               → structural link required
-7.5. False Positive Filter     → V1 FP filter on bound values
-8. Period Inference            → from header_path or context
-9. MetricFact Construction     → with evidence_pack
-10. Deduplication              → by identity tuple
-11. Validation & Review Routing → confidence-based
-12. Chart Fact Bridge (optional) → cohort facts from chart images
+Stage order (image stages 4-5b and ``IMAGE_CLASSIFY`` are conditional;
+see ``_setup_stages``):
+
+1.    Ingestion & Parsing            → Segments with XPath locators
+2.    Section Classification         → MD&A, Risk Factors, etc.
+3.    Table Reconstruction           → header_path, stub_path per cell
+4.    Image Triage                   → chart, table_image, decorative
+5.    OCR & Chart Extraction         → labeled values only (Vision)
+5a.   Chart Fact Bridge              → presence pairs to v2_image_assets.detected_metrics
+                                       (rule-based; no per-value chart facts post-#86)
+5b.   Image Classify                 → Vision metric-classifier audit trail
+                                       (gated by ENABLE_METRIC_CLASSIFY)
+6.    Metric Candidate Generation    → YAML taxonomy matching
+7.    Value Binding                  → structural link required
+7.5.  False Positive Filter          → 13 rule-based suppression rules
+8.    Period Inference               → from header_path or context
+9.    MetricFact Construction        → with evidence_pack
+9.5.  Definition Extraction          → methodology / definition segments
+10.   Deduplication                  → by identity tuple
+11.   Validation & Review Routing    → confidence-based
+12.   MetricPresenceStage (final)    → aggregate facts/charts/definitions
+                                       → v2_text_metric_presence (primary scoring surface)
 
 Design principles:
+- Presence-first, values advisory (chart pipeline emits no per-value facts post-#86)
 - Structure-first, LLM-second
-- No value without provenance
+- No claim without provenance (presence rows carry evidence_segment_ids + advisory_fact_ids)
 - Fail closed (ambiguous → review, don't guess)
 - Charts only when labeled (never interpolate from axis)
 """

--- a/src/review/README.md
+++ b/src/review/README.md
@@ -5,6 +5,14 @@ layer. The package is named `review/` for historical reasons (the V1 candidate
 generator lived here); a full rename to `extraction_shared/` would churn ~70
 files and is not worth the diff noise.
 
+> **Pivot status (2026-04-25):** Outputs from these modules feed advisory facts
+> in `v2_metric_facts`, which in turn flow through `MetricPresenceStage` into
+> `v2_text_metric_presence` (the primary scoring surface). When changing
+> `false_positive_filter.py`, `keyword_matching.py`, or `value_binding.py`
+> related logic in `src/extraction_v2/`, run `python3 -m src.gold_standard.v2_validator`
+> to check for Tier-1 regression — gate flip to presence-recall pending PR2
+> of the text-presence pivot. See `docs/operations/text-pipeline-presence-pivot-plan.md`.
+
 | Module | Exported symbols | Importer |
 |--------|-----------------|----------|
 | `false_positive_filter.py` | `FalsePositiveFilter`, `should_treat_as_percentage` | `src/extraction_v2/stages/false_positive_filter.py` |

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -352,7 +352,16 @@ def unskip_image_candidate(img_id):
 @api_unified_bp.route("/missed-metric", methods=["POST"])
 def add_missed_metric():
     """
-    Manually add a metric fact that the pipeline missed.
+    Manually add a metric fact (the manual value-entry path).
+
+    Under the chart-presence pivot (#86, 2026-04-23) the pipeline does not
+    auto-emit per-value chart facts; this endpoint is the primary path by
+    which CMASB-required values enter ``v2_metric_facts`` for chart-native
+    metrics. It is also used to capture text-fact values that the pipeline
+    missed entirely. The resulting fact carries ``extraction_method='manual'``
+    and propagates through ``MetricPresenceStage`` on the next re-extraction
+    via ``advisory_fact_ids``. See
+    ``docs/operations/text-pipeline-presence-pivot-plan.md``.
 
     Request Body:
         {


### PR DESCRIPTION
Bring root README, docs/README, and MANUAL_TESTING_GUIDE in line with the
presence-focused extraction pivot:

- Lead with presence as the primary scoring surface (per-(doc_id, metric_id))
  and reframe per-value extraction as advisory evidence
- Add Pivot status callout (chart-presence live #86; text-presence PR1 #182
  landed; PR2-PR5 pending; legacy-097/098 open)
- Add Presence and Provenance / Audit Trail to Key Concepts in docs/README
- Add presence-with-provenance SQL example (v2_text_metric_presence +
  reverse-trace to v2_segments) alongside legacy v_filing_metric_incidence
- Update V2 stages list to include MetricPresenceStage and image_classify
- Replace HUMAN_REVIEW_SYSTEM doc-table entry with deprecation pointer
- Banner MANUAL_TESTING_GUIDE as DEPRECATED (full archive in PR 3 of audit)

Architecture, operations, and development docs land in PR 2 and PR 3 of
the documentation audit series. Plan: ~/.claude/plans/now-that-we-are-snuggly-quasar.md