### PR TITLE
fix(runner): add --cleanup-stuck admin flag for stuck-batch recovery (closes legacy-062)

### DIFF
--- a/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
+++ b/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
@@ -4,6 +4,8 @@ discovered: '2026-04-20'
 estimated: S
 id: 62
 note: Resolved — `--cleanup-stuck` admin flag, SIGTERM log update, docs section shipped.
+pr_refs:
+- 303
 severity: low
 slug: local-dev-stuck-batch-recovery-is-manual
 source: legacy

--- a/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
+++ b/docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md
@@ -3,11 +3,11 @@ autonomy: review
 discovered: '2026-04-20'
 estimated: S
 id: 62
-note: Docs + optional admin flag; needs design call
+note: Resolved — `--cleanup-stuck` admin flag, SIGTERM log update, docs section shipped.
 severity: low
 slug: local-dev-stuck-batch-recovery-is-manual
 source: legacy
-status: partially-resolved
+status: resolved
 title: Local-Dev Stuck-Batch Recovery Is Manual
 touches:
 - docs/operations/*
@@ -24,6 +24,20 @@ On Render (Phase 7), a worker service with `--watch` mode will re-claim a batch 
 - **NS1 (docs)** — manual recovery SQL documented in `docs/operations/TICKER_ONBOARDING.md` under "Recovering a stuck batch (local dev)". **Done.**
 - **NS3 (SIGTERM log line)** — `src/universe/onboarding_runner.py` registers a SIGTERM handler via `signal.signal(signal.SIGTERM, _signal_handler)` and logs "Shutdown signal received … will stop after current filing." The signal-trap part is shipped; the message just doesn't yet reference `--cleanup-stuck` because the flag (NS2) doesn't exist. Trivial follow-up to the NS2 work.
 
-### Remaining
+### Resolution (2026-04-28)
 
-- **NS2 (`--cleanup-stuck` admin flag)** — `python3 -m src.universe.onboarding_runner --cleanup-stuck` admin mode that scans for batches with `run_lock_until < NOW() - INTERVAL '1 hour'` still in `running` state and either marks them failed or re-claims them. Once shipped, update the SIGTERM log message to point operators at the flag.
+Shipped:
+
+- **NS2 — `--cleanup-stuck` admin flag.** `python3 -m src.universe.onboarding_runner --cleanup-stuck` scans `v2_ingest_batches` for rows in `status='running'` with `run_lock_until < NOW() - <threshold>`. Dry-run by default (lists candidate `batch_id`s, no writes). `--apply` writes `status='failed'`, `finished_at=NOW()`, `run_lock_until=NULL`. Threshold tunable via `--stuck-threshold` (default `'1 hour'`, any Postgres interval string). Production guard: `--apply` against a `*.neon.tech` `DATABASE_URL` is refused with exit code 2 unless `--allow-prod` is also passed; dry-run mode is unaffected.
+- **NS3 trailer — SIGTERM log message updated** to point operators at the flag: "Shutdown signal received (%s); will stop after current filing. To recover stuck batches afterwards, run: python3 -m src.universe.onboarding_runner --cleanup-stuck".
+- **Docs append.** `docs/operations/TICKER_ONBOARDING.md` gained a `### Cleaning up stuck batches with --cleanup-stuck` subsection under the existing "Recovering a stuck batch (local dev)" heading. Shows dry-run-first, `--apply`, threshold tuning, and the prod guard.
+
+**Design call:** chose mark-failed as the only mode. Rationale: `--watch` mode already re-claims expired rows automatically (see `claim_next_queued_batch` semantics — it picks up rows whose `run_lock_until` is null or past). The point of `--cleanup-stuck` is the abandon path — give the operator a clean way to mark dead batches failed when retry is not what they want. A `--reclaim` mode is out of scope; if a future use case appears, file a separate fragment.
+
+**Test coverage.** Five new integration tests under `tests/integration/universe/test_onboarding_runner_integration.py::TestCleanupStuckBatches`:
+
+1. Dry-run identifies stuck rows without writing.
+2. Apply mode marks `status='failed'`, sets `finished_at`, nulls `run_lock_until`.
+3. Threshold honored — fresh-enough rows are not flagged.
+4. Live-watcher rows (`run_lock_until` in the future) are filtered by construction.
+5. Prod-host guard refuses `--apply` against `*.neon.tech`; dry-run permitted; `--allow-prod` lets the write through.

--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -400,4 +400,64 @@ Partially-processed `v2_ingest_batch_filings` rows with `processing_status='runn
 
 Prod / Render: the `--watch` mode on the worker service automatically re-claims batches whose `run_lock_until` has expired — no manual step needed.
 
-Tracked under [known issue #62](../known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md). A `--cleanup-stuck` CLI flag on `onboarding_runner` and a SIGTERM-log-line hint are still open as follow-ups.
+Prefer the scripted path below over hand-crafted UPDATEs.
+
+### Cleaning up stuck batches with `--cleanup-stuck`
+
+`onboarding_runner` ships an admin mode that finds running batches whose
+`run_lock_until` is older than a tunable threshold and marks them
+`status='failed'`. Always run dry-run first to inspect candidates before
+writing.
+
+**Dry-run (default — no writes):**
+
+```bash
+python3 -m src.universe.onboarding_runner --cleanup-stuck
+```
+
+Sample output:
+
+```
+INFO ... cleanup-stuck: 1 candidate batch(es) older than threshold='1 hour':
+INFO ...   batch_id=4f3a... started_at=2026-04-28 09:14:22+00 run_lock_until=2026-04-28 09:29:22+00
+INFO ... cleanup-stuck: matched=1 marked_failed=0 (dry-run)
+```
+
+**Apply (writes the UPDATE):**
+
+```bash
+python3 -m src.universe.onboarding_runner --cleanup-stuck --apply
+```
+
+Each matched row is set to `status='failed'`, `finished_at=NOW()`,
+`run_lock_until=NULL`. Per-filing rows in `v2_ingest_batch_filings` are not
+touched — partial-progress rows must still be inspected by hand if their
+filings had side effects (image assets written, facts persisted).
+
+**Tunable threshold:**
+
+```bash
+python3 -m src.universe.onboarding_runner --cleanup-stuck \
+    --stuck-threshold '30 minutes'
+```
+
+`--stuck-threshold` accepts any Postgres interval string. Default is
+`'1 hour'`.
+
+**Production guard:** `--apply` against a `*.neon.tech` `DATABASE_URL` is
+refused with exit code `2` unless `--allow-prod` is also passed. Dry-run
+mode is always permitted (no writes). On Render this is unnecessary —
+the worker service running `--watch` already re-claims any batch whose
+lock has expired, so production normally needs no manual intervention.
+
+```bash
+# Required for prod writes (only if you really mean it):
+python3 -m src.universe.onboarding_runner --cleanup-stuck --apply --allow-prod
+```
+
+`--cleanup-stuck` is the *abandon* path: it gives up on a stuck batch
+rather than retrying it. If you instead want to retry, leave the row
+alone and start `--watch`; the existing claim semantics
+(`run_lock_until < NOW()`) will pick it back up automatically.
+
+Tracked under [known issue #62](../known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md).

--- a/src/universe/onboarding_runner.py
+++ b/src/universe/onboarding_runner.py
@@ -7,12 +7,24 @@ filing in sequence and writing progress to v2_ingest_batch_filings.
 Entry point:
     python3 -m src.universe.onboarding_runner --batch-id <UUID>
     python3 -m src.universe.onboarding_runner --watch [--poll-interval 10]
+    python3 -m src.universe.onboarding_runner --cleanup-stuck [--apply]
+        [--stuck-threshold '1 hour'] [--allow-prod]
 
 CLI flags
 ---------
 --batch-id UUID         Process a single batch then exit.
 --watch                 Long-running mode; claim queued batches one at a time.
+--cleanup-stuck         Admin mode: scan for stuck running batches whose
+                        run_lock_until is older than --stuck-threshold and
+                        mark them failed. Dry-run by default; pass --apply
+                        to write. Refuses --apply against a *.neon.tech
+                        host unless --allow-prod is set.
 --poll-interval N       Watch-mode sleep between claims (default: 10 seconds).
+--stuck-threshold T     Postgres interval string for cleanup-stuck cutoff
+                        (default: '1 hour').
+--apply                 cleanup-stuck only: actually write the UPDATE.
+--allow-prod            cleanup-stuck only: permit --apply against a
+                        *.neon.tech DATABASE_URL.
 --verbose               DEBUG-level logging.
 """
 
@@ -25,6 +37,7 @@ import os
 import re
 import signal
 import time
+import urllib.parse
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -54,7 +67,12 @@ _shutdown_requested: bool = False
 def _signal_handler(signum: int, frame: Any) -> None:  # noqa: ANN401
     global _shutdown_requested
     _shutdown_requested = True
-    logger.info("Shutdown signal received (%s); will stop after current filing.", signum)
+    logger.info(
+        "Shutdown signal received (%s); will stop after current filing. "
+        "To recover stuck batches afterwards, run: "
+        "python3 -m src.universe.onboarding_runner --cleanup-stuck",
+        signum,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +185,30 @@ WHERE batch_id = %s;
 """
 
 _FACT_COUNT_RE = re.compile(r"(\d+)\s+facts")
+
+_CLEANUP_STUCK_SELECT_SQL = """\
+SELECT batch_id::text AS batch_id, started_at, run_lock_until
+FROM v2_ingest_batches
+WHERE status = 'running'
+  AND run_lock_until IS NOT NULL
+  AND run_lock_until < NOW() - (%(threshold)s)::interval
+ORDER BY started_at NULLS LAST, batch_id;
+"""
+
+_CLEANUP_STUCK_UPDATE_SQL = """\
+UPDATE v2_ingest_batches
+SET status = 'failed',
+    finished_at = NOW(),
+    run_lock_until = NULL
+WHERE status = 'running'
+  AND run_lock_until IS NOT NULL
+  AND run_lock_until < NOW() - (%(threshold)s)::interval
+RETURNING batch_id::text AS batch_id;
+"""
+
+
+class ProdGuardError(RuntimeError):
+    """Raised when --apply is attempted against a production DATABASE_URL without --allow-prod."""
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +436,97 @@ def _run_populate(db: DatabaseAdapter, batch_row: dict[str, Any]) -> None:
     logger.info("_run_populate: batch_id=%s done", batch_id_str)
 
 
+def _is_prod_db_url(db_url: str) -> bool:
+    """Return True if *db_url*'s host looks like a Neon production endpoint.
+
+    Matches any hostname ending in ``.neon.tech`` (case-insensitive).
+    """
+    try:
+        host = urllib.parse.urlparse(db_url).hostname or ""
+    except (ValueError, AttributeError):
+        return False
+    return host.lower().endswith(".neon.tech")
+
+
+def cleanup_stuck_batches(
+    db: DatabaseAdapter,
+    threshold: str,
+    apply: bool,
+    *,
+    allow_prod: bool = False,
+    db_url: str | None = None,
+) -> dict[str, Any]:
+    """Identify (and optionally fail) batches stuck in ``status='running'``.
+
+    A batch is considered stuck when its ``run_lock_until`` is non-null and
+    older than ``NOW() - threshold``. Live workers extend ``run_lock_until``
+    on every progress event, so any active watcher is filtered out by
+    construction.
+
+    Behaviour
+    ---------
+    Dry-run (``apply=False``): SELECT the candidate rows and return their
+    count. No UPDATE is issued.
+
+    Apply (``apply=True``): UPDATE matched rows to ``status='failed'``,
+    ``finished_at=NOW()``, ``run_lock_until=NULL`` and return the count of
+    rows actually modified (via ``RETURNING``).
+
+    Raises
+    ------
+    ProdGuardError
+        If ``apply=True`` and ``db_url`` points at a ``*.neon.tech`` host
+        without ``allow_prod=True``.
+
+    Returns
+    -------
+    dict with keys ``matched`` (always populated) and ``marked_failed``
+    (zero in dry-run; UPDATE rowcount in apply mode), plus ``batch_ids``
+    (list of stringified candidate batch_ids from the dry-run SELECT).
+    """
+    if apply and db_url is not None and _is_prod_db_url(db_url) and not allow_prod:
+        raise ProdGuardError(
+            "Refusing --apply against a *.neon.tech DATABASE_URL. "
+            "Pass --allow-prod to override (this writes to production)."
+        )
+
+    candidates = db.query(_CLEANUP_STUCK_SELECT_SQL, {"threshold": threshold})
+    matched = len(candidates)
+    batch_ids = [str(r["batch_id"]) for r in candidates]
+
+    if matched:
+        logger.info(
+            "cleanup-stuck: %d candidate batch(es) older than threshold=%r:",
+            matched,
+            threshold,
+        )
+        for row in candidates:
+            logger.info(
+                "  batch_id=%s started_at=%s run_lock_until=%s",
+                row["batch_id"],
+                row["started_at"],
+                row["run_lock_until"],
+            )
+    else:
+        logger.info("cleanup-stuck: no stuck batches matched threshold=%r.", threshold)
+
+    if not apply:
+        logger.info(
+            "cleanup-stuck: matched=%d marked_failed=0 (dry-run)",
+            matched,
+        )
+        return {"matched": matched, "marked_failed": 0, "batch_ids": batch_ids}
+
+    updated = db.execute(_CLEANUP_STUCK_UPDATE_SQL, {"threshold": threshold}, fetch=True)
+    marked_failed = len(updated or [])
+    logger.info(
+        "cleanup-stuck: matched=%d marked_failed=%d (applied)",
+        matched,
+        marked_failed,
+    )
+    return {"matched": matched, "marked_failed": marked_failed, "batch_ids": batch_ids}
+
+
 def main() -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -411,12 +544,42 @@ def main() -> int:
         action="store_true",
         help="Long-running mode; claim queued batches one at a time.",
     )
+    mode_group.add_argument(
+        "--cleanup-stuck",
+        action="store_true",
+        help=(
+            "Admin mode: scan for batches stuck in status='running' with "
+            "run_lock_until older than --stuck-threshold. Dry-run by default; "
+            "pass --apply to mark them failed."
+        ),
+    )
     parser.add_argument(
         "--poll-interval",
         type=int,
         default=10,
         metavar="SECONDS",
         help="Watch-mode sleep between claim attempts (default: 10).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="cleanup-stuck only: actually write the UPDATE (default: dry-run).",
+    )
+    parser.add_argument(
+        "--stuck-threshold",
+        default="1 hour",
+        metavar="INTERVAL",
+        help=(
+            "cleanup-stuck only: Postgres interval string for the stuck cutoff (default: '1 hour')."
+        ),
+    )
+    parser.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help=(
+            "cleanup-stuck only: permit --apply against a *.neon.tech "
+            "DATABASE_URL. Required to write to production."
+        ),
     )
     parser.add_argument(
         "--verbose",
@@ -456,6 +619,23 @@ def main() -> int:
             return 1
 
         run_one(db, batch_row)
+        return 0
+
+    if args.cleanup_stuck:
+        try:
+            result = cleanup_stuck_batches(
+                db,
+                threshold=args.stuck_threshold,
+                apply=args.apply,
+                allow_prod=args.allow_prod,
+                db_url=db_url,
+            )
+        except ProdGuardError as exc:
+            logger.error("%s", exc)
+            return 2
+        # Non-zero exit if apply requested but nothing was written and matches existed
+        # would be misleading; success means "ran cleanly". Caller reads the log line.
+        _ = result
         return 0
 
     # --watch mode

--- a/tests/integration/universe/test_onboarding_runner_integration.py
+++ b/tests/integration/universe/test_onboarding_runner_integration.py
@@ -22,7 +22,9 @@ import pytest
 from src.infra.db import DatabaseAdapter
 from src.universe.onboarding import Candidate, FilingEvent, RunSummary
 from src.universe.onboarding_runner import (
+    ProdGuardError,
     claim_batch,
+    cleanup_stuck_batches,
     run_one,
 )
 
@@ -335,3 +337,110 @@ class TestExpiredLock:
 
         row = claim_batch(db, uuid.UUID(batch_id))
         assert row is None, "Should not be able to claim a batch with an active lock"
+
+
+# ---------------------------------------------------------------------------
+# cleanup_stuck_batches: NS2 admin flag (legacy-062)
+# ---------------------------------------------------------------------------
+
+
+def _set_lock(db: DatabaseAdapter, batch_id: str, interval_sql: str) -> None:
+    """Force-set run_lock_until on a batch (interval is raw SQL, test-only)."""
+    db.execute(
+        f"UPDATE v2_ingest_batches SET run_lock_until = NOW() + ({interval_sql}) "
+        "WHERE batch_id = %s",
+        [batch_id],
+    )
+
+
+class TestCleanupStuckBatches:
+    def test_dry_run_identifies_stuck_rows_without_writing(
+        self, clean_batch_db: DatabaseAdapter
+    ) -> None:
+        db = clean_batch_db
+        batch_id = _insert_batch(db, status="running", total_filings=1)
+        _set_lock(db, batch_id, "INTERVAL '-2 hours'")
+
+        result = cleanup_stuck_batches(db, threshold="1 hour", apply=False)
+
+        assert result["matched"] == 1
+        assert result["marked_failed"] == 0
+        assert batch_id in result["batch_ids"]
+        row = _get_batch(db, batch_id)
+        assert row is not None
+        assert row["status"] == "running"
+        assert row["finished_at"] is None
+
+    def test_apply_marks_failed(self, clean_batch_db: DatabaseAdapter) -> None:
+        db = clean_batch_db
+        batch_id = _insert_batch(db, status="running", total_filings=1)
+        _set_lock(db, batch_id, "INTERVAL '-2 hours'")
+
+        result = cleanup_stuck_batches(db, threshold="1 hour", apply=True)
+
+        assert result["matched"] == 1
+        assert result["marked_failed"] == 1
+        row = _get_batch(db, batch_id)
+        assert row is not None
+        assert row["status"] == "failed"
+        assert row["finished_at"] is not None
+        assert row["run_lock_until"] is None
+
+    def test_threshold_honored(self, clean_batch_db: DatabaseAdapter) -> None:
+        db = clean_batch_db
+        batch_id = _insert_batch(db, status="running", total_filings=1)
+        _set_lock(db, batch_id, "INTERVAL '-30 minutes'")
+
+        result = cleanup_stuck_batches(db, threshold="1 hour", apply=False)
+
+        assert result["matched"] == 0
+        assert result["marked_failed"] == 0
+        row = _get_batch(db, batch_id)
+        assert row is not None
+        assert row["status"] == "running"
+
+    def test_live_watcher_not_flagged(self, clean_batch_db: DatabaseAdapter) -> None:
+        db = clean_batch_db
+        batch_id = _insert_batch(db, status="running", total_filings=1)
+        _set_lock(db, batch_id, "INTERVAL '5 minutes'")
+
+        result = cleanup_stuck_batches(db, threshold="1 hour", apply=True)
+
+        assert result["matched"] == 0
+        assert result["marked_failed"] == 0
+        row = _get_batch(db, batch_id)
+        assert row is not None
+        assert row["status"] == "running"
+
+    def test_prod_host_guard_refuses_apply(self, clean_batch_db: DatabaseAdapter) -> None:
+        db = clean_batch_db
+        batch_id = _insert_batch(db, status="running", total_filings=1)
+        _set_lock(db, batch_id, "INTERVAL '-2 hours'")
+
+        prod_url = "postgresql://user:pw@ep-foo-1234.us-east-2.aws.neon.tech/db"
+        with pytest.raises(ProdGuardError):
+            cleanup_stuck_batches(
+                db,
+                threshold="1 hour",
+                apply=True,
+                allow_prod=False,
+                db_url=prod_url,
+            )
+
+        # Confirm no write occurred.
+        row = _get_batch(db, batch_id)
+        assert row is not None
+        assert row["status"] == "running"
+
+        # Dry-run against the same prod URL is permitted.
+        result = cleanup_stuck_batches(
+            db, threshold="1 hour", apply=False, allow_prod=False, db_url=prod_url
+        )
+        assert result["matched"] == 1
+        assert result["marked_failed"] == 0
+
+        # --allow-prod permits the write.
+        result = cleanup_stuck_batches(
+            db, threshold="1 hour", apply=True, allow_prod=True, db_url=prod_url
+        )
+        assert result["marked_failed"] == 1


### PR DESCRIPTION
Adds NS2 of legacy-062: a `python3 -m src.universe.onboarding_runner --cleanup-stuck`
admin mode that scans v2_ingest_batches for rows still in status='running' whose
run_lock_until is older than --stuck-threshold (default '1 hour') and marks them
failed. Dry-run by default; --apply writes. A *.neon.tech DATABASE_URL refuses
--apply unless --allow-prod is also passed (production guard).

Also ships the NS3 trailer: the SIGTERM log line now points operators at the new
flag, and TICKER_ONBOARDING.md gains a "Cleaning up stuck batches" subsection that
shows dry-run-first then --apply, the threshold knob, and the prod guard.

Design call: mark-failed is the only mode. --watch already re-claims expired rows
automatically; --cleanup-stuck is the abandon path. A --reclaim mode is out of
scope for this PR.

Test coverage: 5 new integration tests under
tests/integration/universe/test_onboarding_runner_integration.py::TestCleanupStuckBatches
covering dry-run, apply, threshold honoring, live-watcher filtering, and the
prod-host guard.
