### PR TITLE
docs(known-issues): close gh-263 — fragment-only follow-up to PR #272

### DIFF
--- a/docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md
+++ b/docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md
@@ -3,7 +3,7 @@ id: 263
 source: gh
 slug: filing-fetcher-8k-exhibit-branch-duplication
 title: FilingFetcher.fetch_filing duplicates 8-K exhibit-99-1 logic across cold-fetch and cached-backfill branches
-status: open
+status: resolved
 severity: low
 autonomy: safe
 estimated: S
@@ -12,6 +12,8 @@ touches:
 discovered: '2026-04-27'
 updated: '2026-04-27'
 gh_issue: 263
+pr_refs:
+  - 272
 ---
 
 ### Problem
@@ -40,3 +42,17 @@ The day someone forgets one branch, we ship a half-fix: the cold-fetch path beha
 ### Out of scope
 
 This is a refactor, not a bug fix. Defer until someone is touching this code path for an unrelated reason — the duplication is a hazard, not a current breakage.
+
+### Resolution
+
+PR #272 (merged 2026-04-28) extracted `_maybe_append_exhibit_991`
+in `src/filing_fetcher/filing_fetcher.py` and routes both the
+cold-fetch and cached-backfill branches through it. Both legacy-058's
+`get_exhibit_99_1_url` fetch logic and legacy-115's PDF skip+warn
+guard now live in the helper, removing the matched-edits hazard
+this fragment flagged.
+
+The fragment was not flipped at PR #272 merge time because `pr_refs`
+was not set on the fragment in that PR — the same drift gh-258
+(PR #286) now warns against. This closure PR is the bookkeeping
+half.


### PR DESCRIPTION
## Summary

Fragment-only closure PR. PR #272 (refactor(filing-fetcher): extract `_maybe_append_exhibit_991` helper, closes #263) merged the actual refactor but did not set `pr_refs` on the gh-263 fragment, so the auto-closer could not flip it. This PR flips `status: open` → `resolved`, sets `pr_refs: [272]`, and appends a Resolution section.

This is exactly the drift gh-258 (PR #286) now warns against — PR #272 merged before that warning landed.

Follows the established fragment-only closure pattern (precedent: PRs #232–#234, #240).

## Changes

- `docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md`
  - `status: open` → `status: resolved`
  - Added `pr_refs: [272]` (integer, per validator)
  - Appended `### Resolution` section pointing to PR #272

## Test plan

- [x] No code changes — docs-only.
- [x] `git diff --name-only origin/main..HEAD` shows only the one fragment file.
- [x] Pre-commit known-issue fragment validator passed.
- [x] gh-258 warning did NOT fire (because `pr_refs` is now correctly set on a `resolved` fragment) — confirmed in commit hook output.