### PR TITLE
feat(review-ui): re-open affordance for reviewed images (#293)

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2166,6 +2166,22 @@ class DatabaseAdapter:
         result = self.query(sql, {"img_id": img_id})
         return len(result) > 0
 
+    def reopen_image_candidate_v2(self, img_id: str) -> bool:
+        """Flip review_status='reviewed' -> 'pending'. Returns True if a row was updated.
+
+        Preserves v2_image_review_decisions and v2_image_metric_confirmations rows
+        (ML training signal — see CLAUDE.md).
+        """
+        sql = """
+            UPDATE v2_image_assets
+            SET review_status = 'pending'
+            WHERE img_id = %(img_id)s
+              AND review_status = 'reviewed'
+            RETURNING img_id
+        """
+        result = self.query(sql, {"img_id": img_id})
+        return len(result) > 0
+
     def get_image_review_progress_v2(self, filing_id: int | None = None) -> dict[str, Any]:
         """
         V2-native progress counts. If filing_id is given, counts are filing-scoped;

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -368,6 +368,66 @@ def unskip_image_candidate(img_id):
         return jsonify({"status": "error", "message": "Internal server error"}), 500
 
 
+@api_unified_bp.route("/image-candidates/<uuid:img_id>/reopen", methods=["POST"])
+def reopen_image_candidate(img_id):
+    """
+    Re-open a reviewed image — flip review_status='reviewed' back to 'pending'.
+
+    Requires X-Reviewer-Id header to identify who is reopening the image.
+    Preserves all v2_image_review_decisions and v2_image_metric_confirmations
+    rows (ML training signal).
+
+    Returns:
+        200: Reopened — returns img_id and new review_status.
+        400: Missing X-Reviewer-Id header.
+        404: Image not found or not in 'reviewed' status.
+        500: Internal server error.
+    """
+    reviewer_id = (request.headers.get("X-Reviewer-Id") or "").strip()
+    if not reviewer_id:
+        return (
+            jsonify({"status": "error", "message": "X-Reviewer-Id header is required"}),
+            400,
+        )
+
+    img_id_str = str(img_id)
+    db = get_db()
+
+    try:
+        success = db.reopen_image_candidate_v2(img_id_str)
+        if not success:
+            logger.warning(f"Reopen: v2 image not found or not reviewed: {img_id_str}")
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": "Image not found or not in 'reviewed' status",
+                    }
+                ),
+                404,
+            )
+
+        logger.info(f"Reopened v2 image {img_id_str} by reviewer {reviewer_id}")
+
+        return jsonify(
+            {
+                "img_id": img_id_str,
+                "review_status": "pending",
+            }
+        ), 200
+
+    except psycopg.DatabaseError as e:
+        logger.error(f"Database error reopening v2 image: {e}", exc_info=True)
+        return (
+            jsonify({"status": "error", "message": "Database error occurred"}),
+            500,
+        )
+
+    except Exception as e:
+        logger.error(f"Unexpected error reopening v2 image: {e}", exc_info=True)
+        return jsonify({"status": "error", "message": "Internal server error"}), 500
+
+
 # =============================================================================
 # Missed Metric (new endpoint)
 # =============================================================================

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -190,6 +190,46 @@
         }
     }
 
+    async function reopenImage() {
+        if (state.submitting) return;
+
+        const btn = document.getElementById('btn-reopen-image');
+        const imgId = (btn && btn.dataset.imgId) || state.currentImgId;
+        if (!imgId) return;
+
+        const reviewerName = (typeof window.requireReviewerName === 'function')
+            ? window.requireReviewerName()
+            : localStorage.getItem('reviewer_name');
+        if (!reviewerName) return;
+
+        state.submitting = true;
+        try {
+            const qs = state.imageStatus && state.imageStatus !== 'all'
+                ? `?image_status=${encodeURIComponent(state.imageStatus)}`
+                : '';
+            const response = await fetch(
+                `/api/v2/image-candidates/${imgId}/reopen${qs}`,
+                {
+                    method: 'POST',
+                    headers: { 'X-Reviewer-Id': reviewerName },
+                }
+            );
+            const data = await response.json();
+            if (response.ok) {
+                showToast('Image re-opened for review', 'success');
+                window.location.href =
+                    `/v2/review/${state.filingId}?tab=images&image_status=pending`;
+            } else {
+                showToast(data.message || 'Failed to re-open image', 'danger');
+            }
+        } catch (err) {
+            showToast('Network error', 'danger');
+            console.error('Reopen error:', err);
+        } finally {
+            state.submitting = false;
+        }
+    }
+
     function navigateNext() {
         const currentIndex = state.candidates.findIndex(c => c.img_id === state.currentImgId);
         if (currentIndex < state.candidates.length - 1) {
@@ -213,9 +253,11 @@
     function bindButtonEvents() {
         const skipBtn = document.getElementById('btn-skip');
         const undoBtn = document.getElementById('btn-undo');
+        const reopenBtn = document.getElementById('btn-reopen-image');
 
         if (skipBtn) skipBtn.addEventListener('click', submitSkip);
         if (undoBtn) undoBtn.addEventListener('click', undoSkip);
+        if (reopenBtn) reopenBtn.addEventListener('click', reopenImage);
     }
 
     function showToast(message, type = 'info') {

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -860,6 +860,17 @@
               </button>
             </div>
           </div>
+          {% elif current_image.review_status == 'reviewed' %}
+          <div class="alert alert-success mb-3">
+            <div class="d-flex justify-content-between align-items-center">
+              <div><strong>Status:</strong> Image reviewed</div>
+              <button type="button" id="btn-reopen-image" class="btn btn-outline-secondary"
+                      data-img-id="{{ current_image.img_id }}"
+                      title="Return this image to the pending queue. Prior decisions are preserved.">
+                Re-open for review
+              </button>
+            </div>
+          </div>
           {% else %}
           <div class="d-flex justify-content-between align-items-center mb-3">
             <div class="d-flex gap-2">

--- a/tests/unit/web/test_api_v2_images_routes.py
+++ b/tests/unit/web/test_api_v2_images_routes.py
@@ -91,3 +91,44 @@ class TestUnskipImageCandidateV2:
 
         resp = client.post(f"/api/v2/image-candidates/{IMG_ID}/unskip")
         assert resp.status_code == 400
+
+
+class TestReopenImageCandidateV2:
+    """Per gh-293 — flip legacy review_status='reviewed' back to 'pending'."""
+
+    def test_reopen_success(self, client, monkeypatch):
+        mock_db = MagicMock()
+        _patch_get_db(monkeypatch, mock_db)
+        mock_db.reopen_image_candidate_v2.return_value = True
+
+        resp = client.post(
+            f"/api/v2/image-candidates/{IMG_ID}/reopen",
+            headers={"X-Reviewer-Id": "RGM"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["img_id"] == IMG_ID
+        assert body["review_status"] == "pending"
+        mock_db.reopen_image_candidate_v2.assert_called_once_with(IMG_ID)
+
+    def test_reopen_missing_reviewer_returns_400(self, client, monkeypatch):
+        mock_db = MagicMock()
+        _patch_get_db(monkeypatch, mock_db)
+
+        resp = client.post(f"/api/v2/image-candidates/{IMG_ID}/reopen")
+
+        assert resp.status_code == 400
+        mock_db.reopen_image_candidate_v2.assert_not_called()
+
+    def test_reopen_not_reviewed_returns_404(self, client, monkeypatch):
+        mock_db = MagicMock()
+        _patch_get_db(monkeypatch, mock_db)
+        mock_db.reopen_image_candidate_v2.return_value = False
+
+        resp = client.post(
+            f"/api/v2/image-candidates/{IMG_ID}/reopen",
+            headers={"X-Reviewer-Id": "RGM"},
+        )
+
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Closes #293. Adds a per-image "Re-open for review" button that flips legacy `v2_image_assets.review_status='reviewed'` rows back to `'pending'` so they re-enter the queue. Validation target: filing 1748 (PayPal Q3'23 8-K) has 18 images decided pre-OCR with fresh OCR text now attached but no per-metric undo path.

## Why a new endpoint

Per-metric undo (`DELETE /api/v2/image-metric-confirmations/<id>`) cannot help these legacy decisions: they were written by the pre-pivot `insert_image_review_decision_v2` flow, so no `v2_image_metric_confirmations` rows exist. The new endpoint is the only path back to `pending` for that population.

## Changes

- **`src/infra/db.py`** — `reopen_image_candidate_v2(img_id)`: `UPDATE v2_image_assets SET review_status='pending' WHERE img_id=… AND review_status='reviewed' RETURNING img_id`. Mirrors the existing `unskip_image_candidate_v2` helper. Preserves all `v2_image_review_decisions` and `v2_image_metric_confirmations` rows (ML training signal).
- **`src/web/routes/api_unified.py`** — `POST /api/v2/image-candidates/<img_id>/reopen`. Validates `X-Reviewer-Id` (400 if missing), calls the helper, returns 200 + `{img_id, review_status: 'pending'}` on flip, 404 if no row matched. Audit logging is automatic via middleware.
- **`src/web/templates/unified_review.html`** — renders a "Re-open for review" button (`#btn-reopen-image`) inside the image card when `current_image.review_status == 'reviewed'`.
- **`src/web/static/js/review_images_v2.js`** — `reopenImage()` POSTs to the new endpoint with the `X-Reviewer-Id` header (sourced via `window.requireReviewerName()` per the reviewer-identity invariant). On success, navigates back to the filing's pending image queue so the just-re-opened image is encountered fresh.
- **`tests/unit/web/test_api_v2_images_routes.py`** — three new route tests: success, missing reviewer (400), helper returns False (404).

## Reviewed-filing guard interaction

The guard in `src/extraction_v2/persistence.py:1083–1114` reads `v2_image_metric_confirmations`, not `review_status`. Flipping status back to `pending` does not weaken the guard — re-extraction of filing 1748 was never gated for these images anyway (no per-metric confirmations exist for them).

## Test plan
- [ ] Visit `/v2/review/1748?tab=images`, locate one of the 18 reviewed images, click **Re-open for review** → image returns to the pending queue with OCR text visible
- [ ] Verify a paired `v2_image_review_decisions` row for that image still exists in the DB
- [ ] POST to the endpoint without `X-Reviewer-Id` → 400
- [ ] POST on an image already `pending` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)