### PR TITLE
chore(supervise-prs): handle DIRTY PRs via dev-implementer auto-rebase

### DIFF
--- a/.claude/commands/supervise-prs.md
+++ b/.claude/commands/supervise-prs.md
@@ -1,6 +1,6 @@
 # Supervise PRs Skill (project-local)
 
-**Purpose:** Single-shot PR-cohort status check. After a planning session dispatches N parallel implementation subagents, invoke via `/loop <interval> /supervise-prs <prs>` to periodically check status, dispatch `/ci-fix` when a required check fails, and hand off to `/cleanup` once every PR reaches a terminal state.
+**Purpose:** Single-shot PR-cohort status check. After a planning session dispatches N parallel implementation subagents, invoke via `/loop <interval> /supervise-prs <prs>` to periodically check status, dispatch `/ci-fix` when a required check fails, resolve `DIRTY` (merge-conflicted) PRs by merging `main` back into the PR branch, and hand off to `/cleanup` once every PR reaches a terminal state.
 
 **Usage:** `/supervise-prs <pr_num>[,<pr_num>...]`
 
@@ -8,13 +8,14 @@ This skill does not loop internally. Repetition is provided by `/loop`.
 
 ## Steps (per iteration)
 
-1. **Parse** the comma-separated PR list. Validate each with `gh pr view <num> --json number,state,mergeable,statusCheckRollup`.
-2. **Classify** each PR:
+1. **Parse** the comma-separated PR list. Validate each with `gh pr view <num> --json number,state,mergeable,mergeStateStatus,headRefName,statusCheckRollup`.
+2. **Classify** each PR (in this priority order):
    - `MERGED` → mark done (record in skill state file at `/tmp/supervise-prs-<session>.json` or echo in output for the next iteration to read).
    - `CLOSED` (not merged) → mark failed.
+   - `OPEN` with `mergeStateStatus == "DIRTY"` (or `mergeable == "CONFLICTING"`) → invoke a `dev-implementer` subagent (`Agent` with `subagent_type: "dev-implementer"`, `model: "sonnet"`, `isolation: "worktree"`) to merge `origin/main` into the PR's `headRefName`, push, and report. Cap total **dirty-resolve** attempts per PR at **1**; if it can't auto-resolve (true conflict requiring human judgment) or the cap is hit, escalate (report to user, mark the PR as `blocked_dirty`, drop from active set). Check this **before** the FAILURE branch — `DIRTY` typically cancels CI runs, so failed checks here are downstream of the conflict.
    - `OPEN` with `statusCheckRollup` showing any required check at `FAILURE` → invoke `/ci-fix <pr_num>` as a subagent: `Agent` with `isolation: "worktree"` and a prompt that reuses the PR's branch. Cap total `/ci-fix` attempts per PR at 2; if exceeded, escalate (report to user and mark the PR as blocked).
    - `OPEN` with checks pending/running → keep in active set.
-3. **Report** current state: `merged=<list>`, `failed=<list>`, `ci_fix_in_progress=<list>`, `active=<list>`.
+3. **Report** current state: `merged=<list>`, `failed=<list>`, `ci_fix_in_progress=<list>`, `dirty_resolve_in_progress=<list>`, `blocked_dirty=<list>`, `active=<list>`.
 4. **Termination signal.** When the active set is empty:
    - Print a clearly parseable completion line: `SUPERVISE_PRS_DONE merged=<n> failed=<n>`.
    - Invoke `/cleanup` to sweep merged branches + worktrees.
@@ -24,6 +25,9 @@ This skill does not loop internally. Repetition is provided by `/loop`.
 
 - Never call `gh pr merge --admin`.
 - Never invoke `/ci-fix` more than 2 times for the same PR — report and stop.
+- Never invoke the dirty-resolve agent more than 1 time for the same PR — if a fresh merge of `origin/main` produces conflicts the agent can't trivially resolve, that's a signal a human should look at it. A second mechanical retry won't change the outcome.
+- The dirty-resolve agent must **only push to the PR's `headRefName`**, never to `main`. It must run inside an isolated worktree (`isolation: "worktree"`) so the supervisor's working directory is unaffected.
+- Conflict resolution policy for the dirty-resolve agent: if the merge produces conflicts, the agent must read the project rules under `.claude/rules/` for any module it's resolving in (e.g. `.claude/rules/web.md` for `src/web/...`), apply the documented canonical contract, and run the relevant unit-test subset before pushing. If the conflict spans extraction code (`src/extraction*`, `config/metric_keywords.yaml`, `src/review/keyword_matching|false_positive_filter`), the agent must escalate instead of resolving — those need gold-standard validation, which is out of scope for an auto-rebase.
 - If a PR's branch is deleted mid-supervision (branch ref gone), log and drop from active set; do not try to recover.
 - Do not duplicate `/cleanup` logic; always hand off.
 


### PR DESCRIPTION
Adds a third classification bucket to /supervise-prs: PRs with
mergeStateStatus=DIRTY (or mergeable=CONFLICTING) now dispatch a
dev-implementer subagent in an isolated worktree to merge origin/main
into the PR branch and push. Surfaced while unsticking PR #276, which
sat DIRTY for ~2 hours because GitHub's auto-merge-squash does not
auto-rebase when main moves under a queued PR.

Caps dirty-resolve at 1 attempt per PR — a second mechanical retry
won't change the outcome of an unresolvable conflict. The agent must
push only to the PR's headRefName, must read .claude/rules/ for the
relevant module before resolving, and must escalate (not auto-resolve)
conflicts in extraction code, where gold-standard validation is
required and out of scope for an auto-rebase.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
