### PR TITLE
feat(extraction-v2): PR2 — flip Tier-1 gate to text-presence-recall

### DIFF
--- a/.claude/rules/gold-standard.md
+++ b/.claude/rules/gold-standard.md
@@ -34,21 +34,24 @@ Non-zero exit indicates a regression.
 
 ### 3. If Regression Detected
 
-Check the **tier breakdown** in validation output to determine severity:
+The validator now prints two tier breakdowns (under the text-presence pivot, PR2):
 
-**Tier 1 regression (must-not-miss metrics):** Blocker. Fix before committing.
-- Investigate root cause (missed keywords, FP rule too aggressive, value binding gap)
-- Do not trade Tier 1 recall for Tier 2 improvements
+- `==== METRIC TIER BREAKDOWN ====` — fact-level P/R/F1 per tier (informational).
+- `==== TEXT-PRESENCE TIER BREAKDOWN (PR2 Tier-1 gate surface) ====` — presence-recall per tier; Tier 1 labelled `[GATE]`, Tier 2 `[informational]`.
 
-**Tier 2 regression (nice-to-have metrics):** Acceptable if Tier 1 improves or holds.
-- Document the trade-off rationale in commit message
-- No need to fix unless Tier 2 drop is severe (>5pp F1)
+**Tier 1 presence-recall regression:** Blocker. The gate fires only on this metric. Fix before committing.
+- Investigate root cause: a Tier-1 metric that was previously surfaced via `MetricPresenceStage` is no longer being surfaced. Check (a) keyword coverage in `config/metric_keywords.yaml`, (b) whether candidate-generation produces any signal for that metric, (c) whether `ChartFactBridgeStage` is contributing presence for chart-only metrics, (d) whether definitions for that metric got dropped.
+- Do not trade Tier 1 presence for Tier 2 improvements.
 
-**Mixed regression:** If Tier 1 improves but Tier 2 regresses, this is generally acceptable. Note the trade-off in the commit message.
+**Tier 1 fact-recall regression (informational):** No longer gates. Reported with `[informational]` label. Worth investigating if downstream fidelity matters, but acceptable for fact numbers to drift while presence holds.
 
