### PR TITLE
docs(known-issues): file fragments for #262 and #263 (surfaced during legacy-115)

### DIFF
--- a/docs/known-issues/gh-262-r2-prod-write-guard-blocks-local-pytest.md
+++ b/docs/known-issues/gh-262-r2-prod-write-guard-blocks-local-pytest.md
@@ -1,0 +1,37 @@
+---
+id: 262
+source: gh
+slug: r2-prod-write-guard-blocks-local-pytest
+title: R2 prod-write guard fails 10 e2e tests on a clean main during local pytest
+status: open
+severity: medium
+autonomy: safe
+estimated: S
+touches:
+  - tests/integration/extraction_v2/test_e2e_pipeline.py
+  - tests/integration/test_full_page_ocr_pipeline.py
+  - src/infra/image_storage.py
+discovered: '2026-04-27'
+updated: '2026-04-27'
+gh_issue: 262
+---
+
+### Problem
+
+When a developer sources `.env` (which sets `R2_BUCKET` to the prod bucket and the matching R2 creds) but does not also set `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1`, ten integration tests fail on a clean `origin/main`:
+
+- `tests/integration/extraction_v2/test_e2e_pipeline.py` — `TestE2ESlackFiling` (4 tests), `TestE2EProvenance::test_e2e_facts_have_valid_provenance`, `TestE2ETableReconstruction::test_e2e_tables_have_header_paths`, `TestE2EPersistence::test_e2e_persistence_roundtrip`, `TestE2EIdempotency::test_e2e_idempotent_rerun`, `TestE2EPerformance` (2 tests)
+- `tests/integration/test_full_page_ocr_pipeline.py::test_full_page_ocr_path_a_synthesizes_image_ocr_segments`
+
+All fail with the same error: `Refusing R2 write — set FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 to allow.`
+
+The R2 prod-write guard is correct and intentional (per `.claude/rules/infrastructure.md` — protects against accidental prod mutations from CLI tools). The problem is the **local-developer experience**: a clean main produces 10 failures on every `pytest -x -q` run, which masks the signal of real regressions and forces every `/commit` flow to re-verify pre-existence.
+
+Discovered while running the full suite during legacy-115 (#260) — not new behavior; reproduces on `origin/main` HEAD.
+
+### Next Steps
+
+Pick one of:
+
+- **Test-side fix (preferred):** Make the affected tests skip (or use `LocalFilesystemStorage`) when `R2_BUCKET` is set but `FILINGS_REVIEWER_ALLOW_PROD_WRITES` is not. The guard's intent is to block real R2 writes in dev; tests don't need real R2 — they should exercise the pipeline against the local cache. A pytest fixture that points the test process at `LocalFilesystemStorage` for the duration of the test would resolve all 10 cases without weakening the guard.
+- **Env-side documentation:** Add a `pyproject.toml` test-env note + `CONTRIBUTING.md` line documenting that local pytest needs `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` *or* an unset `R2_BUCKET`. Cheaper but doesn't actually fix the DX — every fresh checkout will hit the same wall.

--- a/docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md
+++ b/docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md
@@ -1,0 +1,42 @@
+---
+id: 263
+source: gh
+slug: filing-fetcher-8k-exhibit-branch-duplication
+title: FilingFetcher.fetch_filing duplicates 8-K exhibit-99-1 logic across cold-fetch and cached-backfill branches
+status: open
+severity: low
+autonomy: safe
+estimated: S
+touches:
+  - src/filing_fetcher/filing_fetcher.py
+discovered: '2026-04-27'
+updated: '2026-04-27'
+gh_issue: 263
+---
+
+### Problem
+
+`FilingFetcher.fetch_filing` (`src/filing_fetcher/filing_fetcher.py:339-390`) implements the 8-K exhibit-99-1 fetch in **two near-identical blocks**:
+
+1. **Cold-fetch branch** (~line 339) — when `html_path` does not yet exist: download primary, call `get_exhibit_99_1_url`, fetch the exhibit, validate combined content, write.
+2. **Cached-backfill branch** (~line 371) — when `html_path` exists but lacks the exhibit separator: read existing, call `get_exhibit_99_1_url`, fetch the exhibit, write combined.
+
+Both branches share the same call to `sec_client.get_exhibit_99_1_url`, the same `session.get` + `raise_for_status`, and the same `f"{primary}\n{_EXHIBIT_SEPARATOR}\n{exhibit}"` concatenation pattern.
+
+Every bug fix in this area requires matched edits across both branches. Recent precedent:
+
+- **legacy-058** (PR #251) — added `get_exhibit_99_1_url` and the fetch+concat. Both branches needed the new code.
+- **legacy-115** (PR #260) — added the PDF skip+warn guard. Both branches needed the gate.
+
+The day someone forgets one branch, we ship a half-fix: the cold-fetch path behaves correctly but cached filings (the common case in re-extraction) do not, or vice versa. The duplication is invisible at the call site — there's no shared helper and no test that asserts the two branches stay in sync.
+
+### Next Steps
+
+- Extract a helper (sketch): `def _maybe_append_exhibit_991(self, base_html: str, html_path: Path, cik: str, accession_number: str, validate_combined: bool) -> str | None` that handles `get_exhibit_99_1_url` → PDF guard → fetch → concat → optional combined-content validation, returning the combined HTML or `None` on skip.
+- Cold-fetch branch: call with `base_html=response.text`, `validate_combined=True`.
+- Cached-backfill branch: call with `base_html=existing`, `validate_combined=False` (existing primary already validated when it was first written).
+- Existing integration tests in `tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` already cover both branches and should pass unchanged.
+
+### Out of scope
+
+This is a refactor, not a bug fix. Defer until someone is touching this code path for an unrelated reason — the duplication is a hazard, not a current breakage.


### PR DESCRIPTION
## Summary

Files two known-issues fragments for follow-up work surfaced while shipping legacy-115 (#260):

- **#262** — R2 prod-write guard fails 10 e2e tests on a clean main during local pytest when prod creds are sourced without `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1`. Masks regression signal and forces every `/commit` flow to verify pre-existence. Preferred fix is a test-side fixture that points at `LocalFilesystemStorage` when the guard isn't set.
- **#263** — `FilingFetcher.fetch_filing` duplicates the 8-K exhibit-99-1 fetch+concat across cold-fetch and cached-backfill branches. Both legacy-058 and legacy-115 required matched edits in two places — invisible-at-call-site duplication is a hazard pattern. Refactor proposes a `_maybe_append_exhibit_991` helper.

Fragment-only PR, no source changes. Established pattern (`project_fragment_only_closure_pattern`).

## Test plan

- [x] `python3 scripts/validate_known_issues_fragments.py` → \`validated 120 fragment(s): OK\`
- [x] Both fragments use `gh-<issue>-<slug>.md` naming with real GitHub issue numbers (#262, #263) per project rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)