### PR TITLE
fix(db): add LATERAL classification join to get_image_review_candidate_v2

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -1822,11 +1822,21 @@ class DatabaseAdapter:
         """V2-native single-image fetch with decision (if any)."""
         sql = f"""
             SELECT {self._V2_IMAGE_CANDIDATE_SELECT},
-                f.accession_number, c.company_name, c.cik, c.ticker
+                f.accession_number, c.company_name, c.cik, c.ticker,
+                ic.classification_id,
+                ic.predicted_metrics,
+                ic.confidence        AS classification_confidence
             FROM v2_image_assets v
             JOIN filings f ON v.doc_id = f.filing_id
             JOIN companies c ON f.company_id = c.company_id
             LEFT JOIN v2_image_review_decisions d ON d.img_id = v.img_id
+            LEFT JOIN LATERAL (
+                SELECT classification_id, predicted_metrics, confidence
+                FROM v2_image_classifications
+                WHERE img_id = v.img_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) ic ON true
             WHERE v.img_id = %(img_id)s
         """
         results = self.query(sql, {"img_id": img_id})


### PR DESCRIPTION
## Summary

- Applies the `LEFT JOIN LATERAL (...) ic ON true` pattern from `get_image_review_candidates_for_filing_v2` to `get_image_review_candidate_v2`
- Adds `classification_id`, `predicted_metrics`, and `classification_confidence` columns to the single-image SELECT
- Closes issue #106

## Test plan

- [x] All 4 unit tests for skip/unskip image routes pass (`tests/unit/web/test_api_v2_images_routes.py`)
- [x] All 3826 unit tests pass
- [x] `ruff check` passes with no errors
- [ ] Integration tests for `TestGetImageReviewCandidateV2` in `tests/integration/test_db_v2_image_methods.py` will run in CI (no local Postgres in sweep environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)