### PR TITLE
fix(migrations): add 46_extend_audit_http_method_constraint.sql to apply_migrations.py

### DIFF
--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -83,6 +83,7 @@ MIGRATIONS = [
     "44_extend_image_rejection_reason_enum.sql",
     "45_create_v2_image_classifications.sql",
     "46_v2_text_metric_presence.sql",
+    "46_extend_audit_http_method_constraint.sql",
     "47_add_skip_to_image_metric_confirmations.sql",
 ]
 


### PR DESCRIPTION
Closes #204. The migration was present in apply_all_migrations.py but absent
from apply_migrations.py (the deploy-time runner and integration-test conftest).
Any HEAD/OPTIONS request through the audit-log middleware would have hit a
check-constraint violation on DBs bootstrapped via apply_migrations.py.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
