### PR TITLE
fix(filing-fetcher): warn when 8-K exhibit 99.1 is PDF-only (closes legacy-115)

### DIFF
--- a/docs/known-issues/legacy-115-8k-exhibit-99-1-pdf-format-silently-skipped.md
+++ b/docs/known-issues/legacy-115-8k-exhibit-99-1-pdf-format-silently-skipped.md
@@ -1,12 +1,12 @@
 ---
-autonomy: safe
+autonomy: n/a
 discovered: '2026-04-27'
 estimated: S
 id: 115
 severity: low
 slug: 8k-exhibit-99-1-pdf-format-silently-skipped
 source: legacy
-status: open
+status: resolved
 title: 8-K Exhibit 99.1 in PDF Format is Silently Skipped
 touches:
 - src/infra/sec_client.py
@@ -23,3 +23,24 @@ updated: '2026-04-27'
 - Extend `get_exhibit_99_1_url` to also match `.pdf` filenames via the existing `_EXHIBIT_991_RE` regex.
 - In `FilingFetcher.fetch_filing`, if the exhibit URL resolves to a `.pdf`, attempt a text extraction pass (e.g. via `pdfminer` or the existing OCR path) and append the extracted text to the combined HTML. Alternatively log a warning and skip — the warning is the minimum acceptable fix so operators can identify affected filings.
 - Add a test case: `get_exhibit_99_1_url` returns a `.pdf` URL when only a PDF exhibit is listed in the index.
+
+### Resolution
+
+Implemented the minimum-acceptable fix (Path 1 in *Next Steps*): emit an
+operator-grep-able warning rather than attempt PDF text extraction.
+
+- `SECClient.get_exhibit_99_1_url` now accepts `.pdf` filenames in addition
+  to `.htm`/`.html`, and prefers HTML when both are listed (HTML is the
+  canonical extractable form).
+- `FilingFetcher.fetch_filing` detects a `.pdf` exhibit URL, logs a
+  structured WARNING (`exhibit-99-1-pdf-skipped: cik=… accession=… url=…`),
+  and proceeds with primary-only content. Both the cold-fetch and the
+  cached-backfill branches are gated.
+- Operators can now `grep exhibit-99-1-pdf-skipped` to identify affected
+  filings.
+
+PDF text extraction itself is intentionally **not** in scope — the warning
+is the minimum acceptable fix per this fragment, and adding pdfminer / OCR
+would expand the diff into territory needing its own validation surface.
+If/when CMASB needs PDF earnings-release content, it will be filed as a
+separate piece of work.

--- a/src/filing_fetcher/filing_fetcher.py
+++ b/src/filing_fetcher/filing_fetcher.py
@@ -340,6 +340,14 @@ class FilingFetcher:
                     exhibit_url = self.sec_client.get_exhibit_99_1_url(
                         cik, accession_number
                     )
+                    if exhibit_url and exhibit_url.lower().endswith(".pdf"):
+                        logger.warning(
+                            "exhibit-99-1-pdf-skipped: cik=%s accession=%s url=%s",
+                            cik,
+                            accession_number,
+                            exhibit_url,
+                        )
+                        exhibit_url = None
                     if exhibit_url:
                         self._rate_limit()
                         logger.debug(f"Fetching exhibit 99.1: {exhibit_url}")
@@ -374,6 +382,14 @@ class FilingFetcher:
                         exhibit_url = self.sec_client.get_exhibit_99_1_url(
                             cik, accession_number
                         )
+                        if exhibit_url and exhibit_url.lower().endswith(".pdf"):
+                            logger.warning(
+                                "exhibit-99-1-pdf-skipped: cik=%s accession=%s url=%s",
+                                cik,
+                                accession_number,
+                                exhibit_url,
+                            )
+                            exhibit_url = None
                         if exhibit_url:
                             self._rate_limit()
                             exhibit_resp = self.session.get(exhibit_url)

--- a/src/infra/sec_client.py
+++ b/src/infra/sec_client.py
@@ -624,7 +624,13 @@ class SECClient:
     _EXHIBIT_991_RE = re.compile(r"ex(?:hibit)?[-_]?99[-_.]?1", re.IGNORECASE)
 
     def get_exhibit_99_1_url(self, cik: str, accession_number: str) -> str | None:
