### PR TITLE
docs: rename global /commit references to /commit-user

### DIFF
--- a/.claude/commands/commit-proj.md
+++ b/.claude/commands/commit-proj.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Gate code quality before commit (lint, tests, doc-freshness, known-issues triage), then branch + commit + push + open a PR + enable auto-merge. `main` is protected server-side; this skill matches the local flow to the remote contract.
 
-**Renamed from `/commit` to `/commit-proj` to disambiguate from the global `/commit` skill.** The global skill now also branches off main and opens a PR (it learned that pattern from this skill), but it does not handle: the project's `make hooks-install` / `extraction-guard` pre-commit framework, the `docs/known-issues/gh-N-<slug>.md` fragment system with required `gh issue create`, the `legacy-NNN-*` allowlist, or the project's required-checks recital. Use `/commit-proj` here; `/commit` is fine for projects that don't have those.
+**Distinct from the global `/commit-user` skill.** The global skill also branches off main and opens a PR (it learned that pattern from this skill), but it does not handle: the project's `make hooks-install` / `extraction-guard` pre-commit framework, the `docs/known-issues/gh-N-<slug>.md` fragment system with required `gh issue create`, the `legacy-NNN-*` allowlist, or the project's required-checks recital. Use `/commit-proj` here; `/commit-user` is fine for projects that don't have those.
 
 **When to use:** Any time the user asks to commit changes.
 

--- a/.claude/commands/pick-issues.md
+++ b/.claude/commands/pick-issues.md
@@ -101,7 +101,7 @@ You are working <gh-N|legacy-N>: <title>.
 4. **Pre-Implementation Gate** (per global CLAUDE.md). Show the completed checklist and get user approval before writing code.
 5. **Tests.** Per project CLAUDE.md testing standards — `pytest -x -q --tb=short`. Don't skip on failures.
 6. **Update fragment status as part of the same PR.** Flip the fragment's `status: open` → `resolved`, `autonomy: n/a`, set `pr_refs: [<this PR #>]` (added after PR creation), and append a `### Resolution` section. This is the project's `project_fragment_only_closure_pattern` applied inline so the auto-closer doesn't need to do bookkeeping later.
-7. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill). The global `/commit` skill also branches + opens a PR now, but does not handle the project's pre-commit framework, fragment-system OOS triage, or required-checks recital — prefer `/commit-proj` here.
+7. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill). The global `/commit-user` skill also branches + opens a PR now, but does not handle the project's pre-commit framework, fragment-system OOS triage, or required-checks recital — prefer `/commit-proj` here.
 8. **Verify auto-merge.** After /commit-proj returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
 
 ## Out of scope (do NOT expand into)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 
 ## Workflow
 
-**PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit-proj` (project-local; renamed from `/commit` to disambiguate from the global skill of the same name): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass. The global `/commit` will also work in a pinch (it now branches + opens a PR), but it does not handle this project's pre-commit framework, fragment-based known-issues, or required-check recital.
+**PR-required.** `main` is protected — direct pushes are rejected server-side (`enforce_admins: true`). Use `/commit-proj` (project-local): it auto-branches off `main`, commits, pushes the branch, opens a PR via `gh pr create`, and sets `gh pr merge --auto --squash`. GitHub merges when all required checks pass. The global `/commit-user` will also work in a pinch (it now branches + opens a PR), but it does not handle this project's pre-commit framework, fragment-based known-issues, or required-check recital.
 
 **Worktree-first.** Run `/commit-proj` (and any HEAD-moving git work) from a `ccw` worktree, not the primary tree — a PreToolUse guard denies `git checkout`/`switch`/`checkout -b` in the primary tree to protect concurrent sessions. Use `EnterWorktree` inside a session or `ccw [branch]` from the shell. See `docs/development/claude-sessions-and-worktrees.md`.
 
@@ -87,7 +87,7 @@ Metrics are classified into importance tiers based on analytical value. These ti
 
 ## Hooks
 
-A PreToolUse hook nudges `/simplify` when 3+ files are modified before `/commit-proj` (or `/commit`) — see `.claude/hooks/precommit-simplify-check.sh`.
+A PreToolUse hook nudges `/simplify` when 3+ files are modified before `/commit-proj` (or `/commit-user`) — see `.claude/hooks/precommit-simplify-check.sh`.
 
 ## Compact Instructions
 

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -37,8 +37,7 @@ Run `/commit-proj` from a `ccw` worktree. HEAD-moving git commands in the primar
 ### Committing via `/commit-proj` (Claude Code)
 
 The project-local `/commit-proj` skill (`.claude/commands/commit-proj.md`) handles the
-full flow in one invocation. (Renamed from `/commit` to disambiguate from the
-global skill of the same name; the global `/commit` will also branch + open a PR
+full flow in one invocation. (The global `/commit-user` will also branch + open a PR
 now, but does not handle this project's pre-commit framework, fragment-based
 known-issues, or required-checks recital.)
 


### PR DESCRIPTION
The user-level commit skill was renamed from /commit to /commit-user
(file: ~/.claude/commands/commit-user.md) to disambiguate from the
project-local /commit-proj skill. Update CLAUDE.md, CONTRIBUTING.md,
commit-proj.md, and pick-issues.md to refer to the new name.
