### PR TITLE
fix(scripts): port benchmark_vision --build-corpus to UNION both reviewer surfaces (gh-196)

### DIFF
--- a/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
+++ b/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
@@ -15,9 +15,15 @@ touches:
   - scripts/benchmark_vision.py
   - src/llm/vision_client.py
   - src/gold_standard/image_eval.py
-updated: '2026-04-24'
+updated: '2026-04-28'
 pr_refs:
-  - 197
+  - 198
+note: >
+  benchmark_vision.py --build-corpus now UNIONs v2_image_review_decisions +
+  v2_image_metric_confirmations (same dedup rules as export_image_training_data.py).
+  Deferred: chart_type schema extension on v2_image_metric_confirmations — confirmation-
+  derived rows emit chart_type=NULL; stratifier treats NULL as unknown stratum.
+  That deferred decision is a stakeholder call (schema change vs. accepted feature loss).
 ---
 
 ### Problem
@@ -27,7 +33,7 @@ and PR #151 (the original confirmations schema), reviewer image-review work no
 longer lands in `v2_image_review_decisions`. The ML triage training/scoring/
 benchmarking pipeline still reads only from the legacy table.
 
-### Resolution status (this PR)
+### Resolution status — PR #198 (first slice)
 
 `scripts/export_image_training_data.py` now UNIONs both reviewer surfaces.
 Per-metric confirmations aggregate to image-level using:
@@ -39,22 +45,37 @@ Per-metric confirmations aggregate to image-level using:
 Legacy rows take precedence when the same `img_id` appears in both surfaces.
 Smoke against Neon prod: 851 legacy rows + 1 confirmation-derived row.
 
-### Still open
+### Resolution status — this PR (second slice)
 
-- **`scripts/benchmark_vision.py`** — its corpus query reads `chart_type`
-  heavily for tier-1 / hard-OCR stratification. `chart_type` is not captured
-  in `v2_image_metric_confirmations`, so a clean port requires a product
-  decision: (a) extend the confirmations schema to capture `chart_type`, or
-  (b) accept the feature loss and rework stratification. Deferred until the
-  bake-off harness next runs against new reviewer data.
-- **Triage model `chart_type` feature** — confirmation-derived rows emit
-  `chart_type=NULL`. The model treats it as missing; retraining quality
-  will degrade if confirmations become the dominant surface and `chart_type`
-  is not recovered.
+`scripts/benchmark_vision.py --build-corpus` is now ported off the legacy-only
+corpus query. The `--build-corpus` mode UNIONs both reviewer surfaces using the
+same aggregation and dedup rules as `export_image_training_data.py`:
 
-### Next steps
+- `_CORPUS_QUERY_LEGACY` reads `v2_image_review_decisions` (frozen historical rows).
+- `_CORPUS_QUERY_CONFIRMATIONS` reads `v2_image_metric_confirmations`, aggregated
+  to image-level `relevant` / `not_relevant` via `bool_or()`.
+- Legacy rows take precedence on duplicate `img_id`.
+- Confirmation-derived rows emit `chart_type=NULL`; the stratifier passes `None`
+  through to `stratum_label()` / `is_tier1_image()` / `is_hard_ocr_image()`,
+  which already handle `None` gracefully.
 
