### PR TITLE
fix(known-issues): renumber duplicate legacy-111 fragment to legacy-114

### DIFF
--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -2,7 +2,7 @@
 autonomy: safe
 discovered: '2026-04-27'
 estimated: XS
-id: 111
+id: 114
 severity: low
 slug: stale-conftest-checksum-workarounds-after-self-heal
 source: legacy


### PR DESCRIPTION
## Summary

- Two known-issue fragments both claimed `id: 111`: `full-corpus-tier1-presence-recall-regression` (created in #245) and `stale-conftest-checksum-workarounds-after-self-heal` (created in #243)
- The duplicate caused CI failures on all PRs: **Lint** (`Known-issues fragments validate`), **Known-issues rollup artifact**, and **Unit Tests** (`test_dry_run_produces_valid_output`)
- Renumbered the stale-conftest fragment to `id: 114` (next available slot after 113) and renamed the file accordingly

## Test plan

- [x] `test_known_issues_selector.py::TestFragmentParityWithMainBaseline::test_dry_run_produces_valid_output` passes locally
- [ ] CI Lint / Known-issues rollup / Unit Tests pass on this PR
- [ ] PR 248 CI green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)