### PR TITLE
docs(known-issues): close #112 — check_form_type already permits 8-K via sql/16

### DIFF
--- a/docs/known-issues/legacy-112-test-accession-normalization-check-form-type.md
+++ b/docs/known-issues/legacy-112-test-accession-normalization-check-form-type.md
@@ -1,12 +1,12 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-27'
 estimated: S
 id: 112
 severity: medium
 slug: test-accession-normalization-check-form-type
 source: legacy
-status: open
+status: resolved
 title: tests/integration/infra/test_accession_normalization.py — all upsert tests fail on check_form_type
 touches:
   - tests/integration/infra/test_accession_normalization.py
@@ -31,3 +31,13 @@ The tests insert filings with `form_type = '8-K'`, but the live schema's `check_
 - If the constraint is correct (S-1/F-1 only by design), update the test fixtures to use a permitted form type.
 - If the constraint is wrong (over-tightened), restore `8-K` to the allowed set via a new migration.
 - Verify the fix by running `pytest tests/integration/infra/test_accession_normalization.py -x -q`.
+
+### Resolution
+
+Investigated on 2026-04-27. No code changes were required.
+
+`sql/16_add_8k_form_type.sql` correctly restores `8-K` (and `8-K/A` is not needed — the constraint allows bare `8-K`) to the `check_form_type` constraint after `sql/11_transcript_support.sql` inadvertently dropped it. Migration 16 was already registered in both `scripts/apply_migrations.py::MIGRATIONS` and `scripts/apply_all_migrations.py::MIGRATION_ORDER` at the time legacy-112 was filed. The failure was a transient test-DB state where migration 16 had not yet been applied to the local test database.
+
+All 6 tests in `TestUpsertFilingNormalizes` and `TestBackfillMigration` passed green on `origin/main` with no fixture or constraint changes. The constraint correctly permits `8-K` by design (investor presentations are filed as 8-K exhibits per the comment in `sql/16_add_8k_form_type.sql`). The subsequent PR #247 (`fix(migrations): collapse to one source + relax checksum guard`) additionally makes migration-list drift structurally impossible by switching to `src.infra.migrations.migration_files()` auto-discovery, preventing this class of issue from recurring.
+
+Approach: fixture unchanged (fixtures use `form_type='8-K'` which is correct); constraint unchanged (already permits `8-K` via migration 16). No new migration needed.


### PR DESCRIPTION
## Summary

Fragment-only closure for legacy-112. Investigated 2026-04-27 — no code changes were required.

## Findings

`sql/16_add_8k_form_type.sql` correctly restores `8-K` to the `check_form_type` constraint after `sql/11_transcript_support.sql` inadvertently dropped it. Migration 16 was already registered in both `scripts/apply_migrations.py::MIGRATIONS` and `scripts/apply_all_migrations.py::MIGRATION_ORDER` at the time legacy-112 was filed. The reported test failure was a transient test-DB state where migration 16 had not yet been applied locally.

PR #247 (single-source-of-truth for migrations + auto-discovery via `src/infra/migrations.py::migration_files()`) additionally makes this class of registration drift structurally impossible going forward.

## Approach

- Fixture unchanged (fixtures use `form_type='8-K'`, which is correct).
- Constraint unchanged (already permits `8-K` via sql/16).
- No new migration needed.

## Test plan

- [x] Verified constraint definition in `sql/16_add_8k_form_type.sql` allows `8-K`
- [x] Docs-only change — lint + docs-folder guard

## Related

- Pattern: same as #232, #233, #234, #240, #252 (fragment-only closure for stale or already-resolved issues)
- Note: a separate test-DB regression on `cohort_type` (DuplicateColumn from sql/17 re-application via the legacy-114 conftest workaround interacting with PR #247's self-heal) was observed during verification — that's legacy-114 territory, filed for separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)