### PR TITLE
fix(vision): disable Gemini Pro thinking for vision JSON calls (closes legacy-091)

### DIFF
--- a/docs/known-issues/legacy-091-gemini-pro-empty-content-on-vision-json-object.md
+++ b/docs/known-issues/legacy-091-gemini-pro-empty-content-on-vision-json-object.md
@@ -3,15 +3,17 @@ autonomy: n/a
 discovered: '2026-04-23'
 estimated: S
 id: 91
+pr_refs:
+  - 267
 severity: medium
 slug: gemini-pro-empty-content-on-vision-json-object
 source: legacy
-status: open
+status: resolved
 title: gemini-pro Returns Empty Content on vision + response_format=json_object
 touches:
   - src/llm/vision_client.py
   - scripts/benchmark_vision.py
-updated: '2026-04-23'
+updated: '2026-04-27'
 ---
 
 ### Problem
@@ -42,3 +44,23 @@ Not reproducing on any other provider in `PROVIDER_CONFIGS`.
 - Until resolved, omit `gemini-pro` from the classify bake-off order
   (`BAKEOFF_PROVIDER_ORDER_METRIC_CLASSIFY`) — current ordering
   already excludes `two-stage` for a similar reason.
+
+### Resolution
+
+Root cause: Gemini 2.5 Pro runs an extended-thinking phase before emitting
+output tokens. When `max_output_tokens` is low (e.g. 400 for
+`analyze_image_for_metric_classification`), the thinking phase silently
+consumes the entire budget, leaving the text response empty. The
+google-genai SDK's `response.text` property correctly skips `thought=True`
+parts, so the empty-content symptom was masked at the adapter level.
+
+Fix: `GeminiVisionProvider.call_api` in `src/llm/providers/gemini.py` now
+detects thinking-capable models (any model whose name contains
+`"gemini-2.5-pro"`) via the new `_is_thinking_model()` helper, and sets
+`thinking_config=ThinkingConfig(thinking_budget=0)` in the
+`GenerateContentConfig` to disable thinking for vision calls. The
+`response_mime_type="application/json"` field is also now set in the config
+when JSON mode is requested, replacing the prompt-injection-only approach
+with the proper API-level control. Non-Pro Gemini models and non-Gemini
+providers are unaffected. Regression guard: 15 new unit tests in
+`tests/unit/llm/test_gemini_provider.py`.

--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -51,6 +51,23 @@ _MODEL_PRICING: dict[str, tuple[float, float]] = {
 }
 _DEFAULT_PRICING = (1.25, 10.00)  # conservative fallback
 
+# Model name substrings that indicate extended-thinking capability (Gemini 2.5 Pro).
+# These models run a thinking phase before emitting output; when max_output_tokens is
+# low (e.g. 400 for metric-classify), the thinking phase can consume the entire budget
+# and leave an empty text response.  We disable thinking for vision calls so the full
+# token budget is available for the actual JSON response.
+_THINKING_MODEL_SUBSTRINGS: tuple[str, ...] = ("gemini-2.5-pro",)
+
+
+def _is_thinking_model(model: str) -> bool:
+    """Return True if ``model`` is a Gemini thinking model (e.g. Gemini 2.5 Pro).
+
+    Uses substring matching so preview suffixes like ``-preview-05-06`` are
+    recognised automatically.
+    """
+    m = model.lower()
+    return any(sub in m for sub in _THINKING_MODEL_SUBSTRINGS)
+
 
 class GeminiVisionProvider(VisionProvider):
     """Vision provider backed by Google Gemini (google-genai SDK).
@@ -100,17 +117,26 @@ class GeminiVisionProvider(VisionProvider):
         ``detail`` is accepted for interface compatibility but has no effect
         (Gemini does not expose a per-request image-quality parameter).
 
-        ``response_format={"type": "json_object"}`` is handled by appending
-        ``"Return ONLY valid JSON."`` to the prompt when the caller requests
-        JSON mode, matching the OpenAI behavior at the prompt level.
+        ``response_format={"type": "json_object"}`` is handled two ways:
+        1. ``response_mime_type="application/json"`` is set in the generation
+           config so the API enforces valid JSON at the protocol level.
+        2. ``"Return ONLY valid JSON."`` is appended to the prompt when
+           "JSON" does not already appear, as a belt-and-suspenders hint.
+
+        For thinking-capable models (Gemini 2.5 Pro), extended thinking is
+        disabled via ``thinking_config`` with ``thinking_budget=0``.  Without
+        this, the thinking phase can silently consume the entire
+        ``max_output_tokens`` budget and leave an empty text response — the
+        root cause of legacy-091.
         """
         # Build the image Part
         b64_data = base64.standard_b64encode(image_bytes).decode("utf-8")
 
