### PR TITLE
refactor(extraction-v2): drop chart-source branch from MetricPresenceStage (text-presence PR5)

### DIFF
--- a/docs/operations/text-pipeline-presence-pivot-plan.md
+++ b/docs/operations/text-pipeline-presence-pivot-plan.md
@@ -12,7 +12,7 @@ Strategic direction memo: `~/.claude/projects/.../memory/project_presence_first_
 | PR2 | Gold-standard presence derivation + validator + Tier 1 gate flip | Pending | — |
 | PR3 | Reviewer UI surfaces presence (`v2_text_presence_confirmations`) | Pending | sql/48 |
 | PR4 | Tier-1 definition/methodology LLM classifier | Pending | sql/49 |
-| PR5 | MetricPresenceStage chart-contribution removal (cleanup) | Pending | — |
+| PR5 | MetricPresenceStage chart-contribution removal (cleanup) | **Landed** | — |
 
 Full plan files live under `~/.claude/plans/text-presence-pr*.md` and `~/.claude/plans/text-presence-pivot-index.md`.
 
@@ -35,8 +35,8 @@ A parallel image-review redesign (`~/.claude/plans/our-disclosures-review-web-de
 
 ### Agreement (2026-04-24)
 
-1. **`ImageAsset.detected_metrics` in-memory contract is being dropped** by image-review Wave 2. The list is no longer populated after Wave 1 transition ends. Dual-write during the transition keeps the chart-source branch in `MetricPresenceStage` (src/extraction_v2/stages/metric_presence.py:86-95) working until PR5 removes it.
-2. **Text-presence stops aggregating chart contribution.** PR5 (this program) removes the chart-source branch in `MetricPresenceStage` after image-review Wave 1 lands. Non-blocking — image-review agreed to dual-write.
+1. **`ImageAsset.detected_metrics` cross-stage in-memory contract is dropped** (PR5 landed). `ChartFactBridgeStage` still populates `image.detected_metrics` as a private staging buffer for the persistence layer (writes `v2_image_assets.detected_metrics` JSONB) and for `V2GoldStandardValidator._chart_presence_set_from_context` (in-process chart presence-F1 with no persistence). No other stage reads it.
+2. **Text-presence aggregates only text signals.** PR5 removed the chart-source branch in `MetricPresenceStage`; the stage now reads facts + definitions only. Chart-derived presence flows through the image pipeline; unified doc-grain presence is exposed via `v_doc_metric_presence` (UNION of text + image, landing with image-review Wave 2).
 3. **PR2 queries `v_doc_metric_presence`, not `v2_text_metric_presence`,** for Tier 1 gate math. The view captures both text and image presence symmetrically.
 4. **Landing order for the gate transition:** image-review Wave 2 Agent C resets the chart-fact recall baseline FIRST; text PR2 flips the Tier 1 gate from fact-recall to presence-recall SECOND.
 5. **Per-table ownership:** `v2_text_metric_presence` owns text at doc grain; `v2_image_metric_presence` owns image at per-image grain. No unified confirmations table.
