### PR TITLE
fix(filing-fetcher): fetch exhibit 99.1 for 8-K filings (closes #58)

### DIFF
--- a/docs/known-issues/legacy-058-8-k-fetcher-returns-only-primary-doc-earnings-content-lives.md
+++ b/docs/known-issues/legacy-058-8-k-fetcher-returns-only-primary-doc-earnings-content-lives.md
@@ -7,12 +7,13 @@ note: 8-K Exhibit 99.1 fetch; feature add, needs validator run
 severity: medium
 slug: 8-k-fetcher-returns-only-primary-doc-earnings-content-lives
 source: legacy
-status: open
+status: resolved
 title: 8-K Fetcher Returns Only Primary Doc; Earnings Content Lives in Exhibit 99.1
 touches:
 - src/filing_fetcher/*.py
-- tests/unit/filing_fetcher/*.py
-updated: '2026-04-20'
+- src/infra/sec_client.py
+- tests/integration/filing_fetcher/test_8k_exhibit_fetch.py
+updated: '2026-04-27'
 ---
 
 ### Problem

--- a/docs/known-issues/legacy-115-8k-exhibit-99-1-pdf-format-silently-skipped.md
+++ b/docs/known-issues/legacy-115-8k-exhibit-99-1-pdf-format-silently-skipped.md
@@ -1,0 +1,25 @@
+---
+autonomy: safe
+discovered: '2026-04-27'
+estimated: S
+id: 115
+severity: low
+slug: 8k-exhibit-99-1-pdf-format-silently-skipped
+source: legacy
+status: open
+title: 8-K Exhibit 99.1 in PDF Format is Silently Skipped
+touches:
+- src/infra/sec_client.py
+- src/filing_fetcher/filing_fetcher.py
+updated: '2026-04-27'
+---
+
+### Problem
+
+`SECClient.get_exhibit_99_1_url` (added in legacy-058 fix) only matches `.htm` / `.html` filenames when scanning EDGAR `index.json`. If a filer submits exhibit 99.1 as a PDF (e.g. `exhibit99-1.pdf`), the method returns `None` and `FilingFetcher.fetch_filing` silently proceeds with the primary-only content. No warning is emitted. PDF-format earnings releases are not uncommon for some smaller or older filers.
+
+### Next Steps
+
+- Extend `get_exhibit_99_1_url` to also match `.pdf` filenames via the existing `_EXHIBIT_991_RE` regex.
+- In `FilingFetcher.fetch_filing`, if the exhibit URL resolves to a `.pdf`, attempt a text extraction pass (e.g. via `pdfminer` or the existing OCR path) and append the extracted text to the combined HTML. Alternatively log a warning and skip — the warning is the minimum acceptable fix so operators can identify affected filings.
+- Add a test case: `get_exhibit_99_1_url` returns a `.pdf` URL when only a PDF exhibit is listed in the index.

--- a/docs/known-issues/legacy-116-8k-e2e-pipeline-test-for-exhibit-content.md
+++ b/docs/known-issues/legacy-116-8k-e2e-pipeline-test-for-exhibit-content.md
@@ -1,0 +1,24 @@
+---
+autonomy: safe
+discovered: '2026-04-27'
+estimated: S
+id: 116
+severity: low
+slug: 8k-e2e-pipeline-test-for-exhibit-content
+source: legacy
+status: open
+title: Missing E2E Pipeline Test for 8-K Exhibit Metric Extraction
+touches:
+- tests/integration/extraction_v2/
+updated: '2026-04-27'
+---
+
+### Problem
+
+The integration test added with the legacy-058 fix (`tests/integration/filing_fetcher/test_8k_exhibit_fetch.py`) validates only that the fetcher writes the combined HTML correctly. It does not run the full V2 pipeline and cannot assert that segment count is non-trivial (> 20) or that at least one `v2_metric_facts` row is produced from the exhibit content. The pipeline-level assertion was explicitly deferred from the legacy-058 PR scope.
+
+### Next Steps
+
+- Add an E2E test in `tests/integration/extraction_v2/` that feeds a Samsara-shaped 8-K fixture (primary cover page + exhibit 99.1 with known earnings language) through `process_filing`.
+- Assert: (i) `len(result.segments) > 20`, (ii) at least one `MetricFact` is produced whose source segment text contains exhibit-sourced language (e.g. "total revenue" or "ARR").
+- Use the existing `data/gold_standard/` fixture pattern. Samsara 2025-08-21 (CIK 1642545) is the canonical example — a sanitized copy of the exhibit HTML is the recommended fixture source.

--- a/src/filing_fetcher/filing_fetcher.py
+++ b/src/filing_fetcher/filing_fetcher.py
@@ -20,6 +20,8 @@ from src.infra.sec_client import FilingMetadata, SECClient
 
 logger = logging.getLogger(__name__)
 
+_EXHIBIT_SEPARATOR = "<!-- EXHIBIT-99.1 -->"
+
 
 @dataclass
 class FilingContent:
@@ -129,7 +131,11 @@ class FilingFetcher:
         return self.storage_root / cik / accession_clean
 
     def _validate_filing_content(
-        self, html: str, cik: str, accession_number: str
+        self,
+        html: str,
+        cik: str,
+        accession_number: str,
+        skip_size_check: bool = False,
     ) -> tuple[bool, str | None]:
         """
         Validate that HTML content is a real SEC filing, not an error page.
@@ -143,13 +149,16 @@ class FilingFetcher:
             html: HTML content to validate
             cik: Expected CIK for additional validation
             accession_number: Expected accession number
+            skip_size_check: When True, skip the minimum-size guard. Used for
+                8-K cover pages that are legitimately small; the combined
+                primary+exhibit content is validated separately.
 
         Returns:
             Tuple of (is_valid, error_message)
         """
         # Check 1: Minimum size - SEC filings are typically > 15KB
         # Lowered from 20KB to capture small legitimate filings (amendments, etc.)
-        if len(html) < 15_000:
+        if not skip_size_check and len(html) < 15_000:
             return (
                 False,
                 f"Content too small ({len(html):,} bytes, expected > 15KB) - likely an error page",
@@ -289,6 +298,7 @@ class FilingFetcher:
         resolved_url_for_db = None
 
         html_text: str | None = None
+        is_8k = filing_metadata.form_type.upper().startswith("8-K")
 
         try:
             # Fetch HTML filing
@@ -313,9 +323,11 @@ class FilingFetcher:
                 response = self.session.get(primary_doc_url)
                 response.raise_for_status()
 
-                # Validate content before saving
+                # Validate content before saving.
+                # For 8-K forms the primary doc is often a small cover page (<15 KB);
+                # skip the size check here and validate the combined content instead.
                 is_valid, error_msg = self._validate_filing_content(
-                    response.text, cik, accession_number
+                    response.text, cik, accession_number, skip_size_check=is_8k
                 )
                 if not is_valid:
                     raise ValueError(f"Invalid filing content: {error_msg}")
@@ -323,8 +335,59 @@ class FilingFetcher:
                 html_path.write_text(response.text, encoding="utf-8")
                 html_text = response.text
                 logger.info(f"Saved HTML to {html_path}")
+
+                if is_8k:
+                    exhibit_url = self.sec_client.get_exhibit_99_1_url(
+                        cik, accession_number
+                    )
+                    if exhibit_url:
+                        self._rate_limit()
+                        logger.debug(f"Fetching exhibit 99.1: {exhibit_url}")
+                        exhibit_resp = self.session.get(exhibit_url)
+                        exhibit_resp.raise_for_status()
+                        combined = (
+                            response.text
+                            + f"\n{_EXHIBIT_SEPARATOR}\n"
+                            + exhibit_resp.text
+                        )
+                        is_valid, error_msg = self._validate_filing_content(
+                            combined, cik, accession_number
+                        )
+                        if not is_valid:
+                            logger.warning(
+                                f"Combined 8-K content invalid for "
+                                f"{cik}/{accession_number}: {error_msg}; "
+                                f"proceeding with primary only"
+                            )
+                        else:
+                            html_path.write_text(combined, encoding="utf-8")
+                            html_text = combined
+                            logger.info(
+                                f"Appended exhibit 99.1 to {html_path} "
+                                f"({len(combined):,} combined bytes)"
+                            )
             else:
                 logger.debug(f"HTML already cached: {html_path}")
+                if is_8k:
+                    existing = html_path.read_text(encoding="utf-8")
+                    if _EXHIBIT_SEPARATOR not in existing:
+                        exhibit_url = self.sec_client.get_exhibit_99_1_url(
+                            cik, accession_number
+                        )
+                        if exhibit_url:
+                            self._rate_limit()
+                            exhibit_resp = self.session.get(exhibit_url)
+                            exhibit_resp.raise_for_status()
+                            combined = (
+                                existing
+                                + f"\n{_EXHIBIT_SEPARATOR}\n"
+                                + exhibit_resp.text
+                            )
+                            html_path.write_text(combined, encoding="utf-8")
+                            html_text = combined
+                            logger.info(
+                                f"Backfilled exhibit 99.1 into cached {html_path}"
+                            )
 
             # Fetch TXT filing (if requested and URL available)
             # TXT files are optional - don't fail entire fetch if unavailable

--- a/src/infra/sec_client.py
+++ b/src/infra/sec_client.py
@@ -621,6 +621,32 @@ class SECClient:
             logger.error(f"Error resolving primary doc for {cik}/{accession_number}: {e}")
             return None
 
+    _EXHIBIT_991_RE = re.compile(r"ex(?:hibit)?[-_]?99[-_.]?1", re.IGNORECASE)
+
+    def get_exhibit_99_1_url(self, cik: str, accession_number: str) -> str | None:
+        """Return the EDGAR URL of exhibit 99.1 for an 8-K filing, or None if not found."""
+        bare = extract_sec_accession_token(accession_number)
+        if bare is None:
+            return None
+        accession_no_dashes = bare.replace("-", "")
+        index_url = (
+            f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
+            f"{accession_no_dashes}/index.json"
+        )
+        try:
+            data = self._make_request(index_url)
+        except Exception:
+            return None
+        items = data.get("directory", {}).get("item", [])
+        for item in items:
+            name = item.get("name", "")
+            if name.endswith((".htm", ".html")) and self._EXHIBIT_991_RE.search(name):
+                return (
+                    f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
+                    f"{accession_no_dashes}/{name}"
+                )
+        return None
+
     def get_company_info(self, cik: str) -> dict | None:
         """
         Get company information including SIC code from SEC submissions API.

--- a/tests/integration/filing_fetcher/test_8k_exhibit_fetch.py
+++ b/tests/integration/filing_fetcher/test_8k_exhibit_fetch.py
@@ -1,0 +1,224 @@
+"""
+Tests for FilingFetcher 8-K exhibit 99.1 fetching.
+
+Verifies:
+- 8-K filings fetch exhibit 99.1 and concatenate it with the primary document
+- 8-K/A is also covered (form_type.startswith("8-K"))
+- S-1/F-1 filings are unaffected
+- Idempotency: cached file with separator is a no-op on re-fetch
+- Backfill: cached file without separator gets exhibit appended on re-fetch
+- Missing exhibit does not fail the fetch
+
+No database required — all HTTP is mocked.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.filing_fetcher.filing_fetcher import _EXHIBIT_SEPARATOR, FilingFetcher
+from src.infra.sec_client import FilingMetadata
+
+# ---------------------------------------------------------------------------
+# Shared HTML fixtures
+# ---------------------------------------------------------------------------
+
+# Small 8-K cover page (~2 KB) — deliberately below the 15 KB minimum size
+# threshold to reproduce the Samsara 2025-08-21 shape.
+_8K_PRIMARY_HTML = (
+    "<html><head><title>Current Report on Form 8-K</title></head><body>"
+    "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+    "<p>WASHINGTON, D.C. 20549</p>"
+    "<p>FORM 8-K</p>"
+    "<p>CURRENT REPORT</p>"
+    "<p>Pursuant to Section 13 or 15(d) of the Securities Exchange Act of 1934</p>"
+    + " " * 2000
+    + "</body></html>"
+)
+
+# Exhibit 99.1 — earnings press release with customer-metric language.
+# Combined with primary HTML, this pushes total well above 15 KB.
+_EXHIBIT_HTML = (
+    "<html><head><title>Earnings Release Q3 2025</title></head><body>"
+    "<h1>Samsara Inc. Reports Third Quarter Fiscal 2025 Results</h1>"
+    "<p>Total revenue increased 36% year-over-year to $322 million.</p>"
+    "<p>Annual Recurring Revenue (ARR) reached $1.36 billion.</p>"
+    "<p>Net revenue retention rate was 115%.</p>"
+    "<p>Customers with ARR over $100,000 grew to 1,848.</p>"
+    + "X" * 18000
+    + "</body></html>"
+)
+
+_EXHIBIT_URL = (
+    "https://www.sec.gov/Archives/edgar/data/1642545/"
+    "000164254525000123/exhibit991-2025x08x21.htm"
+)
+
+_CIK = "0001642545"
+_ACCESSION = "0001642545-25-000123"
+_PRIMARY_URL = (
+    "https://www.sec.gov/Archives/edgar/data/1642545/"
+    "000164254525000123/primary.htm"
+)
+
+
+def _make_metadata(form_type: str = "8-K") -> FilingMetadata:
+    return FilingMetadata(
+        cik=_CIK,
+        company_name="Samsara Inc.",
+        form_type=form_type,
+        filing_date="2025-08-21",
+        accession_number=_ACCESSION,
+        primary_doc_url=_PRIMARY_URL,
+        txt_url=None,
+    )
+
+
+def _mock_response(text: str) -> Mock:
+    resp = Mock()
+    resp.text = text
+    resp.raise_for_status = Mock()
+    return resp
+
+
+@pytest.fixture
+def fetcher(tmp_path: pathlib.Path) -> FilingFetcher:
+    """FilingFetcher with mocked SECClient and temp storage root; no DB."""
+    mock_sec_client = Mock()
+    mock_sec_client.get_exhibit_99_1_url.return_value = _EXHIBIT_URL
+    mock_sec_client.resolve_primary_document_url.return_value = None
+    return FilingFetcher(
+        storage_root=str(tmp_path / "filings"),
+        sec_client=mock_sec_client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEightKExhibitFetch:
+    def test_exhibit_fetched_and_concatenated(self, fetcher: FilingFetcher) -> None:
+        """Exhibit 99.1 is fetched and concatenated with separator into primary.htm."""
+        md = _make_metadata("8-K")
+
+        with patch.object(
+            fetcher.session,
+            "get",
+            side_effect=[
+                _mock_response(_8K_PRIMARY_HTML),
+                _mock_response(_EXHIBIT_HTML),
+            ],
+        ):
+            content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        assert content is not None
+        html = pathlib.Path(content.html_path).read_text(encoding="utf-8")
+        assert _EXHIBIT_SEPARATOR in html
+        assert "total revenue" in html.lower()
+        assert "arr" in html.lower()
+        assert "net revenue retention" in html.lower()
+
+    def test_8ka_also_fetches_exhibit(self, fetcher: FilingFetcher) -> None:
+        """8-K/A also triggers exhibit fetch (form_type.startswith('8-K') covers it)."""
+        md = _make_metadata("8-K/A")
+
+        with patch.object(
+            fetcher.session,
+            "get",
+            side_effect=[
+                _mock_response(_8K_PRIMARY_HTML),
+                _mock_response(_EXHIBIT_HTML),
+            ],
+        ):
+            content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        assert content is not None
+        assert _EXHIBIT_SEPARATOR in pathlib.Path(content.html_path).read_text(
+            encoding="utf-8"
+        )
+
+    def test_exhibit_fetch_skipped_for_s1(self, fetcher: FilingFetcher) -> None:
+        """S-1 filings do not trigger exhibit fetch; get_exhibit_99_1_url not called."""
+        md = _make_metadata("S-1")
+        s1_html = (
+            "<html><head><title>S-1</title></head><body>"
+            "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+            "<p>FORM S-1</p>"
+            + "X" * 20000
+            + "</body></html>"
+        )
+
+        with patch.object(
+            fetcher.session, "get", return_value=_mock_response(s1_html)
+        ):
+            content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        assert content is not None
+        fetcher.sec_client.get_exhibit_99_1_url.assert_not_called()
+        html = pathlib.Path(content.html_path).read_text(encoding="utf-8")
+        assert _EXHIBIT_SEPARATOR not in html
+
+    def test_missing_exhibit_does_not_fail(self, fetcher: FilingFetcher) -> None:
+        """If index.json has no exhibit 99.1 match, fetch succeeds with primary only."""
+        fetcher.sec_client.get_exhibit_99_1_url.return_value = None
+        md = _make_metadata("8-K")
+        large_primary = (
+            "<html><head><title>8-K</title></head><body>"
+            "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+            "<p>FORM 8-K</p>"
+            + "X" * 20000
+            + "</body></html>"
+        )
+
+        with patch.object(
+            fetcher.session, "get", return_value=_mock_response(large_primary)
+        ):
+            content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        assert content is not None
+        html = pathlib.Path(content.html_path).read_text(encoding="utf-8")
+        assert _EXHIBIT_SEPARATOR not in html
+
+    def test_idempotency_cached_file_without_separator(
+        self, fetcher: FilingFetcher
+    ) -> None:
+        """Cached primary.htm lacking separator gets exhibit appended on re-fetch."""
+        md = _make_metadata("8-K")
+        storage_dir = fetcher._get_storage_dir(md.cik, md.accession_number)
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        (storage_dir / "primary.htm").write_text(_8K_PRIMARY_HTML, encoding="utf-8")
+
+        with patch.object(
+            fetcher.session,
+            "get",
+            return_value=_mock_response(_EXHIBIT_HTML),
+        ):
+            content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        assert content is not None
+        html = pathlib.Path(content.html_path).read_text(encoding="utf-8")
+        assert _EXHIBIT_SEPARATOR in html
+        assert "total revenue" in html.lower()
+
+    def test_idempotency_cached_file_with_separator(
+        self, fetcher: FilingFetcher
+    ) -> None:
+        """Cached primary.htm with separator triggers no HTTP calls on re-fetch."""
+        md = _make_metadata("8-K")
+        already_combined = (
+            _8K_PRIMARY_HTML + f"\n{_EXHIBIT_SEPARATOR}\n" + _EXHIBIT_HTML
+        )
+        storage_dir = fetcher._get_storage_dir(md.cik, md.accession_number)
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        (storage_dir / "primary.htm").write_text(already_combined, encoding="utf-8")
+
+        with patch.object(fetcher.session, "get") as mock_get:
+            fetcher.fetch_filing(md, fetch_txt=False)
+
+        mock_get.assert_not_called()
+        fetcher.sec_client.get_exhibit_99_1_url.assert_not_called()


### PR DESCRIPTION
## Summary

- `SECClient.get_exhibit_99_1_url` queries EDGAR `index.json` for an exhibit matching the 99.1 filename pattern (`ex(?:hibit)?[-_]?99[-_.]?1`) and returns its URL
- `FilingFetcher.fetch_filing` for 8-K/8-K/A form types fetches the exhibit and concatenates it with the primary document using an HTML comment sentinel (`<!-- EXHIBIT-99.1 -->`)
- `_validate_filing_content` gains a `skip_size_check` parameter so legitimate 8-K cover pages under 15 KB pass primary-doc validation; the combined blob is then validated at the full threshold
- Idempotency: the sentinel prevents re-fetching on subsequent runs; cached files without the marker are silently upgraded on next extraction
- S-1/F-1/10-K fetch behavior is byte-identical to before (entire change gated on `is_8k`)

## Root cause

Samsara 2025-08-21: `primary.htm` was 9,336 bytes (below the 15 KB validation threshold), so `fetch_filing` returned `None` and the pipeline never ran. All customer-metric content was in `exhibit991-2025x08x21.htm`, which was never fetched.

## Test plan

- [x] `pytest -x -q tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` — 6 new tests pass (fresh fetch, 8-K/A, S-1 unaffected, missing exhibit, idempotency with/without sentinel)
- [x] `pytest -x -q tests/unit/filing_fetcher/` — 70 existing tests pass (no S-1/F-1 regression)
- [x] `ruff check src/ tests/` — clean

## Backfill

Post-merge: run `scripts/backfill_8k_exhibits.py` (to be written as a follow-up PR) against the dev DB using the SQL query in the plan. Existing 8-K filings will also self-heal on their next extraction run via the idempotency path.

## Known limitations filed

- legacy-115: PDF-format exhibit 99.1 silently skipped (only `.htm`/`.html` matched)
- legacy-116: E2E pipeline test asserting segment count and metric facts deferred to follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)