### PR TITLE
docs(known-issues): log issues #293 (undo review affordance) + #294 (image-tab shortcut audit)

### DIFF
--- a/docs/known-issues/gh-293-image-card-undo-review-affordance.md
+++ b/docs/known-issues/gh-293-image-card-undo-review-affordance.md
@@ -1,0 +1,47 @@
+---
+id: 293
+source: gh
+slug: image-card-undo-review-affordance
+title: "Image card: 'Undo review' / re-open affordance"
+status: open
+severity: medium
+autonomy: skip
+estimated: S
+touches:
+  - src/web/routes/api_unified.py
+  - src/web/routes/review_unified.py
+  - src/web/templates/unified_review.html
+  - src/web/static/js/review_images_v2.js
+discovered: '2026-04-28'
+updated: '2026-04-28'
+gh_issue: 293
+note: supersedes deferred Step B of legacy-089 with cleaner scope
+---
+
+### Problem
+
+Per-metric undo (`DELETE /api/v2/image-metric-confirmations/<id>`)
+already exists, but legacy `v2_image_review_decisions` rows +
+`v2_image_assets.review_status='reviewed'` decisions made before the
+per-metric pivot have no UI path back to pending. Filing 1748 (PayPal
+Q3'23 8-K) is the canonical case: 18 images decided pre-OCR, now have
+fresh `ocr_text` attached, but the queue treats them as already
+reviewed. Supersedes the deferred Step B of legacy-089 with cleaner
+scope.
+
+### Next Steps
+
+- Add a single button on the image card ("Undo review" / "Re-open for
+  review") that flips `v2_image_assets.review_status='pending'` and
+  writes an audit row.
+- Do NOT delete prior decision rows from `v2_image_review_decisions` or
+  `v2_image_metric_confirmations` — preserve the per-(image, metric)
+  decision trail as ML training signal (memory:
+  `project_image_review_decisions_for_ml_training`).
+- Decide explicitly which surface the button manipulates (image-level
+  `review_status` vs. derived `image_review_state`); audit interaction
+  with per-metric confirmations already in place
+  (memory: `project_image_review_status_not_flipped_by_per_metric`).
+- Validation target: `/v2/review/1748` — pressing the button on any of
+  the 18 images should return it to the pending queue with the OCR'd
+  text visible.

--- a/docs/known-issues/gh-294-image-tab-keyboard-shortcut-audit.md
+++ b/docs/known-issues/gh-294-image-tab-keyboard-shortcut-audit.md
@@ -1,0 +1,40 @@
+---
+id: 294
+source: gh
+slug: image-tab-keyboard-shortcut-audit
+title: "Image tab: keyboard-shortcut audit + parity with text tab"
+status: open
+severity: low
+autonomy: skip
+estimated: S
+touches:
+  - src/web/templates/unified_review.html
+  - src/web/static/js/review_images_v2.js
+  - .claude/rules/web.md
+discovered: '2026-04-28'
+updated: '2026-04-28'
+gh_issue: 294
+note: align image-tab shortcuts with text-tab; add missing 'Reject all' binding
+---
+
+### Problem
+
+Text-tab review uses single-letter shortcuts (P / N / F for prev /
+next / next-filing). The image tab has its own bindings
+(`review_images_v2.js`) but they have drifted vs. the text tab as new
+buttons land — most recently the **Reject all (no relevant metrics)**
+button (PR #284) shipped without a shortcut. Reviewers context-switching
+between tabs lose muscle memory.
+
+### Next Steps
+
+- Tabulate all current shortcuts on both tabs (`unified_review.html` +
+  `static/js/review_images_v2.js`).
+- Decide the policy for destructive / bulk actions: chord (Shift+R,
+  Ctrl+R) vs single-letter. Recommendation: chord for "Reject all",
+  since it touches every detected metric on the image at once.
+- Add the missing shortcut for "Reject all (no relevant metrics)".
+- Where text and image share semantics (next/prev, next-filing), align
+  on the same key.
+- Document the final mapping in `.claude/rules/web.md` so future buttons
+  are added with shortcuts from day one.


### PR DESCRIPTION
#293 — supersedes the deferred Step B of legacy-089 with cleaner scope:
a single 'Undo review' button on the image card that flips
v2_image_assets.review_status back to pending without deleting prior
decision rows (preserves ML training signal).

#294 — keyboard-shortcut parity audit. 'Reject all (no relevant
metrics)' shipped in PR #284 without a binding; recommendation is to
chord destructive bulk actions and align text/image tabs on shared
semantics.
