### PR TITLE
fix(test-infra): drop stale conftest checksum workarounds (closes legacy-114)

### DIFF
--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -3,6 +3,8 @@ autonomy: n/a
 discovered: '2026-04-27'
 estimated: XS
 id: 114
+pr_refs:
+  - '#255'
 severity: low
 slug: stale-conftest-checksum-workarounds-after-self-heal
 source: legacy

--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -4,7 +4,7 @@ discovered: '2026-04-27'
 estimated: XS
 id: 114
 pr_refs:
-  - '#255'
+  - 255
 severity: low
 slug: stale-conftest-checksum-workarounds-after-self-heal
 source: legacy

--- a/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
+++ b/docs/known-issues/legacy-114-stale-conftest-checksum-workarounds-after-self-heal.md
@@ -1,17 +1,55 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-27'
 estimated: XS
 id: 114
 severity: low
 slug: stale-conftest-checksum-workarounds-after-self-heal
 source: legacy
-status: open
+status: resolved
 title: Stale checksum-drift workarounds in tests/integration/conftest.py after self-heal landed
 touches:
   - tests/integration/conftest.py
 updated: '2026-04-27'
 ---
+
+### Resolution (2026-04-27)
+
+Both workaround blocks have been removed from
+`tests/integration/conftest.py::_apply_migrations_to_test_db`:
+
+- The `_CHECKSUM_REFRESH_ALLOWLIST = {"37_create_analytics_role.sql"}`
+  pre-emptive ledger refresh was deleted in a prior cleanup (origin/main
+  pre this PR).
+- The try/except retry around `apply_migration` that caught any
+  `RuntimeError("Checksum mismatch")` on the test DB, deleted the stale
+  ledger row, logged `Auto-recovered checksum drift for ...`, and
+  re-applied the migration is removed in this PR.
+
+The per-row self-heal in `scripts/apply_migrations.py::apply_migration`
+(lines 162–173 — `if stored_checksum == _raw_checksum(sql): UPDATE
+schema_migrations SET checksum = ...`) now handles the comment-only-edit
+case the workarounds were guarding by proving byte-identity to what was
+previously applied and reconciling the ledger row in place. Genuine drift
+(neither new-rule nor raw-byte hash matches what's stored) raises as
+designed.
+
+The conftest workaround was actively destructive: when `apply_migration`
+raised because raw-hash also missed, the workaround deleted the ledger row
+and re-ran the SQL — re-applying DDL like
+`17_add_cohort_type_to_v2.sql::ALTER TABLE … ADD COLUMN cohort_type` against
+a DB where the column already existed produced
+`psycopg.errors.DuplicateColumn`, breaking
+`tests/integration/infra/test_accession_normalization.py` and the broader
+integration suite on developer machines. With both blocks gone, that
+failure path no longer exists; legitimate drift on a stale local test DB
+is now recoverable by dropping and recreating it (`dropdb` + `createdb`),
+not by ledger surgery.
+
+The cluster-DDL advisory-lock serialization
+(`SELECT pg_advisory_lock(MIGRATION_LOCK_KEY)` against the `postgres` admin
+DB) is unchanged — that protects against concurrent migration application
+under `pytest-xdist` and is unrelated to checksum drift.
 
 ### Problem
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -378,33 +378,10 @@ def _apply_migrations_to_test_db(_isolate_xdist_worker_database, _terminate_stal
 
         bootstrap_ledger(db)
 
-        # The legacy _CHECKSUM_REFRESH_ALLOWLIST workaround for sql/37 is gone:
-        # the new comment-stripping `_checksum` (legacy-095 #3) treats whole-line
-        # `--` edits as semantic no-ops, so cosmetic edits no longer trip the
-        # guard. The test_url-exact-match recovery below still handles genuine
-        # schema-affecting edits during local dev.
         for migration_name in MIGRATIONS:
             sql_file = sql_dir / migration_name
             if sql_file.exists():
-                try:
-                    apply_migration(db, sql_dir, migration_name)
-                except RuntimeError as exc:
-                    test_url = os.getenv("TEST_DATABASE_URL", "")
-                    if "Checksum mismatch" in str(exc) and url == test_url and test_url:
-                        # Test DB only: drop stale ledger row and re-apply
-                        # (test_url exact-match prevents accidental trigger on prod URLs)
-                        with db.get_connection() as conn:
-                            with conn.cursor() as cur:
-                                cur.execute(
-                                    "DELETE FROM schema_migrations WHERE id = %s",
-                                    [migration_name],
-                                )
-                        logger.warning(
-                            "Auto-recovered checksum drift for %s on test DB", migration_name
-                        )
-                        apply_migration(db, sql_dir, migration_name)
-                    else:
-                        raise
+                apply_migration(db, sql_dir, migration_name)
     finally:
         lock_conn.close()  # closing the session releases the advisory lock
 


### PR DESCRIPTION
## Summary

- Removes the try/except retry around `apply_migration` in
  `tests/integration/conftest.py::_apply_migrations_to_test_db` that
  auto-recovered "checksum drift" on the test DB. The block predated the
  comment-stripping `_checksum` rule + per-row self-heal in
  `scripts/apply_migrations.py::apply_migration` (legacy-095) and was
  actively destructive: when `apply_migration` raised because raw-hash
  also missed, the workaround deleted the ledger row and re-ran the SQL,
  re-applying DDL against a DB where it had already been applied —
  producing `psycopg.errors.DuplicateColumn` for migrations like
  `17_add_cohort_type_to_v2.sql`.
- Updates `docs/known-issues/legacy-114-…` frontmatter (`status: resolved`,
  `autonomy: n/a`) and appends a `### Resolution` close-note in the
  established style (#232 / #234 / #240 / #252 / #253 / legacy-103).
- Cluster-DDL advisory-lock serialization is unchanged.

## Test plan

- [x] `uv run pytest tests/integration/infra/test_accession_normalization.py -x -q`
      — all 6 tests pass after dropdb + createdb of the local test DB.
      `cohort_type` `DuplicateColumn` is gone.
- [x] `uv run pytest -x -q --ignore=tests/integration/extraction_v2/test_e2e_pipeline.py`
      — 4152 passed locally. The `test_e2e_pipeline.py::TestE2ESlackFiling`
      / `TestE2EProvenance` failures are a pre-existing
      `FILINGS_REVIEWER_ALLOW_PROD_WRITES` guard tripping when local prod
      creds are in scope; verified to reproduce on `origin/main` HEAD
      without this PR's changes (legacy-080 territory).
- [x] `python3 scripts/validate_known_issues_fragments.py --path
      docs/known-issues/legacy-114-…` — passes.
- [ ] CI Integration Tests + UI E2E green (will block auto-merge until they pass).

## Recovery for stale local test DBs

If a developer's local test DB is in the corrupt "ledger row missing,
column already exists" state this workaround was creating, recovery is now
explicit and one-shot:

```
PGPASSWORD=dev dropdb -h localhost -p 5433 -U dev filings_analysis_test
PGPASSWORD=dev createdb -h localhost -p 5433 -U dev filings_analysis_test
```

(or the equivalent for whatever `TEST_DATABASE_URL` resolves to).