@@ -90,15 +90,14 @@ Field names match SQL column names 1:1 except for the DB-managed columns (`prese
 
 `src.extraction_v2.stages.metric_presence.MetricPresenceStage` runs as the **final stage** in `V2Pipeline._setup_stages`, after `ValidationStage`. Enum: `PipelineStage.METRIC_PRESENCE = "metric_presence"`.
 
-The stage reads:
+The stage reads (PR5, post chart-contribution removal):
 
 - `context.deduplicated_facts` (falls back to `context.facts` when dedup didn't run)
-- `context.images` (contributes `image.detected_metrics`)
 - `context.definitions` (contributes at floor score `_DEFINITION_ONLY_PRESENCE_SCORE = 0.5`)
 
-And writes `context.presences: list[MetricPresence]`.
+And writes `context.presences: list[MetricPresence]`. Chart-derived presence is NOT read here — it lives on `v2_image_assets.detected_metrics` (and `v2_image_metric_presence` under image-review Wave 2). Cross-source unification happens in the `v_doc_metric_presence` view, not in-stage.
 
-Scoring: max across contributing signals. Evidence: union of segment IDs from facts + definitions (chart-only presences have empty `evidence_segment_ids`). `advisory_fact_ids` lists contributing fact IDs (empty when presence comes solely from charts or definitions).
+Scoring: max across contributing text signals. Evidence: union of segment IDs from facts + definitions. `advisory_fact_ids` lists contributing fact IDs (empty when presence comes solely from definitions).
 
 ### PipelineResult field
 

--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -672,15 +672,20 @@ class DetectedMetric:
 
 @dataclass
 class MetricPresence:
-    """Per-(doc, metric) presence signal emitted by MetricPresenceStage.
+    """Per-(doc, metric) text-presence signal emitted by MetricPresenceStage.
 
     Persisted to `v2_text_metric_presence` (sql/46). Aggregates signals
-    across the text pipeline (facts from html_table / text / ocr_table
-    sources) and the chart pipeline (`ImageAsset.detected_metrics`) into
-    one record per `(doc_id, canonical_metric_id)` pair.
+    from the text pipeline only — facts from html_table / text / ocr_table
+    sources, plus definitions — into one record per
+    `(doc_id, canonical_metric_id)` pair.
 
-    Primary scoring surface for the Tier 1 regression gate under the
-    presence-first pivot — see `docs/operations/text-pipeline-presence-pivot-plan.md`.
+    Chart-derived presence lives on the image pipeline at per-image grain
+    (`v2_image_assets.detected_metrics` JSONB; `v2_image_metric_presence`
+    under image-review Wave 2). Unified doc-grain presence is exposed
+    via the `v_doc_metric_presence` view (UNION of text + image).
+
+    Primary scoring surface for the text-side Tier 1 regression gate under
+    the presence-first pivot — see `docs/operations/text-pipeline-presence-pivot-plan.md`.
     """
 
     canonical_metric_id: str

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -518,10 +518,11 @@ class V2Pipeline:
         # Stage 11: Validation & Review Routing
         self._stages.append((PipelineStage.VALIDATION, ValidationStage()))
 
-        # Stage 12: Metric Presence — final stage. Aggregates dedup'd facts,
-        # chart detected_metrics, and definitions into per-(doc, metric)
-        # presence records. Primary scoring surface under the text-presence
-        # pivot (see docs/operations/text-pipeline-presence-pivot-plan.md).
+        # Stage 12: Metric Presence — final stage. Aggregates dedup'd facts
+        # and definitions into per-(doc, metric) text-presence records
+        # (v2_text_metric_presence). Chart-derived presence is owned by the
+        # image pipeline; unified doc-grain presence is exposed via
+        # v_doc_metric_presence. See docs/operations/text-pipeline-presence-pivot-plan.md.
         self._stages.append((PipelineStage.METRIC_PRESENCE, MetricPresenceStage()))
 
     def process(

--- a/src/extraction_v2/stages/metric_presence.py
+++ b/src/extraction_v2/stages/metric_presence.py
@@ -1,30 +1,36 @@
 """
 Stage 12: Metric Presence Aggregation.
 
-Final stage of the V2 pipeline. Aggregates extraction signals across all
-surfaces — deduplicated facts (text / html_table / ocr_table / chart),
-chart-image `detected_metrics`, and definitions — into one
-``MetricPresence`` record per ``(doc, canonical_metric_id)`` pair.
+Final stage of the V2 pipeline. Aggregates text-side signals —
+deduplicated facts (text / html_table / ocr_table) and definitions —
+into one ``MetricPresence`` record per ``(doc, canonical_metric_id)``
+pair, persisted to ``v2_text_metric_presence``.
 
-Primary scoring surface for the Tier 1 regression gate under the
-text-presence pivot. See ``docs/operations/text-pipeline-presence-pivot-plan.md``.
+Chart-derived presence is owned by the image pipeline at per-image grain
+(``v2_image_assets.detected_metrics`` JSONB today; ``v2_image_metric_presence``
+under image-review Wave 2). Unified doc-grain presence is exposed via the
+``v_doc_metric_presence`` view (UNION of text + image). See
+``docs/operations/text-pipeline-presence-pivot-plan.md`` — agreement (5):
+per-table ownership, no in-stage cross-write.
+
+Primary scoring surface for the text-side Tier 1 regression gate under
+the text-presence pivot.
 
 Design invariants (must hold; downstream PRs depend on them):
 
 - One record per ``(doc_id, canonical_metric_id)``. Duplicates are an error
   upstream; ``_persist_presence_in_tx`` upsert would otherwise collapse
   them silently.
-- ``score`` is the MAX confidence across all contributing signals.
+- ``score`` is the MAX confidence across all contributing text signals.
 - ``evidence_segment_ids`` is the union of segment IDs from contributing
   facts (via ``fact.source_locator.segment_id``) and from definitions
-  (``definition_segment_id`` / ``methodology_segment_id``). Chart-only
-  presences have no segment IDs — evidence lives on the image row.
+  (``definition_segment_id`` / ``methodology_segment_id``).
 - ``advisory_fact_ids`` lists the fact IDs that contributed. Empty when
-  presence comes solely from chart ``detected_metrics`` or definitions.
+  presence comes solely from definitions.
 - ``advisory_value_count`` is the count of contributing facts (not unique
   values). Rough disclosure-depth signal for downstream UI.
 
-The stage never mutates ``context.facts`` / ``context.images`` / etc. — it
+The stage never mutates ``context.facts`` / ``context.definitions`` — it
 only reads them and writes ``context.presences``.
 """
 
@@ -42,16 +48,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Scores assigned to presence signals when no explicit confidence exists.
-# Facts always carry ``confidence``; charts carry ``DetectedMetric.score``.
-# Definition-only presence is weaker than a value-bearing fact, so we floor
-# it at 0.5 — same threshold the chart pipeline uses for minimum presence
-# emission (``chart_presence_min_score``).
+# Score assigned to definition-only presence when no fact carries a
+# canonical_metric_id. Facts always carry ``confidence``; definition-only
+# presence is weaker than a value-bearing fact, so we floor it at 0.5.
 _DEFINITION_ONLY_PRESENCE_SCORE = 0.5
 
 
 class MetricPresenceStage:
-    """Aggregate per-(doc, metric) presence records from all surfaces."""
+    """Aggregate per-(doc, metric) text-presence records from facts + definitions."""
 
     def process(self, context: PipelineContext) -> StageResult:
         from src.extraction_v2.pipeline import PipelineStage, StageResult
@@ -83,19 +87,10 @@ class MetricPresenceStage:
             if seg_id:
                 acc.segment_ids.add(seg_id)
 
-        # Source 2: chart detected_metrics from ChartFactBridgeStage.
-        for image in context.images:
-            for detected in image.detected_metrics:
-                if not detected.metric_id:
-                    continue
-                acc = accumulator.setdefault(
-                    detected.metric_id,
-                    _Accumulator(first_stage=PipelineStage.CHART_FACT_BRIDGE.value),
-                )
-                acc.score = max(acc.score, float(detected.score))
-
-        # Source 3: definitions (weaker signal; contributes only when
+        # Source 2: definitions (weaker signal; contributes only when
         # no stronger signal exists, but always adds evidence segment IDs).
+        # Chart-derived presence is owned by the image pipeline and surfaces
+        # via v_doc_metric_presence — see module docstring.
         for definition in context.definitions:
             if not definition.canonical_metric_id:
                 continue
@@ -133,15 +128,13 @@ class MetricPresenceStage:
             stage=PipelineStage.METRIC_PRESENCE,
             success=True,
             duration_ms=duration_ms,
-            items_processed=len(facts) + len(context.images) + len(context.definitions),
+            items_processed=len(facts) + len(context.definitions),
             items_output=len(context.presences),
             metadata={
                 "metrics_present": len(context.presences),
                 "fact_contributors": sum(p.advisory_value_count for p in context.presences),
-                "chart_only_presences": sum(
-                    1
-                    for p in context.presences
-                    if p.advisory_value_count == 0 and not p.evidence_segment_ids
+                "definition_only_presences": sum(
+                    1 for p in context.presences if p.advisory_value_count == 0
                 ),
             },
         )

--- a/tests/unit/extraction_v2/test_metric_presence_stage.py
+++ b/tests/unit/extraction_v2/test_metric_presence_stage.py
@@ -2,8 +2,12 @@
 Unit tests for MetricPresenceStage.
 
 Contract under the text-presence pivot: produce one MetricPresence record
-per (doc, metric_id) with max score across contributing signals, union of
-evidence segment IDs, and fact_id list for facts that contributed.
+per (doc, metric_id) with max score across contributing TEXT signals
+(facts + definitions), union of evidence segment IDs, and fact_id list
+for facts that contributed. Chart-derived presence is owned by the image
+pipeline (`v2_image_assets.detected_metrics` / `v2_image_metric_presence`)
+and is NOT folded into v2_text_metric_presence — see
+docs/operations/text-pipeline-presence-pivot-plan.md (PR5).
 """
 
 from __future__ import annotations
@@ -139,23 +143,23 @@ class TestMetricPresenceStage:
         assert len(ctx.presences) == 1
         assert ctx.presences[0].score == 0.5
 
-    def test_chart_detected_metrics_contribute(self) -> None:
+    def test_chart_detected_metrics_do_not_contribute(self) -> None:
+        # Per PR5 (text-presence pivot): chart-derived presence is owned by
+        # the image pipeline and lives in v2_image_assets.detected_metrics
+        # (today) / v2_image_metric_presence (Wave 2). MetricPresenceStage
+        # only reads text-side signals; a chart-only image must not produce
+        # a v2_text_metric_presence row.
         img = _chart_image([("cm_revenue_by_cohort", 0.85)])
         ctx = _make_context(images=[img])
 
         MetricPresenceStage().process(ctx)
 
-        assert len(ctx.presences) == 1
-        p = ctx.presences[0]
-        assert p.canonical_metric_id == "cm_revenue_by_cohort"
-        assert p.score == 0.85
-        assert p.advisory_value_count == 0  # chart-only, no text facts
-        assert p.advisory_fact_ids == []
-        assert p.evidence_segment_ids == []  # chart evidence lives on image
-        assert p.detected_at_stage == PipelineStage.CHART_FACT_BRIDGE.value
+        assert ctx.presences == []
 
-    def test_fact_and_chart_merge_into_single_presence(self) -> None:
-        # Chart detects metric at 0.7; text fact independently binds at 0.9.
+    def test_chart_does_not_affect_fact_presence(self) -> None:
+        # A text fact for the same metric a chart also detects — the chart
+        # contribution is ignored; the resulting presence record reflects
+        # only the fact's score, fact_ids, and evidence segments.
         fact = _fact("cm_revenue_by_cohort", confidence=0.9, segment_id="seg-1")
         img = _chart_image([("cm_revenue_by_cohort", 0.7)])
         ctx = _make_context(dedup=[fact], images=[img])
@@ -164,11 +168,10 @@ class TestMetricPresenceStage:
 
         assert len(ctx.presences) == 1
         p = ctx.presences[0]
-        assert p.score == 0.9  # max of fact + chart
+        assert p.score == 0.9  # fact only; chart 0.7 ignored
         assert p.advisory_value_count == 1
         assert p.advisory_fact_ids == [fact.fact_id]
         assert p.evidence_segment_ids == ["seg-1"]
-        # detected_at_stage comes from whoever seeded the accumulator first
         assert p.detected_at_stage == PipelineStage.FACT_CONSTRUCTION.value
 
     def test_definition_alone_emits_presence_at_floor_score(self) -> None:
@@ -233,15 +236,24 @@ class TestMetricPresenceStage:
         assert [p.canonical_metric_id for p in ctx.presences] == ["cm_real"]
 
     def test_stage_result_metadata_has_counters(self) -> None:
+        # One fact-backed metric, one definition-only metric. Chart image
+        # carries detected_metrics that should NOT be counted by this stage
+        # (chart presence lives on the image pipeline).
         fact = _fact("cm_a", confidence=0.8, segment_id="seg")
-        img = _chart_image([("cm_b", 0.6)])
-        ctx = _make_context(dedup=[fact], images=[img])
+        defn = MetricDefinition(
+            canonical_metric_id="cm_b",
+            doc_id="42",
+            definition_text="cm_b is...",
+            definition_segment_id="seg-def",
+        )
+        img = _chart_image([("cm_c", 0.6)])  # ignored by MetricPresenceStage
+        ctx = _make_context(dedup=[fact], definitions=[defn], images=[img])
 
         result = MetricPresenceStage().process(ctx)
 
         assert result.success
         assert result.stage == PipelineStage.METRIC_PRESENCE
-        assert result.items_output == 2
+        assert result.items_output == 2  # cm_a + cm_b only; cm_c ignored
         assert result.metadata["metrics_present"] == 2
         assert result.metadata["fact_contributors"] == 1
-        assert result.metadata["chart_only_presences"] == 1
+        assert result.metadata["definition_only_presences"] == 1


### PR DESCRIPTION
## Summary

Implements **PR5** from `docs/operations/text-pipeline-presence-pivot-plan.md` — the *MetricPresenceStage chart-contribution removal (cleanup)*. After this lands, `v2_text_metric_presence` is text-only; chart-derived presence is owned exclusively by the image pipeline (`v2_image_assets.detected_metrics` JSONB today; `v2_image_metric_presence` under image-review Wave 2). Unified doc-grain presence will surface via the `v_doc_metric_presence` UNION view.

## What changed

- `src/extraction_v2/stages/metric_presence.py` — drop the chart-source loop (formerly Source 2). Stage now reads facts + definitions only. Metadata counter renamed `chart_only_presences` → `definition_only_presences`. Module + class docstrings rewritten to describe text-only ownership.
- `src/extraction_v2/models.py` — `MetricPresence` docstring rewritten (text-only).
- `src/extraction_v2/pipeline.py` — Stage 12 setup comment updated.
- `tests/unit/extraction_v2/test_metric_presence_stage.py` — three tests inverted: `test_chart_detected_metrics_do_not_contribute` (was `..._contribute`), `test_chart_does_not_affect_fact_presence` (was `test_fact_and_chart_merge_into_single_presence`), and `test_stage_result_metadata_has_counters` (now exercises a definition-only path and asserts `definition_only_presences=1`).
- `docs/operations/text-pipeline-presence-pivot-plan.md` — PR5 row flipped to **Landed**, agreement (1)/(2) and the PR1 contract \"Source 2\" line reworded.

## What did NOT change (intentionally)

- `ChartFactBridgeStage` still populates `image.detected_metrics`. It is no longer a *cross-stage* contract — it is a private staging buffer for `V2PersistenceAdapter._persist_images_in_tx` (writes the JSONB column) and for `V2GoldStandardValidator._chart_presence_set_from_context` (in-process chart presence-F1, no persistence). No other stage reads it.
- The `ImageAsset.detected_metrics` model field stays. Removing it would force a parallel in-memory transport for marginal cleanliness — out of scope for PR5.

## Coordination

Per the cross-pivot coordination memo, agreement (2):
> Text-presence stops aggregating chart contribution. PR5 (this program) removes the chart-source branch in MetricPresenceStage after image-review Wave 1 lands. Non-blocking — image-review agreed to dual-write.

- This PR must NOT merge before **text-presence PR2 (Tier-1 gate flip)** OR PR2 must be aware of it. PR2 was not yet open at authoring time (`gh pr list` was empty); PR2 will read `v_doc_metric_presence` for Tier-1 math, which captures chart presence symmetrically once image-review Wave 2 lands its `v2_image_metric_presence` table + view.
- Image-review Wave 2 is independent of this PR — Wave 1 dual-write keeps `v2_image_assets.detected_metrics` JSONB populated, so the validator and JSONB readers stay green throughout.

## Test plan

- [x] `pytest tests/unit` — 3929 passed, 5 skipped
- [x] `pytest tests/integration/extraction_v2/test_persistence_guard.py tests/integration/extraction_v2/test_presence_persistence.py` — 24 passed
- [x] `python3 -m src.gold_standard.v2_validator --limit 3 --workers 1` — Tier 1 P=91.7% R=64.7% F1=75.9% (validator's chart presence-F1 path reads `image.detected_metrics` directly; numbers confirm it is unchanged by this refactor)
- [x] Pre-commit + pre-push hooks (ruff, extraction/docs guard, pytest pre-push) — all passed
- [ ] CI green (Lint, Unit Tests, Integration Tests, Vulnerability Scan, UI E2E)
- [ ] Confirmation in linked PR2 thread that PR2 author is aware (or PR2 has merged before this PR auto-merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)