### PR TITLE
fix(gold-standard): refuse --fail-on-regression with --companies/--limit (legacy-108)

### DIFF
--- a/.claude/rules/gold-standard.md
+++ b/.claude/rules/gold-standard.md
@@ -70,6 +70,7 @@ python3 -m src.gold_standard.v2_validator --limit 3 --workers 1
 - `--limit N`: cap at the first N companies (applied after `--companies` filter).
 - `--workers N`: parallel worker count (default 4; use `--workers 1` for sequential debugging).
 - `--update-baseline` is **incompatible** with `--companies` or `--limit` — the CLI errors out to prevent writing a partial baseline. Always run the full set before updating the baseline.
+s- `--fail-on-regression` is also **incompatible** with `--companies` or `--limit` (CLI exits 2). Subset-run aggregate metrics (including `tier1_presence_recall`) are structurally incomparable to the full-corpus baseline — `compare_to_baseline` would produce spurious regressions for any company whose own metrics fall below the corpus average. Use subset runs without the gate flag for development inspection; gate only on full-corpus runs (legacy-108).
 
 ## Key Metrics
 

--- a/docs/analysis/gs-baseline-drift-investigation-2026-04-25.md
+++ b/docs/analysis/gs-baseline-drift-investigation-2026-04-25.md
@@ -217,3 +217,39 @@ This is more complex but allows meaningful regression detection within a subset.
 ## 8. Prior Art
 
 The Farfetch FP pattern (period + value mismatches on `cm_active_customers_total` and `cm_purchase_transactions_overall`) was previously analyzed in `docs/analysis/INV-1_FARFETCH_EXTRACTION_REPORT.md` and `docs/analysis/HRV-4_FARFETCH_VALIDATION.md`. Those reports document the same html_table false positives. The current 11 FPs are consistent with those prior findings.
+
+---
+
+## 9. 2026-04-27 Update — Reproduction under PR2 baseline + Option A landed
+
+After this investigation closed, the PR2 baseline pivot replaced `data/gold_standard/v2_baseline.json` (new `baseline_date` `2026-04-25T20:43:45+00:00`, gate metric `tier1_presence_recall`). The structural comparator flaw persisted; only the surface symptom shifted.
+
+**Re-reproduction on Farfetch (clean main, today):**
+
+```
+python3 -m src.gold_standard.v2_validator --companies "Farfetch Limited" --workers 1 --fail-on-regression
+```
+
+| Field | Value |
+|---|---|
+| Subset `tier1_presence_recall` | 0.500 (2/4: `cm_ltv_to_cac_ratio`, `cm_ltv_to_cac_ratio_by_cohort` detected; `cm_gross_margin_by_cohort`, `cm_revenue_by_cohort` not) |
+| Baseline `tier1_presence_recall` (corpus) | 0.853 |
+| `tier1_presence_recall_delta` | −0.353 |
+| `has_regression` | **True** (`[GATE] tier1_presence_recall`, `[informational] precision`) |
+
+The gate metric moved from `precision` (pre-PR2) to `tier1_presence_recall` (post-PR2). Same root cause: subset `current.tier1_presence_recall` compared against `baseline.tier1_presence_recall` (corpus aggregate). Any company whose subset tier-1 presence-recall lies below 0.853 trips the false positive.
+
+**Cross-corpus check — Datadog, Inc. (clean main, today):**
+
+| Field | Value |
+|---|---|
+| Subset `tier1_presence_recall` | 1.000 |
+| Baseline `tier1_presence_recall` (corpus) | 0.853 |
+| `tier1_presence_recall_delta` | +0.147 |
+| `has_regression` | False (passes) |
+
+Datadog passes because its subset value sits above the corpus baseline. Combined with the precision-era Chewy reproduction (§4), this confirms the false positive is structural and cross-corpus — not Farfetch-specific extraction drift.
+
+**Resolution.** Option A from §7 was implemented in this branch: the `logger.warning` at `src/gold_standard/v2_validator.py:2395` was replaced with `print(...)` + `sys.exit(2)`, making `--fail-on-regression` mutually incompatible with `--companies` / `--limit`. The pre-existing test asserting the warning behavior was rewritten to assert `SystemExit(2)`, and a companion test for `--limit` was added. `.claude/rules/gold-standard.md` §"Subsetting during iteration" now documents the new constraint alongside the existing `--update-baseline` rule. Known-issue `legacy-108` flipped to `status: resolved`.
+
+Option B (subset-aware comparison) is **not** pursued: it would require capturing per-company `tier1_presence_recall` in the baseline schema (currently corpus-only at `baseline.py:62-63`). The pre-commit hook and CI both run full-corpus validation, so subset-gating has no production use case to justify the schema work.

