### PR TITLE
worktree fix+legacy 097 chart only backfill

### DIFF
--- a/docs/known-issues/gh-298-chart-only-drain-branch-unreachable.md
+++ b/docs/known-issues/gh-298-chart-only-drain-branch-unreachable.md
@@ -1,0 +1,26 @@
+---
+id: 298
+source: gh
+slug: chart-only-drain-branch-unreachable
+title: chart_only=True drain branch is unreachable post-presence-pivot
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: '2026-04-28'
+updated: '2026-04-28'
+gh_issue: 298
+note: '`_persist_facts_in_tx` early-returns on empty filtered facts before guard+DELETE; post-pivot pipeline always emits zero chart facts so chart_only drain is a no-op.'
+---
+
+### Problem
+
+`V2PersistenceAdapter._persist_facts_in_tx` at `src/extraction_v2/persistence.py:1038-1042` filters inbound facts to `source_type='chart'` and then returns `0` early on `if not facts: return 0`, *before* the reviewed-filing guard and the DELETE on line 1118. Under the chart-presence pivot (#86), `enable_chart_candidate_emission=False` means the filter always produces an empty list, so the drain semantics documented in `.claude/rules/v2-pipeline.md#chart-only-re-extraction` are unreachable.
+
+Discovered 2026-04-28 during the legacy-097 drain attempt: `scripts/batch_v2_extraction.py --chart-only --force-reextract` ran on 7 filings with chart-fact reviewer decisions and produced zero `force-reextract purging reviewed filing` log lines; `chart_facts` count remained at 30. The drain ultimately had to be done via direct SQL DELETE.
+
+### Next Steps
+
+- Move the `if not facts: return 0` early-return below the chart-decision guard + DELETE block when `chart_only=True`. Emptiness is the expected post-pivot state, not a no-op signal.
+- Add a unit test: `_persist_facts_in_tx(facts=[], chart_only=True, force=True)` deletes existing chart facts and CASCADEs their reviewer decisions on the target filing.

--- a/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
+++ b/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
@@ -1,0 +1,25 @@
+---
+id: 299
+source: gh
+slug: stale-onedrive-paths-in-html-storage
+title: Stale OneDrive paths in filings.html_storage_path block re-extraction
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: '2026-04-28'
+updated: '2026-04-28'
+gh_issue: 299
+note: '5 known filings (and likely more corpus-wide) carry html_storage_path values under /Users/.../OneDrive-CMASB/... with NULL html_content; ingestion times out when files are not hydrated.'
+---
+
+### Problem
+
+5 filings (filing_ids 1539, 1544, 1546, 1548, 1551 — Datadog, Maplebear, Samsara, Slack, Torrid) carry `filings.html_storage_path` values under `/Users/.../OneDrive-CMASB/.../data/gold_standard/<Company>/filing.html` with NULL `html_content`. OneDrive cloud-only files are no longer reliably hydrated locally; 3 of these 5 timed out during a 2026-04-28 backfill (`Operation timed out`), 2 happened to be hydrated and succeeded. Canonical local copies all exist at `data/gold_standard/<Company>/filing.html` (2–5 MB each). Likely broader than these 5 — any filing ingested before the OneDrive→local migration may share the pattern.
+
+### Next Steps
+
+- Audit `filings` for `html_storage_path LIKE '/Users/%/OneDrive-CMASB/%'`. Count + report scope.
+- Migration script to rewrite paths to the worktree-relative form, verifying each rewritten path resolves to a real file. Fall back to `sec_html_url` fetch for missing files.
+- Optionally populate `html_content` from disk so re-extraction does not depend on file paths.

--- a/docs/known-issues/gh-300-migrate-filing-htmls-to-r2.md
+++ b/docs/known-issues/gh-300-migrate-filing-htmls-to-r2.md
@@ -1,0 +1,26 @@
+---
+id: 300
+source: gh
+slug: migrate-filing-htmls-to-r2
+title: Migrate filing HTMLs to R2 long-haul storage (architecture)
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches: []
+discovered: '2026-04-28'
+updated: '2026-04-28'
+gh_issue: 300
+note: 'Apply the existing R2 image-bytes pattern to filing HTMLs to remove local-disk / OneDrive dependency from extraction.'
+---
+
+### Problem
+
+Filing source HTML is stored on local disk and read by `src/extraction_v2/stages/ingestion.py` from `filings.html_storage_path`. This couples extraction to local filesystem state and creates ongoing data-hygiene burden (see #299). Image bytes already live in R2 (`src/infra/image_storage.py`); the same pattern can apply to filing HTMLs. Storage cost is trivial (~$1/month at the current corpus size).
+
+### Next Steps
+
+- New `src/infra/filing_storage.py` abstraction analogous to `image_storage.py`, with `R2FilingStorage` (prod) and `LocalFilesystemFilingStorage` (dev) backends, gated by the existing `FILINGS_REVIEWER_ALLOW_PROD_WRITES` env.
+- Refactor `src/extraction_v2/stages/ingestion.py` to fetch HTML via the storage abstraction (opaque storage key in `html_storage_path`) instead of `Path(...).read_text()`.
+- One-time migration: upload each filing's HTML bytes to R2 under a deterministic key (e.g., `filings/<cik>/<accession>/primary.htm`) and rewrite `html_storage_path`.
+- Update other consumers of `html_storage_path` (e.g., reviewer UI source-rendering).

--- a/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
+++ b/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
@@ -8,13 +8,14 @@ note: 'Residual pre-pivot chart facts (30 rows across 10 filings) remain in
   CASCADE-destroy on DELETE. Low blast radius — new UI does not read them,
   validator bypasses them — but analytics views filtering on source_type=chart
   still see them.'
+pr_refs: []
 severity: low
 slug: residual-chart-facts-after-presence-pivot
 source: legacy
-status: open
+status: resolved
 title: Residual Chart Facts Remain After Chart-Presence Pivot (Drain Deferred)
 touches: []
-updated: '2026-04-24'
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -62,3 +63,28 @@ Three paths, pick at triage time:
 - See also legacy-053 — chart OCR dollar budget on the same pipeline post-pivot; both are residual-concern fragments rooted in the chart-presence transition.
 - Reviewed-filing guard: `src/extraction_v2/persistence.py::_persist_facts_in_tx`, `ReviewedFilingError`.
 - Cascade path: `v2_review_decisions.fact_id ON DELETE CASCADE` (sql/05 originally; `chart_only=True` guard in `persist_pipeline_result` refuses when decisions exist).
+
+### Resolution
+
+Drained the 30 residual chart `v2_metric_facts` rows on **2026-04-28** via direct SQL DELETE in a single transaction (Option 1 from the original deferred-next-steps list). The pivot from the planned Option 2 (`chart_only --force-reextract` with lifted budget) is recorded below.
+
+**Measured outcome (post-drain audit, `scripts/audit_residual_chart_facts.py`):**
+
+| Quantity | Pre-drain | Post-drain |
+|---|---|---|
+| `v2_metric_facts WHERE source_type='chart'` | 30 | **0** |
+| Chart-fact reviewer decisions (CASCADE-destroyed, intentional) | 28 | **0** |
+| Text-fact reviewer decisions on the 10 affected filings | 146 | **146** (unchanged) |
+| Image-metric confirmations on PYPL filing 1753 | 3 | **4** (unchanged by drain; +1 from concurrent reviewer action) |
+| Vision API spend | — | $2–5 (from the abandoned Option-2 attempt) |
+
+The 28 destroyed decisions accumulated to 28 (from 18 at fragment-write time on 2026-04-24) over the four-day deferral window. Pre-drain breakdown was 17 by `RGM` (15 reject / accept / correct) plus 1 bulk-system entry; the additional 10 since 2026-04-24 followed the same shape.
+
+**Why a direct DELETE replaced the planned `chart_only --force-reextract`:** the Option-2 attempt ran the full pipeline on all 10 filings (`scripts/batch_v2_extraction.py --chart-only --force-reextract`) and produced **zero** purge-warning log lines. Investigation (`src/extraction_v2/persistence.py:1038-1042`) showed that `_persist_facts_in_tx` early-returns on `if not facts: return 0` *before* the reviewed-filing guard and the DELETE — and the post-pivot pipeline emits zero chart-source facts (`enable_chart_candidate_emission=False`), so the filter at line 1039 always produces an empty list. The drain branch is therefore unreachable post-pivot. Documented separately as a follow-up (see "Follow-ups discovered" below). The marginal benefit Option 2 was sized for — refreshing `v2_image_assets.detected_metrics` to seed the per-image review queue — was also measured at zero usable signal: only 1 of 128 surviving chart-classified images gained a `detected_metrics` entry across 7 successful filings, and 3 of 10 filings could not even ingest because their `html_storage_path` still pointed at unhydrated OneDrive files.
+
+**Pre-drain archive:** `data/audit/chart_fact_drain_predrain_<UTC-ts>.csv` (gitignored). Captures all 30 facts joined to all 28 reviewer decisions, including `decision`, `assigned_metric_id`, `corrected_value`, `rejection_reason`, `rejection_category`, and `reviewer_notes`. Recoverable as JSON if specific decisions ever need to be cited.
+
+**Follow-ups discovered:**
+- `chart_only=True` is a no-op post-pivot — the early-return at `persistence.py:1041-1042` defeats the drain branch when the pipeline emits zero chart facts (now always). Should be filed as a separate fix.
+- 5 of the 10 affected filings have stale `filings.html_storage_path` values pointing at unhydrated OneDrive paths with NULL `html_content` (filing_ids 1539, 1544, 1546, 1548, 1551). Re-extraction on those filings fails ingestion; canonical local copies live under `data/gold_standard/<Company>/filing.html`.
+- Long-haul: filings could move to R2 (analogous to image bytes) to remove local-disk / OneDrive dependency entirely.

--- a/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
+++ b/docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md
@@ -8,7 +8,8 @@ note: 'Residual pre-pivot chart facts (30 rows across 10 filings) remain in
   CASCADE-destroy on DELETE. Low blast radius — new UI does not read them,
   validator bypasses them — but analytics views filtering on source_type=chart
   still see them.'
-pr_refs: []
+pr_refs:
+- 301
 severity: low
 slug: residual-chart-facts-after-presence-pivot
 source: legacy

--- a/scripts/audit_residual_chart_facts.py
+++ b/scripts/audit_residual_chart_facts.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Audit residual chart facts after the chart-presence pivot (legacy-097).
+
+Read-only. For each filing carrying `v2_metric_facts WHERE source_type='chart'`,
+reports the work that would be lost / re-done under each drain option:
+
+- Chart-fact reviewer-decision count (the 18 decisions targeted for abandonment)
+- Total chart-classified v2_image_assets on the filing (re-review surface under
+  the per-(image, metric) flow if we re-extract or surface the images for
+  fresh confirmation)
+- Existing v2_image_metric_confirmations (post-pivot reviewer work that would
+  be at risk if we did a full re-extraction with force=True)
+- Text-fact reviewer-decision count (also at risk under full re-extraction)
+
+Output is a per-filing table + verdict on whether a surgical drain is safe
+(no other reviewer work to disturb).
+
+Usage:
+    DATABASE_URL=... python3 scripts/audit_residual_chart_facts.py
+    python3 scripts/audit_residual_chart_facts.py --database-url postgresql://...
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.infra.db import DatabaseAdapter
+
+QUERY = """
+WITH chart_filings AS (
+    SELECT DISTINCT doc_id AS filing_id
+    FROM v2_metric_facts
+    WHERE source_type = 'chart'
+),
+chart_fact_counts AS (
+    SELECT doc_id AS filing_id, COUNT(*) AS chart_fact_count
+    FROM v2_metric_facts
+    WHERE source_type = 'chart'
+    GROUP BY doc_id
+),
+chart_fact_decisions AS (
+    SELECT mf.doc_id AS filing_id, COUNT(*) AS chart_fact_decision_count
+    FROM v2_review_decisions rd
+    JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
+    WHERE mf.source_type = 'chart'
+    GROUP BY mf.doc_id
+),
+text_fact_decisions AS (
+    SELECT mf.doc_id AS filing_id, COUNT(*) AS text_fact_decision_count
+    FROM v2_review_decisions rd
+    JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
+    WHERE mf.source_type <> 'chart'
+    GROUP BY mf.doc_id
+),
+chart_images AS (
+    SELECT doc_id AS filing_id,
+           COUNT(*) AS chart_image_count,
+           COUNT(*) FILTER (WHERE detected_metrics IS NOT NULL
+                            AND jsonb_typeof(detected_metrics) = 'array'
+                            AND jsonb_array_length(detected_metrics) > 0)
+               AS chart_images_with_detected_metrics
+    FROM v2_image_assets
+    WHERE classification = 'chart'
+    GROUP BY doc_id
+),
+image_confirmations AS (
+    SELECT ia.doc_id AS filing_id,
+           COUNT(DISTINCT (imc.img_id, COALESCE(imc.detected_metric_id, imc.confirmed_metric_id, ''), imc.reviewer_id))
+               AS image_metric_confirmation_count
+    FROM v2_image_metric_confirmations imc
+    JOIN v2_image_assets ia ON ia.img_id = imc.img_id
+    GROUP BY ia.doc_id
+)
+SELECT
+    f.filing_id,
+    c.cik,
+    c.ticker,
+    f.form_type,
+    f.filing_date,
+    cfc.chart_fact_count,
+    COALESCE(cfd.chart_fact_decision_count, 0) AS chart_fact_decisions,
+    COALESCE(ci.chart_image_count, 0) AS chart_images_total,
+    COALESCE(ci.chart_images_with_detected_metrics, 0) AS chart_images_with_detected,
+    COALESCE(ic.image_metric_confirmation_count, 0) AS image_metric_confirmations,
+    COALESCE(tfd.text_fact_decision_count, 0) AS text_fact_decisions
+FROM chart_filings cf
+JOIN filings f ON f.filing_id = cf.filing_id
+JOIN companies c ON c.cik = f.cik
+LEFT JOIN chart_fact_counts cfc ON cfc.filing_id = cf.filing_id
+LEFT JOIN chart_fact_decisions cfd ON cfd.filing_id = cf.filing_id
+LEFT JOIN chart_images ci ON ci.filing_id = cf.filing_id
+LEFT JOIN image_confirmations ic ON ic.filing_id = cf.filing_id
+LEFT JOIN text_fact_decisions tfd ON tfd.filing_id = cf.filing_id
+ORDER BY chart_fact_decisions DESC, cfc.chart_fact_count DESC, f.filing_date DESC;
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres connection string (default: $DATABASE_URL)",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        print("ERROR: --database-url or $DATABASE_URL required", file=sys.stderr)
+        return 2
+
+    db = DatabaseAdapter(args.database_url)
+    rows = db.query(QUERY)
+
+    if not rows:
+        print("No filings carry residual chart facts. legacy-097 may already be drained.")
+        return 0
+
+    headers = [
+        "filing_id",
+        "ticker",
+        "cik",
+        "form",
+        "date",
+        "chart_facts",
+        "fact_decs",
+        "chart_imgs",
+        "imgs_w_det",
+        "img_confs",
+        "text_decs",
+    ]
+    widths = [len(h) for h in headers]
+    fmt_rows = []
+    for r in rows:
+        fmt = [
+            str(r["filing_id"]),
+            str(r["ticker"] or "")[:8],
+            str(r["cik"]),
+            str(r["form_type"] or "")[:8],
+            str(r["filing_date"]),
+            str(r["chart_fact_count"]),
+            str(r["chart_fact_decisions"]),
+            str(r["chart_images_total"]),
+            str(r["chart_images_with_detected"]),
+            str(r["image_metric_confirmations"]),
+            str(r["text_fact_decisions"]),
+        ]
+        fmt_rows.append(fmt)
+        for i, cell in enumerate(fmt):
+            widths[i] = max(widths[i], len(cell))
+
+    line = "  ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
+    print(line)
+    print("  ".join("-" * w for w in widths))
+    for fmt in fmt_rows:
+        print("  ".join(fmt[i].ljust(widths[i]) for i in range(len(fmt))))
+
+    totals = {
+        "filings": len(rows),
+        "chart_facts": sum(r["chart_fact_count"] for r in rows),
+        "chart_fact_decisions": sum(r["chart_fact_decisions"] for r in rows),
+        "chart_images_total": sum(r["chart_images_total"] for r in rows),
+        "chart_images_with_detected": sum(r["chart_images_with_detected"] for r in rows),
+        "image_metric_confirmations": sum(r["image_metric_confirmations"] for r in rows),
+        "text_fact_decisions": sum(r["text_fact_decisions"] for r in rows),
+    }
+    print()
+    print("TOTALS")
+    for k, v in totals.items():
+        print(f"  {k}: {v}")
+
+    surgical_safe = [
+        r for r in rows if r["image_metric_confirmations"] == 0 and r["text_fact_decisions"] == 0
+    ]
+    risky = [r for r in rows if r not in surgical_safe]
+    print()
+    print("VERDICT")
+    print(
+        f"  Surgical-safe filings (no other reviewer work to disturb): {len(surgical_safe)} / {len(rows)}"
+    )
+    if risky:
+        print("  Filings with other reviewer work at risk under full re-extraction:")
+        for r in risky:
+            print(
+                f"    filing_id={r['filing_id']} {r['ticker']} {r['form_type']} {r['filing_date']}: "
+                f"img_confs={r['image_metric_confirmations']} text_decs={r['text_fact_decisions']}"
+            )
+
+    re_review_surface = sum(r["chart_images_total"] for r in rows)
+    print()
+    print(
+        f"Re-review surface under per-image flow: {re_review_surface} chart-classified images "
+        f"across {len(rows)} filings (avg {re_review_surface / len(rows):.1f}/filing) "
+        f"vs {totals['chart_fact_decisions']} chart-fact decisions abandoned."
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- **docs(known-issues): close legacy-097 — drain residual chart facts via direct DELETE**
- **docs(known-issues): log issues #298, #299, #300 — chart_only drain bug, stale OneDrive paths, R2 filings storage**
