### PR TITLE
docs(known-issues): close legacy-84, file gh-258 for residual pr_refs gap

### DIFF
--- a/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
+++ b/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
@@ -1,0 +1,46 @@
+---
+autonomy: review
+discovered: '2026-04-27'
+estimated: S
+gh_issue: 258
+id: 258
+note: Auto-closer (legacy-084 / PR #177) only fires when pr_refs is populated; many fix-PRs forget to set it
+severity: low
+slug: fix-pr-not-setting-pr-refs-on-resolved-fragment
+source: gh
+status: open
+title: Fix-PR Authors Don't Set pr_refs on the Fragment They Resolve
+touches:
+  - .claude/commands/commit.md
+  - scripts/validate_known_issues_fragments.py
+updated: '2026-04-27'
+---
+
+### Problem
+
+PR #177 (legacy-84) shipped an auto-closer that flips a fragment from `status: open` → `status: resolved` once every PR listed in its `pr_refs` field is `MERGED` on GitHub. The script runs nightly (pre-selector step in `scripts/run_nightly_sweep.sh`) and is unit-tested.
+
+The closer can only act on fragments whose `pr_refs` is populated. In practice, the field is rarely set at fix-PR time — today's session (2026-04-27) had to ship four fragment-only closure PRs (#251–#253 and the legacy-58 closure) for fragments whose underlying fix-PRs had merged days earlier. Sampling those fragments confirms the pattern:
+
+- **legacy-58** — no `pr_refs` field at all
+- **legacy-110** — `pr_refs: []` (empty list)
+- **legacy-112** — no `pr_refs` field
+- **legacy-66** — eventually had `pr_refs: [199]`, likely added during the manual closure rather than at fix-PR time
+
+The auto-closer is functioning correctly. The drift comes from a process gap upstream: nothing prompts a fix-PR author to write the resolved fragment's id into the fragment's `pr_refs` list before merging. Without that, every closure is still manual — defeating the point of legacy-84.
+
+### Next Steps
+
+Pick one (cheapest first):
+
+- **Option C — Pre-commit nudge.** Extend `scripts/validate_known_issues_fragments.py` (or a sibling pre-commit hook) to detect: a known-issue fragment was modified in the staged diff, its `status` is `open`, and its `pr_refs` is empty / missing. Print a `WARNING: did you mean to set pr_refs on this fragment? auto-closer can't see it otherwise` message — non-blocking. Cheapest, low coupling. Doesn't help fragments that aren't touched by the fix-PR (most of them).
+- **Option B — `/commit` skill hint.** Add a `resolves: #N` field to the project-local `/commit` skill. When set, the skill: (1) verifies the named fragment exists, (2) appends the new PR number to its `pr_refs`, (3) stages the fragment edit alongside the user's diff. Closes the loop end-to-end but couples fragment bookkeeping to the `/commit` happy path.
+- **Option D — Backfill sweep.** One-shot script that walks closed fix-PRs, parses commit messages / PR descriptions for `legacy-NN` references, and adds them to the corresponding fragment's `pr_refs`. Useful as a one-time cleanup before turning on stricter checks; not a steady-state fix.
+
+Recommend starting with **Option C** as the steady-state nudge, then **Option B** if drift continues.
+
+### Notes
+
+- Today's manual closures (#251, #252, #253, etc.) shipped before this fragment was filed; they don't need to be retroactively rewritten.
+- The auto-closer itself is fine — do not modify `scripts/sync_known_issue_status.py` as part of this work.
+- Worker should not expand scope into legacy-84's tool — that work is closed.

--- a/docs/known-issues/legacy-084-fragment-status-drift-after-pr-merge.md
+++ b/docs/known-issues/legacy-084-fragment-status-drift-after-pr-merge.md
@@ -1,18 +1,20 @@
 ---
-autonomy: review
+autonomy: n/a
 discovered: '2026-04-22'
 estimated: S
 id: 84
-note: Cross-reference pr_refs with GitHub API; auto-update status=resolved on merge
+note: Resolved by PR #177 (Option A); see gh-258 for the residual gap
+pr_refs:
+- 177
 severity: low
 slug: fragment-status-drift-after-pr-merge
 source: legacy
-status: open
+status: resolved
 title: Fragment Status Drift After PR Merge (Needs Auto-Update Mechanism)
 touches:
   - scripts/known_issues_selector.py
   - .claude/commands/commit.md
-updated: '2026-04-22'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -28,3 +30,9 @@ The selector's Phase 3 status filter (issue #79) correctly excludes `status in {
 - Option C: A pre-commit check that warns (not fails) when a fragment's `pr_refs` all point at merged PRs but `status` is still `open`. Low-cost nudge.
 
 Recommend Option A — simplest, runs outside the happy path, no coupling to `/commit`.
+
+### Resolution
+
+Closed by PR #177 (`feat(ops): auto-resolve known-issue fragments when pr_refs all merge`, merged 2026-04-22). Option A shipped as `scripts/sync_known_issue_status.py`, wired into `scripts/run_nightly_sweep.sh` step 2b (pre-selector). Tests in `tests/unit/scripts/test_sync_known_issue_status.py` cover all-merged flip, mixed-state no-flip, malformed/missing pr_refs, and already-resolved skip.
+
+This fragment was missed by the auto-updater because its own frontmatter had no `pr_refs` field — the script can only close fragments whose `pr_refs` are populated. That residual gap (fix-PR authors not setting `pr_refs` on the fragment they resolve) is tracked separately as **gh-258**. `pr_refs: [177]` is now set here so a future sync run would have closed this fragment automatically, demonstrating the design works end-to-end.


### PR DESCRIPTION
## Summary

- Closes **legacy-84** (fragment status drift after PR merge) — already shipped in PR #177 (`scripts/sync_known_issue_status.py`, wired into `scripts/run_nightly_sweep.sh` step 2b). The fragment's own `pr_refs` was empty, so the auto-closer couldn't close itself. Adds `pr_refs: [177]`, flips `status: resolved`, `autonomy: n/a`, appends a `### Resolution` section.
- Files **gh-258** (#258) for the residual root-cause gap: fix-PR authors don't set `pr_refs` on the resolved fragment, which is why today's session needed four manual closure PRs (#251–#253 + legacy-58) for fragments whose fixes merged days earlier. Three options listed (C: pre-commit nudge, B: `/commit` skill hint, D: backfill sweep). Recommend Option C first.

## Why this isn't the original brief

The brief asked for a fresh implementation of Option A. Exploration revealed Option A is already shipped end-to-end (script + sweep wiring + tests in `tests/unit/scripts/test_sync_known_issue_status.py`). Re-implementing would duplicate working code; the actual unmet need is the upstream `pr_refs` population gap, now tracked as gh-258.

## Test plan

- [x] `python3 scripts/validate_known_issues_fragments.py` passes (118 fragments OK)
- [x] No code files staged → lint and pytest skipped per /commit skill
- [x] CI Lint will re-validate fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)