+        wants_json = response_format and response_format.get("type") == "json_object"
+
         effective_prompt = prompt
-        if response_format and response_format.get("type") == "json_object":
-            if "JSON" not in prompt:
-                effective_prompt = prompt + "\n\nReturn ONLY valid JSON."
+        if wants_json and "JSON" not in prompt:
+            effective_prompt = prompt + "\n\nReturn ONLY valid JSON."
 
         try:
             import google.genai.types as genai_types  # type: ignore[import-untyped]
@@ -121,10 +147,19 @@ class GeminiVisionProvider(VisionProvider):
             )
             contents = [image_part, effective_prompt]
 
-            generation_config = genai_types.GenerateContentConfig(
-                max_output_tokens=max_tokens,
-                temperature=0.0,
-            )
+            config_kwargs: dict[str, Any] = {
+                "max_output_tokens": max_tokens,
+                "temperature": 0.0,
+            }
+            if wants_json:
+                config_kwargs["response_mime_type"] = "application/json"
+            if _is_thinking_model(self.model):
+                # Disable extended thinking so the full token budget is
+                # available for the JSON response (fixes legacy-091).
+                config_kwargs["thinking_config"] = genai_types.ThinkingConfig(
+                    thinking_budget=0
+                )
+            generation_config = genai_types.GenerateContentConfig(**config_kwargs)
         except ImportError:
             # Older google-genai API (pre-1.0) uses dict-based parts
             contents = _build_legacy_contents(b64_data, mime_type, effective_prompt)