--- a/docs/known-issues/legacy-108-gs-validator-baseline-drift-farfetch.md
+++ b/docs/known-issues/legacy-108-gs-validator-baseline-drift-farfetch.md
@@ -6,12 +6,12 @@ id: 108
 severity: medium
 slug: gs-validator-baseline-drift-farfetch
 source: legacy
-status: partially-resolved
+status: resolved
 title: GS Validator Baseline Drift — Farfetch Reports has_regression=True on Unmodified Main
 touches:
   - src/gold_standard/v2_validator.py
   - data/gold_standard/Farfetch_Limited
-updated: '2026-04-25'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -45,3 +45,11 @@ Cross-corpus check on Chewy confirms the pattern is systemic: Chewy's company-sp
 **Recommendation:** Do NOT update the baseline. Fix `src/gold_standard/v2_validator.py` lines 2224–2228 to refuse (exit 2) rather than warn when `--fail-on-regression` is combined with `--companies` or `--limit`. The comparison is structurally invalid for subset runs. See Option A in the analysis doc for the exact change. **The user must approve and run any code change.**
 
 Tier 1 metrics (cm_ltv_to_cac_ratio, cm_ltv_to_cac_ratio_by_cohort) are perfect on Farfetch (P=R=F1=100%). The 11 FPs are pre-existing Tier 2 issues (period/value mismatches on html_table rows for cm_active_customers_total and cm_purchase_transactions_overall) unchanged since at least HRV-4.
+
+### Resolution 2026-04-27
+
+After the PR2 baseline pivot (2026-04-25T20:43:45) the same structural false positive reproduced — the gate metric simply moved from `precision` to `tier1_presence_recall` (Farfetch subset 0.50 vs corpus baseline 0.853, delta −0.353). Cross-corpus check on Datadog (subset 1.00 vs 0.853) confirmed the pattern is structural and not Farfetch-specific. See `docs/analysis/gs-baseline-drift-investigation-2026-04-25.md` §9 for the post-PR2 numbers.
+
+Implemented Option A from the analysis doc: replaced the `logger.warning` at `src/gold_standard/v2_validator.py:2395` with `print(...)` + `sys.exit(2)` so `--fail-on-regression` is mutually incompatible with `--companies` / `--limit`. Subset runs without the gate flag continue to work for development inspection; the pre-commit hook and CI run full-corpus validation, which is unaffected.
+
+Tests: rewrote `test_run_validation_subset_warning_logged` → `test_run_validation_rejects_companies_with_fail_on_regression` (asserts `SystemExit(2)`); added companion `test_run_validation_rejects_limit_with_fail_on_regression`. Documented the new constraint in `.claude/rules/gold-standard.md` §"Subsetting during iteration".

