### PR TITLE
docs(known-issues): legacy fragment cleanup — flip stale statuses, rewrite for current code

### DIFF
--- a/docs/known-issues/gh-273-gs-gate-cache-turnover-tolerance.md
+++ b/docs/known-issues/gh-273-gs-gate-cache-turnover-tolerance.md
@@ -1,0 +1,48 @@
+---
+autonomy: review
+discovered: '2026-04-28'
+estimated: M
+gh_issue: 273
+id: 273
+note: Carries structural concern out of legacy-111; three durable-fix options documented
+severity: low
+slug: gs-gate-cache-turnover-tolerance
+source: gh
+status: open
+title: GS gate has no tolerance band for LLM cache-turnover noise
+touches:
+  - src/gold_standard/baseline.py
+  - src/gold_standard/v2_validator.py
+updated: '2026-04-28'
+---
+
+### Problem
+
+The Tier-1 presence-recall regression gate in `compare_to_baseline` (`src/gold_standard/baseline.py`) is zero-tolerance: any negative delta on `tier1_presence_recall` sets `has_regression=True` and blocks the commit. This has tripped twice with no production code change:
+
+- PR #87 — text-recall regression was an env artifact, not a code bug
+- legacy-111 — transient regression on clean main; self-resolved on re-run after LLM cache re-warming
+
+Root cause is structural: LLM responses can vary by 1–2 cells on cache miss even at `temperature=0`. With ~176 Tier-1 cells in the corpus (~16 metrics × 11 companies), that is ~1pp of recall noise — enough to trip a zero-tolerance gate.
+
+### Why this carries from legacy-111
+
+legacy-111 flipped to `resolved` after the immediate symptom cleared (cache re-warmed, two clean runs matched baseline exactly). The structural risk is independent of that resolution and warrants its own tracking entry: any future cache eviction in a Tier-1-relevant prompt can re-trip the gate.
+
+### Durable-fix options
+
+1. **Widen tolerance band** — accept up to ~0.5–1pp negative delta on `tier1_presence_recall` before flagging regression. Trade-off: opens a small false-negative window for real shallow regressions.
+2. **Re-run-on-fail retry** — inside `compare_to_baseline`, on first fail re-run validation once and treat consistent failure as the regression signal. Trade-off: ~3 min runtime cost on every gate-trip; requires careful fixture isolation.
+3. **Pin cache contents** — capture the exact LLM cache rows needed for full-corpus runs into a fixture so cache state is reproducible. Trade-off: ongoing maintenance burden as prompts evolve.
+
+Decision needed before implementing.
+
+### Operator workaround (current)
+
+Documented in legacy-111 and memory `feedback_reproduce_before_bisect_transient_regression`: re-run `python3 -m src.gold_standard.v2_validator --fail-on-regression` once. If a second consecutive run still shows `tier1_presence_recall_delta < 0`, treat as a real regression and bisect; if the second run is clean, it was cache turnover.
+
+### Cross-references
+
+- legacy-111 (resolved 2026-04-28) — full incident report and bisect surface.
+- Memory `project_zero_tolerance_gate_fragility` — documents both prior trips.
+- Memory `feedback_reproduce_before_bisect_transient_regression` — the re-run-once protocol.

--- a/docs/known-issues/legacy-053-chart-call-limit-10-truncates-ocr-on-high-chart-filings.md
+++ b/docs/known-issues/legacy-053-chart-call-limit-10-truncates-ocr-on-high-chart-filings.md
@@ -3,31 +3,32 @@ autonomy: skip
 discovered: '2026-04-21'
 estimated: M
 id: 53
-note: 'Chart call limit; needs data-driven tuning. Post-#86 chart-presence pivot
-  (2026-04-23), truncation affects presence coverage only (missed detected_metrics
-  signals) — no per-value correctness impact because the pipeline no longer emits
-  per-value chart facts.'
+note: Count cap superseded by dollar budget in PR #131; residual concern is presence-coverage truncation on non-Tier-1 charts post-pivot
+pr_refs:
+  - 131
 severity: low
 slug: chart-call-limit-10-truncates-ocr-on-high-chart-filings
 source: legacy
 status: open