-For any regression:
-- Check if trade-off is intentional (precision vs recall)
-- If unintentional on Tier 1, fix before committing
+**Tier 2 regression (presence or fact):** Acceptable if Tier 1 holds. Document the trade-off in the commit message; no fix required unless Tier-2 presence-recall drop exceeds ~5pp.
+
+**Mixed regression:** Tier 1 presence holding + everything else dropping is acceptable under PR2. The pivot intentionally accepts fact-level drift in favor of presence stability.
+
+For any Tier-1 presence regression:
+- Check if trade-off is intentional (precision vs recall on the presence side)
+- If unintentional, fix before committing
 
 ### 4. Update V2 Baseline (after intentional changes)
 ```bash
@@ -76,10 +79,10 @@ python3 -m src.gold_standard.v2_validator --limit 3 --workers 1
 
 ## Thresholds
 
-- Regression tolerance: 1% (configurable via `--tolerance`)
-- Validator fails if any metric drops below baseline - tolerance
-- **Tier-aware policy:** Tier 1 regressions are blockers; Tier 2 regressions are acceptable trade-offs (see "If Regression Detected" above)
-- Tier definitions: `config/metric_keywords.yaml` (`tier:` field per metric)
+- Regression tolerance: 0% by default (zero-tolerance on Tier-1 presence-recall under PR2 — `compare_to_baseline` accepts a `tolerance` arg, but `--fail-on-regression` does not currently expose it).
+- **Gate metric (PR2):** `tier1_presence_recall` from the regenerated `data/gold_standard/v2_baseline.json`. Validator fails if `current.tier1_presence_recall - baseline.tier1_presence_recall < -tolerance`.
+- **Tier-aware policy:** Tier 1 presence-recall regression is the sole blocker; everything else (fact-level deltas, per-company drops, chart presence_f1, Tier-2 presence-recall) is informational.
+- Tier definitions: `config/metric_keywords.yaml` (`tier:` field per metric).
 
 ## Transcript Gold Standard
 

--- a/.claude/rules/v2-pipeline.md
+++ b/.claude/rules/v2-pipeline.md
@@ -153,7 +153,10 @@ alongside `chart_only=True` to explicitly accept that loss.
 When improving keywords, FP rules, or value binding, prioritize **Tier 1** metrics. Tier definitions live in `config/metric_keywords.yaml` (`tier:` field). See CLAUDE.md for the full tier listing.
 
 **Tier 1 measurement under the chart-presence pivot (#86, shipped 2026-04-23):**
-Chart-native metrics are measured via **presence-F1** on `v2_image_assets.detected_metrics` (see `docs/GOLD_STANDARD_SPECIFICATION.md` and PR #150). Per-value value-F1 on chart rows is no longer meaningful — the pipeline does not emit per-value chart facts. Text/table-sourced facts continue to be measured via value-F1. Text-pipeline Tier 1 recall work concluded 2026-04-16 (commits dd5c90a, 09a8f64); chart-pipeline gains now accrue via presence-F1 and reviewer confirmation throughput.
+Chart-native metrics are measured via **presence-F1** on `v2_image_assets.detected_metrics` (see `docs/GOLD_STANDARD_SPECIFICATION.md` and PR #150). Per-value value-F1 on chart rows is no longer meaningful — the pipeline does not emit per-value chart facts. Text/table-sourced facts continue to be measured via value-F1.
+
+**Tier 1 measurement under the text-presence pivot (PR2, this PR):**
+The Tier-1 regression gate now keys on **`tier1_presence_recall`** in `data/gold_standard/v2_baseline.json`, derived from `MetricPresenceStage` output (`PipelineResult.presences` — text + chart + definitions, aggregated). Fact-level Tier-1 R/P/F1, per-company drops, and chart `presence_f1` are computed and printed as `[informational]` but no longer set `has_regression`. See `docs/operations/text-pipeline-presence-pivot-plan.md` for the full pivot plan.
 
 **Known chart-pipeline considerations (post-pivot):**
 - **Chart OCR JSON quality** — `VisionClient.analyze_image()` passes `response_format={"type": "json_object"}` so gpt-4o returns valid JSON; `_parse_chart_json` has a truncation-repair fallback. Malformed `chart_data` now degrades the *presence signal* (classifier may miss a metric), not downstream per-value correctness.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ Metrics are classified into importance tiers based on analytical value. These ti
 - All other `cm_*` metrics (customer counts, MAU/DAU, ARPU, AOV, etc.)
 
 **Rules:**
-- Tier 1 regression in gold standard validation = blocker, must fix before the PR can merge (enforced locally by the pre-commit hook, again in CI on the PR)
+- **Tier 1 presence-recall regression = blocker** under the text-presence pivot (PR #182, PR2 — `docs/operations/text-pipeline-presence-pivot-plan.md`). Enforced by `compare_to_baseline` in `src/gold_standard/baseline.py`, fired by `python3 -m src.gold_standard.v2_validator --fail-on-regression` (local pre-commit hook + CI). The gate uses `tier1_presence_recall` on `data/gold_standard/v2_baseline.json`.
+- Tier-1 fact-recall + per-company fact-recall + chart presence_f1 are still computed and printed but are **informational only** — they no longer set `has_regression`. The pivot's primary scoring surface is per-(document, metric) presence detection; fact emission is advisory evidence.
 - Tier 2 regression = acceptable trade-off if Tier 1 improves; note in PR description
 - Extraction improvements (keywords, FP rules, value binding) should prioritize Tier 1 recall gaps first
 - Gold standard coverage expansion should target Tier 1 metrics with low coverage

--- a/data/gold_standard/v2_baseline.json
+++ b/data/gold_standard/v2_baseline.json
@@ -1,10 +1,10 @@
 {
-  "baseline_date": "2026-04-24T02:46:34.842851+00:00",
-  "description": "Post-#158 cohort-pivot cleanup drift: recall +12%, F1 +7%, Slack precision -0.87%. Accepted as new truth before Leg B lands.",
+  "baseline_date": "2026-04-25T16:30:38.275531+00:00",
+  "description": "PR2 — flip Tier-1 gate to text-presence-recall. Tier-1 presence-recall blocker; fact-level + presence_f1 + per-company demoted to informational. Captures post-#182 (text-presence pivot) and post-#192 (chart-fact promotion) state.",
   "overall": {
-    "precision": 0.6593886462882096,
-    "recall": 0.5807692307692308,
-    "f1": 0.6175869120654397
+    "precision": 0.6507936507936508,
+    "recall": 0.3025830258302583,
+    "f1": 0.41309823677581864
   },
   "by_company": {
     "Chewy, Inc.": {
@@ -18,9 +18,9 @@
       "f1": 0.45454545454545453
     },
     "Farfetch Limited": {
-      "precision": 0.5925925925925926,
-      "recall": 1.0,
-      "f1": 0.7441860465116279
+      "precision": 0.0,
+      "recall": 0.0,
+      "f1": 0.0
     },
     "Flywire Corp": {
       "precision": 1.0,
@@ -58,14 +58,14 @@
       "f1": 0.4444444444444445
     },
     "Slack Technologies": {
-      "precision": 0.868421052631579,
-      "recall": 0.9705882352941176,
-      "f1": 0.9166666666666667
+      "precision": 0.0,
+      "recall": 0.0,
+      "f1": 0.0
     },
     "Slack Technologies, Inc.": {
-      "precision": 0.5263157894736842,
-      "recall": 0.9090909090909091,
-      "f1": 0.6666666666666666
+      "precision": 0.0,
+      "recall": 0.0,
+      "f1": 0.0
     },
     "Snowflake Inc": {
       "precision": 0.7586206896551724,
@@ -82,5 +82,7 @@
       "recall": 0.3333333333333333,
       "f1": 0.4736842105263157
     }
-  }
+  },
+  "tier1_presence_recall": 0.8529411764705882,
+  "tier2_presence_recall": 0.9130434782608695
 }

--- a/docs/development/metrics-taxonomy.md
+++ b/docs/development/metrics-taxonomy.md
@@ -14,13 +14,13 @@ This document defines the **metric taxonomy** for the Customer Metrics Filings A
 
 It serves four purposes:
 
-- Define a **controlled vocabulary** of metrics and concepts  
-- Specify **business definitions** and **calculation rules** for Phase 1 Core Metrics  
-- Enumerate **synonyms and variants** we expect to see in SEC filings  
+- Define a **controlled vocabulary** of metrics and concepts
+- Specify **business definitions** and **calculation rules** for Phase 1 Core Metrics
+- Enumerate **synonyms and variants** we expect to see in SEC filings
 - Provide a foundation for:
-  - Data model design (`03_DATA_MODEL_SPEC.md`)  
-  - Extraction rules and prompts  
-  - Quality/comparability assessment  
+  - Data model design (`03_DATA_MODEL_SPEC.md`)
+  - Extraction rules and prompts
+  - Quality/comparability assessment
 
 All extraction, QA, and analysis must use these canonical metric IDs and definitions.
 
@@ -32,37 +32,37 @@ All extraction, QA, and analysis must use these canonical metric IDs and definit
 
 We classify metrics into three groups:
 
-1. **Core Metrics (Phase 1)**  
-   - Highest priority for S-1 analysis  
-   - Must be handled with the strongest detection, extraction, and QA  
-   - Definitions should be as close as possible to CMASB’s long-term standards  
+1. **Core Metrics (Phase 1)**
+   - Highest priority for S-1 analysis
+   - Must be handled with the strongest detection, extraction, and QA
+   - Definitions should be as close as possible to CMASB’s long-term standards
 
-2. **Extended Metrics (Phase 1)**  
-   - Important, but secondary to Core Metrics in Phase 1  
-   - We track incidence and basic values when feasible  
-   - Definitions can be somewhat looser initially  
+2. **Extended Metrics (Phase 1)**
+   - Important, but secondary to Core Metrics in Phase 1
+   - We track incidence and basic values when feasible
+   - Definitions can be somewhat looser initially
 
-3. **Future Metrics (Phase 2+)**  
-   - Anticipated metrics for later phases (e.g., full NRR, GRR, LTV)  
-   - Included here to ensure the taxonomy will scale, but not required for Phase 1 delivery  
+3. **Future Metrics (Phase 2+)**
+   - Anticipated metrics for later phases (e.g., full NRR, GRR, LTV)
+   - Included here to ensure the taxonomy will scale, but not required for Phase 1 delivery
 
 ### 2.2 Canonical IDs and naming
 
-- All metrics use **lower_snake_case** IDs.  
+- All metrics use **lower_snake_case** IDs.
 - Prefix `cm_` for customer metrics to avoid collisions with generic financial metrics.
 
 Examples:
 
-- Core: `cm_new_customers_acquired`  
-- Extended: `cm_active_customers_total`, `cm_revenue_per_customer`  
+- Core: `cm_new_customers_acquired`
+- Extended: `cm_active_customers_total`, `cm_revenue_per_customer`
 - Future: `cm_lifetime_value_per_customer`
 
 These IDs are the **single source of truth** across:
 
-- Data model fields  
-- Extraction rules  
-- LLM prompts  
-- Analytics code  
+- Data model fields
+- Extraction rules
+- LLM prompts
+- Analytics code
 
 ### 2.3 Data model mapping
 
@@ -89,9 +89,9 @@ All references to "Core", "Extended", or "Future" metrics in this document are i
 
 ### 3.1 CM1 – New Customers Acquired per Period
 
-**ID:** `cm_new_customers_acquired`  
-**Class:** Core (Phase 1)  
-**Tier:** 1 (promoted 2026-04-15)  
+**ID:** `cm_new_customers_acquired`
+**Class:** Core (Phase 1)
+**Tier:** 1 (promoted 2026-04-15)
 
 **Business intent**
 
@@ -111,57 +111,57 @@ Measure how many **new customers** a company acquires in each reporting period. 
 
 - **Time**:
   - `period_start`, `period_end`
-  - `period_type` (e.g., FY, Q, half-year, month)  
+  - `period_type` (e.g., FY, Q, half-year, month)
 - **Company**:
-  - `cik`, `company_id`  
+  - `cik`, `company_id`
 
 **Optional dimensions**
 
-- Acquisition channel (e.g., direct, partner, marketplace)  
-- Geography  
-- Customer type (consumer, SMB, enterprise)  
+- Acquisition channel (e.g., direct, partner, marketplace)
+- Geography
+- Customer type (consumer, SMB, enterprise)
 
 **Calculation rules (ideal standard)**
 
-1. A “new customer” is one whose **first transaction** or **first billed revenue** occurs in the period.  
-2. Customers who previously churned and then reactivated should be counted separately as **reactivated customers**, not as “new customers,” where such information is available.  
+1. A “new customer” is one whose **first transaction** or **first billed revenue** occurs in the period.
+2. Customers who previously churned and then reactivated should be counted separately as **reactivated customers**, not as “new customers,” where such information is available.
 3. The count should be based on the same underlying system as revenue recognition (e.g., billing, CRM, subscription system).
 
 **What counts in Phase 1**
 
 - Any disclosed metric clearly described as:
-  - “New customers”  
-  - “New subscribers”  
-  - “Gross adds”  
-  - “New logos”  
-  - “New paying accounts”  
+  - “New customers”
+  - “New subscribers”
+  - “Gross adds”
+  - “New logos”
+  - “New paying accounts”
 - We will flag whether the issuer:
-  - Includes reactivated customers  
-  - Includes non-paying users  
+  - Includes reactivated customers
+  - Includes non-paying users
   - Uses a different definition (see Section 7 on alignment)
 
 **Common synonyms and phrases**
 
-- New customers  
-- New paying customers  
-- New subscribers  
-- Gross customer adds  
-- New logos  
-- First-time buyers  
+- New customers
+- New paying customers
+- New subscribers
+- Gross customer adds
+- New logos
+- First-time buyers
 
 **Out-of-scope / must not map here**
 
-- Total customers at period end  
-- Total users (including non-paying) unless clearly defined as “customers”  
-- Sales leads, sign-ups, or app downloads without evidence of economic activity  
+- Total customers at period end
+- Total users (including non-paying) unless clearly defined as “customers”
+- Sales leads, sign-ups, or app downloads without evidence of economic activity
 
 ---
 
 ### 3.2 CM2 – Customers at Period End by Tenure Cohort
 
-**ID:** `cm_customers_period_end_by_tenure`  
-**Class:** Core (Phase 1)  
-**Tier:** 1 (promoted 2026-04-15)  
+**ID:** `cm_customers_period_end_by_tenure`
+**Class:** Core (Phase 1)
+**Tier:** 1 (promoted 2026-04-15)
 
 **Business intent**
 
@@ -173,64 +173,64 @@ Measure the **size and age structure** of the active customer base at the end of
 
 Example tenure buckets (illustrative):
 
-- 0–1 years since first purchase  
-- 1–2 years  
-- 2–3 years  
-- 3–5 years  
-- 5+ years  
+- 0–1 years since first purchase
+- 1–2 years
+- 2–3 years
+- 3–5 years
+- 5+ years
 
 **Units**
 
-- Integer count of customers  
+- Integer count of customers
 
 **Required dimensions**
 
 - Time:
-  - `period_end`, `period_type`  
+  - `period_end`, `period_type`
 - Tenure cohort:
-  - `cohort_type = 'tenure'`  
-  - `cohort_bucket` (e.g., “0–1 years”)  
+  - `cohort_type = 'tenure'`
+  - `cohort_bucket` (e.g., “0–1 years”)
 
 **Optional dimensions**
 
-- Customer type (consumer, SMB, enterprise)  
-- Geography  
-- Product / subscription plan  
+- Customer type (consumer, SMB, enterprise)
+- Geography
+- Product / subscription plan
 
 **Calculation rules (ideal standard)**
 
-1. Customer tenure is measured from **first qualifying economic activity**.  
+1. Customer tenure is measured from **first qualifying economic activity**.
 2. A customer is **included in a tenure cohort** if:
-   - They are **active** at period end (see definition of Active Customer)  
-   - Their tenure falls into the bucket at period end.  
+   - They are **active** at period end (see definition of Active Customer)
+   - Their tenure falls into the bucket at period end.
 3. Reporting should **cover all tenure cohorts** that sum to total active customers.
 
 **What counts in Phase 1**
 
-- Any disclosure tabulating customers by age or tenure, including:  
-  - “Customers by duration of relationship”  
-  - “Subscribers by years since subscription start”  
-  - “Cohort of customers acquired before 2020 vs 2020 vs 2021…”, when framed as tenure  
+- Any disclosure tabulating customers by age or tenure, including:
+  - “Customers by duration of relationship”
+  - “Subscribers by years since subscription start”
+  - “Cohort of customers acquired before 2020 vs 2020 vs 2021…”, when framed as tenure
 - We will capture the exact bins provided, even if they differ from our ideal set.
 
 **Common synonyms and phrases**
 
-- Customer tenure cohorts  
-- Age of relationship  
-- Vintage cohorts (if expressed in tenure terms)  
-- Duration since sign-up / first transaction  
+- Customer tenure cohorts
+- Age of relationship
+- Vintage cohorts (if expressed in tenure terms)
+- Duration since sign-up / first transaction
 
 **Out-of-scope / must not map here**
 
-- Customer count by **acquisition year** only (that belongs in revenue-by-cohort or other cohort metrics) unless also clearly used as a tenure breakdown  
-- Purely product segmentation with no tenure dimension  
+- Customer count by **acquisition year** only (that belongs in revenue-by-cohort or other cohort metrics) unless also clearly used as a tenure breakdown
+- Purely product segmentation with no tenure dimension
 
 ---
 
 ### 3.3 CM3 – Revenue by Customer Cohort
 
-**ID:** `cm_revenue_by_cohort`  
-**Class:** Core (Phase 1)  
+**ID:** `cm_revenue_by_cohort`
+**Class:** Core (Phase 1)
 
 **Business intent**
 
@@ -242,62 +242,62 @@ Measure how much **revenue** each customer cohort generates over time, enabling 
 
 We accept both:
 
-- **Acquisition cohorts** (customers acquired in a specific year/quarter)  
+- **Acquisition cohorts** (customers acquired in a specific year/quarter)
 - **Tenure cohorts** (customers grouped by tenure at period end)
 
 **Units**
 
-- Monetary (e.g., USD, EUR)  
+- Monetary (e.g., USD, EUR)
 
 **Required dimensions**
 
 - Time:
-  - `period_start`, `period_end`, `period_type`  
+  - `period_start`, `period_end`, `period_type`
 - Cohort:
-  - `cohort_type` (`'acquisition'` or `'tenure'`)  
-  - `cohort_bucket` (e.g., “2021 acquisition cohort,” “0–1 years tenure”)  
+  - `cohort_type` (`'acquisition'` or `'tenure'`)
+  - `cohort_bucket` (e.g., “2021 acquisition cohort,” “0–1 years tenure”)
 
 **Optional dimensions**
 
-- Product or service  
-- Geography  
-- Customer segment (consumer, SMB, enterprise)  
+- Product or service
+- Geography
+- Customer segment (consumer, SMB, enterprise)
 
 **Calculation rules (ideal standard)**
 
-1. Revenue must be consistent with the company’s **GAAP revenue** for the period when aggregated.  
+1. Revenue must be consistent with the company’s **GAAP revenue** for the period when aggregated.
 2. Cohort attribution must be:
-   - Based on where the revenue-causing customer belongs (by acquisition date or tenure)  
-   - Not double-counted across cohorts.  
+   - Based on where the revenue-causing customer belongs (by acquisition date or tenure)
+   - Not double-counted across cohorts.
 3. Non-recurring and recurring revenue should be distinguishable where disclosed.
 
 **What counts in Phase 1**
 
 - Any table or narrative that clearly attributes **revenue** to:
-  - Acquisition cohorts  
-  - Vintage years  
-  - Tenure cohorts  
+  - Acquisition cohorts
+  - Vintage years
+  - Tenure cohorts
 - Even if not reconciled to total GAAP revenue, we still record values and note misalignment.
 
 **Common synonyms and phrases**
 
-- Cohort revenue  
-- Revenue by customer vintage  
-- Revenue by signup year  
-- Revenue contribution by cohort  
-- Revenue by customer tenure  
+- Cohort revenue
+- Revenue by customer vintage
+- Revenue by signup year
+- Revenue contribution by cohort
+- Revenue by customer tenure
 
 **Out-of-scope / must not map here**
 
-- Revenue by product or geography without a cohort dimension  
-- ARR/MRR by cohort **only** if it is clearly about contracted revenue without recognition; these may be tracked as extended metrics  
+- Revenue by product or geography without a cohort dimension
+- ARR/MRR by cohort **only** if it is clearly about contracted revenue without recognition; these may be tracked as extended metrics
 
 ---
 
 ### 3.4 CM4 – Purchase Transactions by Cohort
 
-**ID:** `cm_transactions_by_cohort`  
-**Class:** Core (Phase 1)  
+**ID:** `cm_transactions_by_cohort`
+**Class:** Core (Phase 1)
 
 **Business intent**
 
@@ -309,54 +309,54 @@ Measure **purchase intensity** and **engagement** by cohort, independent of tick
 
 **Units**
 
-- Integer count of transactions  
+- Integer count of transactions
 
 **Required dimensions**
 
 - Time:
-  - `period_start`, `period_end`, `period_type`  
+  - `period_start`, `period_end`, `period_type`
 - Cohort:
-  - `cohort_type` (`'acquisition'` or `'tenure'`)  
-  - `cohort_bucket`  
+  - `cohort_type` (`'acquisition'` or `'tenure'`)
+  - `cohort_bucket`
 
 **Optional dimensions**
 
-- Product/service  
-- Channel (in-store, online, app, etc.)  
-- Geography  
+- Product/service
+- Channel (in-store, online, app, etc.)
+- Geography
 
 **Calculation rules (ideal standard)**
 
-1. Count each **completed purchase** as one transaction, regardless of order value.  
-2. Returns/refunds should be handled consistently (ideally separate).  
+1. Count each **completed purchase** as one transaction, regardless of order value.
+2. Returns/refunds should be handled consistently (ideally separate).
 3. If the issuer uses order lines vs orders, we will follow their definition but flag it.
 
 **What counts in Phase 1**
 
 - Any disclosures that report:
-  - Transaction counts by cohort  
-  - Orders per cohort by period  
-  - Purchase frequency by cohort (if can be converted to counts with provided base)  
+  - Transaction counts by cohort
+  - Orders per cohort by period
+  - Purchase frequency by cohort (if can be converted to counts with provided base)
 
 **Common synonyms and phrases**
 
-- Number of orders  
-- Transactions  
-- Purchases  
-- Rides / deliveries (for rideshare/delivery)  
-- Bookings (if clearly used as transaction counts)  
+- Number of orders
+- Transactions
+- Purchases
+- Rides / deliveries (for rideshare/delivery)
+- Bookings (if clearly used as transaction counts)
 
 **Out-of-scope / must not map here**
 
-- Page views, app sessions, or logins  
-- “Engagement events” that are not economic transactions  
+- Page views, app sessions, or logins
+- “Engagement events” that are not economic transactions
 
 ---
 
 ### 3.5 CM4b – Purchase Transactions (Overall)
 
-**ID:** `cm_purchase_transactions_overall`  
-**Class:** Core (Phase 1)  
+**ID:** `cm_purchase_transactions_overall`
+**Class:** Core (Phase 1)
 
 **Business intent**
 
@@ -368,31 +368,31 @@ Measure total **purchase transaction volume** across all customers in the period
 
 **Units**
 
-- Integer count of transactions  
+- Integer count of transactions
 
 **Required dimensions**
 
 - Time:
-  - `period_start`, `period_end`, `period_type`  
+  - `period_start`, `period_end`, `period_type`
 
 **What counts in Phase 1**
 
-- “Number of orders”  
-- “Total orders”  
-- “Purchase transactions” (without cohort qualifier)  
+- “Number of orders”
+- “Total orders”
+- “Purchase transactions” (without cohort qualifier)
 - “Order count” or “order volume”
 
 **Out-of-scope / must not map here**
 
-- Transaction counts broken down by cohort (those belong to `cm_transactions_by_cohort`)  
-- Page views, sessions, or non-purchase engagement events  
+- Transaction counts broken down by cohort (those belong to `cm_transactions_by_cohort`)
+- Page views, sessions, or non-purchase engagement events
 
 ---
 
 ### 3.6 CM5 – Customers at Period End (Total)
 
-**ID:** `cm_customers_period_end`  
-**Class:** Core (Phase 1)  
+**ID:** `cm_customers_period_end`
+**Class:** Core (Phase 1)
 
 **Business intent**
 
@@ -404,28 +404,28 @@ Measure the **total size of the customer base** at the end of each period. This 
 
 **Units**
 
-- Integer count of customers  
+- Integer count of customers
 
 **Required dimensions**
 
 - Time:
-  - `period_end`, `period_type`  
+  - `period_end`, `period_type`
 - Company:
-  - `cik`, `company_id`  
+  - `cik`, `company_id`
 
 **What counts in Phase 1**
 
-- “Total customers”  
-- “Paid customers” / “paying customers”  
-- “Total paying organizations”  
-- “Customer base” disclosures with a count  
+- “Total customers”
+- “Paid customers” / “paying customers”
+- “Total paying organizations”
+- “Customer base” disclosures with a count
 - Period-end subscriber counts (telecom, SaaS)
 
 **Out-of-scope / must not map here**
 
-- Active customers based on engagement criteria (those belong to `cm_active_customers_total`)  
-- New customers acquired in the period (those belong to `cm_new_customers_acquired`)  
-- Leads, sign-ups, or app downloads without evidence of economic activity  
+- Active customers based on engagement criteria (those belong to `cm_active_customers_total`)
+- New customers acquired in the period (those belong to `cm_new_customers_acquired`)
+- Leads, sign-ups, or app downloads without evidence of economic activity
 
 ---
 
@@ -435,8 +435,8 @@ Extended metrics are **not primary** for Phase 1 but provide important context. 
 
 ### 4.1 Active Customers (Total)
 
-**ID:** `cm_active_customers_total`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_active_customers_total`
+**Class:** Extended (Phase 1)
 
 **Intent**
 