--- a/docs/known-issues/legacy-111-full-corpus-tier1-presence-recall-regression.md
+++ b/docs/known-issues/legacy-111-full-corpus-tier1-presence-recall-regression.md
@@ -1,0 +1,38 @@
+---
+autonomy: review
+discovered: '2026-04-27'
+estimated: M
+id: 111
+severity: high
+slug: full-corpus-tier1-presence-recall-regression
+source: legacy
+status: open
+title: Full-corpus Tier-1 presence-recall regression on clean main blocks --fail-on-regression gate
+touches:
+  - data/gold_standard/v2_baseline.json
+  - src/extraction_v2/
+updated: '2026-04-27'
+---
+
+### Problem
+
+`python3 -m src.gold_standard.v2_validator --fail-on-regression` on unmodified `origin/main` (today, 2026-04-27) reports `has_regression=True`:
+
+```
+ComparisonResult(precision_delta=+0.0086, recall_delta=+0.2782, f1_delta=+0.2045,
+                 has_regression=True, regressed_companies=[],
+                 regressed_metrics=['[GATE] tier1_presence_recall', '[informational] tier2_presence_recall'],
+                 tier1_presence_recall_delta=-0.012, tier2_presence_recall_delta=-0.010)
+COMMIT BLOCKED: V2 gold standard regression detected
+```
+
+Current full-corpus `tier1_presence_recall = 0.841` vs baseline `0.853` (1.2pp drop). The gate metric is the production purpose of `--fail-on-regression`, so it currently blocks any commit that triggers the gate. This is the *real* regression (distinct from the legacy-108 false-positive subset comparator flaw, which was fixed by the CLI guard in PR/commit landing 2026-04-27).
+
+Discovered while running step 3 of the legacy-108 verification plan; the failure is on clean main and reproduces without local changes (CLI guard change only affects `--companies`/`--limit` paths).
+
+### Next Steps
+
+- Identify which Tier-1 metric(s) lost presence: re-run with `--fn-diagnostics` and inspect the `==== TEXT-PRESENCE TIER BREAKDOWN ====` per-metric block for any Tier-1 row that dropped to <100% recall vs baseline.
+- Bisect commits between baseline date `2026-04-25T20:43:45+00:00` and HEAD against `src/extraction_v2/`, `config/metric_keywords.yaml`, and `src/shared/keyword_config.py`.
+- Either (a) fix the regression in code, or (b) if the drop is intentional, run `--update-baseline --description "..."` on the full corpus to recalibrate.
+- Until resolved, full-corpus `--fail-on-regression` is unusable; document the workaround if needed.

--- a/docs/known-issues/legacy-112-test-accession-normalization-check-form-type.md
+++ b/docs/known-issues/legacy-112-test-accession-normalization-check-form-type.md
@@ -1,0 +1,33 @@
+---
+autonomy: safe
+discovered: '2026-04-27'
+estimated: S
+id: 112
+severity: medium
+slug: test-accession-normalization-check-form-type
+source: legacy
+status: open
+title: tests/integration/infra/test_accession_normalization.py — all upsert tests fail on check_form_type
+touches:
+  - tests/integration/infra/test_accession_normalization.py
+  - sql/
+updated: '2026-04-27'
+---
+
+### Problem
+
+On clean `origin/main`, every test in `TestUpsertFilingNormalizes` (e.g. `test_path_prefixed_accession_stored_as_bare_token`, `test_bare_token_unchanged`) fails with:
+
+```
+psycopg.errors.CheckViolation: new row for relation "filings" violates check constraint "check_form_type"
+DETAIL: Failing row contains (..., 8-K, 2023-11-01, ...)
+```
+
+The tests insert filings with `form_type = '8-K'`, but the live schema's `check_form_type` constraint apparently no longer permits `8-K`. Either the constraint tightened (S-1/F-1 only) or the test fixture was never updated when the constraint changed. Reproducible under `git stash` of all local changes.
+
+### Next Steps
+
+- Inspect the live `check_form_type` constraint definition: `psql -c "\d+ filings"` against the test database, or grep `sql/` for `check_form_type`.
+- If the constraint is correct (S-1/F-1 only by design), update the test fixtures to use a permitted form type.
+- If the constraint is wrong (over-tightened), restore `8-K` to the allowed set via a new migration.
+- Verify the fix by running `pytest tests/integration/infra/test_accession_normalization.py -x -q`.