-title: Chart Call Limit (10) Truncates OCR on High-Chart Filings
+title: Chart OCR dollar budget may truncate non-Tier-1 presence signals on high-chart filings
 touches: []
-updated: '2026-04-23'
+updated: '2026-04-28'
 ---
 
-### Problem
+### Original problem (2026-04-21)
 
-`OCRExtractionStage` enforces a hard cap on per-filing chart OCR calls. During the Chewy smoke (`logs/issue_35_prod_smoke3.log`), only 10 of 20 queued chart/table images were OCR'd before:
+`OCRExtractionStage` enforced a hard count cap (`MAX_CHART_CALLS_PER_DOCUMENT=10`) on per-filing chart OCR calls. During the Chewy smoke (`logs/issue_35_prod_smoke3.log`), only 10 of 20 queued chart/table images were OCR'd before logging `Chart call limit (10) reached`. Filings with >10 charts silently lost trailing-image coverage.
 
-```
-WARNING:src.extraction_v2.stages.ocr_extraction:Chart call limit (10) reached
-```
+### Superseded by Wave A3 (PR #131, commit `7b02584`, 2026-04-22)
 
-Filings with lots of charts (Chewy has 16 chart-classified images; Snowflake has 8; on-average-larger S-1s exceed 10 easily) silently lose extraction coverage on the trailing images. The skipped images never get queried, so any Tier 1 cohort/NRR chart in positions 11+ is invisible to the bridge regardless of whether the OCR would have succeeded.
+The count cap was replaced by a per-filing dollar budget (`DEFAULT_CHART_BUDGET_PER_FILING_USD=0.25`) in `src/extraction_v2/stages/ocr_extraction.py:113`. Tier-1 charts bypass the budget entirely; non-Tier-1 charts share the dollar pool. The `Chart call limit (10) reached` warning is no longer emitted.
 
-### Next Steps
+### Residual concern (post-#86 chart-presence pivot)
 
