### PR TITLE
docs(known-issues): close #106 — mark LATERAL join fix resolved (merged in #224)

### DIFF
--- a/docs/known-issues/legacy-106-get-image-review-candidate-v2-lacks-classification-join.md
+++ b/docs/known-issues/legacy-106-get-image-review-candidate-v2-lacks-classification-join.md
@@ -6,12 +6,12 @@ id: 106
 severity: low
 slug: get-image-review-candidate-v2-lacks-classification-join
 source: legacy
-status: open
+status: resolved
 title: get_image_review_candidate_v2 Missing Classification LATERAL Join
 touches:
   - src/infra/db.py
   - src/web/routes/api_unified.py
-updated: '2026-04-24'
+updated: '2026-04-27'
 ---
 
 ### Problem


### PR DESCRIPTION
The get_image_review_candidate_v2 classification join was already applied
in PR #224 (commit 96403ba). Updating fragment status to resolved.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
