### PR TITLE
chore(commands): rename project-local /commit -> /commit-proj

### DIFF
--- a/.claude/commands/commit-proj.md
+++ b/.claude/commands/commit-proj.md
@@ -1,6 +1,8 @@
-# Safe Commit + PR Skill (project-local)
+# Safe Commit + PR Skill (project-local) — `/commit-proj`
 
 **Purpose:** Gate code quality before commit (lint, tests, doc-freshness, known-issues triage), then branch + commit + push + open a PR + enable auto-merge. `main` is protected server-side; this skill matches the local flow to the remote contract.
+
+**Renamed from `/commit` to `/commit-proj` to disambiguate from the global `/commit` skill.** The global skill now also branches off main and opens a PR (it learned that pattern from this skill), but it does not handle: the project's `make hooks-install` / `extraction-guard` pre-commit framework, the `docs/known-issues/gh-N-<slug>.md` fragment system with required `gh issue create`, the `legacy-NNN-*` allowlist, or the project's required-checks recital. Use `/commit-proj` here; `/commit` is fine for projects that don't have those.
 
 **When to use:** Any time the user asks to commit changes.
 

--- a/.claude/commands/pick-issues.md
+++ b/.claude/commands/pick-issues.md
@@ -101,8 +101,8 @@ You are working <gh-N|legacy-N>: <title>.
 4. **Pre-Implementation Gate** (per global CLAUDE.md). Show the completed checklist and get user approval before writing code.
 5. **Tests.** Per project CLAUDE.md testing standards — `pytest -x -q --tb=short`. Don't skip on failures.
 6. **Update fragment status as part of the same PR.** Flip the fragment's `status: open` → `resolved`, `autonomy: n/a`, set `pr_refs: [<this PR #>]` (added after PR creation), and append a `### Resolution` section. This is the project's `project_fragment_only_closure_pattern` applied inline so the auto-closer doesn't need to do bookkeeping later.
-7. **Commit + PR.** Use the **project-local** `/commit` skill (Safe Commit + PR Skill). Per `feedback_commit_skill_name_collision`, the global skill may load instead — if you see "Safe Commit Skill" without a PR step, follow up manually with `gh pr create` + `gh pr merge --auto --squash`.
-8. **Verify auto-merge.** After /commit returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
+7. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill). The global `/commit` skill also branches + opens a PR now, but does not handle the project's pre-commit framework, fragment-system OOS triage, or required-checks recital — prefer `/commit-proj` here.
+8. **Verify auto-merge.** After /commit-proj returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
 
 ## Out of scope (do NOT expand into)
 <List from fragment's body + any concurrent-worktree footprints from `git worktree list`. Be specific about file paths.>
@@ -111,7 +111,6 @@ You are working <gh-N|legacy-N>: <title>.
 <Pull from MEMORY.md the entries that touch this fragment's `touches:` paths or topic. Always include:>
 - `feedback_verify_issue_status` — verify on origin/main first
 - `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
-- `feedback_commit_skill_name_collision` — global vs project-local /commit
 - `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
 - `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
 
@@ -144,7 +143,7 @@ Print, in this exact order:
    - docs/worker-prompts/PICK_<id2>_<slug2>.md
    - docs/worker-prompts/PICK_<id3>_<slug3>.md
 
-   Dispatch each plan to a separate subagent and run them in parallel. Each subagent should follow its plan end-to-end (worktree, plan-mode, /plan-review, Pre-Implementation Gate, tests, project-local /commit, fragment-status flip, auto-merge verification) and return its PR URL. Report all PR URLs when every subagent has finished.
+   Dispatch each plan to a separate subagent and run them in parallel. Each subagent should follow its plan end-to-end (worktree, plan-mode, /plan-review, Pre-Implementation Gate, tests, project-local /commit-proj, fragment-status flip, auto-merge verification) and return its PR URL. Report all PR URLs when every subagent has finished.
    ```
 
    **Multiple picks with any other strategy** (footprints not verified disjoint — sequential is safer):

