### PR TITLE
fix(sql,ops): make sql/31 idempotent + catch renames in pre-commit migration guard

### DIFF
--- a/scripts/pre-commit-migration-name-guard.sh
+++ b/scripts/pre-commit-migration-name-guard.sh
@@ -7,13 +7,14 @@
 # 11, 12, 46 are the historical casualties). Timestamps eliminate this.
 # Legacy files stay; new migrations must use YYYYMMDDHHMM_description.sql.
 #
-# Scope: only NEW (added) sql/*.sql files. Edits/renames/deletes of legacy
-# NN_*.sql files are not blocked, so authors can freely tweak existing
-# migrations (comment fixes, etc.) without bypassing the hook.
+# Scope: NEW (added) and RENAMED sql/*.sql files. A git mv sql/old.sql
+# sql/new.sql changes the migration ID under databases that already ran
+# old.sql — the guard must catch renames as well as pure adds. Edits and
+# deletes of legacy NN_*.sql files are still not blocked.
 
 set -euo pipefail
 
-added_sql=$(git diff --cached --name-only --diff-filter=A \
+added_sql=$(git diff --cached --name-only --diff-filter=AR \
     | grep -E '^sql/.*\.sql$' || true)
 
 if [ -z "$added_sql" ]; then

--- a/sql/31_drop_v1_review_tables.sql
+++ b/sql/31_drop_v1_review_tables.sql
@@ -40,7 +40,7 @@ DROP TABLE IF EXISTS source_segments CASCADE;
 
 -- 4. Create v2_audit_log — replaces review_audit_log without the candidate_id
 --    FK (V1 candidates are gone). Schema mirrors the V1 columns we still use.
-CREATE TABLE v2_audit_log (
+CREATE TABLE IF NOT EXISTS v2_audit_log (
     log_id          BIGSERIAL PRIMARY KEY,
     timestamp       TIMESTAMPTZ NOT NULL DEFAULT now(),
     session_id      VARCHAR(255),
@@ -59,10 +59,10 @@ CREATE TABLE v2_audit_log (
         CHECK (response_status >= 100 AND response_status < 600)
 );
 
-CREATE INDEX idx_v2_audit_log_timestamp ON v2_audit_log(timestamp DESC);
-CREATE INDEX idx_v2_audit_log_session   ON v2_audit_log(session_id) WHERE session_id IS NOT NULL;
-CREATE INDEX idx_v2_audit_log_route     ON v2_audit_log(route_name);
-CREATE INDEX idx_v2_audit_log_filing    ON v2_audit_log(filing_id) WHERE filing_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_v2_audit_log_timestamp ON v2_audit_log(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_v2_audit_log_session   ON v2_audit_log(session_id) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_v2_audit_log_route     ON v2_audit_log(route_name);
+CREATE INDEX IF NOT EXISTS idx_v2_audit_log_filing    ON v2_audit_log(filing_id) WHERE filing_id IS NOT NULL;
 
 COMMENT ON TABLE  v2_audit_log IS 'Audit trail for V2 review/api_unified routes (replaces V1 review_audit_log).';
 COMMENT ON COLUMN v2_audit_log.route_name IS 'Flask endpoint name (e.g., review_unified.review_filing).';

--- a/tests/unit/scripts/test_migration_name_guard.py
+++ b/tests/unit/scripts/test_migration_name_guard.py
@@ -1,0 +1,140 @@
+"""Unit tests for scripts/pre-commit-migration-name-guard.sh.
+
+Verifies that the guard catches both newly added files (diff-filter=A) and
+renamed files (diff-filter=R) so that a `git mv sql/old.sql sql/new.sql`
+cannot silently change a migration ID on databases that already ran the old
+filename.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_GUARD = Path(__file__).resolve().parents[3] / "scripts" / "pre-commit-migration-name-guard.sh"
+
+
+def _clean_env() -> dict[str, str]:
+    # pre-commit / pre-push hooks set GIT_DIR + GIT_WORK_TREE to the host repo,
+    # which overrides cwd= for any git invocation. Strip them so tests get a
+    # clean environment that respects cwd.
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Initialise a minimal git repo with a sql/ dir and one committed migration."""
+    env = _clean_env()
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    sql_dir = tmp_path / "sql"
+    sql_dir.mkdir()
+    # Commit an initial legacy-style migration (not subject to the guard).
+    legacy = sql_dir / "31_drop_old.sql"
+    legacy.write_text("-- legacy\n")
+    subprocess.run(
+        ["git", "add", str(legacy)], cwd=tmp_path, check=True, capture_output=True, env=env
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init", "--no-gpg-sign"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    return tmp_path
+
+
+def _run_guard(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_GUARD)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+class TestMigrationNameGuardAdds:
+    def test_valid_timestamp_name_passes(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        f = repo / "sql" / "202601010000_add_something.sql"
+        f.write_text("-- ok\n")
+        subprocess.run(
+            ["git", "add", str(f)], cwd=repo, check=True, capture_output=True, env=_clean_env()
+        )
+        result = _run_guard(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_legacy_prefix_add_is_blocked(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        f = repo / "sql" / "99_new_migration.sql"
+        f.write_text("-- bad\n")
+        subprocess.run(
+            ["git", "add", str(f)], cwd=repo, check=True, capture_output=True, env=_clean_env()
+        )
+        result = _run_guard(repo)
+        assert result.returncode == 1
+        assert "legacy" in result.stderr.lower() or "NN_" in result.stderr
+
+    def test_bad_format_add_is_blocked(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        f = repo / "sql" / "add_something.sql"
+        f.write_text("-- bad\n")
+        subprocess.run(
+            ["git", "add", str(f)], cwd=repo, check=True, capture_output=True, env=_clean_env()
+        )
+        result = _run_guard(repo)
+        assert result.returncode == 1
+
+    def test_no_staged_sql_exits_0(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        result = _run_guard(repo)
+        assert result.returncode == 0
+
+
+class TestMigrationNameGuardRenames:
+    def test_rename_of_legacy_to_bad_name_is_blocked(self, tmp_path: Path) -> None:
+        """git mv of a legacy file to a non-timestamp name must be caught."""
+        repo = _init_repo(tmp_path)
+        old = repo / "sql" / "31_drop_old.sql"
+        new = repo / "sql" / "99_renamed.sql"
+        subprocess.run(
+            ["git", "mv", str(old), str(new)],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=_clean_env(),
+        )
+        result = _run_guard(repo)
+        assert result.returncode == 1, (
+            "Guard should reject the rename — the new name uses the legacy NN_ scheme"
+        )
+
+    def test_rename_to_valid_timestamp_passes(self, tmp_path: Path) -> None:
+        """git mv to a properly-formatted timestamp name should pass."""
+        repo = _init_repo(tmp_path)
+        old = repo / "sql" / "31_drop_old.sql"
+        new = repo / "sql" / "202601010000_drop_old.sql"
+        subprocess.run(
+            ["git", "mv", str(old), str(new)],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=_clean_env(),
+        )
+        result = _run_guard(repo)
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- **C1 (sql/31):** Added `IF NOT EXISTS` to `CREATE TABLE v2_audit_log` and its four `CREATE INDEX` statements. Replay (after manual `schema_migrations` row delete or partial apply) is now safe.
- **C3 (migration name guard):** Widened `--diff-filter=A` → `--diff-filter=AR` so a `git mv sql/old.sql sql/new.sql` can't silently change the migration ID under databases that already ran the old name.
- **New tests** (`tests/unit/scripts/test_migration_name_guard.py`): 6 cases covering valid timestamps, legacy adds, bad-format adds, no-staged-sql, rename-to-bad-name (blocked), rename-to-valid-timestamp (passes). Tests strip `GIT_DIR`/`GIT_WORK_TREE` from the env so they remain robust under pre-commit/pre-push hook contexts.

## Background
Caught by Codex on PRs #197 and #206; verified still applicable.

## Test plan
- [x] `pytest tests/unit/scripts/test_migration_name_guard.py -x -v` — 6/6 pass
- [x] Pre-push hooks (ruff, ruff-format, pytest, migration-order check) all pass
- [ ] Live DB idempotency check (sql/31 applied twice on a fresh DB) — skipped locally; CI will exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)