### PR TITLE
fix(extraction-cron): fail batch on stage error (legacy-101)

### DIFF
--- a/docs/known-issues/legacy-101-extraction-cron-silent-success-on-pipeline-error.md
+++ b/docs/known-issues/legacy-101-extraction-cron-silent-success-on-pipeline-error.md
@@ -6,7 +6,7 @@ id: 101
 severity: high
 slug: extraction-cron-silent-success-on-pipeline-error
 source: legacy
-status: open
+status: resolved
 title: Extraction Cron Reports Success With 0 Facts on Fatal Pipeline Error
 touches:
   - scripts/batch_v2_extraction.py
@@ -22,11 +22,12 @@ persists 0 facts, and still increments the success counter. The final log line r
 successful with no alert. The issue was observed on 2026-04-24 when the boto3 lockfile
 omission caused every run to silently extract nothing.
 
-### Next Steps
+### Resolution
 
-- In `batch_v2_extraction.py`, distinguish a pipeline exception (which should count as
-  a failure and exit non-zero) from a legitimate empty result (filing has no relevant
-  segments).
-- Consider adding a minimum-facts guard: if a filing has content and the pipeline
-  returns 0 facts, treat it as a soft failure and log at `ERROR` level.
-- Add a test that injects a stage exception and asserts the batch exits non-zero.
+`scripts/batch_v2_extraction.py` now checks `result.success` after `pipeline.process()`
+returns. When a critical stage emits `V2FatalError` and the pipeline returns
+`PipelineResult(success=False, error_message=...)`, the worker marks the filing
+`extraction_failed`, propagates `success=False` to the batch stats, and skips the
+empty persist. The batch's existing exit-code logic
+(`sys.exit(1) if stats.failed > stats.succeeded`) then surfaces the failure to Render.
+Regression guard: `tests/unit/test_batch_v2_extraction.py::TestPipelineFailurePropagates`.

--- a/scripts/batch_v2_extraction.py
+++ b/scripts/batch_v2_extraction.py
@@ -292,6 +292,30 @@ def _process_filing_worker(
                 "retried": False,
             }
 
+        # Pipeline-level failure (legacy-101): a critical stage hit V2FatalError
+        # or returned success=False. Without this guard, an empty PipelineResult
+        # would persist trivially (0 rows succeed), the filing would be marked
+        # 'extracted' with zero facts, and the worker would report success.
+        if not result.success:
+            try:
+                _db = DatabaseAdapter(db_url)
+                _db.execute(
+                    "UPDATE filings SET processing_status = 'extraction_failed', updated_at = now()"
+                    " WHERE filing_id = %(filing_id)s",
+                    {"filing_id": filing_id},
+                )
+            except Exception:
+                pass
+            return {
+                "filing_id": filing_id,
+                "success": False,
+                "fact_count": 0,
+                "definition_count": 0,
+                "error": result.error_message or "pipeline reported failure",
+                "duration_ms": duration_ms,
+                "retried": False,
+            }
+
         # Persist results
         db = DatabaseAdapter(db_url)
         adapter = V2PersistenceAdapter(db)

--- a/tests/unit/test_batch_v2_extraction.py
+++ b/tests/unit/test_batch_v2_extraction.py
@@ -697,3 +697,63 @@ class TestChartOnlyConfig:
             "chart_only": config.chart_only,
         }
         assert worker_dict["chart_only"] is True
+
+
+class TestPipelineFailurePropagates:
+    """Regression guard for legacy-101: pipeline failure must not be reported as success."""
+
+    def _failed_pipeline_result(self):
+        result = MagicMock()
+        result.success = False
+        result.error_message = "Critical stage fatal error: ingestion: No module named 'boto3'"
+        result.fact_count = 0
+        result.facts = []
+        result.definitions = []
+        result.segments = []
+        return result
+
+    def test_worker_reports_failure_when_pipeline_fails(self, tmp_path):
+        """A PipelineResult with success=False must mark filing extraction_failed
+        and return success=False — not get persisted as an empty 'extracted' result."""
+        html_file = tmp_path / "filing.htm"
+        html_file.write_text("<html><body>x</body></html>")
+
+        db_executes = []
+        with patch("src.infra.db.DatabaseAdapter") as mock_db_cls:
+            mock_db = MagicMock()
+            mock_db.execute.side_effect = lambda sql, params: db_executes.append((sql, params))
+            mock_db_cls.return_value = mock_db
+
+            with patch("src.extraction_v2.pipeline.V2Pipeline") as mock_pipeline_cls:
+                mock_pipeline = MagicMock()
+                mock_pipeline.process.return_value = self._failed_pipeline_result()
+                mock_pipeline_cls.return_value = mock_pipeline
+
+                with patch(
+                    "src.extraction_v2.persistence.V2PersistenceAdapter"
+                ) as mock_adapter_cls:
+                    mock_adapter = MagicMock()
+                    mock_adapter_cls.return_value = mock_adapter
+
+                    result = _process_filing_worker(
+                        filing_id=1545,
+                        html_path=str(html_file),
+                        company_name="TestCo",
+                        company_id=1,
+                        cik="0001234",
+                        accession_number="0001234-24-000001",
+                        filing_date=None,
+                        db_url="postgresql://test/db",
+                        config_dict={},
+                    )
+
+                    assert mock_adapter.persist_pipeline_result.call_count == 0, (
+                        "persist must be skipped when pipeline reports failure"
+                    )
+
+        assert result["success"] is False
+        assert result["fact_count"] == 0
+        assert "boto3" in result["error"]
+        assert any("extraction_failed" in sql for sql, _ in db_executes), (
+            "filing must be marked extraction_failed"
+        )


### PR DESCRIPTION
## Summary

- Closes legacy-101: extraction cron silently reported success on fatal pipeline errors
- `scripts/batch_v2_extraction.py` now inspects `result.success` after `pipeline.process()` and marks the filing `extraction_failed` when a critical stage emits `V2FatalError`. Without this guard, an empty `PipelineResult` persisted trivially (0 rows succeed), the filing got stamped `extracted`, and the worker reported `1/1 succeeded` — masking outages
- Observed live on the 2026-04-24 06:00 UTC Render run, where boto3 was missing from the docker image and every filing silently extracted nothing (boto3 itself was fixed by #174; this PR closes the silent-success class of bug)
- Adds regression guard `tests/unit/test_batch_v2_extraction.py::TestPipelineFailurePropagates::test_worker_reports_failure_when_pipeline_fails`
- Flips `docs/known-issues/legacy-101-*.md` to `status: resolved`

## Test plan

- [x] `pytest tests/unit/test_batch_v2_extraction.py -x -q` — 38 passed
- [x] `pytest tests/unit/ -x -q` — 3930 passed, 5 skipped
- [x] `ruff check src/ tests/ scripts/` — clean
- [ ] Confirm next 06:00 UTC `filings-extraction` Render run records `1/1 succeeded` (or honest failure) instead of silent success with 0 facts

🤖 Generated with [Claude Code](https://claude.com/claude-code)