--- a/docs/known-issues/legacy-113-test-db-filings-reviewers-v2-documents-missing.md
+++ b/docs/known-issues/legacy-113-test-db-filings-reviewers-v2-documents-missing.md
@@ -1,0 +1,35 @@
+---
+autonomy: safe
+discovered: '2026-04-27'
+estimated: S
+id: 113
+severity: medium
+slug: test-db-filings-reviewers-v2-documents-missing
+source: legacy
+status: open
+title: test_db_filings_reviewers.py — test_reviewers_aggregates_text_and_image_sources fails on missing v2_documents relation
+touches:
+  - tests/integration/test_db_filings_reviewers.py
+  - sql/
+updated: '2026-04-27'
+---
+
+### Problem
+
+`tests/integration/test_db_filings_reviewers.py::TestReviewerAggregation::test_reviewers_aggregates_text_and_image_sources` fails on clean `origin/main`:
+
+```
+psycopg.errors.UndefinedTable: relation "v2_documents" does not exist
+LINE 2: INSERT INTO v2_documents (filing_id, parse_version, ...
+```
+
+The test inserts directly into `v2_documents`, but the integration test database setup did not create the V2 schema. Either the test conftest is missing a migration step, the migration registry is out of order (cf. legacy-110), or the per-worker DB isolation fixture (`tests/integration/conftest.py::_isolate_xdist_worker_database`) is skipping V2 tables. Reproducible under `git stash` of all local changes.
+
+This is **not** the same as legacy-076 (which was about *missing tests*; that test was added). This is the test breaking due to schema setup drift.
+
+### Next Steps
+
+- Run the integration conftest migration step manually against the test DB and confirm whether `v2_documents` is created (`\dt v2_*` in `psql`).
+- Cross-reference with legacy-110 (migration registry drift between apply scripts) — likely the same root cause.
+- Either fix the migration registry / conftest setup, or update the test to skip when V2 schema is absent (last resort).
+- Confirm by running `pytest tests/integration/test_db_filings_reviewers.py -x -q`.