--- a/.claude/hooks/precommit-simplify-check.sh
+++ b/.claude/hooks/precommit-simplify-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Reminds Claude to run /simplify before /commit when 3+ files are modified.
-# Wired as PreToolUse(Skill) hook in .claude/settings.json; filters for the
-# commit skill by parsing the tool-call JSON payload on stdin.
+# Reminds Claude to run /simplify before /commit-proj (or /commit) when 3+
+# files are modified. Wired as PreToolUse(Skill) hook in .claude/settings.json;
+# filters for either commit skill by parsing the tool-call JSON payload on stdin.
 
 INPUT=$(cat)
 
@@ -11,21 +11,24 @@ else
   SKILL=$(echo "$INPUT" | grep -oE '"skill"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 fi
 
-[ "${SKILL:-}" = "commit" ] || exit 0
+case "${SKILL:-}" in
+  commit|commit-proj) ;;
+  *) exit 0 ;;
+esac
 
 CHANGED=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "${CHANGED:-0}" -ge 3 ]; then
   cat <<'EOF'
 
-REMINDER: 3+ files changed this session. Before proceeding with /commit,
+REMINDER: 3+ files changed this session. Before proceeding with /commit-proj,
 consider running /simplify to catch:
   - Duplicate helpers or utilities
   - Unnecessary abstractions / scope creep
   - Dead imports, unused code, leftover comments
 
 If you've already simplified (or the changes are isolated / mechanical),
-proceed with /commit as usual.
+proceed with /commit-proj as usual.
 EOF
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'cmd=\"${CLAUDE_TOOL_INPUT_command:-$1}\"; case \"$cmd\" in *\"git commit\"*) br=$(git -C \"$CLAUDE_PROJECT_DIR\" branch --show-current 2>/dev/null); if [ \"$br\" = \"main\" ] || [ \"$br\" = \"master\" ]; then echo \"BLOCKED: refusing to commit on $br. Use /commit (auto-branches) or git checkout -b <branch> first.\" >&2; exit 2; fi ;; esac' _ \"$CLAUDE_TOOL_INPUT_command\""
+            "command": "bash -c 'cmd=\"${CLAUDE_TOOL_INPUT_command:-$1}\"; case \"$cmd\" in *\"git commit\"*) br=$(git -C \"$CLAUDE_PROJECT_DIR\" branch --show-current 2>/dev/null); if [ \"$br\" = \"main\" ] || [ \"$br\" = \"master\" ]; then echo \"BLOCKED: refusing to commit on $br. Use /commit-proj (auto-branches) or git checkout -b <branch> first.\" >&2; exit 2; fi ;; esac' _ \"$CLAUDE_TOOL_INPUT_command\""
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 
 ## Workflow
 
-**PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit` (project-local): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass.
+**PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit-proj` (project-local; renamed from `/commit` to disambiguate from the global skill of the same name): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass. The global `/commit` will also work in a pinch (it now branches + opens a PR), but it does not handle this project's pre-commit framework, fragment-based known-issues, or required-check recital.
 
-**Worktree-first.** Run `/commit` (and any HEAD-moving git work) from a `ccw` worktree, not the primary tree — a PreToolUse guard denies `git checkout`/`switch`/`checkout -b` in the primary tree to protect concurrent sessions. Use `EnterWorktree` inside a session or `ccw [branch]` from the shell. See `docs/development/claude-sessions-and-worktrees.md`.
+**Worktree-first.** Run `/commit-proj` (and any HEAD-moving git work) from a `ccw` worktree, not the primary tree — a PreToolUse guard denies `git checkout`/`switch`/`checkout -b` in the primary tree to protect concurrent sessions. Use `EnterWorktree` inside a session or `ccw [branch]` from the shell. See `docs/development/claude-sessions-and-worktrees.md`.
 
-**Planning rule.** For any plan touching 3+ files or new deps / config, make worktree setup (`EnterWorktree` or `ccw <branch>`) the first step. The `/commit` skill assumes you're in one.
+**Planning rule.** For any plan touching 3+ files or new deps / config, make worktree setup (`EnterWorktree` or `ccw <branch>`) the first step. The `/commit-proj` skill assumes you're in one.
 
 Required status checks: **Lint**, **Unit Tests**, **Vulnerability Scan**, **Integration Tests**, **UI E2E (Playwright)**. Use `/ci-fix` when checks fail; `/merge-check` for a manual pre-merge sweep.
 