-- Locate the limit in `src/extraction_v2/stages/ocr_extraction.py` (likely a module-level constant or `PipelineConfig` field) and either raise the default, convert to a per-filing override, or expose via CLI flag on `batch_v2_extraction.py`.
-- Re-run the Chewy smoke with the cap raised to quantify the missed-recall impact.
-- Consider prioritization: OCR charts in likely-Tier-1 sections first (MDA, financials) rather than HTML order.
+Post-pivot (2026-04-23, #86), the pipeline no longer emits per-value chart facts — chart processing is purely a presence signal. The dollar budget can still truncate trailing non-Tier-1 charts on filings with many charts, which translates to **missed `detected_metrics` presence signals** rather than missed values. Whether this matters depends on how many high-chart filings have Tier-1-relevant non-Tier-1 metric coverage in positions past the budget.
+
+### Next steps
+
+- Quantify on a high-chart filing (Chewy / Snowflake / Robinhood S-1) how many non-Tier-1 charts the dollar budget skips.
+- If the missed presence signal is non-trivial, raise `DEFAULT_CHART_BUDGET_PER_FILING_USD` or prioritize charts in likely-Tier-2-relevant sections (MDA, financials) first within the non-Tier-1 pool.
+- See also legacy-097 (residual chart facts after presence pivot) — same code area, same pivot context.

--- a/docs/known-issues/legacy-058-8-k-fetcher-returns-only-primary-doc-earnings-content-lives.md
+++ b/docs/known-issues/legacy-058-8-k-fetcher-returns-only-primary-doc-earnings-content-lives.md
@@ -4,6 +4,8 @@ discovered: '2026-04-20'
 estimated: S
 id: 58
 note: 8-K Exhibit 99.1 fetch; feature add, needs validator run
+pr_refs:
+  - 251
 severity: medium
 slug: 8-k-fetcher-returns-only-primary-doc-earnings-content-lives
 source: legacy

--- a/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
+++ b/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
@@ -12,19 +12,18 @@ title: Local-Dev Stuck-Batch Recovery Is Manual
 touches:
 - docs/operations/*
 - src/universe/onboarding_runner.py
-updated: '2026-04-20'
+updated: '2026-04-28'
 ---
 
 ### Problem
 
 On Render (Phase 7), a worker service with `--watch` mode will re-claim a batch whose `run_lock_until` has expired. On local dev there is no watcher — if the `onboarding_runner` subprocess dies mid-batch (kernel OOM, user kills the Flask server, etc.), the batch stays in `status='running'` forever. Currently recovery requires a hand-crafted `UPDATE v2_ingest_batches SET status='failed' WHERE batch_id=...` plus a cleanup of partially-processed `v2_ingest_batch_filings` rows.
 
-### Partial Resolution (2026-04-21)
+### Partial Resolution (2026-04-21, refreshed 2026-04-28)
 
-Manual recovery SQL documented in `docs/operations/TICKER_ONBOARDING.md` under the new "Recovering a stuck batch (local dev)" section. Operators can now self-serve stuck-batch recovery without improvising SQL. Next Steps 2 (`--cleanup-stuck` admin flag) and 3 (SIGTERM log line) remain open.
+- **NS1 (docs)** — manual recovery SQL documented in `docs/operations/TICKER_ONBOARDING.md` under "Recovering a stuck batch (local dev)". **Done.**
+- **NS3 (SIGTERM log line)** — `src/universe/onboarding_runner.py` registers a SIGTERM handler via `signal.signal(signal.SIGTERM, _signal_handler)` and logs "Shutdown signal received … will stop after current filing." The signal-trap part is shipped; the message just doesn't yet reference `--cleanup-stuck` because the flag (NS2) doesn't exist. Trivial follow-up to the NS2 work.
 
-### Next Steps
+### Remaining
 
-1. Document the manual recovery SQL in `docs/operations/TICKER_ONBOARDING.md` (or a new batch-ingest runbook) when that file lands in Phase 7.
-2. Consider a `python3 -m src.universe.onboarding_runner --cleanup-stuck` admin flag that scans for batches with `run_lock_until < NOW() - INTERVAL '1 hour'` still in `running` state and either marks them failed or re-claims them.
-3. Add a CLI log line to the runner on SIGTERM that tells the operator "batch <id> interrupted — run `... --cleanup-stuck` to recover".
+- **NS2 (`--cleanup-stuck` admin flag)** — `python3 -m src.universe.onboarding_runner --cleanup-stuck` admin mode that scans for batches with `run_lock_until < NOW() - INTERVAL '1 hour'` still in `running` state and either marks them failed or re-claims them. Once shipped, update the SIGTERM log message to point operators at the flag.

--- a/docs/known-issues/legacy-069-dockerfile-nightly-sweep-installs-claude-gh-unpinned.md
+++ b/docs/known-issues/legacy-069-dockerfile-nightly-sweep-installs-claude-gh-unpinned.md
@@ -4,6 +4,9 @@ discovered: '2026-04-21'
 estimated: S
 id: 69
 note: Pin claude + gh versions; needs validation step
+pr_refs:
+  - 176
+  - 217
 severity: low
 slug: dockerfile-nightly-sweep-installs-claude-gh-unpinned
 source: legacy

--- a/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
+++ b/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
@@ -3,24 +3,33 @@ autonomy: skip
 discovered: '2026-04-21'
 estimated: S
 id: 75
-note: Playwright E2E gap — cross-filing auto-advance; needs stub-server extension
+note: Text-queue variant landed in PR #178; image-queue variant remains open
+pr_refs:
+  - 178
 severity: low
 slug: missing-playwright-e2e-for-cross-filing-auto-advance
 source: legacy
-status: open
-title: Missing Playwright E2E for Cross-Filing Auto-Advance
+status: partially-resolved
+title: Missing Playwright E2E for image-queue cross-filing auto-advance
 touches:
 - tests/ui/*.spec.js
 - tests/ui/test_server.py
-updated: '2026-04-21'
+updated: '2026-04-28'
 ---
 
-### Problem
+### Original problem
 
-The "auto-advance to next filing when queue empties" behavior is tested at the route-plumbing layer (`tests/unit/web/test_review_v2_routes.py::test_next_filing_preserves_sort_order` and siblings) but not at the browser layer. A regression in `unified_review.html:~1047` (text completion) or `review_images_v2.js:navigateAfterQueueEmpty` would slip past current CI. Prior regressions of this behavior (commits `5f16360`, `34ec47e`) are the reason this PR exists.
+The "auto-advance to next filing when queue empties" behavior is tested at the route-plumbing layer (`tests/unit/web/test_review_v2_routes.py::test_next_filing_preserves_sort_order` and siblings) but not at the browser layer. A regression in `unified_review.html:~1047` (text completion) or `review_images_v2.js:navigateAfterQueueEmpty` would slip past current CI. Prior regressions of this behavior (commits `5f16360`, `34ec47e`) are the original motivation for this fragment.
 
-### Next Steps
+### Resolved (text-queue variant)
 
-- Add a Playwright spec in `tests/ui/` that seeds two filings with pending facts, sets sort to `company asc` on the list, approves the last pending fact in filing A, and asserts the browser lands on filing B (not the list, not default date-desc order).
-- Repeat the assertion with image-queue completion as the trigger (relevant → non-relevant → skip the last image).
-- Reuse the stub-server pattern in `tests/ui/test_server.py`; extend it with a `/filings-list-stub` route that renders `unified_filing_list.html` with two seeded filings.
+PR #178 (commit `ecc8b30`, 2026-04-24) added `tests/ui/review.spec.js` test 19 ("text-queue completion navigates to next filing") covering the text-fact path.
+
+### Remaining (image-queue variant)
+
+The image-queue completion variant is still missing. `tests/ui/review.spec.js:1136` carries an explicit `// Image-queue completion variant deferred` stub. Implementing it requires extending the stub-server XHR catch-all in `tests/ui/test_server.py` to handle the image confirmation endpoints; PR #178's scope cut left this undone.
+
+### Next steps
+
+- Implement the image-queue variant: seed two filings with pending image confirmations, confirm the last image in filing A (relevant → non-relevant → skip), and assert the browser lands on filing B preserving sort order.
+- Extend the stub-server XHR catch-all in `tests/ui/test_server.py` to handle the `/api/v2/image-confirmation/*` endpoints.

--- a/docs/known-issues/legacy-081-paypal-pre-2024-8-ks-extract-no-facts-body-is-page-image-sca.md
+++ b/docs/known-issues/legacy-081-paypal-pre-2024-8-ks-extract-no-facts-body-is-page-image-sca.md
@@ -3,13 +3,16 @@ autonomy: n/a
 discovered: '2026-04-22'
 estimated: —
 id: 81
+note: Pipeline merged in PR #110; remaining work is operator activation (smoke + prod enable + backfill)
+pr_refs:
+  - 110
 severity: medium
 slug: paypal-pre-2024-8-ks-extract-no-facts-body-is-page-image-sca
 source: legacy
 status: open
 title: PayPal Pre-2024 8-Ks Extract No Facts — Body Is Page-Image Scans
 touches: []
-updated: '2026-04-22'
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -34,9 +37,11 @@ rollback).
 
 ### Next Steps
 
-1. Merge the feature branch with both flags default-off; CI green.
+1. ~~Merge the feature branch with both flags default-off; CI green.~~ — **Done in PR #110** (commit `b517f75`); both flags are default-off on main.
 2. Dev smoke test on one PayPal 8-K; eyeball segments + facts.
 3. Enable `FULL_PAGE_OCR_ENABLED=true` in prod; run
    `scripts/backfill_full_page_ocr.py --confirm --cik 0001633917 --form-type 8-K --filing-date-before 2024-01-01`.
 4. Stability permitting, enable `IMAGE_KEYWORD_PRESCAN_ENABLED=true`
    and re-extract 5 investor-deck-style filings to exercise Path B.
+
+Steps 2–4 are operator-driven; this fragment stays open until the prod backfill verifies the pipeline produces facts on a real PayPal 8-K.

--- a/docs/known-issues/legacy-089-image-ocr-segments-not-surfaced-in-review-ui.md
+++ b/docs/known-issues/legacy-089-image-ocr-segments-not-surfaced-in-review-ui.md
@@ -63,8 +63,7 @@ directly or pull up individual image-review pages.
 
 ### Cross-references
 
-- #81 — PayPal pre-2024 8-K page-scan coverage (full-page-OCR feature).
-- #82 — Full-page-OCR pipeline integration test missing; this issue
-  adds the UI-surfacing layer to that integration gap.
-- PR #139 — landed the three backfill fixes that made filing 1748
-  ingest cleanly; this issue is the logical follow-up.
+- legacy-081 — PayPal pre-2024 8-K page-scan coverage (full-page-OCR feature).
+- legacy-082 — Full-page-OCR pipeline integration test (now **resolved** via PR #221); this fragment adds the UI-surfacing layer to that integration gap.
+- gh-196 — ML triage feed gaps from `v2_image_metric_confirmations`. Also concerns review-surface completeness for image data; different code path (training-data schema vs UI rendering) but worth coordinating if either is reworked.
+- PR #139 — landed the three backfill fixes that made filing 1748 ingest cleanly; this fragment is the logical follow-up.

--- a/docs/known-issues/legacy-093-rejection-reason-enum-lacks-table-handled-elsewhere.md
+++ b/docs/known-issues/legacy-093-rejection-reason-enum-lacks-table-handled-elsewhere.md
@@ -33,8 +33,13 @@ Landed with Leg B of the metric-classify tripod:
   this PR closes the loop so the emission now has a valid downstream
   slot.
 
-`scripts/benchmark_vision.py` still has its own frozenset copy; harness-side
-alignment tracked on the harness branch.
+`scripts/benchmark_vision.py` still has its own frozenset copy missing
+`table_handled_elsewhere`. **Out of scope (accepted):** the harness is a dev
+script, not a prod surface — its frozenset is not consumed by the pipeline
+or DB. Earlier wording ("tracked on the harness branch") was misleading;
+no harness branch ever landed and none is planned. If the harness is ever
+extended to bake-off `table_handled_elsewhere` emissions, sync the frozenset
+at that point.
 
 ### Problem
 

--- a/docs/known-issues/legacy-095-migrations-drift-from-prod-no-post-deploy-apply.md
+++ b/docs/known-issues/legacy-095-migrations-drift-from-prod-no-post-deploy-apply.md
@@ -3,17 +3,22 @@ autonomy: review
 discovered: '2026-04-23'
 estimated: M
 id: 95
+note: Phase 1 shipped via PRs #199, #243, #247; Phase 2 items reframed as accepted-risk deferrals
+pr_refs:
+  - 199
+  - 243
+  - 247
 severity: high
 slug: migrations-drift-from-prod-no-post-deploy-apply
 source: legacy
-status: partially-resolved
+status: resolved
 title: Schema Migrations Drift From Prod — No Post-Deploy Apply Step
 touches:
   - scripts/apply_migrations.py
   - render.yaml
   - src/web/app.py
   - sql/
-updated: '2026-04-27'
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -89,8 +94,12 @@ Pick one (or more) of:
 
 **Operator caution before running `--reconcile-checksums` against Neon prod.** During local verification of this PR, `--check-checksums` flagged 1 WARN on `sql/31_drop_v1_review_tables.sql` — the stored hash matched neither legacy nor new because PR #220 (`9ce34b9`, 2026-04-25) made the file idempotent *after* it had been applied. The reconciler correctly refused to silently update the row. The same drift may exist on Neon's ledger. **Run `--check-checksums` against Neon first**; if WARN appears on sql/31, drop the stale ledger row (`DELETE FROM schema_migrations WHERE id = '31_drop_v1_review_tables.sql';`) so the next predeploy re-applies the now-idempotent migration cleanly.
 
-### Remaining (Phase 2)
+### Phase 2 — accepted-risk deferrals (2026-04-28)
 
-- **#2 App-startup migration sentinel** — fail-fast in `create_app` if `MAX(id) FROM schema_migrations` lags the expected head.
-- **#4 CI schema-drift check** — diff applied set against `sql/` directory and fail if any file is unregistered (now redundant given the source-of-truth glob, but worth keeping as a defense-in-depth check that nothing was deleted from disk after application).
-- **#5 Alerting** — Render log alert on `MIGRATION_DRIFT_DETECTED` token from #2.
+The remaining Phase 2 items are explicitly deferred (not forgotten). The practical risk this fragment opened against — prod features silently breaking on any PR that adds a migration — is closed by the Phase 1 pair (`preDeployCommand` blocks deploy on migration failure; the `migration_files()` glob makes registration-drift structurally impossible). The Phase 2 items are defense-in-depth only:
+
+- **#2 App-startup migration sentinel** — _accepted-risk deferral._ Redundant with `preDeployCommand`: if migrations fail, the deploy never cuts over to traffic. The sentinel would only catch the case of a manual restart against a stale DB, which has never been the reported failure mode.
+- **#4 CI schema-drift check** — _accepted-risk deferral._ Redundant with the glob-based source-of-truth in `migration_files()` — a `sql/*.sql` file that exists on disk is automatically registered, so the "added but forgot to register" failure mode is structurally impossible.
+- **#5 Alerting** — _accepted-risk deferral._ Out of proportion to current risk. The remaining failure surface (manual restart against stale DB) does not warrant a dedicated alerting layer; a `MIGRATION_DRIFT_DETECTED` Render log alert can be added in ~10 minutes if the failure mode is ever observed.
+
+If any of these deferrals proves wrong (e.g., a manual-restart incident occurs), file a fresh `gh-*` fragment scoped to the specific failure observed rather than reopening this one.

--- a/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
+++ b/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
@@ -52,12 +52,13 @@ Three paths, pick at triage time:
 
 1. **Archive decisions + DELETE.** Export the 18 `v2_review_decisions` rows (plus the 30 facts) to `data/audit/chart_fact_decisions_predrain_<ts>.json` for historical reference, then `DELETE FROM v2_metric_facts WHERE source_type='chart'` in a transaction. Reviewer work preserved as JSON, not queryable live.
 2. **Migrate accepts + corrects to `v2_image_metric_confirmations`.** For each chart fact with `source_locator.img_id` not null: derive a `(img_id, detected_metric_id=canonical_metric_id, decision)` row. Rejects have no natural img-level equivalent (the "this value is wrong" signal doesn't map cleanly to "this metric is not present"), so rejects would still be lost. Complex but preserves the most work as live signal.
-3. **Keep deferred.** No action; residual 30 rows are inert. Revisit only if analytics downstream actually needs them gone.
+3. **Keep deferred (current default).** No action; residual 30 rows are inert. **Drain intentionally deferred indefinitely; reviewer decisions preserved.** Revisit only if analytics downstream actually reports impact from the residual rows.
 
 ### Cross-References
 
 - Parent rollout: legacy-096 (chart-presence pivot rollout, resolved).
 - Dissolved root cause: legacy-086 (dedup stage collapse).
 - Dissolved consequence: legacy-035 (pre-2026-04-17 chart-fact backfill).
+- See also legacy-053 — chart OCR dollar budget on the same pipeline post-pivot; both are residual-concern fragments rooted in the chart-presence transition.
 - Reviewed-filing guard: `src/extraction_v2/persistence.py::_persist_facts_in_tx`, `ReviewedFilingError`.
 - Cascade path: `v2_review_decisions.fact_id ON DELETE CASCADE` (sql/05 originally; `chart_only=True` guard in `persist_pipeline_result` refuses when decisions exist).

--- a/docs/known-issues/legacy-100-classify-cost-usd-not-plumbed-from-vision-client.md
+++ b/docs/known-issues/legacy-100-classify-cost-usd-not-plumbed-from-vision-client.md
@@ -3,6 +3,8 @@ autonomy: safe
 discovered: '2026-04-23'
 estimated: S
 id: 100
+pr_refs:
+  - 170
 severity: low
 slug: classify-cost-usd-not-plumbed-from-vision-client
 source: legacy

--- a/docs/known-issues/legacy-111-full-corpus-tier1-presence-recall-regression.md
+++ b/docs/known-issues/legacy-111-full-corpus-tier1-presence-recall-regression.md
@@ -3,15 +3,16 @@ autonomy: review
 discovered: '2026-04-27'
 estimated: M
 id: 111
+note: Symptom self-resolved (cache turnover); structural concern split out to gh-273
 severity: high
 slug: full-corpus-tier1-presence-recall-regression
 source: legacy
-status: partially-resolved
+status: resolved
 title: Full-corpus Tier-1 presence-recall regression on clean main blocks --fail-on-regression gate
 touches:
   - data/gold_standard/v2_baseline.json
   - src/extraction_v2/
-updated: '2026-04-27'
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -82,6 +83,10 @@ Per-metric Tier-1 breakdown (run 1):
 
 This is the same failure mode as resolved issue #87 (commit `08b6269` — "text-recall regression was an env artifact, not a code bug"). The known flaky-cell guidance in `.claude/rules/gold-standard.md` ("TMUS_2025-04-24 and META_2025-04-30 vary by 1 TP between runs") confirms the structural noise floor.
 
-**Why partially-resolved (not resolved):** the immediate symptom has cleared, but the underlying structural risk remains: a zero-tolerance gate combined with stochastic LLM responses on cache miss means any future cache eviction in a Tier-1-relevant prompt can re-trip the gate. A durable fix would either (a) widen `--fail-on-regression` tolerance to ~0.5–1pp on Tier-1 presence-recall, (b) add a re-run-on-fail retry inside `compare_to_baseline`, or (c) pin the cache contents required for full-corpus runs. None of those is in scope for this fragment.
+**Resolution (2026-04-28):** the immediate symptom cleared on re-run and has not re-occurred. The underlying structural risk (zero-tolerance gate + stochastic LLM responses on cache miss) is real but is independent of this incident; it is now tracked separately in **gh-273** (GS gate has no tolerance band for LLM cache-turnover noise), which carries forward the three durable-fix options:
 
-**Operator workaround if it re-occurs:** re-run `python3 -m src.gold_standard.v2_validator --fail-on-regression` once. If a second consecutive run still shows `tier1_presence_recall_delta < 0`, treat as a real regression and bisect; if the second run is clean, it was cache turnover.
+- (a) widen `--fail-on-regression` tolerance to ~0.5–1pp on Tier-1 presence-recall;
+- (b) add a re-run-on-fail retry inside `compare_to_baseline`;
+- (c) pin the cache contents required for full-corpus runs.
+
+**Operator workaround if it re-occurs:** re-run `python3 -m src.gold_standard.v2_validator --fail-on-regression` once. If a second consecutive run still shows `tier1_presence_recall_delta < 0`, treat as a real regression and bisect; if the second run is clean, it was cache turnover. (Also documented in memory `feedback_reproduce_before_bisect_transient_regression`.)


### PR DESCRIPTION
Audit of all 113 legacy-* fragments + 5 gh-* fragments. Verified each open and
partially-resolved fragment against current code state via grep + git log.
Three fragments self-resolved on main during the audit window (091, 113, 116)
and were dropped from scope.

Status flips:
  - legacy-095 → resolved (Phase 1 shipped via #199, #243, #247; Phase 2 reframed
    as accepted-risk deferrals — preDeployCommand + glob registration close the
    practical risk; sentinel/CI-diff/alerting are redundant defense-in-depth)
  - legacy-111 → resolved (cache-turnover transient; structural gate-fragility
    concern split out to gh-273)

Rewrites for current code:
  - legacy-053: count cap superseded by dollar budget (#131); residual scope is
    non-Tier-1 presence-coverage post-pivot
  - legacy-075 → partially-resolved: text-queue variant landed (#178); image-queue
    variant remains
  - legacy-081: NS1 marked done (#110); 2–4 still operator-driven
  - legacy-093: clarify harness-side enum sync as accepted-out-of-scope (was
    misleadingly "tracked separately")

Coordination cross-references:
  - legacy-089 → see also gh-196; #82 marked resolved
  - legacy-097 → see also legacy-053; explicit "drain deferred indefinitely"
  - legacy-062: trim NS3 (SIGTERM signal handler ships; just lacks --cleanup-stuck
    referent), narrow remaining scope to NS2

pr_refs backfill (gh-258 class):
  - legacy-058 → #251
  - legacy-069 → #176, #217
  - legacy-100 → #170

New tracking fragment:
  - gh-273: GS gate has no tolerance band for LLM cache-turnover noise
    (carries structural concern out of legacy-111)