--- a/src/gold_standard/v2_validator.py
+++ b/src/gold_standard/v2_validator.py
@@ -2393,10 +2393,17 @@ def run_validation(
         validator.save_baseline(metrics, description=baseline_description)
 
     if fail_on_regression and (companies or limit is not None):
-        logger.warning(
-            "fail_on_regression with a subset: comparison is partial; "
-            "regressions outside the subset will not be caught"
+        print(
+            "ERROR: --fail-on-regression cannot be combined with --companies or --limit.\n"
+            "Subset-run aggregate metrics (including tier1_presence_recall) are\n"
+            "structurally incomparable to the full-corpus baseline. The comparator\n"
+            "compares the subset's overall against baseline.overall, producing\n"
+            "spurious regressions for any company whose own metrics fall below the\n"
+            "corpus average. Run without --companies/--limit for regression gating;\n"
+            "use --companies for development inspection without the gate.",
+            file=sys.stderr,
         )
+        sys.exit(2)
 
     if fail_on_regression:
         try:

--- a/tests/unit/gold_standard/test_v2_validator.py
+++ b/tests/unit/gold_standard/test_v2_validator.py
@@ -2373,12 +2373,13 @@ class TestRunValidationGuardsAndWorkers:
         call_kwargs = mock_instance.validate_all.call_args
         assert call_kwargs.kwargs.get("max_workers") == 4
 
-    @patch("src.gold_standard.v2_validator.logger")
     @patch("src.gold_standard.v2_validator.V2GoldStandardValidator")
-    def test_run_validation_subset_warning_logged(
-        self, mock_validator_cls: MagicMock, mock_logger: MagicMock
+    def test_run_validation_rejects_companies_with_fail_on_regression(
+        self, mock_validator_cls: MagicMock
     ) -> None:
-        """fail_on_regression with a subset logs a 'comparison is partial' warning."""
+        """fail_on_regression combined with --companies must exit(2): subset
+        aggregates are structurally incomparable to the full-corpus baseline
+        (legacy-108)."""
         mock_instance = mock_validator_cls.return_value
         mock_instance.validate_all.return_value = []
         mock_instance.compute_metrics.return_value = AggregateMetrics(
@@ -2389,15 +2390,35 @@ class TestRunValidationGuardsAndWorkers:
             total_false_positives=1,
             total_false_negatives=1,
         )
-        # compare_to_baseline raises FileNotFoundError so fail_on_regression exits cleanly
-        mock_instance.compare_to_baseline.side_effect = FileNotFoundError
 
         from src.gold_standard.v2_validator import run_validation
 
-        run_validation(companies=["SomeCo"], fail_on_regression=True)
+        with pytest.raises(SystemExit) as exc:
+            run_validation(companies=["SomeCo"], fail_on_regression=True)
+        assert exc.value.code == 2
 
-        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        assert any("comparison is partial" in msg for msg in warning_calls)
+    @patch("src.gold_standard.v2_validator.V2GoldStandardValidator")
+    def test_run_validation_rejects_limit_with_fail_on_regression(
+        self, mock_validator_cls: MagicMock
+    ) -> None:
+        """fail_on_regression combined with --limit must exit(2) for the same
+        structural reason as --companies (legacy-108)."""
+        mock_instance = mock_validator_cls.return_value
+        mock_instance.validate_all.return_value = []
+        mock_instance.compute_metrics.return_value = AggregateMetrics(
+            precision=0.5,
+            recall=0.5,
+            f1=0.5,
+            total_true_positives=1,
+            total_false_positives=1,
+            total_false_negatives=1,
+        )
+
+        from src.gold_standard.v2_validator import run_validation
+
+        with pytest.raises(SystemExit) as exc:
+            run_validation(limit=3, fail_on_regression=True)
+        assert exc.value.code == 2
 
 
 class TestStageTimingSummary:


### PR DESCRIPTION
## Summary

Resolves [legacy-108](docs/known-issues/legacy-108-gs-validator-baseline-drift-farfetch.md) — the GS validator's `has_regression=True` false positive when `--companies` (or `--limit`) is combined with `--fail-on-regression`. The 2026-04-25 investigation diagnosed it as a comparator design flaw (subset-run aggregates compared against the full-corpus baseline); after the PR2 baseline pivot the symptom moved from `precision` → `tier1_presence_recall` (Farfetch subset 0.50 vs corpus baseline 0.853) but the structural cause persisted.

This PR implements **Option A** from the analysis doc: replace the silent `logger.warning` at `v2_validator.py:2395` with `print(... file=sys.stderr) + sys.exit(2)`, mirroring the existing pattern for `--update-baseline` + subset (line 2338). Subset runs without `--fail-on-regression` continue to work for development inspection; full-corpus gating is unaffected.

Cross-corpus check captured in §9 of the analysis doc — Datadog subset (`tier1_presence_recall = 1.00 > 0.853`) passes, confirming the false positive is structural, not Farfetch-specific.

- Code: 8-line CLI guard added (mirrors v2_validator.py:2338 pattern).
- Tests: 1 rewritten + 1 new — both assert `SystemExit(2)`. All 3828 unit tests pass.
- Docs: analysis doc §9 (post-PR2 reproduction + Datadog cross-corpus), known-issue flipped to `resolved`, one sentence in `.claude/rules/gold-standard.md`.

## Out-of-scope issues filed (separate commit)

Three pre-existing issues surfaced during verification (all reproduce on stashed clean main):

- `legacy-111` (high) — full-corpus `tier1_presence_recall` regression on clean main blocks `--fail-on-regression` (current 0.841 vs baseline 0.853, delta −0.012)
- `legacy-112` (medium) — `tests/integration/infra/test_accession_normalization.py` upsert tests fail with `check_form_type` rejecting `'8-K'`
- `legacy-113` (medium) — `test_db_filings_reviewers.py::test_reviewers_aggregates_text_and_image_sources` fails on missing `v2_documents` relation

## Test plan

- [x] `python3 -m src.gold_standard.v2_validator --companies "Farfetch Limited" --workers 1 --fail-on-regression` → exits 2 with the new error message
- [x] `python3 -m src.gold_standard.v2_validator --companies "Farfetch Limited" --workers 1` → full report, exits 0
- [x] `python3 -m src.gold_standard.v2_validator --fail-on-regression` (full corpus) → comparator runs unchanged (separate pre-existing regression filed as legacy-111)
- [x] `pytest tests/unit/ -x -q` → 3828 passed
- [x] `pre-commit run --files <changed>` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)