@@ -28,7 +28,7 @@ See `docs/development/CONTRIBUTING.md` for the full flow.
 
 **Nightly autonomous sweeper:** `filings-nightly-sweep` cron runs 06:00 UTC daily, picks up to 5 eligible issues (autonomy `safe`, status `open` or `partially-resolved`) from `docs/known-issues/` fragment frontmatter, auto-merges on green CI, and writes a morning-review digest to `.claude/sweep-digests/`. Gated by `SWEEP_FORCE=1` in Render's `filings-claude-secrets` env group; unset (or set to anything else) to pause. See `docs/operations/nightly-sweep-runbook.md` and the `/sweep` skill for manual runs. The rollup `docs/KNOWN_ISSUES.md` is not tracked in git — CI regenerates it as a build artifact on every run (see `.github/workflows/ci.yml` job `known-issues-artifact`).
 
-**Known-issues fragments use `gh-<issue>-<slug>.md`** — server-allocated GitHub issue numbers, no local coordination, no collisions. The validator rejects any new `legacy-*` filename; the frozen set lives in `docs/known-issues/.legacy-allowlist.txt`. See `docs/development/CONTRIBUTING.md` and `.claude/commands/commit.md` step 9.
+**Known-issues fragments use `gh-<issue>-<slug>.md`** — server-allocated GitHub issue numbers, no local coordination, no collisions. The validator rejects any new `legacy-*` filename; the frozen set lives in `docs/known-issues/.legacy-allowlist.txt`. See `docs/development/CONTRIBUTING.md` and `.claude/commands/commit-proj.md` step 9.
 
 ## Key Commands
 
@@ -87,7 +87,7 @@ Metrics are classified into importance tiers based on analytical value. These ti
 
 ## Hooks
 
-A PreToolUse hook nudges `/simplify` when 3+ files are modified before `/commit` — see `.claude/hooks/precommit-simplify-check.sh`.
+A PreToolUse hook nudges `/simplify` when 3+ files are modified before `/commit-proj` (or `/commit`) — see `.claude/hooks/precommit-simplify-check.sh`.
 
 ## Compact Instructions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -391,16 +391,16 @@ Workflow commands for common tasks:
 | Command | Purpose |
 |---------|---------|
 | `/cleanup` | Project-local: prune merged branches, stale remote-tracking refs, and dead Claude worktrees. Safe to re-run. |