-        """Return the EDGAR URL of exhibit 99.1 for an 8-K filing, or None if not found."""
+        """Return the EDGAR URL of exhibit 99.1 for an 8-K filing, or None if not found.
+
+        Prefers ``.htm`` / ``.html`` filenames (the canonical extractable form).
+        Falls back to ``.pdf`` when only a PDF exhibit is listed; callers are
+        expected to log+skip PDF URLs since the extraction pipeline cannot
+        ingest PDF bytes today (see ``FilingFetcher.fetch_filing``).
+        """
         bare = extract_sec_accession_token(accession_number)
         if bare is None:
             return None
@@ -638,14 +644,24 @@ class SECClient:
         except Exception:
             return None
         items = data.get("directory", {}).get("item", [])
+        html_match: str | None = None
+        pdf_match: str | None = None
         for item in items:
             name = item.get("name", "")
-            if name.endswith((".htm", ".html")) and self._EXHIBIT_991_RE.search(name):
-                return (
-                    f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
-                    f"{accession_no_dashes}/{name}"
-                )
-        return None
+            if not self._EXHIBIT_991_RE.search(name):
+                continue
+            lower = name.lower()
+            if html_match is None and lower.endswith((".htm", ".html")):
+                html_match = name
+            elif pdf_match is None and lower.endswith(".pdf"):
+                pdf_match = name
+        chosen = html_match or pdf_match
+        if chosen is None:
+            return None
+        return (
+            f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
+            f"{accession_no_dashes}/{chosen}"
+        )
 
     def get_company_info(self, cik: str) -> dict | None:
         """

--- a/tests/integration/filing_fetcher/test_8k_exhibit_fetch.py
+++ b/tests/integration/filing_fetcher/test_8k_exhibit_fetch.py
@@ -222,3 +222,49 @@ class TestEightKExhibitFetch:
 
         mock_get.assert_not_called()
         fetcher.sec_client.get_exhibit_99_1_url.assert_not_called()
+
+    def test_pdf_exhibit_logs_warning_and_skips(
+        self,
+        fetcher: FilingFetcher,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """PDF exhibit 99.1 is skipped with a structured warning (legacy-115).
+
+        The warning gives operators a grep target so they can identify
+        affected filings; the fetch then proceeds with primary-only content.
+        """
+        pdf_url = (
+            "https://www.sec.gov/Archives/edgar/data/1642545/"
+            "000164254525000123/exhibit99-1.pdf"
+        )
+        fetcher.sec_client.get_exhibit_99_1_url.return_value = pdf_url
+        md = _make_metadata("8-K")
+        large_primary = (
+            "<html><head><title>8-K</title></head><body>"
+            "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+            "<p>FORM 8-K</p>"
+            + "X" * 20000
+            + "</body></html>"
+        )
+
+        with caplog.at_level("WARNING", logger="src.filing_fetcher.filing_fetcher"):
+            with patch.object(
+                fetcher.session, "get", return_value=_mock_response(large_primary)
+            ) as mock_get:
+                content = fetcher.fetch_filing(md, fetch_txt=False)
+
+        # Primary fetched, exhibit fetch skipped.
+        assert mock_get.call_count == 1
+        assert content is not None
+        html = pathlib.Path(content.html_path).read_text(encoding="utf-8")
+        assert _EXHIBIT_SEPARATOR not in html
+
+        # Structured warning emitted with cik/accession/url.
+        skip_records = [
+            r for r in caplog.records if "exhibit-99-1-pdf-skipped" in r.getMessage()
+        ]
+        assert len(skip_records) == 1
+        msg = skip_records[0].getMessage()
+        assert f"cik={_CIK}" in msg
+        assert f"accession={_ACCESSION}" in msg
+        assert f"url={pdf_url}" in msg

--- a/tests/unit/infra/test_sec_client.py
+++ b/tests/unit/infra/test_sec_client.py
@@ -1748,3 +1748,69 @@ class TestImageCaching:
         result = client.fetch_image("0001234567", "0001234567-24-000001", "chart.jpg")
 
         assert result == image_bytes
+
+
+class TestGetExhibit991Url:
+    """Test suite for get_exhibit_99_1_url method (legacy-115)."""
+
+    _CIK = "0001234567"
+    _ACCESSION = "0001234567-24-000001"
+    _INDEX_URL = (
+        "https://www.sec.gov/Archives/edgar/data/0001234567/"
+        "000123456724000001/index.json"
+    )
+
+    def _client_for(self, items: list[dict]) -> SECClient:
+        response_data = {"directory": {"item": items}}
+        mock_response = HTTPResponse(
+            status_code=200,
+            content=json.dumps(response_data).encode("utf-8"),
+            headers={},
+            url=self._INDEX_URL,
+            elapsed_seconds=0.1,
+        )
+        mock_client = MockHTTPClient()
+        mock_client.responses[self._INDEX_URL] = mock_response
+        return SECClient(http_client=mock_client)
+
+    def test_returns_pdf_when_only_pdf_listed(self):
+        """Filers who submit exhibit 99.1 as PDF return the .pdf URL (legacy-115)."""
+        client = self._client_for(
+            [
+                {"name": "primary.htm", "size": 100000},
+                {"name": "exhibit99-1.pdf", "size": 200000},
+            ]
+        )
+
+        url = client.get_exhibit_99_1_url(self._CIK, self._ACCESSION)
+
+        assert url is not None
+        assert url.endswith("exhibit99-1.pdf")
+
+    def test_prefers_html_over_pdf_when_both_exist(self):
+        """When both formats are listed, prefer the canonical HTML version."""
+        client = self._client_for(
+            [
+                # PDF listed first to prove preference is not order-driven.
+                {"name": "exhibit99-1.pdf", "size": 200000},
+                {"name": "exhibit99-1.htm", "size": 50000},
+            ]
+        )
+
+        url = client.get_exhibit_99_1_url(self._CIK, self._ACCESSION)
+
+        assert url is not None
+        assert url.endswith("exhibit99-1.htm")
+
+    def test_returns_none_when_no_exhibit_match(self):
+        """No file matches the exhibit-99-1 pattern → returns None."""
+        client = self._client_for(
+            [
+                {"name": "primary.htm", "size": 100000},
+                {"name": "ex10-1.htm", "size": 50000},
+            ]
+        )
+
+        url = client.get_exhibit_99_1_url(self._CIK, self._ACCESSION)
+
+        assert url is None


### PR DESCRIPTION
## Summary

- `SECClient.get_exhibit_99_1_url` now recognizes `.pdf` filenames and prefers `.htm`/`.html` when both formats are listed.
- `FilingFetcher.fetch_filing` emits a structured `exhibit-99-1-pdf-skipped: cik=… accession=… url=…` WARNING when the resolved exhibit URL is a PDF, and skips the fetch+concat — both the cold-fetch and cached-backfill branches are gated.
- Operators can now grep `exhibit-99-1-pdf-skipped` to identify affected filings.

Implements **Path 1 (warning)** of the legacy-115 fragment. PDF text extraction (pdfminer / OCR) is intentionally **not** in scope per the fragment's "minimum acceptable fix" line.

Closes legacy-115 — fragment frontmatter flipped to `status: resolved` + `autonomy: n/a` and a `### Resolution` section added in this PR.

## Test plan

- [x] 3 new unit tests for `get_exhibit_99_1_url` — PDF-only returns the `.pdf` URL; prefers HTML over PDF when both exist; returns None when no match.
- [x] 1 new integration test — `FilingFetcher` emits the structured warning, calls `session.get` only once (primary, not exhibit), and the saved HTML contains no exhibit separator.
- [x] Targeted runs: `pytest tests/unit/infra/test_sec_client.py::TestGetExhibit991Url tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` → 10 passed.
- [x] Full suite: 4177 passed; 10 pre-existing failures in `test_e2e_pipeline.py` / `test_full_page_ocr_pipeline.py` related to `FILINGS_REVIEWER_ALLOW_PROD_WRITES` R2 guard — unrelated to this change, also fail on `origin/main` HEAD.
- [x] `ruff check` on changed files → all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)