### PR TITLE
fix(migrations): relax checksum guard for comment-only edits (legacy-095)

### DIFF
--- a/docs/known-issues/legacy-095-migrations-drift-from-prod-no-post-deploy-apply.md
+++ b/docs/known-issues/legacy-095-migrations-drift-from-prod-no-post-deploy-apply.md
@@ -6,14 +6,14 @@ id: 95
 severity: high
 slug: migrations-drift-from-prod-no-post-deploy-apply
 source: legacy
-status: open
+status: resolved
 title: Schema Migrations Drift From Prod — No Post-Deploy Apply Step
 touches:
   - scripts/apply_migrations.py
   - render.yaml
   - src/web/app.py
   - sql/
-updated: '2026-04-23'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -81,3 +81,16 @@ Pick one (or more) of:
 - **legacy-090** — integration tests fail on sql/37 checksum. Same class of problem.
 - Commit `8d09001` (#111) — added the cluster-DDL pre-commit guard and the `-- cluster-ddl-ok:` marker that caused this round's checksum drift.
 - PR #151 — shipped `v.detected_metrics` SELECT without enforcing migration apply; the trigger case for this issue.
+
+### Resolution
+
+Pre-deploy hook landed in PR #199 (commit `eed95a8`, `render.yaml:36`).
+Comment-only checksum guard relaxed in this PR — `_checksum` now strips
+line-leading SQL comments before hashing, with a per-row self-heal in
+`apply_migration` that updates ledger entries whose stored hash matches the
+pre-rule-change raw-byte hash. Phase-2 items (#2 app-startup migration check,
+#4 CI schema-drift check, #5 alerting) are not currently tracked — file new
+fragments if re-prioritized. Note: this fix updates only
+`scripts/apply_migrations.py`. The parallel runner
+`scripts/apply_all_migrations.py` retains its own checksum logic and is
+tracked under legacy-110 (registry drift between the two scripts).

--- a/docs/known-issues/legacy-111-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-111-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -1,0 +1,62 @@
+---
+autonomy: safe
+discovered: '2026-04-27'
+estimated: XS
+id: 111
+severity: low
+slug: stale-conftest-checksum-workarounds-after-self-heal
+source: legacy
+status: open
+title: Stale checksum-drift workarounds in tests/integration/conftest.py after self-heal landed
+touches:
+  - tests/integration/conftest.py
+updated: '2026-04-27'
+---
+
+### Problem
+
+`tests/integration/conftest.py::_apply_migrations_to_test_db` carries two
+defensive workarounds that pre-date the comment-stripping `_checksum` rule
++ per-row self-heal landed in `scripts/apply_migrations.py` (legacy-095
+Phase-1 finish):
+
+1. **Lines 383–403** — `_CHECKSUM_REFRESH_ALLOWLIST = {"37_create_analytics_role.sql"}`
+   pre-emptively `DELETE`s the ledger row for sql/37 when its current
+   raw-byte hash differs from the stored checksum, so the normal apply
+   loop re-applies it cleanly.
+2. **Lines 408–426** — try/except around `apply_migration` that catches
+   any `RuntimeError("Checksum mismatch")` on the test DB, deletes the
+   stale ledger row, logs `Auto-recovered checksum drift for ...`, and
+   retries.
+
+Both were workarounds for the exact failure mode the legacy-095 self-heal
+now handles cleanly: when a migration file gains a comment-only edit, the
+new-rule hash differs from the stored raw-byte hash, but `apply_migration`
+recognizes the file is byte-identical to what was applied (raw hash
+matches stored) and `UPDATE`s the ledger row in place.
+
+### Why not fix in legacy-095
+
+The legacy-095 PR was deliberately scoped to `scripts/apply_migrations.py`
++ unit tests + the legacy-095 fragment flip. Touching the integration
+conftest expands the diff into a different module and is better as a
+follow-up cleanup once the self-heal has soaked in CI for a few runs.
+
+### Next steps
+
+- Confirm the self-heal triggers correctly under the parallel
+  `_apply_migrations_to_test_db` path (advisory-lock serialized, per-worker
+  DBs) on at least one CI Integration Tests run.
+- Delete `_CHECKSUM_REFRESH_ALLOWLIST` and the surrounding pre-emptive
+  ledger refresh block.
+- Delete the try/except retry branch around `apply_migration`; let the
+  self-heal do the work, and let any genuine drift raise as designed.
+- Keep the cluster-DDL advisory-lock serialization — that's unrelated to
+  checksum drift.
+
+### Cross-references
+
+- legacy-095 — `migrations-drift-from-prod-no-post-deploy-apply` (parent;
+  introduced the self-heal that supersedes these workarounds).
+- legacy-110 — `migration-registry-drift-between-apply-scripts` (separate
+  drift-class issue; not a precondition for this cleanup).

--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -5,6 +5,11 @@ Apply SQL migrations to the database.
 Tracks applied migrations in a schema_migrations ledger table. Skips already-applied
 migrations. Raises on checksum mismatch to prevent silent schema drift.
 
+`_checksum` strips line-leading SQL comments before hashing so cosmetic edits
+(e.g. adding a `-- cluster-ddl-ok:` marker, fixing a typo in a header comment)
+do not trip the guard. Ledger rows written before this rule existed self-heal
+on next encounter — see `apply_migration`.
+
 Usage:
     python3 scripts/apply_migrations.py          # Uses DATABASE_URL (required)
     python3 scripts/apply_migrations.py --test    # Uses TEST_DATABASE_URL (required)
@@ -15,6 +20,7 @@ import argparse
 import hashlib
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -96,7 +102,19 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 """
 
 
+_LINE_COMMENT_RE = re.compile(r"^\s*--")
+
+
 def _checksum(sql: str) -> str:
+    # Strip line-leading SQL comments so cosmetic edits don't trip the ledger guard.
+    lines = sql.splitlines(keepends=True)
+    stripped = "".join(line for line in lines if not _LINE_COMMENT_RE.match(line))
+    return hashlib.sha256(stripped.encode()).hexdigest()
+
+
+def _raw_checksum(sql: str) -> str:
+    # Pre-rule-change hash; used only by `apply_migration` to recognize ledger rows
+    # written before `_checksum` started stripping comments.
     return hashlib.sha256(sql.encode()).hexdigest()
 
 
@@ -137,6 +155,22 @@ def apply_migration(
     if rows:
         stored_checksum = rows[0]["checksum"]
         if stored_checksum != chk:
+            # Self-heal the rule-change transition: a ledger row written before
+            # `_checksum` started stripping comments may match the raw-byte hash
+            # even though it no longer matches the new-rule hash. Proves the file
+            # is byte-identical to what was applied — update the ledger row only.
+            if stored_checksum == _raw_checksum(sql):
+                with db.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "UPDATE schema_migrations SET checksum = %(checksum)s "
+                            "WHERE id = %(id)s",
+                            {"checksum": chk, "id": migration_name},
+                        )
+                logger.info(
+                    f"  RECONCILED: {migration_name} (rule-change checksum update)"
+                )
+                return "skipped"
             raise RuntimeError(
                 f"Checksum mismatch for {migration_name}: "
                 f"expected {stored_checksum[:8]}…, got {chk[:8]}…. "

--- a/tests/unit/test_apply_migrations.py
+++ b/tests/unit/test_apply_migrations.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from scripts.apply_migrations import (  # noqa: E402
     MIGRATIONS,
     _checksum,
+    _raw_checksum,
     apply_migration,
 )
 
@@ -172,3 +173,89 @@ def test_migration_16_registered():
     idx_15 = MIGRATIONS.index("15_rename_cohort_heatmap_to_parfait.sql")
     idx_16 = MIGRATIONS.index("16_add_8k_form_type.sql")
     assert idx_16 > idx_15
+
+
+# ---------------------------------------------------------------------------
+# Tests for the comment-stripping checksum rule + rule-transition self-heal
+# (legacy-095)
+# ---------------------------------------------------------------------------
+
+
+def test_checksum_ignores_line_leading_comments():
+    """Two SQL strings differing only in line-leading -- comments hash equally."""
+    bare = "CREATE TABLE foo (id INT);\n"
+    with_comments = (
+        "-- header comment\n"
+        "  -- indented marker\n"
+        "CREATE TABLE foo (id INT);\n"
+        "-- trailing footer\n"
+    )
+    assert _checksum(bare) == _checksum(with_comments)
+
+
+def test_checksum_distinguishes_real_ddl_changes():
+    """Two SQL strings differing in actual DDL hash to different checksums."""
+    a = "CREATE TABLE foo (id INT);\n"
+    b = "CREATE TABLE foo (id BIGINT);\n"
+    assert _checksum(a) != _checksum(b)
+
+
+def test_checksum_preserves_inline_trailing_comments():
+    """Trailing -- after a statement is part of the line (not stripped)."""
+    bare = "SELECT 1;\n"
+    inline = "SELECT 1; -- note\n"
+    # Spec: only line-leading -- lines are stripped. Inline -- after a
+    # statement remains in the hashed content.
+    assert _checksum(bare) != _checksum(inline)
+
+
+def test_apply_migration_self_heals_rule_transition(tmp_path):
+    """A ledger row with the pre-rule-change raw-byte hash is auto-reconciled."""
+    name = "legacy_ledger.sql"
+    sql = "-- header comment\nCREATE TABLE foo (id INT);\n"
+    (tmp_path / name).write_text(sql)
+
+    # Stored hash predates the comment-strip rule (raw bytes).
+    stored = _raw_checksum(sql)
+    assert stored != _checksum(sql), "fixture must exercise the transition path"
+
+    executed = []
+
+    db = MagicMock()
+    db.query.side_effect = lambda q, params=None: (
+        [{"checksum": stored}] if params and params.get("id") == name else []
+    )
+
+    @contextmanager
+    def fake_get_connection():
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.execute.side_effect = lambda q, params=None: executed.append((q, params))
+        conn.cursor.return_value.__enter__ = lambda s: cur
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        yield conn
+
+    db.get_connection.side_effect = fake_get_connection
+
+    result = apply_migration(db, tmp_path, name)
+    assert result == "skipped"
+
+    update_calls = [
+        (q, p) for q, p in executed if "UPDATE schema_migrations" in q
+    ]
+    assert len(update_calls) == 1, f"expected exactly one UPDATE, got {executed}"
+    _, params = update_calls[0]
+    assert params == {"checksum": _checksum(sql), "id": name}
+
+
+def test_apply_migration_raises_when_neither_hash_matches(tmp_path):
+    """Stored matches neither new-rule nor raw hash: existing RuntimeError fires."""
+    name = "drifted.sql"
+    sql = "-- header\nCREATE TABLE foo (id INT);\n"
+    (tmp_path / name).write_text(sql)
+
+    # Some unrelated stored value — file was actually modified post-apply.
+    db = make_db(ledger_rows={name: "deadbeef" * 8})
+
+    with pytest.raises(RuntimeError, match="Checksum mismatch"):
+        apply_migration(db, tmp_path, name)


### PR DESCRIPTION
## Summary

- Closes the Phase-1 work for **legacy-095** — the pre-deploy hook half shipped in PR #199 (commit `eed95a8`); this PR ships the comment-stripping checksum half.
- `scripts/apply_migrations.py::_checksum` now strips line-leading `--` SQL comments before hashing, so cosmetic edits (e.g. `-- cluster-ddl-ok:` markers from #111, typo fixes in header comments) no longer flip the hash and halt deploys.
- `apply_migration` adds a per-row self-heal: when the stored checksum matches the raw-byte hash but not the new-rule hash, the file is proven byte-identical to what was applied — `UPDATE schema_migrations` for that single row and skip. Genuine drift (file actually edited post-apply) still raises `RuntimeError("Checksum mismatch")` as today.
- Filed **legacy-111** as a follow-up: the existing pre-emptive `_CHECKSUM_REFRESH_ALLOWLIST` and auto-recovery `try/except` blocks in `tests/integration/conftest.py` (lines 383–426) become redundant once this self-heal soaks in CI; they should be deleted in a separate PR.

### Why per-row self-heal

54 of 56 `sql/*.sql` files have line-leading `--` comments. Today prod's `schema_migrations` ledger stores `sha256(raw bytes)`. After the rule change, `_checksum` returns `sha256(stripped bytes)` — different for any file with comment lines. Without the self-heal, the **next** prod deploy after this merges would halt at the first commented migration, defeating the entire fix. The self-heal is **not** a mass update: each row is reconciled only when proven byte-identical to its applied version.

### Decision: line-leading-only stripping

Strip `^\s*--.*` whole lines. Do **not** strip trailing `--` after a statement (would need a SQL-aware parser to avoid stripping inside string literals) or `/* ... */` block comments (almost never used here, multi-line scanning is parser-prone). Every observed real-world drift case — sql/37 `cluster-ddl-ok:`, header comments, operator notes — is a line-leading comment. Test `test_checksum_preserves_inline_trailing_comments` pins this contract.

## Test plan

- [x] `pytest -x -q tests/unit/test_apply_migrations.py` — 12 passed (7 existing + 5 new: comment-line equivalence, real-DDL distinction, inline-trailing preservation, self-heal happy path, raises-when-neither-hash-matches).
- [x] `pytest -x -q tests/unit/` — 3832 passed; no regressions.
- [x] `ruff check scripts/apply_migrations.py tests/unit/test_apply_migrations.py` — clean.
- [ ] CI **Integration Tests** must pass — `tests/integration/test_migration_safety.py::test_migration_idempotency` and the `_apply_migrations_to_test_db` session fixture exercise the full apply path, including the new `_checksum` rule and self-heal branch on every worker DB.
- [ ] Confirm post-merge: tail Render `filings-reviewer` predeploy log on the next deploy and confirm any expected `RECONCILED: <name>` lines fire cleanly without halting.

## Out of scope (per task brief)

- `render.yaml` (Phase-1 already shipped in PR #199).
- `scripts/apply_all_migrations.py` registry drift — tracked under **legacy-110**.
- Phase-2 items: app-startup migration check (#2), CI schema-drift check (#4), alerting (#5). Not currently tracked; file new fragments if re-prioritized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)