-| `/commit` | Project-local: auto-branch off main, commit, push, open PR, enable auto-merge. See [CONTRIBUTING.md](development/CONTRIBUTING.md#committing-via-commit-claude-code). |
+| `/commit-proj` | Project-local: auto-branch off main, commit, push, open PR, enable auto-merge. Renamed from `/commit` to disambiguate from the global skill of the same name. See [CONTRIBUTING.md](development/CONTRIBUTING.md#committing-via-commit-claude-code). |
 | `/doc-audit` | Run documentation freshness audit (reports staleness, does not auto-fix) |
 | `/metric-lifecycle` | Guidance for adding, deprecating, or removing metrics |
 | `/project-tutorial [lesson]` | Interactive project lessons with live codebase walkthroughs (10 topics) |
 | `/supervise-prs` | Project-local: single-shot PR-cohort status check; compose with `/loop <interval> /supervise-prs <prs>` to poll merges, dispatch `/ci-fix` on required-check failures, and hand off to `/cleanup`. |
-| `/ci-fix` | Global/plugin: iterate ruff / mypy / pytest to green on a red PR, then defer to `/commit`. |
+| `/ci-fix` | Global/plugin: iterate ruff / mypy / pytest to green on a red PR, then defer to `/commit-proj`. |
 | `/merge-check` | Global/plugin: pre-merge sanity sweep (CI status, migrations, import integrity, tests, type check, branch freshness). |
 | `/plan-review` | Global/plugin: review and critique a plan before execution. |
 
-> **Note:** `/cleanup`, `/commit`, `/doc-audit`, `/metric-lifecycle`, `/project-tutorial`, and `/supervise-prs` are project-local command files under `.claude/commands/`. `/ci-fix`, `/merge-check`, and `/plan-review` are delivered via Claude Code skills/plugins rather than project-local files.
+> **Note:** `/cleanup`, `/commit-proj`, `/doc-audit`, `/metric-lifecycle`, `/project-tutorial`, and `/supervise-prs` are project-local command files under `.claude/commands/`. `/ci-fix`, `/merge-check`, and `/plan-review` are delivered via Claude Code skills/plugins rather than project-local files. `/commit-proj` was renamed from `/commit` to disambiguate from the global skill of the same name.
 
 ### Sub-Agents (`.claude/agents/`)
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -32,19 +32,22 @@ feature branch → PR against main → CI green → squash-merge
 [`docs/operations/ci-branch-protection.md`](../operations/ci-branch-protection.md)).
 Direct pushes are refused; a red CI blocks the merge button. Branches do NOT need to be up-to-date with `main` before merging — auto-merge squash-merges whichever PR finishes CI first; subsequent PRs merge on top.
 
-Run `/commit` from a `ccw` worktree. HEAD-moving git commands in the primary tree are blocked by a PreToolUse hook — see `docs/development/claude-sessions-and-worktrees.md`.
+Run `/commit-proj` from a `ccw` worktree. HEAD-moving git commands in the primary tree are blocked by a PreToolUse hook — see `docs/development/claude-sessions-and-worktrees.md`.
 
-### Committing via `/commit` (Claude Code)
+### Committing via `/commit-proj` (Claude Code)
 
-The project-local `/commit` skill (`.claude/commands/commit.md`) handles the
-full flow in one invocation:
+The project-local `/commit-proj` skill (`.claude/commands/commit-proj.md`) handles the
+full flow in one invocation. (Renamed from `/commit` to disambiguate from the
+global skill of the same name; the global `/commit` will also branch + open a PR
+now, but does not handle this project's pre-commit framework, fragment-based
+known-issues, or required-checks recital.)
 
-1. **Branch preflight.** `/commit` must run inside a `ccw` worktree — the
+1. **Branch preflight.** `/commit-proj` must run inside a `ccw` worktree — the
    PreToolUse hook in `~/.claude/hooks/guard-destructive-git.sh` refuses
    `git checkout -b` in the primary tree. If no worktree exists yet, enter
    one first (`EnterWorktree` from a Claude session, or `ccw [branch]`
    from a shell). See [§ Orchestration pattern](claude-sessions-and-worktrees.md#orchestration-pattern-planning-session--parallel-subagents)
-   for the recommended flow. On first-commit for a branch, `/commit` derives
+   for the recommended flow. On first-commit for a branch, `/commit-proj` derives
    the branch name (`claude/<type>-<slug>`) from the staged diff; on a
    pre-existing branch it reuses the current one.
 2. **Pre-commit framework check.** Verifies `.git/hooks/pre-commit` is
@@ -63,12 +66,12 @@ Local safety rails in `.claude/settings.json`:
 - `git push origin main`, `git push --force*`, and `gh pr merge*--admin*` are
   denied before the Bash tool fires them.
 - A PreToolUse hook refuses `git commit` while on `main` (belt-and-suspenders
-  if you bypass `/commit`).
+  if you bypass `/commit-proj`).
 
 ### When checks fail
 
 - **Red CI on a PR:** invoke `/ci-fix` — it iterates ruff/mypy/pytest to
-  green, then defers to `/commit` to push the fix. Auto-merge stays armed and
+  green, then defers to `/commit-proj` to push the fix. Auto-merge stays armed and
   completes when the next run is green.
 - **Pre-merge sanity:** `/merge-check` runs the full local gauntlet (CI
   status, migrations, import integrity, tests, type check, branch freshness)
@@ -154,6 +157,6 @@ specific files by name.
 
 ## Known-issues triage
 
-New issues surfaced during contribution go into a new `docs/known-issues/gh-N-<slug>.md` fragment file, where `N` is the GitHub issue number returned by `gh issue create`. The `/commit` skill step 9 automates this — see the frontmatter template there. Existing `legacy-NNN-*.md` fragments (pre-2026-04-24) are frozen in place; do not rename them, and **do not mint new `legacy-*` filenames** — the validator (`scripts/validate_known_issues_fragments.py`, run by pre-commit and CI) rejects any `legacy-*` filename not listed in `docs/known-issues/.legacy-allowlist.txt`. GitHub issue numbers are server-allocated, so `gh-N` cannot collide. Fragments are the source of truth.
+New issues surfaced during contribution go into a new `docs/known-issues/gh-N-<slug>.md` fragment file, where `N` is the GitHub issue number returned by `gh issue create`. The `/commit-proj` skill step 9 automates this — see the frontmatter template there. Existing `legacy-NNN-*.md` fragments (pre-2026-04-24) are frozen in place; do not rename them, and **do not mint new `legacy-*` filenames** — the validator (`scripts/validate_known_issues_fragments.py`, run by pre-commit and CI) rejects any `legacy-*` filename not listed in `docs/known-issues/.legacy-allowlist.txt`. GitHub issue numbers are server-allocated, so `gh-N` cannot collide. Fragments are the source of truth.
 
 The rollup `docs/KNOWN_ISSUES.md` is not tracked in git — CI regenerates it as a build artifact on every run (`.github/workflows/ci.yml` job `known-issues-artifact`). Download the latest rendered rollup from the Actions tab of any `main` build. To regenerate locally for preview: `python3 scripts/regenerate_known_issues.py --output /tmp/KNOWN_ISSUES.md`.

--- a/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
+++ b/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
@@ -11,7 +11,7 @@ source: gh
 status: open
 title: Fix-PR Authors Don't Set pr_refs on the Fragment They Resolve
 touches:
-  - .claude/commands/commit.md
+  - .claude/commands/commit-proj.md
   - scripts/validate_known_issues_fragments.py
 updated: '2026-04-27'
 ---
@@ -34,7 +34,7 @@ The auto-closer is functioning correctly. The drift comes from a process gap ups
 Pick one (cheapest first):
 
 - **Option C — Pre-commit nudge.** Extend `scripts/validate_known_issues_fragments.py` (or a sibling pre-commit hook) to detect: a known-issue fragment was modified in the staged diff, its `status` is `open`, and its `pr_refs` is empty / missing. Print a `WARNING: did you mean to set pr_refs on this fragment? auto-closer can't see it otherwise` message — non-blocking. Cheapest, low coupling. Doesn't help fragments that aren't touched by the fix-PR (most of them).
-- **Option B — `/commit` skill hint.** Add a `resolves: #N` field to the project-local `/commit` skill. When set, the skill: (1) verifies the named fragment exists, (2) appends the new PR number to its `pr_refs`, (3) stages the fragment edit alongside the user's diff. Closes the loop end-to-end but couples fragment bookkeeping to the `/commit` happy path.
+- **Option B — `/commit-proj` skill hint.** Add a `resolves: #N` field to the project-local `/commit-proj` skill. When set, the skill: (1) verifies the named fragment exists, (2) appends the new PR number to its `pr_refs`, (3) stages the fragment edit alongside the user's diff. Closes the loop end-to-end but couples fragment bookkeeping to the `/commit-proj` happy path.
 - **Option D — Backfill sweep.** One-shot script that walks closed fix-PRs, parses commit messages / PR descriptions for `legacy-NN` references, and adds them to the corresponding fragment's `pr_refs`. Useful as a one-time cleanup before turning on stricter checks; not a steady-state fix.
 
 Recommend starting with **Option C** as the steady-state nudge, then **Option B** if drift continues.

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -172,7 +172,7 @@ sweep_issue() {
     return
   fi
 
-  # Prompt briefs Claude on the issue, restricts scope, calls /commit.
+  # Prompt briefs Claude on the issue, restricts scope, calls /commit-proj.
   local prompt
   prompt=$(cat <<EOF
 You are the nightly autonomous sweeper working issue #${issue}.
@@ -182,9 +182,9 @@ Classification: Autonomy=${autonomy}. Note: "${note}".
 Rules (STRICT):
 1. Find the fragment file for issue #${issue} under docs/known-issues/ (filename prefix is either legacy- or gh-, e.g. legacy-${issue}-*.md or gh-${issue}-*.md) and read it in full. Do exactly what its "Next Steps" section asks, no more.
 2. If the issue requires schema migrations, infra edits, credential changes, or anything outside the "Touches" globs declared in the classification table: ABORT and explain.
-3. After implementing, invoke the /commit skill. The skill handles branch/tests/PR/auto-merge.
+3. After implementing, invoke the /commit-proj skill (project-local; renamed from /commit). The skill handles branch/tests/PR/auto-merge.
 4. If tests fail or you cannot complete the work cleanly, abort. Do NOT update baselines, do NOT skip tests, do NOT use --no-verify.
-5. On successful /commit, report the PR URL on stdout as: "PR_URL=<url>".
+5. On successful /commit-proj, report the PR URL on stdout as: "PR_URL=<url>".
 6. On abort, report the reason on stdout as: "ABORT_REASON=<short reason>".
 
 Begin.


### PR DESCRIPTION
## Summary

The project-local Safe Commit + PR Skill (`.claude/commands/commit.md`) and the global Safe Commit Skill (`~/.claude/commands/commit.md`) both registered under the slash command name `/commit`, so the Skill tool's auto-loader could pick the wrong one. When it picked the global flavor (no PR step), the resulting `git push` was rejected by branch protection, requiring manual fallback every time. Renaming to `/commit-proj` removes the collision.

This PR is the project-side half. The global `/commit` skill was upgraded separately (outside the repo) to also branch off main + open a PR + enable auto-merge — so it now works correctly for any branch-protected repo, not just this one. The two skills now do similar things, but `/commit-proj` retains the project-specific extras the global skill doesn't carry: the `make hooks-install` / `extraction-guard` pre-commit framework, the `docs/known-issues/gh-N-<slug>.md` fragment system with mandatory `gh issue create`, the `legacy-NNN-*` allowlist, and the project's required-checks recital.

## Why

Tracked in memory as `feedback_commit_skill_name_collision` — a recurring tax this session paid again when `/commit` loaded the global skill mid-edit. The memory entry was a workaround; this rename is the durable fix. Memory entry has been deleted (no longer relevant); a related entry referencing the skill name has been updated.

## Changes

- `.claude/commands/commit.md` -> `.claude/commands/commit-proj.md` (rename)
- `commit-proj.md`: H1 updated, brief disambiguation note added
- `.claude/hooks/precommit-simplify-check.sh`: matches either `commit` or `commit-proj` (so the simplify nudge still fires whichever skill the user picks)
- `.claude/settings.json`: `BLOCKED: refusing to commit on $br` message now points to `/commit-proj`
- `CLAUDE.md`: workflow section + hooks reference
- `docs/README.md`: command table + project-local-list note
- `docs/development/CONTRIBUTING.md`: 4 references in the committing-via-commit section
- `scripts/run_nightly_sweep.sh`: dispatched-prompt instructions
- `.claude/commands/pick-issues.md`: 3 references in step 6 + dispatch template
- `docs/known-issues/gh-258-*.md`: `touches:` list + body reference
- Resolved `legacy-084` fragment intentionally left as historical record (its `touches:` references the original path).

## Test plan

- [ ] Invoke `/commit-proj` in a fresh session — Skill tool loads the project-local skill (Safe Commit + PR), no collision
- [ ] Invoke `/commit` in a fresh session — Skill tool loads the global skill (which now also opens a PR; works correctly here too, just without project-specific extras)
- [ ] PreToolUse simplify hook fires for both `commit` and `commit-proj` skill invocations when 3+ files staged
- [ ] PreToolUse `git commit` blocker on `main` directs the user to `/commit-proj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)