### PR TITLE
fix(gold-standard): always set retain_context on validator pipeline (closes #98)

### DIFF
--- a/docs/known-issues/legacy-098-validator-presence-f1-not-populated.md
+++ b/docs/known-issues/legacy-098-validator-presence-f1-not-populated.md
@@ -10,12 +10,12 @@ note: 'PR #150 added the presence P/R/F1 infrastructure to the validator + basel
 severity: low
 slug: validator-presence-f1-not-populated
 source: legacy
-status: open
+status: resolved
 title: Validator presence_f1 Stays Null — detected_metrics Not Populated in-Memory
 touches:
   - src/gold_standard/v2_validator.py
   - src/extraction_v2/stages/chart_fact_bridge.py
-updated: '2026-04-24'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -54,3 +54,7 @@ Confirmed via grep: `_chart_presence_set_from_context` (`v2_validator.py` around
 - Parent rollout: legacy-096.
 - Introducing PR: #150.
 - Baseline refresh PR (where this was surfaced): PR 4b.
+
+### Resolution
+
+Closed in PR #<n> — `V2GoldStandardValidator.__init__` now unconditionally sets `retain_context=True` on the pipeline config (previously gated on `fn_diagnostics=True`). Without `retain_context`, `pipeline.process()` returned no `v2_context`, so `_chart_presence_set_from_context` could not read `v2_context.images[*].detected_metrics` and `presence_tp/fp/fn` stayed zero. With the fix, the next vision-enabled baseline refresh will populate `presence_f1` (an empirical run was not possible in the development environment due to vision API gating; the unit test in `TestValidatorFNDiagnosticsFlag` confirms `retain_context=True` is now always set).

--- a/src/gold_standard/v2_validator.py
+++ b/src/gold_standard/v2_validator.py
@@ -459,12 +459,13 @@ class V2GoldStandardValidator:
         self.gold_standard_path = Path(gold_standard_path)
         self.fn_diagnostics = fn_diagnostics
 
-        # When FN diagnostics are enabled, set retain_context on the pipeline config
-        if fn_diagnostics:
-            base = v2_config or PipelineConfig()
-            self.v2_config = dc_replace(base, retain_context=True)
-        else:
-            self.v2_config = v2_config or PipelineConfig()
+        # retain_context=True is always required so that validate_filing() can
+        # access v2_context.images[*].detected_metrics for chart-presence P/R scoring
+        # (the block at line ~827 guards on `v2_context is not None`).  Previously this
+        # was only set when fn_diagnostics=True, which caused presence_tp/fp/fn to stay
+        # zero on normal runs and presence_f1 to never appear in the baseline.
+        base = v2_config or PipelineConfig()
+        self.v2_config = dc_replace(base, retain_context=True)
 
         self.value_tolerance = value_tolerance
         self.min_confidence = min_confidence

--- a/tests/unit/gold_standard/test_v2_validator.py
+++ b/tests/unit/gold_standard/test_v2_validator.py
@@ -2176,7 +2176,11 @@ class TestPrintFNDiagnostics:
 
 
 class TestValidatorFNDiagnosticsFlag:
-    """Tests that fn_diagnostics flag correctly sets retain_context."""
+    """Tests that retain_context is always enabled on the validator's pipeline config.
+
+    retain_context=True is unconditionally set so that _chart_presence_set_from_context
+    can inspect v2_context.images after pipeline.process(), regardless of fn_diagnostics.
+    """
 
     def test_fn_diagnostics_true_sets_retain_context(self) -> None:
         validator = V2GoldStandardValidator(
@@ -2186,16 +2190,17 @@ class TestValidatorFNDiagnosticsFlag:
         assert validator.fn_diagnostics is True
         assert validator.v2_config.retain_context is True
 
-    def test_fn_diagnostics_false_does_not_set_retain_context(self) -> None:
+    def test_fn_diagnostics_false_still_sets_retain_context(self) -> None:
+        """retain_context is always True regardless of fn_diagnostics (fixes #98)."""
         validator = V2GoldStandardValidator(
             gold_standard_path="/dev/null",
             fn_diagnostics=False,
         )
         assert validator.fn_diagnostics is False
-        assert validator.v2_config.retain_context is False
+        assert validator.v2_config.retain_context is True
 
-    def test_custom_config_retain_context_preserved(self) -> None:
-        """When fn_diagnostics=True, retain_context is set regardless of base config."""
+    def test_custom_config_retain_context_always_forced_true(self) -> None:
+        """retain_context is forced True even when base config sets it False."""
         base_config = PipelineConfig(retain_context=False, enable_image_extraction=False)
         validator = V2GoldStandardValidator(
             gold_standard_path="/dev/null",


### PR DESCRIPTION
## Summary

- **Root cause**: `V2GoldStandardValidator.__init__` only set `retain_context=True` when `fn_diagnostics=True`. When `fn_diagnostics` was `False` (the default), `pipeline.process()` returned no `v2_context`, so `_chart_presence_set_from_context` could not read `v2_context.images[*].detected_metrics` and `presence_tp/fp/fn` stayed zero — causing `presence_f1` to remain `None` in every baseline run since PR #150 landed.
- **Fix**: Remove the `fn_diagnostics` gate; `retain_context=True` is now unconditionally set on the pipeline config in `__init__`.
- **Test update**: `TestValidatorFNDiagnosticsFlag` — the test that previously asserted `retain_context is False` when `fn_diagnostics=False` is inverted to assert `is True`. All 186 tests in the validator test file pass.

## Caveat — empirical presence_f1 confirmation pending

An end-to-end validator run with vision-enabled images was not possible in this development environment (no `OPENAI_API_KEY`). Confirming that `presence_f1` is non-null in `v2_baseline.json` requires a separate vision-enabled baseline refresh PR (standard ritual per CLAUDE.md). This PR ships the structural fix only.

## Test plan

- [x] `pytest -x -q tests/unit/gold_standard/test_v2_validator.py::TestValidatorFNDiagnosticsFlag` — 3 passed
- [x] `pytest -x -q tests/unit/gold_standard/test_v2_validator.py` — 186 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)