### PR TITLE
fix(web/ingest): correct persisted_count filter + close subprocess log handles

### DIFF
--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -388,11 +388,12 @@ def ingest_start():
         log_dir = _PROJECT_ROOT / "logs"
         log_dir.mkdir(exist_ok=True)
         log_path = log_dir / f"ingest_runner_{batch_id}.log"
+        log_fh = open(log_path, "ab")
         try:
             subprocess.Popen(
                 [sys.executable, "-m", "src.universe.onboarding_runner", "--batch-id", batch_id],
                 start_new_session=True,
-                stdout=open(log_path, "ab"),  # noqa: SIM115
+                stdout=log_fh,
                 stderr=subprocess.STDOUT,
                 cwd=str(_PROJECT_ROOT),
             )
@@ -404,6 +405,8 @@ def ingest_start():
                 "Contact an administrator to start processing.",
                 "warning",
             )
+        finally:
+            log_fh.close()
 
     resp = redirect(url_for("ingest.ingest_batch", batch_id=batch_id))
     resp.set_cookie("ingest_reviewer", reviewer_name, max_age=30 * 24 * 3600)
@@ -499,11 +502,12 @@ def populate():
         log_dir = _PROJECT_ROOT / "logs"
         log_dir.mkdir(exist_ok=True)
         log_path = log_dir / f"ingest_runner_{batch_id}.log"
+        log_fh = open(log_path, "ab")
         try:
             subprocess.Popen(
                 [sys.executable, "-m", "src.universe.onboarding_runner", "--batch-id", batch_id],
                 start_new_session=True,
-                stdout=open(log_path, "ab"),  # noqa: SIM115
+                stdout=log_fh,
                 stderr=subprocess.STDOUT,
                 cwd=str(_PROJECT_ROOT),
             )
@@ -516,6 +520,8 @@ def populate():
                     "Contact an administrator to start processing.",
                     "warning",
                 )
+        finally:
+            log_fh.close()
 
     if is_xhr:
         return jsonify({"batch_id": batch_id}), 202
@@ -570,7 +576,7 @@ def ingest_history():
             b.created_at,
             b.criteria,
             COUNT(ibf.filing_id)                                                  AS total_filings,
-            COUNT(ibf.filing_id) FILTER (WHERE ibf.current_status = 'complete')  AS persisted_count,
+            COUNT(ibf.filing_id) FILTER (WHERE ibf.current_status = 'persisted') AS persisted_count,
             COUNT(ibf.filing_id) FILTER (WHERE ibf.current_status = 'failed')    AS failed_count
         FROM v2_ingest_batches b
         LEFT JOIN v2_ingest_batch_filings ibf ON ibf.batch_id = b.batch_id
@@ -761,11 +767,12 @@ def ingest_retry_failed(batch_id: str):
         log_dir = _PROJECT_ROOT / "logs"
         log_dir.mkdir(exist_ok=True)
         log_path = log_dir / f"ingest_runner_{batch_id}.log"
+        log_fh = open(log_path, "ab")
         try:
             subprocess.Popen(
                 [sys.executable, "-m", "src.universe.onboarding_runner", "--batch-id", batch_id],
                 start_new_session=True,
-                stdout=open(log_path, "ab"),  # noqa: SIM115
+                stdout=log_fh,
                 stderr=subprocess.STDOUT,
                 cwd=str(_PROJECT_ROOT),
             )
@@ -778,6 +785,8 @@ def ingest_retry_failed(batch_id: str):
                 "warning",
             )
             return redirect(url_for("ingest.ingest_batch", batch_id=batch_id))
+        finally:
+            log_fh.close()
 
     flash(f"Re-queued {retry_count} failed filing(s). Runner restarted.", "success")
     return redirect(url_for("ingest.ingest_batch", batch_id=batch_id))

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -561,3 +561,33 @@ def test_ingest_preview_template_has_section_ids(client):
     assert 'id="section-new"' in body
     assert 'id="section-no-review"' in body
     assert 'id="section-reviewed"' in body
+
+
+# ---------------------------------------------------------------------------
+# GET /ingest/history — persisted_count filter uses 'persisted' not 'complete'
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_history_persisted_count_uses_persisted_status(client):
+    """GET /ingest/history issues SQL with current_status = 'persisted' for persisted_count.
+
+    Regression test for the bug where the FILTER used 'complete', which is
+    never written by onboarding_runner — the canonical terminal-success state
+    is 'persisted'.
+    """
+    mock_db = MagicMock()
+    # Return an empty list so the template renders without needing real row data.
+    mock_db.query.return_value = []
+
+    with patch("src.web.routes.ingest.get_db", return_value=mock_db):
+        resp = client.get("/ingest/history")
+
+    assert resp.status_code == 200
+    mock_db.query.assert_called_once()
+    sql_issued = mock_db.query.call_args[0][0]
+    assert "'persisted'" in sql_issued, (
+        "persisted_count FILTER must use current_status = 'persisted', not 'complete'"
+    )
+    assert "'complete'" not in sql_issued, (
+        "SQL must not filter on 'complete' — that status is never written by onboarding_runner"
+    )


### PR DESCRIPTION
## Summary
- **A1:** `ingest_history` was filtering on `current_status='complete'`, but the canonical terminal-success state in `onboarding_runner.py:107` is `'persisted'`. Every successful filing reported as 0 on `/ingest/history`.
- **A2:** Three `subprocess.Popen` call sites opened log files inline with `# noqa: SIM115`, leaking file descriptors. Switched to open-then-close pattern (subprocess inherits the fd; safe to close the parent handle).

## Background
Caught by Codex review on PR #184; verified still applicable on `main` during the PR-review audit (see `~/.claude/plans/can-you-read-through-stateless-popcorn.md`).

## Test plan
- [x] New unit test asserts `persisted_count` reflects rows with `current_status='persisted'`
- [x] Full unit suite green (26 tests including the new one)
- [x] `ruff check` clean (no SIM115 errors after `noqa` removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)