### PR TITLE
ci: skip claude-review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]'` to the `claude-review` job
- Dependabot PRs run with restricted secret access (`Secret source: Dependabot`), so `CLAUDE_CODE_OAUTH_TOKEN` is unavailable and the job always fails
- All 5 open dependabot PRs (#227–231) are stuck with a failed `claude-review` check; once this merges I'll re-run those checks and enable auto-merge on each

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, re-run failed `claude-review` checks on PRs #227–231 — they should now show as skipped/green
- [ ] Enable auto-merge on each dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)