### PR TITLE
fix(image-cache): reinsert accession dashes before fetch_image

### DIFF
--- a/src/web/routes/image_cache.py
+++ b/src/web/routes/image_cache.py
@@ -55,12 +55,20 @@ def serve_cached_image(cik: str, accession_no: str, filename: str):
     user_agent = os.environ.get("SEC_USER_AGENT", "filings-reviewer info@example.com")
     sec_client = SECClient(user_agent=user_agent, db_adapter=db)
 
-    # fetch_image expects accession_number with dashes; reconstruct from no-dashes form
-    # SEC EDGAR URL pattern: /Archives/edgar/data/{cik}/{accession_no_no_dashes}/{filename}
-    # SECClient.fetch_image accepts accession_number with or without dashes — it strips them internally
+    # SECClient.fetch_image extracts the canonical accession token via
+    # SEC_ACCESSION_PATTERN (\d{10}-\d{2}-\d{6}), which requires dashes — the
+    # URL path here carries the dashes-stripped form, so reinsert them. The
+    # SQL builder in _V2_IMAGE_CANDIDATE_SELECT guarantees 18 digits for
+    # well-formed inputs; anything else is forwarded as-is and will surface a
+    # 404 the same way it did before.
+    if len(accession_no) == 18 and accession_no.isdigit():
+        accession_for_fetch = f"{accession_no[:10]}-{accession_no[10:12]}-{accession_no[12:]}"
+    else:
+        accession_for_fetch = accession_no
+
     image_bytes = sec_client.fetch_image(
         cik=cik,
-        accession_number=accession_no,  # already no-dashes; fetch_image will strip, no-op
+        accession_number=accession_for_fetch,
         filename=filename,
     )
 

--- a/tests/unit/web/test_image_cache_route.py
+++ b/tests/unit/web/test_image_cache_route.py
@@ -94,13 +94,38 @@ class TestImageCacheRouteMiss:
         mock_db.get_cached_image.return_value = None
         mock_sec = MagicMock()
         mock_sec.fetch_image.return_value = FAKE_IMAGE
-        with patch("src.web.routes.image_cache.get_db", return_value=mock_db), \
-             patch("src.web.routes.image_cache.SECClient", return_value=mock_sec):
+        with (
+            patch("src.web.routes.image_cache.get_db", return_value=mock_db),
+            patch("src.web.routes.image_cache.SECClient", return_value=mock_sec),
+        ):
             resp = client.get(ROUTE)
         assert resp.status_code == 200
+        # The URL path carries the dashes-stripped 18-digit form, but
+        # SECClient.fetch_image extracts via SEC_ACCESSION_PATTERN which
+        # requires dashes — the route must reinsert them. (Regression
+        # guard for PR #244 / gh-image-cache-proxy-404.)
         mock_sec.fetch_image.assert_called_once_with(
             cik=CIK,
-            accession_number=ACCESSION,
+            accession_number="0001193125-20-311265",
+            filename=FILENAME,
+        )
+
+    def test_passes_through_non_18_digit_accession(self, client, mock_db):
+        """Non-canonical accession path is forwarded as-is so fetch_image's
+        own warning + 404 path still surfaces (no silent reformatting)."""
+        mock_db.get_cached_image.return_value = None
+        mock_sec = MagicMock()
+        mock_sec.fetch_image.return_value = None
+        weird_acc = "not-an-accession"
+        with (
+            patch("src.web.routes.image_cache.get_db", return_value=mock_db),
+            patch("src.web.routes.image_cache.SECClient", return_value=mock_sec),
+        ):
+            resp = client.get(f"/images/cache/{CIK}/{weird_acc}/{FILENAME}")
+        assert resp.status_code == 404
+        mock_sec.fetch_image.assert_called_once_with(
+            cik=CIK,
+            accession_number=weird_acc,
             filename=FILENAME,
         )
 
@@ -108,8 +133,10 @@ class TestImageCacheRouteMiss:
         mock_db.get_cached_image.return_value = None
         mock_sec = MagicMock()
         mock_sec.fetch_image.return_value = None  # SEC fetch failed
-        with patch("src.web.routes.image_cache.get_db", return_value=mock_db), \
-             patch("src.web.routes.image_cache.SECClient", return_value=mock_sec):
+        with (
+            patch("src.web.routes.image_cache.get_db", return_value=mock_db),
+            patch("src.web.routes.image_cache.SECClient", return_value=mock_sec),
+        ):
             resp = client.get(ROUTE)
         assert resp.status_code == 404
 
@@ -117,8 +144,10 @@ class TestImageCacheRouteMiss:
         mock_db.get_cached_image.return_value = None
         mock_sec = MagicMock()
         mock_sec.fetch_image.return_value = b"\x89PNG\r\n"
-        with patch("src.web.routes.image_cache.get_db", return_value=mock_db), \
-             patch("src.web.routes.image_cache.SECClient", return_value=mock_sec):
+        with (
+            patch("src.web.routes.image_cache.get_db", return_value=mock_db),
+            patch("src.web.routes.image_cache.SECClient", return_value=mock_sec),
+        ):
             resp = client.get(f"/images/cache/{CIK}/{ACCESSION}/chart.png")
         assert resp.content_type.startswith("image/png")
 
@@ -127,8 +156,10 @@ class TestImageCacheRouteMiss:
         mock_sec = MagicMock()
         mock_sec.fetch_image.return_value = FAKE_IMAGE
         mock_sec_class = MagicMock(return_value=mock_sec)
-        with patch("src.web.routes.image_cache.get_db", return_value=mock_db), \
-             patch("src.web.routes.image_cache.SECClient", mock_sec_class):
+        with (
+            patch("src.web.routes.image_cache.get_db", return_value=mock_db),
+            patch("src.web.routes.image_cache.SECClient", mock_sec_class),
+        ):
             client.get(ROUTE)
         _, kwargs = mock_sec_class.call_args
         assert kwargs.get("db_adapter") is mock_db


### PR DESCRIPTION
PR #244 routed SECClient.fetch_image through extract_sec_accession_token,
which uses SEC_ACCESSION_PATTERN = \d{10}-\d{2}-\d{6} — a strict regex that
requires dashes. The /images/cache/<cik>/<acc-no-dashes>/<file> proxy route
forwards the dashes-stripped form from the URL path, so every cache miss
now returns None from fetch_image (logged as "no SEC accession token in
'<18 digits>'") and the route 404s. Symptom: "Unable to load image" inline
in the V2 review UI even though the SEC EDGAR fallback link works.

Reinsert dashes when the path arg is the canonical 18-digit form before
calling fetch_image; forward anything else as-is so fetch_image's own
warning path still surfaces. Updated the existing test that was locking
in the broken behavior, added a regression guard for the non-canonical
fallthrough.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
