### PR TITLE
feat(review-ui): image-tab keyboard shortcut audit + parity (#294)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -56,3 +56,44 @@ The unified review UI persists filter/sort/tab state client-side via localStorag
 **Tab taxonomy**: the three analytical tabs ("IPO Filings", "Earnings", "Investor Day") are mapped to SQL filters by `src/infra/db.py::TAB_SQL_FILTERS`. Tab keys (`ipo`, `earnings`, `investor_day`) combine `v2_documents.document_type` with `filings.form_type`; adding a tab means adding a row to that dict and updating `VALID_TABS` in `src/web/routes/review_unified.py` plus `VALID_DOC_TYPES` in the template JS.
 
 **Presence-based exception (`cmasb:filings:reviewers`)**: the reviewer filter uses URL *presence* (not value) as the signal, because HTML forms drop unchecked checkboxes — a cleared filter and a fresh visit would otherwise look identical. The reviewer form carries a hidden `<input name="reviewer_id" value="">` and the Clear link emits `?reviewer_id=` explicitly; an empty `reviewer_id=` in the URL means "explicitly cleared" and suppresses the localStorage restore.
+
+## Keyboard Shortcuts
+
+The unified review page (`unified_review.html`) binds shortcuts on both tabs. Cross-tab semantics (next/prev navigation, next-filing) should match — when adding a new button, give it a shortcut from day one and follow the rule below.
+
+**Rule**: image-tab buttons that affect a single detected metric get a single-letter shortcut; bulk/destructive buttons that touch every detected metric on the image at once get a chord (`Shift+key`).
+
+**Text tab** (`unified_review.html:1355–1392`, only active when `active_tab == 'text'`):
+
+| Key       | Action                |
+|-----------|-----------------------|
+| `A`       | Accept fact           |
+| `R`       | Open reject form      |
+| `C`       | Open correct form     |
+| `N` / `→` | Next fact             |
+| `P` / `←` | Previous fact         |
+| `F`       | Next filing           |
+
+**Image tab — image-level** (`static/js/review_images_v2.js`, fires when no per-metric row is focused except where noted):
+
+| Key        | Action                                      |
+|------------|---------------------------------------------|
+| `S`        | Skip image                                  |
+| `U`        | Undo skip                                   |
+| `←` / `→`  | Previous / next image                       |
+| `N` / `P`  | Next / previous image (alias)               |
+| `?` / `H`  | Toggle help overlay                         |
+| `F`        | Next filing                                 |
+| `Shift+R`  | Reject all (no relevant metrics) — chord, fires regardless of row focus |
+
+**Image tab — per-metric row** (when `state.focusedRow` is set):
+
+| Key       | Action                       |
+|-----------|------------------------------|
+| `A`       | Accept row                   |
+| `R`       | Open reject form             |
+| `C`       | Open correct form            |
+| `S`       | Skip row                     |
+| `N`       | Focus next unreviewed row    |
+
+`Shift+R` is intercepted at image-level before the per-row handler runs, so a focused-row `Shift+R` does not also fire `openReject` on that row.

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -67,7 +67,26 @@
         if (event.metaKey || event.ctrlKey || event.altKey) return;
         if (state.submitting) return;
 
+        // Shift+R — reject all (no relevant metrics). Fires regardless of
+        // whether a per-metric row is focused, so this check must come before
+        // the focusedRow early-return below.
+        if (event.shiftKey && (event.key === 'R' || event.key === 'r')) {
+            event.preventDefault();
+            rejectAllUnreviewed();
+            return;
+        }
+
         const key = event.key.toLowerCase();
+
+        // N / P image-level navigation — only fire when no per-metric row is
+        // focused (per-row N uses focusNextUnreviewed instead).
+        if (key === 'n' || key === 'p') {
+            if (state.focusedRow) return;
+            event.preventDefault();
+            if (key === 'n') navigateNext();
+            else navigatePrevious();
+            return;
+        }
 
         switch (key) {
             case 's':
@@ -484,6 +503,9 @@
             event.stopPropagation();
             acceptRow(row);
         } else if (key === 'r') {
+            // Shift+R is handled at the image level (rejectAllUnreviewed).
+            // Let it propagate up rather than opening the per-row reject form.
+            if (event.shiftKey) return;
             event.preventDefault();
             event.stopPropagation();
             openReject(row);

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -1086,19 +1086,15 @@
     <div class="container-fluid">
       <div class="d-flex justify-content-between align-items-center">
         <div class="hints-content">
-          <kbd>Y</kbd> Relevant
-          <span class="mx-1">|</span>
-          <kbd>N</kbd> Not Relevant
-          <span class="mx-1">|</span>
           <kbd>S</kbd> Skip
           <span class="mx-1">|</span>
           <kbd>U</kbd> Undo
           <span class="mx-1">|</span>
-          <kbd>&larr;&rarr;</kbd> Navigate
+          <kbd>&larr;&rarr;</kbd> / <kbd>N</kbd>/<kbd>P</kbd> Navigate
+          <span class="mx-1">|</span>
+          <kbd>Shift+R</kbd> Reject all
           <span class="mx-1">|</span>
           <kbd>F</kbd> Next filing
-          <span class="mx-1">|</span>
-          <kbd>1-7</kbd> Quick Select
           <span class="mx-1">|</span>
           <kbd>?</kbd> Help
         </div>


### PR DESCRIPTION
## Summary

Closes #294. Aligns image-tab keyboard shortcuts with the text tab and gives the recently-shipped **Reject all (no relevant metrics)** button (PR #284) a chord shortcut.

- **Shift+R** at image-level → `rejectAllUnreviewed()`. Fires regardless of per-metric row focus; the per-row R handler now early-returns on `shiftKey` so a focused-row Shift+R does not also open the per-row reject form.
- **N / P** at image-level → next / previous image (parity with text tab's N/P). Guarded with `focusedRow` check so per-row **N** (`focusNextUnreviewed`) still wins when a row has focus.
- Help bar refreshed: drops stale `Y` / `1-7` / "Not Relevant" entries left from before the per-metric pivot; surfaces N/P and Shift+R alongside existing S / U / arrows / F / ?.
- `.claude/rules/web.md` gains a **Keyboard Shortcuts** section with three tables (text tab, image-level, per-metric row) and a rule: image-tab buttons that affect a single detected metric get a single-letter shortcut; bulk/destructive buttons that touch every detected metric get a chord (`Shift+key`).

## Files changed
- `src/web/static/js/review_images_v2.js` — handler additions + per-row Shift+R early-return
- `src/web/templates/unified_review.html` — help-bar refresh
- `.claude/rules/web.md` — new Keyboard Shortcuts section

## Test plan
- [ ] On `/v2/review/<filing>?tab=images` with no per-metric row focused: press **N** / **P** → navigates to next / previous image
- [ ] Focus a per-metric row, press **N** → focuses next unreviewed row (existing behavior preserved)
- [ ] Press **Shift+R** with no row focused → `rejectAllUnreviewed` confirm dialog appears
- [ ] Focus a per-metric row, press **Shift+R** → bulk reject fires, per-row reject form does NOT open
- [ ] Press **?** or **H** → help overlay shows the new bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)