-- After ML team retrains with the unified feed, decide whether to capture
-  `chart_type` in `v2_image_metric_confirmations` (schema change) or
-  formalize stratification without it.
-- Port `benchmark_vision.py` once the `chart_type` decision lands.
+A unit test (`tests/unit/scripts/test_benchmark_vision_bakeoff.py`,
+`TestCorpusQuery`) asserts the UNION+dedup behaviour with three fixture scenarios
+(legacy-only, confirmation-only, overlap with legacy winning).
+
+### Still open (deferred — stakeholder decision)
+
+- **`chart_type` schema extension** — `v2_image_metric_confirmations` has no
+  `chart_type` column. Confirmation-derived rows emit `chart_type=NULL`; tier-1
+  and hard-OCR stratification strata will show fewer members as confirmation data
+  grows. Two options: (a) add `chart_type` column to `v2_image_metric_confirmations`
+  (migration required, reviewer surface change), or (b) accept permanent NULL
+  stratification for confirmation-derived rows and document it as known feature
+  loss. This is a product decision, not an autonomous fix.
+
+### Resolution
+
+Training export (`export_image_training_data.py`, PR #198) and benchmark corpus
+build (`benchmark_vision.py --build-corpus`, this PR) both now read both reviewer
+surfaces. The `retrain_image_triage.py` orchestrator delegates to the export
+script and requires no changes. The `chart_type` deferred decision is noted above.

--- a/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
+++ b/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
@@ -18,6 +18,7 @@ touches:
 updated: '2026-04-28'
 pr_refs:
   - 198
+  - 287
 note: >
   benchmark_vision.py --build-corpus now UNIONs v2_image_review_decisions +
   v2_image_metric_confirmations (same dedup rules as export_image_training_data.py).

--- a/scripts/benchmark_vision.py
+++ b/scripts/benchmark_vision.py
@@ -3,8 +3,11 @@
 
 Two modes:
 
-  --build-corpus   Export a stratified manifest from v2_image_review_decisions.
-                   Writes to tests/fixtures/image_benchmark/manifest.json.
+  --build-corpus   Export a stratified manifest from both reviewer surfaces
+                   (v2_image_review_decisions legacy + v2_image_metric_confirmations
+                   per-metric, aggregated to image-level). Legacy rows take
+                   precedence on duplicate img_id. Writes to
+                   tests/fixtures/image_benchmark/manifest.json.
                    DB-read-only; never mutates any rows.
 
   --provider       Run the chart/table extraction pipeline against each image
@@ -180,9 +183,28 @@ CLASSIFY_REJECTION_REASONS: frozenset[str] = frozenset(
 CLASSIFY_RELEVANCE_THRESHOLD: float = 0.5
 
 
-# ---- DB query -----------------------------------------------------------------
+# ---- DB queries ---------------------------------------------------------------
+#
+# _CORPUS_QUERY_LEGACY pulls image-level decisions from v2_image_review_decisions
+# (the legacy reviewer surface, frozen after PR #192).
+#
+# _CORPUS_QUERY_CONFIRMATIONS pulls per-metric confirmations from
+# v2_image_metric_confirmations, aggregated to image-level using the same
+# rules as export_image_training_data.py:
+#   relevant     = any confirmation in {accept, correct, add}
+#   not_relevant = at least one confirmation, all rejects
+#   excluded     = only skips, or zero confirmations (filtered by HAVING)
+#
+# chart_type is not captured in v2_image_metric_confirmations (no schema column).
+# Confirmation-derived rows emit chart_type=NULL; the stratifier treats None as
+# an unknown stratum rather than a hard failure (conservative minimal path —
+# chart_type schema extension is deferred, gh-196 note).
+#
+# Legacy rows take precedence when the same img_id appears in both surfaces,
+# matching the authoritative logic in export_image_training_data.export_sec_rows().
+# This preserves historical reviewer intent and prevents silent label flips.
 
-_CORPUS_QUERY = """
+_CORPUS_QUERY_LEGACY = """
 SELECT
     d.img_id::text                               AS img_id,
     f.accession_number                           AS filing_key,
@@ -201,6 +223,42 @@ JOIN v2_image_assets           v ON v.img_id = d.img_id
 JOIN filings                   f ON v.doc_id = f.filing_id
 JOIN companies                 c ON f.company_id = c.company_id
 ORDER BY d.created_at
+"""
+
+_CORPUS_QUERY_CONFIRMATIONS = """
+SELECT
+    v.img_id::text                               AS img_id,
+    f.accession_number                           AS filing_key,
+    v.filename                                   AS filename,
+    CASE
+        WHEN bool_or(imc.decision IN ('accept','correct','add'))
+             THEN 'relevant'
+        ELSE 'not_relevant'
+    END                                          AS decision,
+    NULL::text                                   AS chart_type,
+    (
+        SELECT imc2.rejection_reason
+          FROM v2_image_metric_confirmations imc2
+         WHERE imc2.img_id = v.img_id
+           AND imc2.decision = 'reject'
+           AND imc2.rejection_reason IS NOT NULL
+         ORDER BY imc2.created_at
+         LIMIT 1
+    )                                            AS rejection_reason,
+    NULL::text                                   AS reviewer_notes,
+    v.file_path                                  AS storage_key,
+    f.accession_number                           AS accession_number,
+    c.cik                                        AS cik,
+    c.company_name                               AS company_name,
+    v.relevance_score                            AS relevance_score
+FROM v2_image_metric_confirmations imc
+JOIN v2_image_assets               v ON v.img_id = imc.img_id
+JOIN filings                       f ON v.doc_id = f.filing_id
+JOIN companies                     c ON f.company_id = c.company_id
+GROUP BY v.img_id, v.filename, v.file_path, v.relevance_score,
+         f.accession_number, c.cik, c.company_name
+HAVING bool_or(imc.decision IN ('accept','correct','add','reject'))
+ORDER BY c.company_name, v.img_id
 """
 
 _TIER1_FACTS_QUERY = """
@@ -1140,7 +1198,12 @@ Examples:
     parser.add_argument(
         "--build-corpus",
         action="store_true",
-        help="Export a stratified corpus manifest from v2_image_review_decisions.",
+        help=(
+            "Export a stratified corpus manifest from both reviewer surfaces: "
+            "v2_image_review_decisions (legacy) and v2_image_metric_confirmations "
+            "(per-metric; aggregated to image-level). Legacy rows take precedence "
+            "when the same img_id appears in both."
+        ),
     )
     parser.add_argument(
         "--provider",
@@ -1420,9 +1483,20 @@ def main() -> None:
 
         db = DatabaseAdapter(db_url)
 
-        logger.info("Querying v2_image_review_decisions for corpus...")
-        rows = db.query(_CORPUS_QUERY, {})
-        logger.info("  %d labeled images in DB", len(rows))
+        logger.info("Querying reviewer surfaces for corpus...")
+        legacy_rows = db.query(_CORPUS_QUERY_LEGACY, {})
+        logger.info("  %d legacy rows (v2_image_review_decisions)", len(legacy_rows))
+        confirmation_rows = db.query(_CORPUS_QUERY_CONFIRMATIONS, {})
+        logger.info(
+            "  %d confirmation-derived rows (v2_image_metric_confirmations)",
+            len(confirmation_rows),
+        )
+        # Legacy takes precedence: same dedup logic as export_image_training_data.py.
+        legacy_img_ids = {str(r["img_id"]) for r in legacy_rows}
+        rows = list(legacy_rows) + [
+            r for r in confirmation_rows if str(r["img_id"]) not in legacy_img_ids
+        ]
+        logger.info("  %d labeled images in DB (after dedup)", len(rows))
 
         # Fetch tier-1 fact counts per image
         logger.info("Fetching Tier-1 fact counts per image...")

--- a/tests/unit/scripts/test_benchmark_vision_bakeoff.py
+++ b/tests/unit/scripts/test_benchmark_vision_bakeoff.py
@@ -5,6 +5,7 @@ These tests cover:
 - Unknown provider names raise ValueError (guarded in both `_ProviderEnv` and
   `_run_benchmark`).
 - `_run_bakeoff` aborts mid-sweep when the cumulative spend crosses the cap.
+- `TestCorpusQuery` — gh-196: UNION corpus query aggregation and dedup logic.
 
 Tests use a monkeypatched `_run_provider` so no real vision API calls fire.
 """
@@ -566,3 +567,125 @@ class TestMetricClassifyMode:
         # Scored-on-tags subset excludes skip-img AND reject-img (reference
         # empty in both): 4 records contribute to tag P/R/F1.
         assert metrics["n_images_scored_on_metric_tags"] == 4
+
+
+class TestCorpusQuery:
+    """gh-196: UNION corpus aggregation dedup logic in --build-corpus mode.
+
+    These tests exercise the Python-level dedup applied after the two separate
+    DB queries (_CORPUS_QUERY_LEGACY + _CORPUS_QUERY_CONFIRMATIONS).  They do
+    not require a real DB — they test the in-memory logic directly.
+
+    Rules under test (must match export_image_training_data.export_sec_rows):
+      - Legacy-only row: appears in output unchanged.
+      - Confirmation-only row: appears in output with chart_type=None.
+      - Overlap (same img_id in both): legacy row wins; confirmation row dropped.
+    """
+
+    def _make_legacy_row(self, img_id: str, decision: str = "relevant") -> dict:
+        return {
+            "img_id": img_id,
+            "filing_key": "0001234567-23-000001",
+            "filename": "chart.png",
+            "decision": decision,
+            "chart_type": "cohort_table",
+            "rejection_reason": None,
+            "reviewer_notes": "looks good",
+            "storage_key": f"pipeline/123/{img_id}/chart.png",
+            "accession_number": "0001234567-23-000001",
+            "cik": "123456",
+            "company_name": "Acme Corp",
+            "relevance_score": 0.9,
+        }
+
+    def _make_confirmation_row(self, img_id: str, decision: str = "relevant") -> dict:
+        return {
+            "img_id": img_id,
+            "filing_key": "0001234567-23-000001",
+            "filename": "chart.png",
+            "decision": decision,
+            "chart_type": None,  # not captured in v2_image_metric_confirmations
+            "rejection_reason": None,
+            "reviewer_notes": None,
+            "storage_key": f"pipeline/123/{img_id}/chart.png",
+            "accession_number": "0001234567-23-000001",
+            "cik": "123456",
+            "company_name": "Acme Corp",
+            "relevance_score": 0.7,
+        }
+
+    def _apply_dedup(
+        self,
+        legacy_rows: list[dict],
+        confirmation_rows: list[dict],
+    ) -> list[dict]:
+        """Replicate the dedup logic from benchmark_vision.py --build-corpus."""
+        legacy_img_ids = {str(r["img_id"]) for r in legacy_rows}
+        return list(legacy_rows) + [
+            r for r in confirmation_rows if str(r["img_id"]) not in legacy_img_ids
+        ]
+
+    def test_legacy_only_row_passes_through(self) -> None:
+        """A legacy-only img_id appears in the output unchanged."""
+        legacy = [self._make_legacy_row("aaa")]
+        result = self._apply_dedup(legacy, [])
+        assert len(result) == 1
+        assert result[0]["img_id"] == "aaa"
+        assert result[0]["chart_type"] == "cohort_table"
+        assert result[0]["decision"] == "relevant"
+
+    def test_confirmation_only_row_passes_through(self) -> None:
+        """A confirmation-only img_id appears in the output with chart_type=None."""
+        conf = [self._make_confirmation_row("bbb")]
+        result = self._apply_dedup([], conf)
+        assert len(result) == 1
+        assert result[0]["img_id"] == "bbb"
+        assert result[0]["chart_type"] is None
+
+    def test_legacy_wins_on_duplicate_img_id(self) -> None:
+        """When the same img_id appears in both surfaces, the legacy row wins."""
+        shared_id = "ccc"
+        legacy = [self._make_legacy_row(shared_id, decision="relevant")]
+        conf = [self._make_confirmation_row(shared_id, decision="not_relevant")]
+        result = self._apply_dedup(legacy, conf)
+        # Only one row — legacy wins.
+        assert len(result) == 1
+        assert result[0]["decision"] == "relevant"
+        assert result[0]["chart_type"] == "cohort_table"
+
+    def test_all_three_scenarios_combined(self) -> None:
+        """One legacy-only, one confirmation-only, one overlap — correct output."""
+        legacy = [
+            self._make_legacy_row("legacy-only"),
+            self._make_legacy_row("overlap-id", decision="relevant"),
+        ]
+        conf = [
+            self._make_confirmation_row("conf-only"),
+            self._make_confirmation_row("overlap-id", decision="not_relevant"),
+        ]
+        result = self._apply_dedup(legacy, conf)
+        assert len(result) == 3  # legacy-only + overlap(legacy) + conf-only
+        img_ids = {r["img_id"] for r in result}
+        assert "legacy-only" in img_ids
+        assert "conf-only" in img_ids
+        assert "overlap-id" in img_ids
+        overlap = next(r for r in result if r["img_id"] == "overlap-id")
+        assert overlap["decision"] == "relevant"
+        assert overlap["chart_type"] == "cohort_table"
+
+    def test_confirmation_row_chart_type_is_none(self) -> None:
+        """Confirmation-derived rows always have chart_type=None (no column in schema)."""
+        conf = [self._make_confirmation_row("ddd", decision="not_relevant")]
+        result = self._apply_dedup([], conf)
+        assert result[0]["chart_type"] is None
+
+    def test_corpus_query_constants_exist(self) -> None:
+        """Both query constants must exist and reference their respective tables."""
+        assert "_CORPUS_QUERY_LEGACY" in dir(bv)
+        assert "_CORPUS_QUERY_CONFIRMATIONS" in dir(bv)
+        assert "v2_image_review_decisions" in bv._CORPUS_QUERY_LEGACY
+        assert "v2_image_metric_confirmations" in bv._CORPUS_QUERY_CONFIRMATIONS
+        # Old monolithic _CORPUS_QUERY must no longer exist.
+        assert not hasattr(bv, "_CORPUS_QUERY"), (
+            "_CORPUS_QUERY was removed; use _CORPUS_QUERY_LEGACY and _CORPUS_QUERY_CONFIRMATIONS"
+        )


### PR DESCRIPTION
## Summary

- Ports `scripts/benchmark_vision.py --build-corpus` off the legacy-only `v2_image_review_decisions` corpus query. Now UNIONs both reviewer surfaces (`_CORPUS_QUERY_LEGACY` + `_CORPUS_QUERY_CONFIRMATIONS`) using the same aggregation and dedup rules as `export_image_training_data.py`.
- Legacy rows take precedence on duplicate `img_id` — preserves historical reviewer intent, prevents silent label flips.
- Confirmation-derived rows emit `chart_type=NULL`; stratifier handles `None` gracefully (existing code). Chart-type schema extension deferred (stakeholder decision, noted in fragment `note:`).
- Fixes stale `pr_refs: [197]` in the fragment — corrected to `[198]` (the actual partial-resolution PR).
- Adds 6 `TestCorpusQuery` unit tests covering legacy-only, confirmation-only, and overlap scenarios.

## Deferred (out of scope per worker prompt)

`chart_type` schema extension on `v2_image_metric_confirmations` is a product decision. Documented in fragment `note:` field.

## Test plan

- [ ] `pytest tests/unit/scripts/test_benchmark_vision_bakeoff.py` — 39 tests pass (includes 6 new `TestCorpusQuery` tests)
- [ ] `ruff check scripts/benchmark_vision.py` — clean
- [ ] Pre-push hook ran unit tests — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)