### PR TITLE
feat(render): healthcheck + tighter .dockerignore + explicit Dockerfile COPY

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -54,6 +54,10 @@ Region is pinned so blueprint re-deploys do not scatter services across regions.
 
 **Limitations.** Only `filings-reviewer` has the predeploy hook. Other services (`filings-extraction`, `filings-onboarding-runner`, `filings-nightly-sweep`, `filings-metabase`) rely on `filings-reviewer` running its predeploy first when a schema change ships — they redeploy in parallel but share the database, so the order doesn't matter for safety, only for log visibility.
 
+### Healthcheck
+
+`filings-reviewer` declares `healthCheckPath: /health` in `render.yaml`. The endpoint is registered in `src/web/app.py::_register_health_check`, requires no auth, and returns 200 when the DB pool is reachable, 503 otherwise. Render uses it to flip traffic to the new container the moment the app is live (vs. waiting on TCP-probe heuristics) and to abort a deploy whose container never reports healthy. Transient 503s during pool init are tolerated by Render's retry window.
+
 ## DATABASE_URL vs TEST_DATABASE_URL — IMPORTANT
 
 **In this project's `.env`, `DATABASE_URL` points at the Neon prod database, NOT local Postgres.** The local Docker Postgres is addressed by `TEST_DATABASE_URL`.

--- a/.dockerignore
+++ b/.dockerignore
@@ -45,3 +45,34 @@ README.md
 **/filings_cache
 **/logs
 **/data
+
+# Dev tooling, IDE, and AI assistant scaffolding — not read at runtime.
+**/.claude
+**/.github
+**/.idea
+**/.benchmarks
+**/.githooks
+**/.claudeignore
+
+# Test, docs, and design assets — not read by deployed services.
+**/screenshots
+**/ast-grep-rules
+**/tests
+**/docs
+
+# Build/dev manifests — runtime uses requirements.lock only.
+**/Makefile
+**/requirements-dev.txt
+**/uv.lock
+**/package.json
+**/package-lock.json
+**/pyproject.toml
+
+# Repo metadata not needed inside the image.
+**/render.yaml
+**/sgconfig.yml
+**/metrics_catalog.csv
+**/MANUAL_TESTING_GUIDE.md
+**/README.Docker.md
+**/CLAUDE.md
+**/.env.template

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.lock,target=requirements.lock \
     python -m pip install -r requirements.lock
 
-# Copy the source code into the container.
-COPY --chown=appuser:appuser . .
+# Copy only the dirs read at runtime. Keeping this list explicit prevents
+# unrelated tree changes (docs, tests, .claude/) from busting the layer cache.
+COPY --chown=appuser:appuser src/ ./src/
+COPY --chown=appuser:appuser scripts/ ./scripts/
+COPY --chown=appuser:appuser sql/ ./sql/
+COPY --chown=appuser:appuser config/ ./config/
 
 # Create directories for logs, data, and coverage with proper permissions
 RUN mkdir -p /app/logs /app/data /app/filings_cache /app/htmlcov && \

--- a/render.yaml
+++ b/render.yaml
@@ -34,6 +34,7 @@ services:
     # (schema_migrations ledger) so this is safe on every push to main.
     # DATABASE_URL is available here via the filings-shared-secrets group below.
     preDeployCommand: python3 scripts/apply_migrations.py
+    healthCheckPath: /health
     envVars:
       - fromGroup: filings-shared-secrets
       - key: SECRET_KEY


### PR DESCRIPTION
Cuts deploy time on Render in three independent ways:

- Add `healthCheckPath: /health` to filings-reviewer so Render flips
  traffic the moment the container is live (vs. slow TCP probing) and
  aborts deploys that never report healthy. Endpoint already exists in
  src/web/app.py:_register_health_check, no auth required.
- Tighten .dockerignore to exclude .claude/, .github/, .idea/, tests/,
  docs/, screenshots/, ast-grep-rules/, pyproject.toml, package*.json,
  Makefile, render.yaml, CLAUDE.md, MANUAL_TESTING_GUIDE.md, and other
  dev-only artifacts. Smaller build context = faster upload to Render's
  builder.
- Replace `COPY . .` in Dockerfile with explicit `COPY src/ scripts/
  sql/ config/ ./`. Defense-in-depth against .dockerignore misses, and
  changes to docs/tests/.claude/ no longer invalidate the layer cache.

Verified locally: docker build succeeds, /health returns 200 against a
real DB and 503 against an unreachable one, all three entrypoints
(web, batch_v2_extraction, onboarding_runner) start, migration runner
finds 53 sql/ files inside the image.

This is PR1 of the deploy-speed plan. PR2 (multi-stage Dockerfile)
follows; PR3 (GHCR base image) is deferred unless needed.