@@ -444,139 +444,139 @@ Total number of **active customers** as defined by the issuer at period end.
 
 We will:
 
-- Capture the number  
-- Capture the issuer’s definition of “active” (see Section 5)  
-- Link to revenue and cohort metrics where possible  
+- Capture the number
+- Capture the issuer’s definition of “active” (see Section 5)
+- Link to revenue and cohort metrics where possible
 
 ### 4.2 Revenue per Customer (ARPU)
 
-**ID:** `cm_revenue_per_customer`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_revenue_per_customer`
+**Class:** Extended (Phase 1)
 
 Any metric clearly framed as revenue per user/customer/subscriber over a defined period. Common labels include ARPU (average revenue per user) and ARPA (average revenue per account).
 
 We will:
 
-- Capture values and definitions  
-- Not enforce a single standard definition yet  
+- Capture values and definitions
+- Not enforce a single standard definition yet
 
 ### 4.3 CAC and CAC Payback
 
 **IDs:**
 
-- `cm_customer_acquisition_cost`  
-- `cm_cac_payback_period`  
+- `cm_customer_acquisition_cost`
+- `cm_cac_payback_period`
 
 We will:
 
-- Track their incidence and disclosed values  
-- Capture methodology text  
-- Flag alignment/misalignment with a future CMASB standard  
+- Track their incidence and disclosed values
+- Capture methodology text
+- Flag alignment/misalignment with a future CMASB standard
 
 ### 4.4 Retention and Churn (Basic)
 
 **IDs:**
 
-- `cm_customer_retention_rate`  
-- `cm_customer_churn_rate`  
+- `cm_customer_retention_rate`
+- `cm_customer_churn_rate`
 
 Phase 1:
 
-- Focus on incidence and basic extraction of values  
-- Defer detailed comparability analysis to Phase 2  
+- Focus on incidence and basic extraction of values
+- Defer detailed comparability analysis to Phase 2
 
 ### 4.5 Large Customers at Period End
 
-**ID:** `cm_large_customers_period_end`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_large_customers_period_end`
+**Class:** Extended (Phase 1)
 **Tier:** 1 (promoted 2026-04-15)
 
 Count of customers exceeding a revenue or ARR threshold defined by the issuer (e.g., customers with trailing 12-month revenue greater than $100,000). Common in SaaS and enterprise software filings.
 
 ### 4.6 Net Revenue Retention
 
-**ID:** `cm_net_revenue_retention`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_net_revenue_retention`
+**Class:** Extended (Phase 1)
 
 Revenue retained from the prior-period cohort of customers including expansion, net of churn and contraction. Also referred to as Net Dollar Retention (NDR) or dollar-based net retention. A value above 100% indicates expansion outweighs churn.
 
 ### 4.7 Gross Revenue Retention
 
-**ID:** `cm_gross_revenue_retention`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_gross_revenue_retention`
+**Class:** Extended (Phase 1)
 
 Revenue retained from the prior-period cohort of customers excluding expansion (churn and contraction only). Represents the floor of revenue retained, capped at 100%. Also referred to as GRR.
 
 ### 4.8 Monthly Active Users
 
-**ID:** `cm_monthly_active_users`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_monthly_active_users`
+**Class:** Extended (Phase 1)
 
 Count of unique users or accounts that meet the issuer's activity criteria within a calendar month. Commonly abbreviated MAU. Widely disclosed by consumer internet, social media, and payments companies.
 
 ### 4.9 Daily Active Users
 
-**ID:** `cm_daily_active_users`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_daily_active_users`
+**Class:** Extended (Phase 1)
 
 Count of unique users or accounts that meet the issuer's activity criteria within a single day. Commonly abbreviated DAU. Often disclosed alongside MAU to show engagement depth.
 
 ### 4.10 Gross Margin by Cohort
 
-**ID:** `cm_gross_margin_by_cohort`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_gross_margin_by_cohort`
+**Class:** Extended (Phase 1)
 
 Gross margin or contribution margin analyzed by customer acquisition cohort or vintage. Captures how unit economics evolve as cohorts mature. Common in e-commerce and marketplace filings (e.g., order contribution margin for new vs. existing customers).
 
 ### 4.11 Annual Recurring Revenue
 
-**ID:** `cm_arr`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_arr`
+**Class:** Extended (Phase 1)
 **Status:** Deprecated 2026-04-15. ARR is a financial reporting metric, not a customer-level disclosure. Customer-relevant uses are captured by `cm_large_customers_period_end` ("customers with >$100K ARR") and `cm_revenue_by_cohort` ("ARR by cohort").
 
 Annualized value of subscription or recurring contract revenue as of a point in time. Commonly abbreviated ARR. A standard SaaS metric; includes annualized run-rate variants disclosed by issuers.
 
 ### 4.12 Monthly Recurring Revenue
 
-**ID:** `cm_mrr`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_mrr`
+**Class:** Extended (Phase 1)
 **Status:** Deprecated 2026-04-15. Monthly analogue of ARR; same rationale. Zero gold standard coverage across all datasets confirms it is rarely disclosed in S-1/F-1 filings.
 
 Monthly subscription or recurring contract revenue as of a point in time. Commonly abbreviated MRR. The monthly analogue of ARR; typically used by earlier-stage SaaS companies or those with monthly billing cycles.
 
 ### 4.13 Expansion Revenue
 
-**ID:** `cm_expansion_revenue`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_expansion_revenue`
+**Class:** Extended (Phase 1)
 **Status:** Deprecated 2026-04-15. Zero gold standard coverage across all datasets; no evidence of standalone disclosure in S-1/F-1 filings. Expansion in the context of retained revenue is captured by `cm_net_revenue_retention`.
 
 Revenue generated from existing customers beyond their initial contract or baseline spend. Includes upsell, cross-sell, and additional product adoption. Sometimes expressed as products per customer or transactions per active account.
 
 ### 4.14 Revenue Concentration
 
-**ID:** `cm_revenue_concentration`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_revenue_concentration`
+**Class:** Extended (Phase 1)
 
 Measure of how revenue is distributed across the customer base. Commonly disclosed as revenue from the top N customers, a named customer's revenue percentage, or a statement that no single customer exceeds a given threshold. Signals customer dependency risk.
 
 ### 4.15 Average Order Value
 
-**ID:** `cm_average_order_value`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_average_order_value`
+**Class:** Extended (Phase 1)
 
 Average revenue per purchase transaction, also referred to as average ticket size or average basket size. Commonly abbreviated AOV. Primarily used in e-commerce and retail filings.
 
 ### 4.16 Repeat Purchase Rate
 
-**ID:** `cm_repeat_purchase_rate`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_repeat_purchase_rate`
+**Class:** Extended (Phase 1)
 
 The proportion of customers who make more than one purchase, or the frequency with which customers reorder. Common labels include repeat purchase rate, purchase frequency, reorder rate, and repurchase rate.
 
 ### 4.17 LTV/CAC Ratio by Cohort
 
-**ID:** `cm_ltv_to_cac_ratio_by_cohort`  
-**Class:** Extended (Phase 1)  
+**ID:** `cm_ltv_to_cac_ratio_by_cohort`
+**Class:** Extended (Phase 1)
 
 The ratio of customer lifetime value to customer acquisition cost, analyzed by acquisition cohort. Captures how unit economics vary across cohorts over time. May be disclosed with temporal qualifiers such as "6-month LTV/CAC" or "LTV/CAC after 12 months."
 
@@ -594,8 +594,8 @@ Working definition for Phase 1:
 
 We will:
 
-- Prefer the issuer’s explicit definition where provided  
-- Capture issuer-specific definitions verbatim in the definitions table  
+- Prefer the issuer’s explicit definition where provided
+- Capture issuer-specific definitions verbatim in the definitions table
 - Map them to this working concept for alignment scoring
 
 ### 5.2 Active Customer
@@ -606,14 +606,14 @@ Working definition for Phase 1:
 
 Common issuer definitions include:
 
-- At least one transaction in the last X months  
-- Current subscription without cancellation  
+- At least one transaction in the last X months
+- Current subscription without cancellation
 - Logged-in or transacting above a minimum threshold
 
 The system must:
 
-- Capture the issuer’s explicit definition text  
-- Classify the definition type where possible (e.g., “recency-based,” “subscription-status-based”)  
+- Capture the issuer’s explicit definition text
+- Classify the definition type where possible (e.g., “recency-based,” “subscription-status-based”)
 
 ### 5.3 Cohort
 
@@ -623,15 +623,15 @@ Generic concept:
 
 Two primary cohort types in scope:
 
-1. **Acquisition Cohort**  
-   - Grouped by time of first qualifying economic activity (e.g., “2021 Acquisition Cohort”)  
+1. **Acquisition Cohort**
+   - Grouped by time of first qualifying economic activity (e.g., “2021 Acquisition Cohort”)
 
-2. **Tenure Cohort**  
-   - Grouped by time since first qualifying economic activity (e.g., “0–1 year tenure”)  
+2. **Tenure Cohort**
+   - Grouped by time since first qualifying economic activity (e.g., “0–1 year tenure”)
 
 In the data model, we will capture:
 
-- `cohort_type` (e.g., `'acquisition'`, `'tenure'`)  
+- `cohort_type` (e.g., `'acquisition'`, `'tenure'`)
 - `cohort_bucket` (issuer-specific label, plus normalized where possible)
 
 ### 5.4 Qualifying Economic Activity
@@ -642,9 +642,9 @@ Working definition:
 
 Examples:
 
-- Purchase of a product or service  
-- Subscription sign-up that leads to billing  
-- Usage that triggers usage-based fees  
+- Purchase of a product or service
+- Subscription sign-up that leads to billing
+- Usage that triggers usage-based fees
 
 We will capture issuer-specific criteria when disclosed.
 
@@ -656,13 +656,13 @@ Working definition:
 
 We will:
 
-- Use issuer’s definitions where available  
+- Use issuer’s definitions where available
 - Capture whether transactions are:
-  - Orders  
-  - Rides  
-  - Deliveries  
-  - Bookings  
-  - Other domain-specific constructs  
+  - Orders
+  - Rides
+  - Deliveries
+  - Bookings
+  - Other domain-specific constructs
 
 ---
 
@@ -670,16 +670,16 @@ We will:
 
 For each metric, we will record:
 
-- Whether a disclosed metric **maps** to a canonical metric ID  
+- Whether a disclosed metric **maps** to a canonical metric ID
 - Alignment level:
-  - `aligned` – close to the canonical definition  
-  - `partial` – overlaps but includes or excludes important elements  
-  - `not_aligned` – related but materially different  
+  - `aligned` – close to the canonical definition
+  - `partial` – overlaps but includes or excludes important elements
+  - `not_aligned` – related but materially different
 
 The extraction/QA pipeline must:
 
-- Capture issuer labels and definitions  
-- Map them to canonical IDs where appropriate  
+- Capture issuer labels and definitions
+- Map them to canonical IDs where appropriate
 - Store alignment flags and short notes
 
 ---
@@ -688,19 +688,19 @@ The extraction/QA pipeline must:
 
 ### 7.1 Versioning
 
-- Each metric definition has a **version**.  
+- Each metric definition has a **version**.
 - This document will maintain a **changelog** when definitions change in ways that affect comparability.
 
 Example changes:
 
-- Narrowing or broadening what counts as a “customer”  
-- Changing how acquisition cohorts are defined  
+- Narrowing or broadening what counts as a “customer”
+- Changing how acquisition cohorts are defined
 
 ### 7.2 Backward compatibility
 
 When definitions change:
 
-- We will document whether old data can be mechanically transformed to the new definition.  
+- We will document whether old data can be mechanically transformed to the new definition.
 - If not, we may maintain separate **metric IDs** (e.g., `cm_new_customers_acquired_v1`, `cm_new_customers_acquired_v2`) for internal use, even if public-facing analysis uses a single label.
 
 ---
@@ -709,32 +709,32 @@ When definitions change:
 
 Items to resolve before finalizing v1.0:
 
-1. **Exact list of Phase 1 Core Metrics**  
-   - Confirm that CM1–CM4 are the correct set and that others remain Extended in Phase 1.  
+1. **Exact list of Phase 1 Core Metrics**
+   - Confirm that CM1–CM4 are the correct set and that others remain Extended in Phase 1.
 
-2. **Canonical tenure buckets**  
-   - Decide whether we will enforce a standard set (0–1, 1–2, 2–3, 3–5, 5+ years) or simply normalize issuer buckets where possible.  
+2. **Canonical tenure buckets**
+   - Decide whether we will enforce a standard set (0–1, 1–2, 2–3, 3–5, 5+ years) or simply normalize issuer buckets where possible.
 
-3. **Treatment of reactivated customers**  
-   - Do we require separate metrics for reactivations in standards, or just capture issuer choices?  
+3. **Treatment of reactivated customers**
+   - Do we require separate metrics for reactivations in standards, or just capture issuer choices?
 
-4. **ARR/MRR vs GAAP revenue**  
-   - For cohort metrics, how do we want to treat ARR/MRR disclosures that are not GAAP revenue but are economically meaningful?  
+4. **ARR/MRR vs GAAP revenue**
+   - For cohort metrics, how do we want to treat ARR/MRR disclosures that are not GAAP revenue but are economically meaningful?
 
-5. **Minimum detail level for Phase 1**  
+5. **Minimum detail level for Phase 1**
    - For Extended Metrics (CAC, ARPU, retention), how much effort do we want to invest now vs Phase 2?
 
 These decisions will influence:
 
-- Extraction complexity  
-- Comparability claims in CMASB reports  
+- Extraction complexity
+- Comparability claims in CMASB reports
 - The degree of “push” on issuers in the first standards proposal
 
 ---
 
 ## 9. References and links
 
-- `01_ANALYTIC_REQUIREMENTS.md`  
-- Proposed Metrics and Definitions_v1.docx (source draft)  
-- Analysis of SEC filings – overview.docx  
+- `01_ANALYTIC_REQUIREMENTS.md`
+- Proposed Metrics and Definitions_v1.docx (source draft)
+- Analysis of SEC filings – overview.docx
 - Future: CMASB Draft Standards (when available)

--- a/docs/development/quality-model.md
+++ b/docs/development/quality-model.md
@@ -122,10 +122,10 @@ Formally, for each `filing_id` × `metric_id`, we set `metric_disclosed_flag` in
 
 We measure **precision**, **recall**, and **F1** against a labeled gold-standard sample.
 
-- **Precision (P):**  
+- **Precision (P):**
   Among filing–metric pairs the system marks as `metric_disclosed_flag = true`, what fraction are truly disclosed?
 
-- **Recall (R):**  
+- **Recall (R):**
   Among filing–metric pairs that truly disclose a metric, what fraction does the system mark as `true`?
 
 We will compute these per metric class:

--- a/docs/operations/gold-standard-runbook.md
+++ b/docs/operations/gold-standard-runbook.md
@@ -128,16 +128,23 @@ Then commit `data/gold_standard/v2_baseline.json` separately with message `chore
 
 ## 7. Reading V2 Validator Output
 
