### PR TITLE
docs(known-issues): close #207 — listing already removed in 524cd5d

### DIFF
--- a/docs/known-issues/gh-207-human-review-system-stale-module-listing.md
+++ b/docs/known-issues/gh-207-human-review-system-stale-module-listing.md
@@ -3,14 +3,14 @@ id: 207
 source: gh
 slug: human-review-system-stale-module-listing
 title: docs/HUMAN_REVIEW_SYSTEM.md module listing references ~8 deleted V1 review files
-status: open
+status: resolved
 severity: low
 autonomy: safe
 estimated: XS
 touches:
   - docs/HUMAN_REVIEW_SYSTEM.md
 discovered: '2026-04-25'
-updated: '2026-04-25'
+updated: '2026-04-27'
 gh_issue: 207
 note: Remove ~8 deleted V1 filenames from the src/review/ module structure listing
 ---
@@ -24,3 +24,7 @@ The `src/review/` module structure listing in `docs/HUMAN_REVIEW_SYSTEM.md` (~li
 - Read the module listing in `docs/HUMAN_REVIEW_SYSTEM.md` and cross-reference against `ls src/review/`.
 - Remove all entries for files that no longer exist on disk.
 - Optionally add entries for live modules missing from the listing.
+
+### Resolution
+
+Closed as already-resolved — stale listing was removed in commit 524cd5d (presence-pivot doc audit, PR 3). docs/HUMAN_REVIEW_SYSTEM.md is now a 60-line pointer doc with no module-structure listing.


### PR DESCRIPTION
## Summary

- Closes known-issue fragment #207: stale `src/review/` module listing in `docs/HUMAN_REVIEW_SYSTEM.md`
- The listing was already removed in commit 524cd5d (presence-pivot doc audit); the doc is now a 60-line pointer with no module-structure listing
- Fragment-only administrative closure — no code or doc content changes

## Changes

- `docs/known-issues/gh-207-human-review-system-stale-module-listing.md`: `status: open` → `status: resolved`, `updated` date bumped, Resolution section appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)