### PR TITLE
feat(known-issues): warn when open fragment staged without pr_refs (closes #258)

### DIFF
--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -160,3 +160,14 @@ specific files by name.
 New issues surfaced during contribution go into a new `docs/known-issues/gh-N-<slug>.md` fragment file, where `N` is the GitHub issue number returned by `gh issue create`. The `/commit-proj` skill step 9 automates this — see the frontmatter template there. Existing `legacy-NNN-*.md` fragments (pre-2026-04-24) are frozen in place; do not rename them, and **do not mint new `legacy-*` filenames** — the validator (`scripts/validate_known_issues_fragments.py`, run by pre-commit and CI) rejects any `legacy-*` filename not listed in `docs/known-issues/.legacy-allowlist.txt`. GitHub issue numbers are server-allocated, so `gh-N` cannot collide. Fragments are the source of truth.
 
 The rollup `docs/KNOWN_ISSUES.md` is not tracked in git — CI regenerates it as a build artifact on every run (`.github/workflows/ci.yml` job `known-issues-artifact`). Download the latest rendered rollup from the Actions tab of any `main` build. To regenerate locally for preview: `python3 scripts/regenerate_known_issues.py --output /tmp/KNOWN_ISSUES.md`.
+
+### Setting pr_refs on the fragment you resolve
+
+If your fix-PR resolves a known issue, add the PR number to the fragment's `pr_refs` list **before merging**:
+
+```yaml
+pr_refs:
+  - 287   # integer, not a quoted string
+```
+
+The auto-closer (`scripts/sync_known_issue_status.py`, runs nightly) flips `status: open` → `status: resolved` only when every PR in `pr_refs` is MERGED on GitHub. Without this field the auto-closer is blind to your fix and every closure stays manual. The pre-commit `known-issues-validate` hook emits a `WARNING` (non-blocking) when you stage a fragment that is still `status: open` with an empty or missing `pr_refs` — that warning is your reminder.

--- a/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
+++ b/docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md
@@ -5,15 +5,17 @@ estimated: S
 gh_issue: 258
 id: 258
 note: Auto-closer (legacy-084 / PR #177) only fires when pr_refs is populated; many fix-PRs forget to set it
+pr_refs:
+  - 286
 severity: low
 slug: fix-pr-not-setting-pr-refs-on-resolved-fragment
 source: gh
-status: open
+status: resolved
 title: Fix-PR Authors Don't Set pr_refs on the Fragment They Resolve
 touches:
   - .claude/commands/commit-proj.md
   - scripts/validate_known_issues_fragments.py
-updated: '2026-04-27'
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -44,3 +46,7 @@ Recommend starting with **Option C** as the steady-state nudge, then **Option B*
 - Today's manual closures (#251, #252, #253, etc.) shipped before this fragment was filed; they don't need to be retroactively rewritten.
 - The auto-closer itself is fine — do not modify `scripts/sync_known_issue_status.py` as part of this work.
 - Worker should not expand scope into legacy-84's tool — that work is closed.
+
+### Resolution
+
+PR #286 implemented Option C. `scripts/validate_known_issues_fragments.py` now calls `warn_missing_pr_refs()` after validating each fragment. When a commit stages a known-issue fragment with `status: open` and `pr_refs` missing or empty, the `known-issues-validate` pre-commit hook emits a non-blocking `WARNING` to stderr reminding the author to set `pr_refs` before merging. The warning does not block the commit. Six unit tests cover the four spec cases (open+missing, open+empty list, open+populated, resolved+missing). `docs/development/CONTRIBUTING.md` updated with a "Setting pr_refs on the fragment you resolve" subsection. Option B (`/commit-proj` skill `resolves:` field) was explicitly deferred as out of scope.

--- a/scripts/validate_known_issues_fragments.py
+++ b/scripts/validate_known_issues_fragments.py
@@ -41,6 +41,7 @@ def _load_legacy_allowlist(path: Path = LEGACY_ALLOWLIST_PATH) -> frozenset[str]
         line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
     )
 
+
 REQUIRED_FIELDS: frozenset[str] = frozenset(
     {
         "id",
@@ -247,6 +248,31 @@ def load_all_fragments(fragments_dir: Path) -> list[Fragment]:
     return fragments
 
 
+def warn_missing_pr_refs(fragments: list[Fragment]) -> None:
+    """Emit a non-blocking warning for open fragments with no pr_refs.
+
+    The auto-closer (``scripts/sync_known_issue_status.py``) only fires when
+    *every* PR listed in ``pr_refs`` is MERGED on GitHub.  It cannot see a
+    fragment whose ``pr_refs`` is absent or empty, so the closure will stay
+    manual.  This warning nudges fix-PR authors to populate the field before
+    they merge.
+
+    This check is **informational only** — it always returns without raising
+    and never causes the validator to exit non-zero.
+    """
+    for fragment in fragments:
+        if fragment.status != "open":
+            continue
+        pr_refs = fragment.frontmatter.get("pr_refs")
+        if pr_refs is None or (isinstance(pr_refs, list) and len(pr_refs) == 0):
+            print(
+                f"WARNING: {fragment.path}: status is 'open' but pr_refs is empty/missing. "
+                "Add 'pr_refs: [<this PR #>]' before merging — "
+                "the auto-closer can't see this fragment otherwise.",
+                file=sys.stderr,
+            )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -277,6 +303,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     exit_code = 0
+    parsed_fragments: list[Fragment] = []
     for path in paths:
         try:
             fragment = parse_fragment(path)
@@ -289,6 +316,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: {path}: {err}", file=sys.stderr)
         if errors:
             exit_code = 1
+        else:
+            parsed_fragments.append(fragment)
+
+    warn_missing_pr_refs(parsed_fragments)
 
     if exit_code == 0:
         print(f"validated {len(paths)} fragment(s): OK")

--- a/tests/unit/scripts/test_validate_known_issues_fragments.py
+++ b/tests/unit/scripts/test_validate_known_issues_fragments.py
@@ -257,7 +257,9 @@ class TestLoadAllFragments:
 class TestLegacyAllowlist:
     """Enforce that new `legacy-*` filenames are rejected; only frozen names pass."""
 
-    def _base_fm(self, *, source: str = "legacy", issue_id: int = 68, slug: str = "frozen-fragment") -> dict:
+    def _base_fm(
+        self, *, source: str = "legacy", issue_id: int = 68, slug: str = "frozen-fragment"
+    ) -> dict:
         fm = {
             "id": issue_id,
             "source": source,
@@ -279,7 +281,8 @@ class TestLegacyAllowlist:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
-            _mod, "_load_legacy_allowlist",
+            _mod,
+            "_load_legacy_allowlist",
             lambda *a, **kw: frozenset({"legacy-068-frozen-fragment.md"}),
         )
         p = tmp_path / "legacy-068-frozen-fragment.md"
@@ -290,7 +293,8 @@ class TestLegacyAllowlist:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
-            _mod, "_load_legacy_allowlist",
+            _mod,
+            "_load_legacy_allowlist",
             lambda *a, **kw: frozenset({"legacy-068-frozen-fragment.md"}),
         )
         p = tmp_path / "legacy-999-not-in-list.md"
@@ -302,7 +306,9 @@ class TestLegacyAllowlist:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
-            _mod, "_load_legacy_allowlist", lambda *a, **kw: frozenset(),
+            _mod,
+            "_load_legacy_allowlist",
+            lambda *a, **kw: frozenset(),
         )
         fm = self._base_fm(source="gh", issue_id=300, slug="my-issue")
         p = tmp_path / "gh-300-my-issue.md"
@@ -311,3 +317,97 @@ class TestLegacyAllowlist:
     def test_missing_allowlist_raises_file_not_found(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="legacy allow-list missing"):
             _REAL_LOAD_ALLOWLIST(tmp_path / "does-not-exist.txt")
+
+
+warn_missing_pr_refs = _mod.warn_missing_pr_refs
+
+
+class TestWarnMissingPrRefs:
+    """warn_missing_pr_refs emits warnings for open fragments with no pr_refs."""
+
+    def _open_fragment(self, tmp_path: Path, *, pr_refs: object = None) -> Fragment:
+        fm: dict = {
+            "id": 99,
+            "source": "gh",
+            "slug": "my-open-issue",
+            "title": "T",
+            "status": "open",
+            "severity": "low",
+            "autonomy": "review",
+            "estimated": "S",
+            "touches": ["scripts/foo.py"],
+            "discovered": "2026-04-28",
+            "updated": "2026-04-28",
+            "gh_issue": 99,
+        }
+        if pr_refs is not None:
+            fm["pr_refs"] = pr_refs
+        return Fragment(frontmatter=fm, body="b", path=tmp_path / "gh-99-my-open-issue.md")
+
+    def _resolved_fragment(self, tmp_path: Path) -> Fragment:
+        fm: dict = {
+            "id": 100,
+            "source": "gh",
+            "slug": "my-resolved-issue",
+            "title": "T",
+            "status": "resolved",
+            "severity": "low",
+            "autonomy": "review",
+            "estimated": "S",
+            "touches": ["scripts/foo.py"],
+            "discovered": "2026-04-28",
+            "updated": "2026-04-28",
+            "gh_issue": 100,
+        }
+        return Fragment(frontmatter=fm, body="b", path=tmp_path / "gh-100-my-resolved-issue.md")
+
+    def test_open_missing_pr_refs_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Fragment with status open and no pr_refs field triggers warning."""
+        fragment = self._open_fragment(tmp_path)  # pr_refs not set at all
+        warn_missing_pr_refs([fragment])
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "pr_refs" in captured.err
+        assert "auto-closer" in captured.err
+
+    def test_open_empty_pr_refs_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Fragment with status open and pr_refs: [] (empty list) triggers warning."""
+        fragment = self._open_fragment(tmp_path, pr_refs=[])
+        warn_missing_pr_refs([fragment])
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "pr_refs" in captured.err
+
+    def test_open_with_pr_refs_no_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Fragment with status open and pr_refs: [123] does NOT trigger warning."""
+        fragment = self._open_fragment(tmp_path, pr_refs=[123])
+        warn_missing_pr_refs([fragment])
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_resolved_missing_pr_refs_no_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Fragment with status resolved and no pr_refs does NOT trigger warning."""
+        fragment = self._resolved_fragment(tmp_path)
+        warn_missing_pr_refs([fragment])
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_does_not_exit_nonzero(self, tmp_path: Path) -> None:
+        """warn_missing_pr_refs always returns None (non-blocking)."""
+        fragment = self._open_fragment(tmp_path)
+        result = warn_missing_pr_refs([fragment])
+        assert result is None
+
+    def test_empty_list_no_warnings(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Empty fragment list produces no output."""
+        warn_missing_pr_refs([])
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Summary

- Adds `warn_missing_pr_refs()` to `scripts/validate_known_issues_fragments.py`: a non-blocking WARNING fired to stderr when a staged known-issue fragment has `status: open` and `pr_refs` is missing or empty.
- The `known-issues-validate` pre-commit hook already runs only when `docs/known-issues/*.md` files are staged (`files:` filter in `.pre-commit-config.yaml`), so the nudge fires only on relevant commits.
- Adds 6 unit tests covering all four cases from the spec (open+missing, open+empty, open+populated, resolved+missing) plus non-blocking and empty-list no-op.
- Updates `docs/development/CONTRIBUTING.md` with a new "Setting pr_refs on the fragment you resolve" subsection.

**Live example that motivated this:** PR #272 merged resolving gh-263, but gh-263's fragment on `main` still has `status: open` and empty `pr_refs` (auto-closer dead-ended). That fragment's closure is intentionally out of scope here — it should be a separate fragment-only closure PR per the established pattern.

**Option B (skill-level `resolves: #N` field in `/commit-proj`) is explicitly out of scope for this PR.** It would couple fragment bookkeeping to the skill happy path and is a larger change. Recommend as a follow-up if drift persists after this nudge ships.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_validate_known_issues_fragments.py -x -q` — all 31 tests pass
- [x] pre-push hook ran unit tests: passed
- [x] ruff lint + ruff-format: clean
- [x] Dog-food smoke test: fragment update commit (next commit) will have `pr_refs` set → validator should emit no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)