### PR TITLE
fix(tests): remove stale conftest checksum workarounds (legacy-114)

### DIFF
--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -6,11 +6,12 @@ id: 114
 severity: low
 slug: stale-conftest-checksum-workarounds-after-self-heal
 source: legacy
-status: open
+status: resolved
 title: Stale checksum-drift workarounds in tests/integration/conftest.py after self-heal landed
 touches:
   - tests/integration/conftest.py
 updated: '2026-04-27'
+resolved: '2026-04-27'
 ---
 
 ### Problem
@@ -60,3 +61,32 @@ follow-up cleanup once the self-heal has soaked in CI for a few runs.
   introduced the self-heal that supersedes these workarounds).
 - legacy-110 — `migration-registry-drift-between-apply-scripts` (separate
   drift-class issue; not a precondition for this cleanup).
+
+### Resolution
+
+Deleted both stale workaround blocks from
+`tests/integration/conftest.py::_apply_migrations_to_test_db`:
+
+1. **`_CHECKSUM_REFRESH_ALLOWLIST` block** — removed the comment referencing
+   the `_CHECKSUM_REFRESH_ALLOWLIST` constant (the constant itself had
+   already been partially cleaned up on `origin/main`, but the explanatory
+   comment referencing it remained alongside the try/except retry).
+2. **`try/except RuntimeError("Checksum mismatch")` retry block** — removed
+   the entire try/except around `apply_migration` that caught checksum-drift
+   errors, deleted the stale ledger row, logged
+   `Auto-recovered checksum drift for ...`, and retried. Replaced with a
+   plain `apply_migration(db, sql_dir, migration_name)` call so genuine
+   checksum drift raises as designed.
+
+The `legacy-095` self-heal in `scripts/apply_migrations.py::apply_migration`
+now handles the comment-only-edit failure mode structurally: it computes a
+raw-byte hash equality fallback and, when the file is byte-identical to what
+was previously applied, performs an in-place ledger `UPDATE` rather than
+raising. There is no longer any need for the conftest to pre-empt or catch
+these errors.
+
+The cluster-DDL advisory-lock serialization (acquiring `pg_advisory_lock`
+on the admin `postgres` DB before the apply loop, released by closing the
+connection in the `finally` block) was preserved — it is unrelated to
+checksum drift and guards against concurrent `tuple concurrently updated`
+races on the cluster-level `metabase_ro` role created by sql/37.

--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -11,7 +11,6 @@ title: Stale checksum-drift workarounds in tests/integration/conftest.py after s
 touches:
   - tests/integration/conftest.py
 updated: '2026-04-27'
-resolved: '2026-04-27'
 ---
 
 ### Problem

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -378,33 +378,10 @@ def _apply_migrations_to_test_db(_isolate_xdist_worker_database, _terminate_stal
 
         bootstrap_ledger(db)
 
-        # The legacy _CHECKSUM_REFRESH_ALLOWLIST workaround for sql/37 is gone:
-        # the new comment-stripping `_checksum` (legacy-095 #3) treats whole-line
-        # `--` edits as semantic no-ops, so cosmetic edits no longer trip the
-        # guard. The test_url-exact-match recovery below still handles genuine
-        # schema-affecting edits during local dev.
         for migration_name in MIGRATIONS:
             sql_file = sql_dir / migration_name
             if sql_file.exists():
-                try:
-                    apply_migration(db, sql_dir, migration_name)
-                except RuntimeError as exc:
-                    test_url = os.getenv("TEST_DATABASE_URL", "")
-                    if "Checksum mismatch" in str(exc) and url == test_url and test_url:
-                        # Test DB only: drop stale ledger row and re-apply
-                        # (test_url exact-match prevents accidental trigger on prod URLs)
-                        with db.get_connection() as conn:
-                            with conn.cursor() as cur:
-                                cur.execute(
-                                    "DELETE FROM schema_migrations WHERE id = %s",
-                                    [migration_name],
-                                )
-                        logger.warning(
-                            "Auto-recovered checksum drift for %s on test DB", migration_name
-                        )
-                        apply_migration(db, sql_dir, migration_name)
-                    else:
-                        raise
+                apply_migration(db, sql_dir, migration_name)
     finally:
         lock_conn.close()  # closing the session releases the advisory lock
 


### PR DESCRIPTION
## Summary

- Removes two stale workaround blocks from `tests/integration/conftest.py::_apply_migrations_to_test_db` that were added to handle checksum-drift errors during local test runs.
- The `legacy-095` self-heal (landed in `scripts/apply_migrations.py`) now handles comment-only checksum drift structurally via a raw-byte equality fallback with an in-place ledger `UPDATE` — making these conftest workarounds unnecessary.
- Flips the `docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md` fragment from `status: open` to `status: resolved` with a `### Resolution` section documenting both deleted blocks.

Resolves docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md

## Deleted blocks

1. **Comment block referencing `_CHECKSUM_REFRESH_ALLOWLIST`** — the constant itself was already removed on `origin/main`; this PR removes the explanatory comment that remained alongside the try/except retry.
2. **`try/except RuntimeError("Checksum mismatch")` retry block** — caught checksum-drift, deleted the stale ledger row, and re-applied the migration. Replaced with a plain `apply_migration(db, sql_dir, migration_name)` call so genuine checksum drift raises as designed.

The advisory-lock serialization (acquiring `pg_advisory_lock` on the admin `postgres` DB) was preserved — it is unrelated to checksum drift and guards against concurrent DDL races.

## Pre-existing test failure

**Test:** `tests/integration/extraction_v2/test_e2e_pipeline.py::TestE2ESlackFiling::test_e2e_slack_filing_runs_all_stages`

**Error:** `Pipeline failed: Critical stage fatal error: ingestion: [ingestion] Refusing R2 write — set FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 to allow.`

This failure **pre-dates this change** and reproduces identically on stashed `origin/main` content (verified via `git stash && pytest <node_id> && git stash pop`). It is caused by missing `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` in the local test environment, not by the conftest edits in this PR.

## Test plan

- [x] `pytest tests/integration -x -q --tb=short` — 14 tests pass; 1 pre-existing failure (`test_e2e_slack_filing_runs_all_stages`) reproduces on unmodified `origin/main`
- [x] `ruff check tests/integration/conftest.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)