-After each validator run (`v2_validator.py`), output includes a Tier breakdown followed by a chart confirmation line:
+After each validator run (`v2_validator.py`), output includes two tier breakdowns plus a chart confirmation line:
 
 ```
-Tier 1 recall: ...
-Tier 2 recall: ...
+==== METRIC TIER BREAKDOWN ====
+  Tier 1 (must-not-miss):  P=...  R=...  F1=...   (informational under PR2)
+  Tier 2 (nice-to-have):   P=...  R=...  F1=...   (informational)
 
-CHART cross-source confirmation: m/n (pct%)
+==== TEXT-PRESENCE TIER BREAKDOWN (PR2 Tier-1 gate surface) ====
+  Tier 1 (must-not-miss) [GATE]:           P=...  R=...  F1=...
+  Tier 2 (nice-to-have) [informational]:   P=...  R=...  F1=...
+
+CHART cross-source confirmation: m/n (pct%)   (informational)
 ```
 
-The `m/n` counts chart facts that were independently confirmed by a second source type (e.g., a TEXT or TABLE fact agreeing on the same metric+period+value slot). `pct%` is `m/n * 100`.
+**The PR2 gate** keys on `Tier 1 [GATE] R=...` (presence-recall). `--fail-on-regression` exits 1 only when that number drops below `tier1_presence_recall` in `data/gold_standard/v2_baseline.json` minus tolerance. All other lines (fact-level Tier 1/2, chart cross-source confirmation, per-company drops) are informational and will be reported in the comparison summary with an `[informational]` prefix but will not block the commit. See `docs/operations/text-pipeline-presence-pivot-plan.md` for the rationale.
+
+The `m/n` chart cross-source counts chart facts independently confirmed by a second source type (TEXT or TABLE fact agreeing on the same metric+period+value slot). `pct%` is `m/n * 100`.
 
 A soft `WARNING` is printed if `pct < 30%`. This warning is not a hard failure and will not block a baseline update, but it indicates that the chart bridge is producing few cross-confirmed facts — which may signal chart OCR quality issues or a gap in the text/table extraction path for those metrics. Discuss with the team before updating the baseline when this warning appears.
 