--- a/tests/unit/llm/test_gemini_provider.py
+++ b/tests/unit/llm/test_gemini_provider.py
@@ -1,0 +1,265 @@
+"""Unit tests for the Gemini vision provider adapter.
+
+Covers:
+- _is_thinking_model helper
+- GeminiVisionProvider.call_api with mocked google-genai SDK
+  - thinking_config is set for Pro models (legacy-091 regression guard)
+  - thinking_config is NOT set for Flash / non-thinking models
+  - response_mime_type is set when response_format=json_object
+  - empty response.text is handled gracefully
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.llm.providers.gemini import _is_thinking_model
+
+# ---------------------------------------------------------------------------
+# _is_thinking_model
+# ---------------------------------------------------------------------------
+
+
+class TestIsThinkingModel:
+    def test_pro_exact(self):
+        assert _is_thinking_model("gemini-2.5-pro") is True
+
+    def test_pro_preview_suffix(self):
+        assert _is_thinking_model("gemini-2.5-pro-preview-05-06") is True
+
+    def test_pro_case_insensitive(self):
+        assert _is_thinking_model("Gemini-2.5-Pro") is True
+
+    def test_flash_not_thinking(self):
+        assert _is_thinking_model("gemini-2.5-flash-lite") is False
+
+    def test_flash_not_thinking_plain(self):
+        assert _is_thinking_model("gemini-2.0-flash") is False
+
+    def test_old_pro_not_thinking(self):
+        # Gemini 1.5 Pro does not have extended thinking
+        assert _is_thinking_model("gemini-1.5-pro") is False
+
+    def test_openai_model_not_thinking(self):
+        assert _is_thinking_model("gpt-4o") is False
+
+    def test_empty_string_not_thinking(self):
+        assert _is_thinking_model("") is False
+
+
+# ---------------------------------------------------------------------------
+# GeminiVisionProvider.call_api — mocked SDK
+# ---------------------------------------------------------------------------
+
+# Minimal PNG bytes (just the magic header + padding)
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+
+def _make_fake_response(text: str | None = '{"ok": true}') -> MagicMock:
+    """Return a mock Gemini GenerateContentResponse."""
+    resp = MagicMock()
+    resp.text = text
+    usage = MagicMock()
+    usage.prompt_token_count = 100
+    usage.candidates_token_count = 20
+    resp.usage_metadata = usage
+    return resp
+
+
+class TestGeminiProviderCallApi:
+    """All tests mock the google-genai SDK — no real API calls."""
+
+    def _make_provider(self, model: str = "gemini-2.0-flash"):
+        """Instantiate GeminiVisionProvider with mocked SDK."""
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}):
+            with patch("google.genai.Client"):
+                from src.llm.providers.gemini import GeminiVisionProvider
+
+                provider = GeminiVisionProvider(model=model)
+                # Replace the real client with a mock
+                provider._client = MagicMock()
+                provider._client.models.generate_content.return_value = (
+                    _make_fake_response()
+                )
+                return provider
+
+    def test_thinking_disabled_for_pro_model(self):
+        """For Gemini 2.5 Pro, thinking_config with budget=0 is set."""
+        provider = self._make_provider(model="gemini-2.5-pro")
+
+        import google.genai.types as genai_types
+
+        captured_configs: list[genai_types.GenerateContentConfig] = []
+        real_gcc = genai_types.GenerateContentConfig
+
+        def capture_config(**kwargs):
+            cfg = real_gcc(**kwargs)
+            captured_configs.append(cfg)
+            return cfg
+
+        with patch("google.genai.types.GenerateContentConfig", side_effect=capture_config):
+            provider.call_api(
+                image_bytes=_FAKE_PNG,
+                mime_type="image/png",
+                prompt="Classify this chart. Return JSON.",
+                max_tokens=400,
+                response_format={"type": "json_object"},
+            )
+
+        assert captured_configs, "GenerateContentConfig was not instantiated"
+        cfg = captured_configs[0]
+        assert cfg.thinking_config is not None, (
+            "thinking_config should be set for Gemini 2.5 Pro (legacy-091)"
+        )
+        assert cfg.thinking_config.thinking_budget == 0, (
+            "thinking_budget should be 0 to disable thinking"
+        )
+
+    def test_thinking_not_set_for_flash_model(self):
+        """For Gemini Flash (non-thinking), thinking_config is not set."""
+        provider = self._make_provider(model="gemini-2.5-flash-lite")
+
+        import google.genai.types as genai_types
+
+        captured_configs: list[genai_types.GenerateContentConfig] = []
+        real_gcc = genai_types.GenerateContentConfig
+
+        def capture_config(**kwargs):
+            cfg = real_gcc(**kwargs)
+            captured_configs.append(cfg)
+            return cfg
+
+        with patch("google.genai.types.GenerateContentConfig", side_effect=capture_config):
+            provider.call_api(
+                image_bytes=_FAKE_PNG,
+                mime_type="image/png",
+                prompt="Classify this chart. Return JSON.",
+                max_tokens=400,
+                response_format={"type": "json_object"},
+            )
+
+        assert captured_configs, "GenerateContentConfig was not instantiated"
+        cfg = captured_configs[0]
+        assert cfg.thinking_config is None, (
+            "thinking_config should NOT be set for Flash models"
+        )
+
+    def test_response_mime_type_set_for_json_mode(self):
+        """response_mime_type='application/json' is set when json_object is requested."""
+        provider = self._make_provider(model="gemini-2.0-flash")
+
+        import google.genai.types as genai_types
+
+        captured_configs: list[genai_types.GenerateContentConfig] = []
+        real_gcc = genai_types.GenerateContentConfig
+
+        def capture_config(**kwargs):
+            cfg = real_gcc(**kwargs)
+            captured_configs.append(cfg)
+            return cfg
+
+        with patch("google.genai.types.GenerateContentConfig", side_effect=capture_config):
+            provider.call_api(
+                image_bytes=_FAKE_PNG,
+                mime_type="image/png",
+                prompt="Return JSON.",
+                max_tokens=400,
+                response_format={"type": "json_object"},
+            )
+
+        assert captured_configs
+        cfg = captured_configs[0]
+        assert cfg.response_mime_type == "application/json"
+
+    def test_response_mime_type_not_set_without_json_mode(self):
+        """response_mime_type is not set when response_format is None."""
+        provider = self._make_provider(model="gemini-2.0-flash")
+
+        import google.genai.types as genai_types
+
+        captured_configs: list[genai_types.GenerateContentConfig] = []
+        real_gcc = genai_types.GenerateContentConfig
+
+        def capture_config(**kwargs):
+            cfg = real_gcc(**kwargs)
+            captured_configs.append(cfg)
+            return cfg
+
+        with patch("google.genai.types.GenerateContentConfig", side_effect=capture_config):
+            provider.call_api(
+                image_bytes=_FAKE_PNG,
+                mime_type="image/png",
+                prompt="Describe this chart.",
+                max_tokens=400,
+                response_format=None,
+            )
+
+        assert captured_configs
+        cfg = captured_configs[0]
+        assert cfg.response_mime_type is None
+
+    def test_empty_response_text_returns_empty_content(self):
+        """When response.text is None or empty, VisionResponse.content is ''."""
+        provider = self._make_provider(model="gemini-2.5-pro")
+        provider._client.models.generate_content.return_value = _make_fake_response(
+            text=None
+        )
+
+        resp = provider.call_api(
+            image_bytes=_FAKE_PNG,
+            mime_type="image/png",
+            prompt="Classify this chart. Return JSON.",
+            max_tokens=400,
+            response_format={"type": "json_object"},
+        )
+
+        assert resp.content == ""
+
+    def test_happy_path_returns_response_content(self):
+        """A normal response is returned with the text content."""
+        provider = self._make_provider(model="gemini-2.5-pro")
+        expected_json = '{"predicted_metrics": [], "confidence": 0.0}'
+        provider._client.models.generate_content.return_value = _make_fake_response(
+            text=expected_json
+        )
+
+        resp = provider.call_api(
+            image_bytes=_FAKE_PNG,
+            mime_type="image/png",
+            prompt="Classify this chart. Return JSON.",
+            max_tokens=400,
+            response_format={"type": "json_object"},
+        )
+
+        assert resp.content == expected_json
+        assert resp.model == "gemini-2.5-pro"
+        assert resp.prompt_tokens == 100
+        assert resp.completion_tokens == 20
+
+    def test_pro_preview_model_also_disables_thinking(self):
+        """gemini-2.5-pro-preview-05-06 also gets thinking_config set."""
+        provider = self._make_provider(model="gemini-2.5-pro-preview-05-06")
+
+        import google.genai.types as genai_types
+
+        captured_configs: list[genai_types.GenerateContentConfig] = []
+        real_gcc = genai_types.GenerateContentConfig
+
+        def capture_config(**kwargs):
+            cfg = real_gcc(**kwargs)
+            captured_configs.append(cfg)
+            return cfg
+
+        with patch("google.genai.types.GenerateContentConfig", side_effect=capture_config):
+            provider.call_api(
+                image_bytes=_FAKE_PNG,
+                mime_type="image/png",
+                prompt="Classify this chart. Return JSON.",
+                max_tokens=400,
+                response_format={"type": "json_object"},
+            )
+
+        assert captured_configs
+        cfg = captured_configs[0]
+        assert cfg.thinking_config is not None
+        assert cfg.thinking_config.thinking_budget == 0


### PR DESCRIPTION
## Summary

- **Root cause (legacy-091):** Gemini 2.5 Pro runs extended thinking before emitting output tokens. With `max_output_tokens=400` (metric-classify default), the thinking phase consumed the entire budget, leaving `response.text` empty — driving 100% parse failure and 0.0 tag-F1 in the 2026-04-23 bake-off.
- **Fix:** `GeminiVisionProvider.call_api` now sets `thinking_config=ThinkingConfig(thinking_budget=0)` for thinking-capable models (detected via `_is_thinking_model()` substring match on `"gemini-2.5-pro"`). Also sets `response_mime_type="application/json"` in `GenerateContentConfig` when JSON mode is requested — replacing the prompt-injection-only approach with proper API-level control.
- **Scope:** Only affects `src/llm/providers/gemini.py`. Non-Pro Gemini models, other providers, and non-JSON calls are unaffected.

## Test plan

- [x] 15 new unit tests in `tests/unit/llm/test_gemini_provider.py` (all pass):
  - `_is_thinking_model` covers Pro exact, preview suffix, case-insensitive, Flash negative, old-Pro negative
  - `call_api` confirms `thinking_config.thinking_budget == 0` for Pro models
  - `call_api` confirms `thinking_config is None` for Flash models
  - `call_api` confirms `response_mime_type="application/json"` when JSON mode requested
  - `call_api` confirms `response_mime_type is None` without JSON mode
  - Empty `response.text` returns `content=""` gracefully
- [x] 3893 unit tests pass (`pytest tests/unit/ -x -q`)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)