### PR TITLE
docs(known-issues): close #66 — Render preDeployCommand already shipped in #199

### DIFF
--- a/docs/known-issues/legacy-066-migrations-not-auto-applied-on-render-deploy.md
+++ b/docs/known-issues/legacy-066-migrations-not-auto-applied-on-render-deploy.md
@@ -1,18 +1,20 @@
 ---
-autonomy: review
+autonomy: n/a
 discovered: '2026-04-21'
 estimated: S
 id: 66
 note: Wire apply_migrations into Render deploy; infra-change risk
+pr_refs:
+- 199
 severity: medium
 slug: migrations-not-auto-applied-on-render-deploy
 source: legacy
-status: open
+status: resolved
 title: Migrations Not Auto-Applied on Render Deploy
 touches:
 - render.yaml
 - .claude/rules/infrastructure.md
-updated: '2026-04-24'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -30,3 +32,7 @@ updated: '2026-04-24'
 - `scripts/apply_migrations.py` — migration runner (idempotent via `schema_migrations` ledger)
 - `sql/39_v2_ingest_batches.sql` — the migration that triggered this discovery
 - `render.yaml` — pre-deploy hook would attach to the web service entry
+
+### Resolution
+
+This fragment is a stale duplicate of legacy-095. The fix it requested — wiring `python3 scripts/apply_migrations.py` as a Render pre-deploy command on the `filings-reviewer` service — was shipped in PR #199 (commit `eed95a8`, `fix(deploy): auto-apply schema migrations on every Render deploy via preDeployCommand`). `render.yaml` line 36 now reads `preDeployCommand: python3 scripts/apply_migrations.py` under the `filings-reviewer` web service entry, exactly as this fragment required. The residual checksum-guard relaxation (comment-only diffs no longer force ledger reconciliation) was finished by PR #243, tracked under legacy-095, which is itself closed as resolved. No further action is needed here.


### PR DESCRIPTION
## Summary

- Closes legacy-066 (`migrations-not-auto-applied-on-render-deploy`) as a stale duplicate of legacy-095.
- The fix requested (wiring `python3 scripts/apply_migrations.py` as Render's `preDeployCommand` on `filings-reviewer`) was already shipped in PR #199 (commit `eed95a8`).
- Verification: `render.yaml` line 36 contains `preDeployCommand: python3 scripts/apply_migrations.py` under the `filings-reviewer` web service; `git log` confirms commit `eed95a8`; legacy-095 is `status: resolved` (closed by PR #243 for checksum-guard relaxation).
- Fragment-only change: frontmatter updated (`status: resolved`, `autonomy: n/a`, `pr_refs: [199]`, `updated: 2026-04-27`); `### Resolution` section appended.

## Test plan

- [ ] No code changes — docs-only commit, lint and test run not required per CLAUDE.md.
- [ ] CI Lint and Unit Tests expected to pass (no src/ changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)