--- a/docs/operations/text-pipeline-presence-pivot-plan.md
+++ b/docs/operations/text-pipeline-presence-pivot-plan.md
@@ -9,12 +9,41 @@ Strategic direction memo: `~/.claude/projects/.../memory/project_presence_first_
 | PR | Scope | Status | Migration |
 |---|---|---|---|
 | PR1 | Schema + presence emission + `presence_only` persistence mode | **Landed** (PR #182) | sql/46 |
-| PR2 | Gold-standard presence derivation + validator + Tier 1 gate flip | Pending | — |
+| PR2 | Gold-standard presence scoring + validator + Tier 1 gate flip | **Landed** (this PR) | — (no schema) |
 | PR3 | Reviewer UI surfaces presence (`v2_text_presence_confirmations`) | Pending | sql/48 |
 | PR4 | Tier-1 definition/methodology LLM classifier | Pending | sql/49 |
 | PR5 | MetricPresenceStage chart-contribution removal (cleanup) | Pending | — |
 
 Full plan files live under `~/.claude/plans/text-presence-pr*.md` and `~/.claude/plans/text-presence-pivot-index.md`.
+
+## PR2 status (2026-04-25)
+
+PR2 ships the validator + gate flip without the originally-planned new module or new SQL migration.
+
+**Structural deviation from the original plan:**
+- The plan assumed a `v_doc_metric_presence` SQL view + `v2_image_metric_presence` table shipped by image-review Wave 1. **Image-review explicitly out-of-scoped both** (`~/.claude/plans/our-disclosures-review-web-deep-blossom.md` line 30); chart-derived presence is now captured by promoting reviewer accept/correct/add decisions into `v2_metric_facts` (`source_type='chart'`, `review_status='accepted'`, PR #192/sql/47).
+- Validator gate reads presence **live from `PipelineResult.presences`** (output of `MetricPresenceStage`, which already aggregates text + chart `image.detected_metrics` + definitions). No DB roundtrip. No view shipped in PR2.
+- The plan's "three corpora" assumption (filing/presentation/transcript) was stale: the live `v2_validator.py` reads only `data/gold_standard/golden_set_260408.csv` (filing corpus). Transcript and presentation pipelines have separate validators (`scripts/validate_transcript_extraction.py` etc.). **PR2 scope is filing-corpus only**; transcript and presentation Tier-1 presence gates are tracked as follow-up work.
+- No new `presence_derivation.py` module — presence projection happens inline in `validate_filing()` from the already-loaded `entries_by_company` dict.
+
+**Code changes:**
+- `src/gold_standard/v2_validator.py`: `ValidationResult` gains `metric_presence_tp/fp/fn` + per-metric breakdowns. `validate_filing()` projects expected presence from gold rows, intersects with `v2_result.presences`. `compute_metrics()` aggregates per-tier; `AggregateMetrics` exposes `tier1_presence_recall` / `tier2_presence_recall`. `print_presence_tier_report()` renders the new section with `[GATE]` / `[informational]` markers.
+- `src/gold_standard/baseline.py`: `BaselineMetrics` gains `tier1_presence_recall` / `tier2_presence_recall` (None on pre-PR2 baselines; loader tolerates absence). `compare_to_baseline()` flips: only Tier-1 presence-recall regression sets `has_regression=True`. Overall fact P/R/F1, per-company drops, chart `presence_f1`, Tier-2 presence-recall are still surfaced but tagged `[informational]`. `ComparisonResult` gains `tier1_presence_recall_delta` / `tier2_presence_recall_delta`.
+- `scripts/backfill_text_presence.py`: new operational script. Defaults to `$TEST_DATABASE_URL`; refuses prod unless `--allow-prod` + `ALLOW_PROD_BACKFILL=yes`. Uses `persist_pipeline_result(presence_only=True)` to populate `v2_text_metric_presence` for reviewed filings without touching `v2_metric_facts` (no `ReviewedFilingError` risk).
+- Tests: extended `tests/unit/gold_standard/test_baseline.py` (gate-flip semantics, tier-field round-trip, pre-PR2 backwards compat) and `tests/unit/gold_standard/test_v2_validator.py` (presence aggregation, tier rollup).
+
+**Baseline numbers (regenerated 2026-04-25, post-#182 + post-#192):**
+- Tier 1 presence-recall: **85.3%** — the new `tier1_presence_recall` gate metric.
+- Tier 2 presence-recall: **91.3%** (informational).
+- Tier 1 fact-recall: 50.5% (informational under PR2).
+- Tier 2 fact-recall: 36.0% (informational).
+- 12 filings ran; ~16s per filing, 193s total wall clock at 4 workers.
+
+**Follow-up workstreams (deferred):**
+- Tier-1 presence-recall gate for `scripts/validate_transcript_extraction.py` (transcript corpus).
+- Tier-1 presence-recall gate for the presentation pipeline.
+- Production run of `scripts/backfill_text_presence.py` against Neon prod (operational; gated behind `--allow-prod` + `ALLOW_PROD_BACKFILL=yes`).
+- Investigate the gold-standard companies whose `filing.html` is missing — separate diligence ticket.
 
 ## Cross-pivot coordination with image-review redesign
 

--- a/scripts/backfill_text_presence.py
+++ b/scripts/backfill_text_presence.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Backfill ``v2_text_metric_presence`` for reviewed filings (PR2 follow-up).
+
+Iterates filings that have any reviewer activity (``v2_review_decisions`` or
+``v2_image_metric_confirmations``) and runs ``V2Pipeline.process`` then
+``V2PersistenceAdapter.persist_pipeline_result(..., presence_only=True)`` to
+populate the ``v2_text_metric_presence`` table. Skips fact persistence
+entirely (so the reviewed-filing guard does not fire and reviewer decisions
+are preserved).
+
+Safety:
+- Defaults to ``$TEST_DATABASE_URL``. Refuses to run against ``$DATABASE_URL``
+  (Neon prod) unless ``--allow-prod`` is explicitly passed AND the user
+  acknowledges via the env var ``ALLOW_PROD_BACKFILL=yes``.
+- ``--limit N`` for smoke runs.
+- ``--dry-run`` prints what it would do without writing.
+
+Usage::
+
+    # Smoke (one filing) against local DB:
+    python3 scripts/backfill_text_presence.py --limit 1
+
+    # Full local backfill, log to data/gold_standard/baselines/:
+    python3 scripts/backfill_text_presence.py
+
+    # All filings (not just reviewed) — useful for analytics / training:
+    python3 scripts/backfill_text_presence.py --all-filings
+
+This script is part of the text-presence pivot (see
+``docs/operations/text-pipeline-presence-pivot-plan.md``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from src.extraction_v2.exceptions import ReviewedFilingError  # noqa: E402
+from src.extraction_v2.persistence import V2PersistenceAdapter  # noqa: E402
+from src.extraction_v2.pipeline import V2Pipeline  # noqa: E402
+from src.infra.db import DatabaseAdapter  # noqa: E402
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_db_url(allow_prod: bool) -> str:
+    """Pick the right DB URL with hard-coded prod guardrails."""
+    test_url = os.environ.get("TEST_DATABASE_URL")
+    prod_url = os.environ.get("DATABASE_URL")
+
+    if not allow_prod:
+        if not test_url:
+            raise SystemExit(
+                "TEST_DATABASE_URL is unset. Start local Postgres "
+                "(`docker compose up -d`) or pass --allow-prod with "
+                "ALLOW_PROD_BACKFILL=yes to use $DATABASE_URL."
+            )
+        return test_url
+
+    if os.environ.get("ALLOW_PROD_BACKFILL", "").lower() != "yes":
+        raise SystemExit(
+            "--allow-prod requires ALLOW_PROD_BACKFILL=yes in the environment. "
+            "This guard prevents accidental writes to Neon prod."
+        )
+    if not prod_url:
+        raise SystemExit("DATABASE_URL is unset; cannot use --allow-prod.")
+    return prod_url
+
+
+def _select_filings(db: DatabaseAdapter, args: argparse.Namespace) -> list[dict]:
+    """Return filings to process."""
+    # Both v2_metric_facts.doc_id and v2_image_assets.doc_id are BIGINT FKs to
+    # filings.filing_id (despite the column name) — see sql/09_v2_schema.sql.
+    if args.all_filings:
+        sql = """
+            SELECT f.filing_id, f.cik, f.accession_number, f.html_storage_path,
+                   f.filing_date, c.company_name, c.company_id
+              FROM filings f
+              JOIN companies c USING (company_id)
+        """
+        params: dict = {}
+    else:
+        sql = """
+            SELECT DISTINCT f.filing_id, f.cik, f.accession_number,
+                   f.html_storage_path, f.filing_date,
+                   c.company_name, c.company_id
+              FROM filings f
+              JOIN companies c USING (company_id)
+              LEFT JOIN v2_metric_facts mf ON mf.doc_id = f.filing_id
+              LEFT JOIN v2_review_decisions rd ON rd.fact_id = mf.fact_id
+              LEFT JOIN v2_image_assets ia ON ia.doc_id = f.filing_id
+              LEFT JOIN v2_image_metric_confirmations imc ON imc.img_id = ia.img_id
+             WHERE rd.decision_id IS NOT NULL OR imc.id IS NOT NULL
+        """
+        params = {}
+
+    if args.filing_id is not None:
+        sql += (
+            " AND f.filing_id = %(filing_id)s"
+            if not args.all_filings
+            else " WHERE f.filing_id = %(filing_id)s"
+        )
+        params["filing_id"] = args.filing_id
+
+    sql += " ORDER BY f.filing_id"
+
+    if args.limit:
+        sql += f" LIMIT {int(args.limit)}"
+
+    return db.query(sql, params)
+
+
+def _resolve_html(filing: dict, db: DatabaseAdapter) -> tuple[Path | None, str | None]:
+    """Return (resolved_path, temp_path_to_clean_up).
+
+    Tries html_storage_path first, then falls back to ``filings.html_content``
+    written to a temp file (mirrors ``batch_v2_extraction.py`` behavior).
+    """
+    storage_path = filing.get("html_storage_path")
+    if storage_path:
+        p = Path(storage_path)
+        if p.exists():
+            return p, None
+
+    rows = db.query(
+        "SELECT html_content FROM filings "
+        "WHERE filing_id = %(filing_id)s AND html_content IS NOT NULL",
+        {"filing_id": filing["filing_id"]},
+    )
+    if rows and rows[0].get("html_content"):
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".htm", delete=False, encoding="utf-8")
+        tmp.write(rows[0]["html_content"])
+        tmp.close()
+        return Path(tmp.name), tmp.name
+
+    return None, None
+
+
+def _process_one(
+    filing: dict,
+    db_url: str,
+    pipeline: V2Pipeline,
+    dry_run: bool,
+) -> tuple[str, int]:
+    """Process one filing; return (status, presences_upserted)."""
+    db = DatabaseAdapter(db_url)
+    html_path, temp_to_clean = _resolve_html(filing, db)
+    try:
+        if html_path is None:
+            return "no_html", 0
+
+        result = pipeline.process(
+            html_path=html_path,
+            filing_id=filing["filing_id"],
+            cik=filing.get("cik") or "",
+            accession_number=filing.get("accession_number") or "",
+            document_date=filing.get("filing_date"),
+        )
+        if not result.success:
+            return f"pipeline_failed: {result.error_message}", 0
+
+        if dry_run:
+            return f"dry_run (would upsert {len(result.presences)} presences)", len(
+                result.presences
+            )
+
+        adapter = V2PersistenceAdapter(db_url=db_url)
+        try:
+            persistence_result = adapter.persist_pipeline_result(
+                result,
+                filing_id=filing["filing_id"],
+                document_type="sec_filing",
+                presence_only=True,
+            )
+        except ReviewedFilingError as e:  # pragma: no cover — presence_only bypasses fact path
+            return f"reviewed_filing_error_unexpected: {e}", 0
+
+        return "ok", persistence_result.presences_upserted
+    finally:
+        if temp_to_clean:
+            try:
+                os.unlink(temp_to_clean)
+            except OSError:
+                pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=None, help="Process only first N filings")
+    parser.add_argument("--filing-id", type=int, default=None, help="Process only this filing_id")
+    parser.add_argument(
+        "--all-filings",
+        action="store_true",
+        help="Process all filings, not just those with reviewer activity",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run pipeline but skip persistence",
+    )
+    parser.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Allow $DATABASE_URL (Neon prod). Requires ALLOW_PROD_BACKFILL=yes env.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=PROJECT_ROOT / "data" / "gold_standard" / "baselines",
+        help="Directory for run log",
+    )
+    args = parser.parse_args()
+
+    db_url = _resolve_db_url(args.allow_prod)
+    args.log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = args.log_dir / f"presence_backfill_{datetime.now(UTC).strftime('%Y-%m-%d')}.log"
+
+    file_handler = logging.FileHandler(log_path)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    file_handler.setFormatter(fmt)
+    stream_handler.setFormatter(fmt)
+    logging.basicConfig(level=logging.INFO, handlers=[file_handler, stream_handler], force=True)
+
+    logger.info("DB target: %s", db_url.split("@")[-1] if "@" in db_url else "<local>")
+    logger.info("Log: %s", log_path)
+
+    db = DatabaseAdapter(db_url)
+    filings = _select_filings(db, args)
+    logger.info("Selected %d filings", len(filings))
+
+    pipeline = V2Pipeline()  # default config — ChartFactBridgeStage on; metric-classify off
+
+    counts = {"ok": 0, "no_html": 0, "failed": 0, "skipped": 0}
+    total_presences = 0
+    start = time.time()
+
+    for i, filing in enumerate(filings, start=1):
+        fid = filing["filing_id"]
+        company = filing.get("company_name", "?")
+        try:
+            status, presences = _process_one(filing, db_url, pipeline, args.dry_run)
+        except Exception as e:
+            logger.exception("Filing %s (%s) raised: %s", fid, company, e)
+            counts["failed"] += 1
+            continue
+
+        if status == "ok" or status.startswith("dry_run"):
+            counts["ok"] += 1
+            total_presences += presences
+            logger.info(
+                "[%d/%d] filing %s (%s): %s, presences=%d",
+                i,
+                len(filings),
+                fid,
+                company,
+                status,
+                presences,
+            )
+        elif status == "no_html":
+            counts["no_html"] += 1
+            logger.warning(
+                "[%d/%d] filing %s (%s): no HTML available", i, len(filings), fid, company
+            )
+        else:
+            counts["failed"] += 1
+            logger.error("[%d/%d] filing %s (%s): %s", i, len(filings), fid, company, status)
+
+    elapsed = time.time() - start
+    logger.info(
+        "Done. %d ok, %d no_html, %d failed in %.1fs (%d presence rows upserted)",
+        counts["ok"],
+        counts["no_html"],
+        counts["failed"],
+        elapsed,
+        total_presences,
+    )
+
+    return 0 if counts["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gold_standard/baseline.py
+++ b/src/gold_standard/baseline.py
@@ -55,6 +55,12 @@ class BaselineMetrics:
     # expected chart-native metrics on any image in the filing. None on
     # pre-pivot baselines — loader tolerates missing field.
     presence_f1: float | None = None
+    # Text-presence per-tier recall (PR2 pivot). tier1_presence_recall is the
+    # primary Tier-1 regression gate; tier2 is informational. Both default to
+    # None on pre-PR2 baselines; the comparator skips the check + warns rather
+    # than treating absence as zero.
+    tier1_presence_recall: float | None = None
+    tier2_presence_recall: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
@@ -68,6 +74,10 @@ class BaselineMetrics:
             d["unique_recall"] = self.unique_recall
         if self.presence_f1 is not None:
             d["presence_f1"] = self.presence_f1
+        if self.tier1_presence_recall is not None:
+            d["tier1_presence_recall"] = self.tier1_presence_recall
+        if self.tier2_presence_recall is not None:
+            d["tier2_presence_recall"] = self.tier2_presence_recall
         return d
 
     @classmethod
@@ -118,37 +128,63 @@ class BaselineMetrics:
             by_company=by_company,
             unique_recall=data.get("unique_recall"),
             presence_f1=data.get("presence_f1"),
+            tier1_presence_recall=data.get("tier1_presence_recall"),
+            tier2_presence_recall=data.get("tier2_presence_recall"),
         )
 
 
 @dataclass
 class ComparisonResult:
-    """Result of comparing current metrics against a baseline."""
+    """Result of comparing current metrics against a baseline.
+
+    PR2 gate semantics: ``has_regression`` is set ONLY by Tier-1 presence-recall
+    drops (text-presence pivot blocker). Overall fact-level deltas, per-company
+    drops, and chart-presence F1 are still computed and reported, but tagged
+    informational and do NOT contribute to ``has_regression``.
+    """
 
     precision_delta: float  # Positive = improvement
     recall_delta: float
     f1_delta: float
-    has_regression: bool  # True if any metric dropped beyond tolerance
-    regressed_companies: list[str]  # Companies with regressions
-    regressed_metrics: list[str]  # Which overall metrics regressed
+    has_regression: bool  # PR2: True only when Tier-1 presence-recall regresses
+    regressed_companies: list[str]  # Companies with informational regressions
+    regressed_metrics: list[str]  # Metrics that regressed; entries are GATE or [informational]
     # Chart-presence F1 delta (post-PR-1 pivot). None when either baseline or
     # current lacks a presence_f1 value (pre-pivot baseline, or no chart gold
-    # rows evaluated in this run).
+    # rows evaluated in this run). Informational under PR2.
     presence_f1_delta: float | None = None
+    # Tier-1 text-presence recall delta (PR2 pivot). The primary Tier-1
+    # regression gate. None when either side lacks the field (pre-PR2 baseline
+    # or no presence gold rows evaluated) — the comparator skips the gate check
+    # and emits a warning rather than treating absence as zero.
+    tier1_presence_recall_delta: float | None = None
+    tier2_presence_recall_delta: float | None = None
 
     def summary(self) -> str:
-        """Generate a human-readable summary."""
+        """Generate a human-readable summary.
+
+        Tier-1 presence-recall delta is labelled ``[GATE]``; everything else
+        ``[informational]`` to make the gate semantics obvious in CLI output.
+        """
         parts = []
-        parts.append(f"Precision: {self.precision_delta:+.1%}")
-        parts.append(f"Recall: {self.recall_delta:+.1%}")
-        parts.append(f"F1: {self.f1_delta:+.1%}")
+        if self.tier1_presence_recall_delta is not None:
+            parts.append(f"[GATE] Tier1-presence-R: {self.tier1_presence_recall_delta:+.1%}")
+        if self.tier2_presence_recall_delta is not None:
+            parts.append(
+                f"[informational] Tier2-presence-R: {self.tier2_presence_recall_delta:+.1%}"
+            )
+        parts.append(f"[informational] Precision: {self.precision_delta:+.1%}")
+        parts.append(f"[informational] Recall: {self.recall_delta:+.1%}")
+        parts.append(f"[informational] F1: {self.f1_delta:+.1%}")
         if self.presence_f1_delta is not None:
-            parts.append(f"Presence-F1: {self.presence_f1_delta:+.1%}")
+            parts.append(f"[informational] Presence-F1: {self.presence_f1_delta:+.1%}")
 
         if self.has_regression:
             parts.append(f"REGRESSION DETECTED in: {', '.join(self.regressed_metrics)}")
             if self.regressed_companies:
-                parts.append(f"Regressed companies: {', '.join(self.regressed_companies)}")
+                parts.append(
+                    f"Regressed companies (informational): {', '.join(self.regressed_companies)}"
+                )
 
         return " | ".join(parts)
 
@@ -215,6 +251,12 @@ def compare_to_baseline(
     """
     Compare current metrics against a baseline.
 
+    PR2 gate semantics: only Tier-1 presence-recall regression sets
+    ``has_regression=True``. All other deltas (overall fact P/R/F1, per-company
+    fact P/R/F1, chart-presence F1, Tier-2 presence-recall) are computed and
+    reported as informational entries in ``regressed_metrics`` /
+    ``regressed_companies`` but do not gate.
+
     Args:
         current: Current validation metrics
         baseline: Previous baseline metrics
@@ -223,20 +265,24 @@ def compare_to_baseline(
     Returns:
         ComparisonResult with deltas and regression flags
     """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
     precision_delta = current.overall.precision - baseline.overall.precision
     recall_delta = current.overall.recall - baseline.overall.recall
     f1_delta = current.overall.f1 - baseline.overall.f1
 
-    # Check for overall metric regressions
+    # Track informational fact-level regressions (no longer gating).
     regressed_metrics: list[str] = []
     if precision_delta < -tolerance:
-        regressed_metrics.append("precision")
+        regressed_metrics.append("[informational] precision")
     if recall_delta < -tolerance:
-        regressed_metrics.append("recall")
+        regressed_metrics.append("[informational] recall")
     if f1_delta < -tolerance:
-        regressed_metrics.append("f1")
+        regressed_metrics.append("[informational] f1")
 
-    # Check for per-company regressions
+    # Per-company fact regressions — informational only.
     regressed_companies: list[str] = []
     for company, baseline_scores in baseline.by_company.items():
         if company not in current.by_company:
@@ -257,16 +303,34 @@ def compare_to_baseline(
         if company_regressed:
             regressed_companies.append(company)
 
-    # Chart-presence F1 regression (Q1-5 pivot). Only compared when both the
-    # baseline and current run have a presence_f1 value; tolerates pre-pivot
-    # baselines (None → skip check).
+    # Chart-presence F1 regression (chart-stage pivot). Informational under PR2.
     presence_f1_delta: float | None = None
     if current.presence_f1 is not None and baseline.presence_f1 is not None:
         presence_f1_delta = current.presence_f1 - baseline.presence_f1
         if presence_f1_delta < -tolerance:
-            regressed_metrics.append("presence_f1")
+            regressed_metrics.append("[informational] presence_f1")
 
-    has_regression = bool(regressed_metrics) or bool(regressed_companies)
+    # Tier-2 text-presence recall — informational.
+    tier2_delta: float | None = None
+    if current.tier2_presence_recall is not None and baseline.tier2_presence_recall is not None:
+        tier2_delta = current.tier2_presence_recall - baseline.tier2_presence_recall
+        if tier2_delta < -tolerance:
+            regressed_metrics.append("[informational] tier2_presence_recall")
+
+    # Tier-1 text-presence recall — THE GATE.
+    tier1_delta: float | None = None
+    has_regression = False
+    if current.tier1_presence_recall is not None and baseline.tier1_presence_recall is not None:
+        tier1_delta = current.tier1_presence_recall - baseline.tier1_presence_recall
+        if tier1_delta < -tolerance:
+            regressed_metrics.insert(0, "[GATE] tier1_presence_recall")
+            has_regression = True
+    else:
+        logger.warning(
+            "Tier-1 presence-recall not present in %s — skipping the PR2 gate check. "
+            "Run --update-baseline to capture the new field.",
+            "current run" if current.tier1_presence_recall is None else "baseline",
+        )
 
     return ComparisonResult(
         precision_delta=precision_delta,
@@ -276,6 +340,8 @@ def compare_to_baseline(
         regressed_companies=sorted(regressed_companies),
         regressed_metrics=regressed_metrics,
         presence_f1_delta=presence_f1_delta,
+        tier1_presence_recall_delta=tier1_delta,
+        tier2_presence_recall_delta=tier2_delta,
     )
 
 

--- a/src/gold_standard/v2_validator.py
+++ b/src/gold_standard/v2_validator.py
@@ -277,6 +277,19 @@ class ValidationResult:
     # Presence diagnostics for FN chart rows.
     presence_fn_diagnostics: list[FNDiagnostic] = field(default_factory=list)
 
+    # Per-(filing, metric) text-presence scoring (PR2: text-presence pivot Tier 1 gate).
+    # Source: PipelineResult.presences (live from MetricPresenceStage, which already
+    # aggregates text + chart + definitions). Distinct from the chart-only
+    # `presence_*` fields above which feed the legacy `presence_f1` baseline metric.
+    # Expected set is "all non-trap, non-definition-only metric_ids in this filing's
+    # gold rows"; actual set is "metric_ids in MetricPresenceStage output."
+    metric_presence_tp: int = 0
+    metric_presence_fp: int = 0
+    metric_presence_fn: int = 0
+    metric_presence_tp_by_metric: dict[str, int] = field(default_factory=dict)
+    metric_presence_fp_by_metric: dict[str, int] = field(default_factory=dict)
+    metric_presence_fn_by_metric: dict[str, int] = field(default_factory=dict)
+
     # Per-stage pipeline timings for this filing (stage name → duration_ms).
     # Populated from v2_result.stage_results; empty if the pipeline failed.
     stage_timings: dict[str, int] = field(default_factory=dict)
@@ -342,10 +355,19 @@ class AggregateMetrics:
     chart_facts_text_derivable_total: int = 0
     chart_facts_text_derivable_cross_confirmed: int = 0
     chart_facts_by_chart_native_metric: dict[str, int] = field(default_factory=dict)
-    # Chart-presence aggregates (post-PR-1 pivot).
+    # Chart-presence aggregates (post-PR-1 chart-stage pivot, sourced from
+    # v2_image_assets.detected_metrics over chart-segment gold rows).
     total_presence_tp: int = 0
     total_presence_fp: int = 0
     total_presence_fn: int = 0
+
+    # Text-presence aggregates (PR2 text-presence pivot, sourced from
+    # PipelineResult.presences over all non-trap gold rows).
+    total_metric_presence_tp: int = 0
+    total_metric_presence_fp: int = 0
+    total_metric_presence_fn: int = 0
+    presence_by_metric: dict[str, MetricScores] = field(default_factory=dict)
+    presence_by_tier: dict[int, MetricScores] = field(default_factory=dict)
 
     @property
     def presence_precision(self) -> float:
@@ -362,6 +384,18 @@ class AggregateMetrics:
         p, r = self.presence_precision, self.presence_recall
         return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
 
+    @property
+    def tier1_presence_recall(self) -> float | None:
+        """Tier-1 presence recall — primary Tier-1 regression gate (PR2)."""
+        scores = self.presence_by_tier.get(1)
+        return scores.recall if scores is not None else None
+
+    @property
+    def tier2_presence_recall(self) -> float | None:
+        """Tier-2 presence recall — informational under the presence pivot."""
+        scores = self.presence_by_tier.get(2)
+        return scores.recall if scores is not None else None
+
     def to_baseline_metrics(
         self,
         description: str | None = None,
@@ -374,6 +408,13 @@ class AggregateMetrics:
         has_presence = (
             self.total_presence_tp + self.total_presence_fp + self.total_presence_fn
         ) > 0
+        # Same gate for the new tier1/2 text-presence numbers — None when no metric
+        # presence rows were evaluated, so the loader keeps tolerating older baselines.
+        has_metric_presence = (
+            self.total_metric_presence_tp
+            + self.total_metric_presence_fp
+            + self.total_metric_presence_fn
+        ) > 0
         return BaselineMetrics(
             baseline_date=datetime.now(UTC).isoformat(),
             description=description or "V2 pipeline validation",
@@ -384,7 +425,8 @@ class AggregateMetrics:
             ),
             by_company=self.by_company,
             presence_f1=self.presence_f1 if has_presence else None,
-            # V2 baseline marker (via description)
+            tier1_presence_recall=self.tier1_presence_recall if has_metric_presence else None,
+            tier2_presence_recall=self.tier2_presence_recall if has_metric_presence else None,
         )
 
 
@@ -830,6 +872,39 @@ class V2GoldStandardValidator:
             # FPs: metrics detected but not expected in this filing's chart-gold set
             for _ in chart_detected_set - chart_gold_set:
                 result.presence_fp += 1
+
+        # --- Text-presence pivot: per-(filing, metric) presence scoring (PR2) ---
+        # Source: v2_result.presences (output of MetricPresenceStage, which
+        # already aggregates text + chart + definitions into one record per
+        # canonical metric). Expected set: every non-trap, non-definition-only
+        # gold row's metric_id. This is the surface that gates Tier 1 regressions.
+        expected_presence_set: set[str] = {
+            normalize_metric_id(e.metric_id)
+            for e in expected_entries
+            if not e.is_definition_only
+            and normalize_metric_id(e.metric_id)
+            and normalize_metric_id(e.metric_id) != "cm_not_a_customer_metric"
+        }
+        actual_presence_set: set[str] = {
+            normalize_metric_id(p.canonical_metric_id)
+            for p in v2_result.presences
+            if p.canonical_metric_id
+        }
+        for metric_id in expected_presence_set & actual_presence_set:
+            result.metric_presence_tp += 1
+            result.metric_presence_tp_by_metric[metric_id] = (
+                result.metric_presence_tp_by_metric.get(metric_id, 0) + 1
+            )
+        for metric_id in expected_presence_set - actual_presence_set:
+            result.metric_presence_fn += 1
+            result.metric_presence_fn_by_metric[metric_id] = (
+                result.metric_presence_fn_by_metric.get(metric_id, 0) + 1
+            )
+        for metric_id in actual_presence_set - expected_presence_set:
+            result.metric_presence_fp += 1
+            result.metric_presence_fp_by_metric[metric_id] = (
+                result.metric_presence_fp_by_metric.get(metric_id, 0) + 1
+            )
 
         # Store all pre-threshold facts and gold entries so metrics can be
         # recomputed at a different confidence threshold without re-running
@@ -1713,6 +1788,46 @@ class V2GoldStandardValidator:
         return None
 
     @staticmethod
+    def print_presence_tier_report(metrics: AggregateMetrics) -> None:
+        """Print Tier-1/2 presence-recall — primary scoring surface (PR2 pivot).
+
+        Tier 1 presence-recall is the regression gate; Tier 2 is informational.
+        Skips the section entirely when no presence rows were evaluated (keeps
+        output uncluttered for runs predating the pivot).
+        """
+        total = (
+            metrics.total_metric_presence_tp
+            + metrics.total_metric_presence_fp
+            + metrics.total_metric_presence_fn
+        )
+        if total == 0:
+            return
+
+        print("\n==== TEXT-PRESENCE TIER BREAKDOWN (PR2 Tier-1 gate surface) ====")
+        for tier in sorted(metrics.presence_by_tier):
+            scores = metrics.presence_by_tier[tier]
+            label = TIER_LABELS.get(tier, f"tier-{tier}")
+            gate_marker = "[GATE]" if tier == 1 else "[informational]"
+            print(
+                f"  Tier {tier} ({label}) {gate_marker}:  "
+                f"P={scores.precision:.1%}  R={scores.recall:.1%}  F1={scores.f1:.1%}"
+            )
+
+        if not metrics.presence_by_metric:
+            return
+
+        print("\n  Per-metric presence detail:")
+        col_w = max(len(mid) for mid in metrics.presence_by_metric)
+        print(f"  {'Metric':<{col_w}}  Tier  {'P':>6}  {'R':>6}  {'F1':>6}")
+        print("  " + "-" * (col_w + 32))
+        for mid in sorted(metrics.presence_by_metric, key=lambda m: (get_tier(m), m)):
+            s = metrics.presence_by_metric[mid]
+            tier = get_tier(mid)
+            print(
+                f"  {mid:<{col_w}}   T{tier}  {s.precision:>6.1%}  {s.recall:>6.1%}  {s.f1:>6.1%}"
+            )
+
+    @staticmethod
     def print_tier_report(metrics: AggregateMetrics) -> None:
         """Print precision/recall/F1 breakdown by metric importance tier and per metric."""
         print("\n==== METRIC TIER BREAKDOWN ====")
@@ -1871,6 +1986,54 @@ class V2GoldStandardValidator:
         total_presence_fp = sum(r.presence_fp for r in results)
         total_presence_fn = sum(r.presence_fn for r in results)
 
+        # Text-presence aggregation (PR2 pivot, Tier 1 gate).
+        total_metric_presence_tp = sum(r.metric_presence_tp for r in results)
+        total_metric_presence_fp = sum(r.metric_presence_fp for r in results)
+        total_metric_presence_fn = sum(r.metric_presence_fn for r in results)
+
+        presence_tp_per_metric: dict[str, int] = {}
+        presence_fp_per_metric: dict[str, int] = {}
+        presence_fn_per_metric: dict[str, int] = {}
+        for r in results:
+            for mid, c in r.metric_presence_tp_by_metric.items():
+                presence_tp_per_metric[mid] = presence_tp_per_metric.get(mid, 0) + c
+            for mid, c in r.metric_presence_fp_by_metric.items():
+                presence_fp_per_metric[mid] = presence_fp_per_metric.get(mid, 0) + c
+            for mid, c in r.metric_presence_fn_by_metric.items():
+                presence_fn_per_metric[mid] = presence_fn_per_metric.get(mid, 0) + c
+
+        all_presence_metric_ids = (
+            set(presence_tp_per_metric) | set(presence_fp_per_metric) | set(presence_fn_per_metric)
+        )
+        presence_by_metric: dict[str, MetricScores] = {}
+        for mid in sorted(all_presence_metric_ids):
+            tp = presence_tp_per_metric.get(mid, 0)
+            fp = presence_fp_per_metric.get(mid, 0)
+            fn = presence_fn_per_metric.get(mid, 0)
+            p = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            r_score = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            f = 2 * p * r_score / (p + r_score) if (p + r_score) > 0 else 0.0
+            presence_by_metric[mid] = MetricScores(precision=p, recall=r_score, f1=f)
+
+        # Roll up presence by tier (Tier 1 = blocker; Tier 2 = informational).
+        tier_pp_tp: dict[int, int] = {}
+        tier_pp_fp: dict[int, int] = {}
+        tier_pp_fn: dict[int, int] = {}
+        for mid in all_presence_metric_ids:
+            t = get_tier(mid)
+            tier_pp_tp[t] = tier_pp_tp.get(t, 0) + presence_tp_per_metric.get(mid, 0)
+            tier_pp_fp[t] = tier_pp_fp.get(t, 0) + presence_fp_per_metric.get(mid, 0)
+            tier_pp_fn[t] = tier_pp_fn.get(t, 0) + presence_fn_per_metric.get(mid, 0)
+        presence_by_tier: dict[int, MetricScores] = {}
+        for t in sorted(set(tier_pp_tp) | set(tier_pp_fp) | set(tier_pp_fn)):
+            tp = tier_pp_tp.get(t, 0)
+            fp = tier_pp_fp.get(t, 0)
+            fn = tier_pp_fn.get(t, 0)
+            p = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+            r_score = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+            f = 2 * p * r_score / (p + r_score) if (p + r_score) > 0 else 0.0
+            presence_by_tier[t] = MetricScores(precision=p, recall=r_score, f1=f)
+
         return AggregateMetrics(
             precision=precision,
             recall=recall,
@@ -1889,6 +2052,11 @@ class V2GoldStandardValidator:
             total_presence_tp=total_presence_tp,
             total_presence_fp=total_presence_fp,
             total_presence_fn=total_presence_fn,
+            total_metric_presence_tp=total_metric_presence_tp,
+            total_metric_presence_fp=total_metric_presence_fp,
+            total_metric_presence_fn=total_metric_presence_fn,
+            presence_by_metric=presence_by_metric,
+            presence_by_tier=presence_by_tier,
         )
 
     def compute_metrics_at_threshold(
@@ -2194,6 +2362,9 @@ def run_validation(
 
     # Print tier breakdown
     V2GoldStandardValidator.print_tier_report(metrics)
+
+    # Print PR2 text-presence tier breakdown (Tier-1 = regression gate; Tier-2 informational).
+    V2GoldStandardValidator.print_presence_tier_report(metrics)
 
     # Print CHART cross-source confirmation gate (Phase 3 go/no-go).
     V2GoldStandardValidator.print_cross_source_gate(metrics)

--- a/tests/unit/gold_standard/test_baseline.py
+++ b/tests/unit/gold_standard/test_baseline.py
@@ -126,12 +126,8 @@ class TestSerializationRoundTrip:
             description=None,
             overall=MetricScores(precision=0.5, recall=0.5, f1=0.5),
             by_company={
-                "O'Brien & Associates, Inc.": MetricScores(
-                    precision=0.75, recall=0.80, f1=0.77
-                ),
-                'Company with "Quotes"': MetricScores(
-                    precision=0.65, recall=0.70, f1=0.67
-                ),
+                "O'Brien & Associates, Inc.": MetricScores(precision=0.75, recall=0.80, f1=0.77),
+                'Company with "Quotes"': MetricScores(precision=0.65, recall=0.70, f1=0.67),
                 "Société Générale": MetricScores(precision=0.85, recall=0.90, f1=0.87),
             },
         )
@@ -204,7 +200,7 @@ class TestComparisonLogic:
         assert result.regressed_metrics == []
 
     def test_regression_detected(self) -> None:
-        """Negative deltas and regression flag when metrics drop."""
+        """Fact-level deltas are reported but informational under PR2 (no longer gate)."""
         baseline = BaselineMetrics(
             baseline_date="2024-12-01",
             description=None,
@@ -223,10 +219,13 @@ class TestComparisonLogic:
         assert result.precision_delta == pytest.approx(-0.10)
         assert result.recall_delta == pytest.approx(-0.10)
         assert result.f1_delta == pytest.approx(-0.10)
-        assert result.has_regression
-        assert "precision" in result.regressed_metrics
-        assert "recall" in result.regressed_metrics
-        assert "f1" in result.regressed_metrics
+        # PR2: fact-level drops are reported as informational, do NOT gate.
+        assert not result.has_regression
+        assert any("precision" in m for m in result.regressed_metrics)
+        assert any("recall" in m for m in result.regressed_metrics)
+        assert any("f1" in m for m in result.regressed_metrics)
+        # All entries should carry the [informational] label since no Tier-1 fields set.
+        assert all("[informational]" in m for m in result.regressed_metrics)
 
     def test_no_change_zero_delta(self) -> None:
         """Zero deltas when metrics are unchanged."""
@@ -273,7 +272,7 @@ class TestComparisonLogic:
         assert result.regressed_metrics == []
 
     def test_very_small_deltas(self) -> None:
-        """Very small deltas (0.001) are detected correctly."""
+        """Very small deltas (0.001) are detected correctly (informational under PR2)."""
         baseline = BaselineMetrics(
             baseline_date="2024-12-01",
             description=None,
@@ -292,12 +291,12 @@ class TestComparisonLogic:
         assert result.precision_delta == pytest.approx(0.001)
         assert result.recall_delta == pytest.approx(0.001)
         assert result.f1_delta == pytest.approx(-0.001)
-        # F1 dropped, so it's a regression
-        assert result.has_regression
-        assert "f1" in result.regressed_metrics
+        # F1 dropped — reported as informational, does NOT gate under PR2.
+        assert not result.has_regression
+        assert any("f1" in m and "[informational]" in m for m in result.regressed_metrics)
 
     def test_company_regression_detected(self) -> None:
-        """Per-company regression is detected."""
+        """Per-company regression is reported but informational under PR2."""
         baseline = BaselineMetrics(
             baseline_date="2024-12-01",
             description=None,
@@ -319,12 +318,13 @@ class TestComparisonLogic:
 
         result = compare_to_baseline(current, baseline)
 
-        assert result.has_regression
+        # Per-company drops are tracked but no longer gate under PR2.
+        assert not result.has_regression
         assert "Bad Corp" in result.regressed_companies
         assert "Good Corp" not in result.regressed_companies
 
     def test_partial_metric_regression(self) -> None:
-        """Only some metrics regressing is detected correctly."""
+        """Only some metrics regressing — reported informational under PR2."""
         baseline = BaselineMetrics(
             baseline_date="2024-12-01",
             description=None,
@@ -334,9 +334,7 @@ class TestComparisonLogic:
         current = BaselineMetrics(
             baseline_date="2024-12-31",
             description=None,
-            overall=MetricScores(
-                precision=0.85, recall=0.60, f1=0.70
-            ),  # precision up, recall down
+            overall=MetricScores(precision=0.85, recall=0.60, f1=0.70),  # precision up, recall down
             by_company={},
         )
 
@@ -344,9 +342,9 @@ class TestComparisonLogic:
 
         assert result.precision_delta == pytest.approx(0.05)
         assert result.recall_delta == pytest.approx(-0.10)
-        assert result.has_regression
-        assert "recall" in result.regressed_metrics
-        assert "precision" not in result.regressed_metrics
+        assert not result.has_regression
+        assert any("recall" in m for m in result.regressed_metrics)
+        assert not any("precision" in m for m in result.regressed_metrics)
 
 
 class TestErrorHandling:
@@ -484,3 +482,173 @@ class TestComparisonResultSummary:
         assert "REGRESSION DETECTED" in summary
         assert "precision" in summary
         assert "Bad Corp" in summary
+
+
+class TestTier1PresenceGate:
+    """PR2 — Tier-1 presence-recall regression gate.
+
+    Replaces the pre-PR2 fact-level gate. Only Tier-1 presence-recall drops
+    set ``has_regression=True``; everything else (overall fact P/R/F1, per-
+    company fact deltas, presence_f1, Tier-2 presence-recall) is informational.
+    """
+
+    @staticmethod
+    def _baseline(
+        tier1: float | None = None,
+        tier2: float | None = None,
+        presence_f1: float | None = None,
+        precision: float = 0.6,
+        recall: float = 0.6,
+        f1: float = 0.6,
+    ) -> BaselineMetrics:
+        return BaselineMetrics(
+            baseline_date="2026-04-25T00:00:00+00:00",
+            description=None,
+            overall=MetricScores(precision=precision, recall=recall, f1=f1),
+            by_company={},
+            tier1_presence_recall=tier1,
+            tier2_presence_recall=tier2,
+            presence_f1=presence_f1,
+        )
+
+    def test_tier1_drop_blocks(self) -> None:
+        """Tier-1 presence-recall drop is the only thing that gates."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70, tier2=0.50),
+            self._baseline(tier1=0.75, tier2=0.50),
+        )
+        assert result.has_regression
+        assert result.tier1_presence_recall_delta == pytest.approx(-0.05)
+        assert any("[GATE]" in m and "tier1_presence_recall" in m for m in result.regressed_metrics)
+
+    def test_tier2_drop_does_not_block(self) -> None:
+        """Tier-2 drops are reported as informational, never gate."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70, tier2=0.40),
+            self._baseline(tier1=0.70, tier2=0.50),
+        )
+        assert not result.has_regression
+        assert result.tier2_presence_recall_delta == pytest.approx(-0.10)
+        assert any(
+            "[informational]" in m and "tier2_presence_recall" in m
+            for m in result.regressed_metrics
+        )
+
+    def test_fact_level_drop_does_not_block(self) -> None:
+        """Pre-PR2 gate metrics (overall P/R/F1) are now informational."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70, precision=0.4, recall=0.4, f1=0.4),
+            self._baseline(tier1=0.70, precision=0.6, recall=0.6, f1=0.6),
+        )
+        assert not result.has_regression
+        # Fact-level deltas still reported.
+        assert all("[informational]" in m for m in result.regressed_metrics)
+
+    def test_presence_f1_drop_does_not_block(self) -> None:
+        """Chart-presence F1 drop is informational under PR2."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70, presence_f1=0.40),
+            self._baseline(tier1=0.70, presence_f1=0.60),
+        )
+        assert not result.has_regression
+        assert result.presence_f1_delta == pytest.approx(-0.20)
+
+    def test_pre_pr2_baseline_skips_gate(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Loading a baseline without tier1 field skips the gate + warns."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70),
+            self._baseline(tier1=None),  # pre-PR2 baseline
+        )
+        assert not result.has_regression
+        assert result.tier1_presence_recall_delta is None
+        assert any(
+            "Tier-1 presence-recall not present" in record.message for record in caplog.records
+        )
+
+    def test_tier1_unchanged_with_other_drops_no_block(self) -> None:
+        """When Tier-1 holds, drops elsewhere are informational only."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.70, tier2=0.40, presence_f1=0.30, precision=0.4),
+            self._baseline(tier1=0.70, tier2=0.50, presence_f1=0.50, precision=0.6),
+        )
+        assert not result.has_regression
+        assert any("tier2_presence_recall" in m for m in result.regressed_metrics)
+        assert any("presence_f1" in m for m in result.regressed_metrics)
+        assert any("precision" in m for m in result.regressed_metrics)
+
+    def test_tier1_drop_with_other_metrics_still_blocks(self) -> None:
+        """Tier-1 drop blocks even if everything else also dropped (mixed regression)."""
+        result = compare_to_baseline(
+            self._baseline(tier1=0.50, tier2=0.30, precision=0.4),
+            self._baseline(tier1=0.70, tier2=0.50, precision=0.6),
+        )
+        assert result.has_regression
+        # Tier-1 entry should appear first in regressed_metrics (gate marker).
+        assert result.regressed_metrics[0].startswith("[GATE]")
+        assert "tier1_presence_recall" in result.regressed_metrics[0]
+
+
+class TestBaselineMetricsTier1Fields:
+    """PR2 — Tier-1/2 presence-recall round-trip + backwards compat."""
+
+    def test_round_trip_with_tier_fields(self) -> None:
+        b = BaselineMetrics(
+            baseline_date="2026-04-25T00:00:00+00:00",
+            description="PR2 test",
+            overall=MetricScores(precision=0.5, recall=0.5, f1=0.5),
+            by_company={},
+            tier1_presence_recall=0.72,
+            tier2_presence_recall=0.41,
+        )
+        d = b.to_dict()
+        assert d["tier1_presence_recall"] == 0.72
+        assert d["tier2_presence_recall"] == 0.41
+        b2 = BaselineMetrics.from_dict(d)
+        assert b2.tier1_presence_recall == 0.72
+        assert b2.tier2_presence_recall == 0.41
+
+    def test_none_tier_fields_omitted_from_dict(self) -> None:
+        """Pre-PR2 baselines should not gain a serialized null field."""
+        b = BaselineMetrics(
+            baseline_date="2026-04-25T00:00:00+00:00",
+            description=None,
+            overall=MetricScores(precision=0.5, recall=0.5, f1=0.5),
+            by_company={},
+        )
+        d = b.to_dict()
+        assert "tier1_presence_recall" not in d
+        assert "tier2_presence_recall" not in d
+
+    def test_load_pre_pr2_baseline_json(self) -> None:
+        """A baseline JSON predating PR2 must load cleanly with None tier fields."""
+        legacy_json = {
+            "baseline_date": "2026-04-20T00:00:00+00:00",
+            "description": "pre-PR2",
+            "overall": {"precision": 0.65, "recall": 0.55, "f1": 0.60},
+            "by_company": {
+                "Acme, Inc.": {"precision": 0.7, "recall": 0.5, "f1": 0.58},
+            },
+        }
+        b = BaselineMetrics.from_dict(legacy_json)
+        assert b.tier1_presence_recall is None
+        assert b.tier2_presence_recall is None
+
+    def test_save_load_round_trip_via_disk(self) -> None:
+        """to_dict / from_dict via JSON file."""
+        b = BaselineMetrics(
+            baseline_date="2026-04-25T00:00:00+00:00",
+            description="disk round-trip",
+            overall=MetricScores(precision=0.6, recall=0.7, f1=0.65),
+            by_company={"Foo Co.": MetricScores(precision=0.5, recall=0.5, f1=0.5)},
+            tier1_presence_recall=0.81,
+            tier2_presence_recall=0.62,
+        )
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "baseline.json"
+            save_baseline(b, p)
+            loaded = load_baseline(p)
+            assert loaded.tier1_presence_recall == 0.81
+            assert loaded.tier2_presence_recall == 0.62
+            # Verify JSON shape too
+            d = json.loads(p.read_text())
+            assert d["tier1_presence_recall"] == 0.81

--- a/tests/unit/gold_standard/test_v2_validator.py
+++ b/tests/unit/gold_standard/test_v2_validator.py
@@ -1108,6 +1108,103 @@ class TestComputeMetrics:
         assert metrics.f1 == pytest.approx(expected_f1)
 
 
+class TestComputeMetricsPresence:
+    """PR2 — text-presence aggregation in compute_metrics().
+
+    Source signal is `metric_presence_*_by_metric` populated by
+    validate_filing(). Tests use fabricated ValidationResult instances
+    to avoid running the full pipeline.
+    """
+
+    @pytest.fixture()
+    def validator(self) -> V2GoldStandardValidator:
+        with patch.object(V2GoldStandardValidator, "__init__", lambda self: None):
+            v = V2GoldStandardValidator.__new__(V2GoldStandardValidator)
+            return v
+
+    def _vr(
+        self,
+        company: str,
+        tp: dict[str, int] | None = None,
+        fp: dict[str, int] | None = None,
+        fn: dict[str, int] | None = None,
+    ) -> ValidationResult:
+        tp = tp or {}
+        fp = fp or {}
+        fn = fn or {}
+        return ValidationResult(
+            company_name=company,
+            filing_path=f"{company}.html",
+            total_expected=0,
+            matched=0,
+            missed=0,
+            extra=0,
+            metric_presence_tp=sum(tp.values()),
+            metric_presence_fp=sum(fp.values()),
+            metric_presence_fn=sum(fn.values()),
+            metric_presence_tp_by_metric=dict(tp),
+            metric_presence_fp_by_metric=dict(fp),
+            metric_presence_fn_by_metric=dict(fn),
+        )
+
+    def test_aggregates_metric_presence_totals(self, validator: V2GoldStandardValidator) -> None:
+        results = [
+            self._vr(
+                "A", tp={"cm_revenue_concentration": 1}, fn={"cm_lifetime_value_per_customer": 1}
+            ),
+            self._vr("B", tp={"cm_revenue_concentration": 1}, fp={"cm_arpu": 1}),
+        ]
+        m = validator.compute_metrics(results)
+        assert m.total_metric_presence_tp == 2
+        assert m.total_metric_presence_fp == 1
+        assert m.total_metric_presence_fn == 1
+
+    def test_presence_by_metric_breakdown(self, validator: V2GoldStandardValidator) -> None:
+        results = [
+            self._vr("A", tp={"cm_revenue_concentration": 1}, fn={"cm_revenue_concentration": 0}),
+            self._vr("B", tp={"cm_revenue_concentration": 1}),
+            self._vr("C", fn={"cm_revenue_concentration": 1}),  # 1 miss
+        ]
+        m = validator.compute_metrics(results)
+        scores = m.presence_by_metric["cm_revenue_concentration"]
+        # 2 TP, 0 FP, 1 FN → P=1.0, R=2/3
+        assert scores.precision == 1.0
+        assert scores.recall == pytest.approx(2 / 3)
+
+    def test_presence_by_tier_rollup(self, validator: V2GoldStandardValidator) -> None:
+        # cm_revenue_concentration is Tier 1 (per CLAUDE.md tier list);
+        # cm_arpu is Tier 2.
+        results = [
+            self._vr(
+                "A",
+                tp={"cm_revenue_concentration": 1, "cm_arpu": 1},
+                fn={"cm_revenue_concentration": 0, "cm_arpu": 0},
+            ),
+            self._vr(
+                "B",
+                fn={"cm_revenue_concentration": 1, "cm_arpu": 1},
+            ),
+        ]
+        m = validator.compute_metrics(results)
+        # Tier 1 (must-not-miss)
+        t1 = m.presence_by_tier[1]
+        assert t1.recall == pytest.approx(0.5)  # 1 TP, 1 FN
+        # Tier 2 (nice-to-have)
+        t2 = m.presence_by_tier[2]
+        assert t2.recall == pytest.approx(0.5)
+        # Aggregate accessors expose them
+        assert m.tier1_presence_recall == pytest.approx(0.5)
+        assert m.tier2_presence_recall == pytest.approx(0.5)
+
+    def test_no_presence_data_returns_none_tier_recalls(
+        self, validator: V2GoldStandardValidator
+    ) -> None:
+        m = validator.compute_metrics([])
+        assert m.tier1_presence_recall is None
+        assert m.tier2_presence_recall is None
+        assert m.total_metric_presence_tp == 0
+
+
 class TestAggregateMetricsToBaseline:
     """Tests for AggregateMetrics.to_baseline_metrics()."""
 
@@ -2798,6 +2895,11 @@ class TestCompareBaselinePresenceRegression:
         )
 
     def test_presence_f1_regression_flagged(self) -> None:
+        """Under PR2, presence_f1 drops are reported but informational (no longer gate).
+
+        See ``TestTier1PresenceGate`` in test_baseline.py for the new gate semantics:
+        only Tier-1 presence-recall regression sets ``has_regression=True``.
+        """
         from src.gold_standard.baseline import compare_to_baseline
 
         baseline = self._make_baseline(0.85, presence_f1=0.80)
@@ -2805,8 +2907,9 @@ class TestCompareBaselinePresenceRegression:
 
         result = compare_to_baseline(current, baseline)
 
-        assert "presence_f1" in result.regressed_metrics
-        assert result.has_regression is True
+        assert any("presence_f1" in m for m in result.regressed_metrics)
+        assert all("[informational]" in m for m in result.regressed_metrics)
+        assert result.has_regression is False
         assert result.presence_f1_delta == pytest.approx(-0.20)
 
     def test_presence_f1_improvement_not_flagged(self) -> None:
@@ -2817,7 +2920,7 @@ class TestCompareBaselinePresenceRegression:
 
         result = compare_to_baseline(current, baseline)
 
-        assert "presence_f1" not in result.regressed_metrics
+        assert not any("presence_f1" in m for m in result.regressed_metrics)
         assert result.presence_f1_delta == pytest.approx(0.20)
 
     def test_legacy_baseline_without_presence_f1_skipped(self) -> None:
@@ -2828,5 +2931,5 @@ class TestCompareBaselinePresenceRegression:
 
         result = compare_to_baseline(current, baseline)
 
-        assert "presence_f1" not in result.regressed_metrics
+        assert not any("presence_f1" in m for m in result.regressed_metrics)
         assert result.presence_f1_delta is None


### PR DESCRIPTION
## Summary

PR2 of the text-presence pivot (PR #182, sql/46). Flips the Tier-1 gold-standard regression gate from fact-recall to per-(document, metric) **presence-recall**. Fact-level, per-company, and chart `presence_f1` deltas are still printed but tagged `[informational]` and no longer set `has_regression`.

- Gate metric: `tier1_presence_recall` in `data/gold_standard/v2_baseline.json`
- Source: `PipelineResult.presences` (live from `MetricPresenceStage` — already aggregates text + chart `image.detected_metrics` + definitions)
- Scope: filing corpus only (`data/gold_standard/golden_set_260408.csv`)

## Structural deviation from the original PR2 plan

The plan in `~/.claude/plans/text-presence-pr2-validator.md` assumed a `v_doc_metric_presence` SQL view + `v2_image_metric_presence` table from image-review Wave 1. Image-review explicitly **out-of-scoped both** (`our-disclosures-review-web-deep-blossom.md` line 30); chart-derived presence is now captured by PR #192 promoting reviewer accept/correct/add into `v2_metric_facts` (`source_type='chart'`, `review_status='accepted'`).

Therefore PR2:
- Reads presence **live from `PipelineResult.presences`** — no view, no DB roundtrip, no backfill prerequisite for the gate itself.
- Drops the planned `presence_derivation.py` module — presence projection is inline in `validate_filing()`.
- Scopes the gate to the filing corpus. Transcript and presentation Tier-1 gates are tracked as follow-up workstreams in the pivot plan's PR2 status section.

## Baseline numbers (regenerated 2026-04-25)

| Metric | Value | Status |
|---|---|---|
| **Tier-1 presence-recall** | **85.3%** | **`[GATE]`** (blocker) |
| Tier-2 presence-recall | 91.3% | informational |
| Tier-1 fact-recall | 50.5% | informational |
| Tier-2 fact-recall | 36.0% | informational |

12 filings ran (others skipped due to missing `filing.html`); 193s total at 4 workers.

## Test plan

- [x] Unit tests: 3818 passed (`pytest tests/unit/ -x -q`)
- [x] Synthetic Tier-1 regression: gate fires, exit 1, `[GATE] tier1_presence_recall` in `regressed_metrics`
- [x] Synthetic Tier-2 regression: does NOT block, exit 0
- [x] Pre-PR2 baseline JSON (no tier fields) loads cleanly + emits warning, gate skipped
- [x] Backfill smoke (`--dry-run --limit 1` against `$TEST_DATABASE_URL`): selects 0 reviewed filings (expected on clean local DB), no SQL errors
- [x] Lint (`ruff check`): clean
- [x] Pre-commit hooks: clean
- [ ] CI: full test matrix on PR

## Files

- `src/gold_standard/v2_validator.py` — extend `ValidationResult` / `AggregateMetrics`; presence projection in `validate_filing`; tier-aware aggregation in `compute_metrics`; new `print_presence_tier_report`
- `src/gold_standard/baseline.py` — extend `BaselineMetrics` with `tier1/2_presence_recall` (backwards-compat); flip `compare_to_baseline` gate semantics; extend `ComparisonResult`
- `scripts/backfill_text_presence.py` — new operational script (default `$TEST_DATABASE_URL`; refuses prod without `--allow-prod` + `ALLOW_PROD_BACKFILL=yes`)
- `data/gold_standard/v2_baseline.json` — regenerated with `tier1/2_presence_recall` populated
- `tests/unit/gold_standard/test_baseline.py` — `TestTier1PresenceGate` + `TestBaselineMetricsTier1Fields`; updates to existing fact-level assertions to match new informational semantics
- `tests/unit/gold_standard/test_v2_validator.py` — `TestComputeMetricsPresence`; updates to `TestCompareBaselinePresenceRegression`
- `CLAUDE.md`, `.claude/rules/gold-standard.md`, `.claude/rules/v2-pipeline.md`, `docs/operations/gold-standard-runbook.md`, `docs/operations/text-pipeline-presence-pivot-plan.md` — gate-semantics docs flipped to presence-recall

## Follow-up workstreams (deferred, documented in pivot plan)

- Tier-1 presence-recall gate for `scripts/validate_transcript_extraction.py`
- Tier-1 presence-recall gate for the presentation pipeline
- Production run of `scripts/backfill_text_presence.py` against Neon (operational)
- Investigate gold-standard companies with missing `filing.html`

## Refs

- PR #182 (text-presence schema + stage interface, sql/46)
- PR #192 (chart-fact promotion to `v2_metric_facts`)
- `docs/operations/text-pipeline-presence-pivot-plan.md` (PR2 status block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)