### PR TITLE
docs(known-issues): close #204 — mark 46_extend_audit_http_method_constraint resolved

### DIFF
--- a/docs/known-issues/gh-204-46-extend-audit-missing-from-apply-migrations.md
+++ b/docs/known-issues/gh-204-46-extend-audit-missing-from-apply-migrations.md
@@ -3,7 +3,7 @@ id: 204
 source: gh
 slug: 46-extend-audit-missing-from-apply-migrations
 title: 46_extend_audit_http_method_constraint.sql missing from apply_migrations.py MIGRATIONS list
-status: open
+status: resolved
 severity: low
 autonomy: safe
 estimated: XS


### PR DESCRIPTION
Step 1 (add migration to apply_migrations.py MIGRATIONS) was completed by
PR #226. Idempotency verified: check_v2_audit_http_method constraint is
always defined by migration 31 before migration 46 runs, so DROP CONSTRAINT
without IF EXISTS is safe. No further changes needed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
