### PR TITLE
feat(render): multi-stage Dockerfile for filings-reviewer + nightly-sweep

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -58,6 +58,17 @@ Region is pinned so blueprint re-deploys do not scatter services across regions.
 
 `filings-reviewer` declares `healthCheckPath: /health` in `render.yaml`. The endpoint is registered in `src/web/app.py::_register_health_check`, requires no auth, and returns 200 when the DB pool is reachable, 503 otherwise. Render uses it to flip traffic to the new container the moment the app is live (vs. waiting on TCP-probe heuristics) and to abort a deploy whose container never reports healthy. Transient 503s during pool init are tolerated by Render's retry window.
 
+### Multi-stage Dockerfile shape
+
+Both `Dockerfile` and `Dockerfile.nightly-sweep` are multi-stage builds:
+
+- **builder** (`python:3.11-slim`) installs `gcc` + `libpq-dev` and runs `pip install -r requirements.lock` into `/opt/venv`.
+- **runtime** (`python:3.11-slim`) installs only `libpq5` (the runtime shared library psycopg links against), copies `/opt/venv` from the builder, and adds the application source. The `gcc`/`libpq-dev` headers and pip's intermediate cache do not ship.
+
+Net effect on Render: smaller cached layers → faster pull from the build cache, faster image pull on the runtime VM, and faster cold-start. The builder/runtime stages share an identical Python base so wheels compiled against builder glibc remain ABI-compatible with runtime.
+
+The nightly-sweep image's runtime stage additionally pulls in `git`, `curl`, `ca-certificates` and the pinned `gh` and `claude` CLI binaries — those tools are invoked by `scripts/run_nightly_sweep.sh` at run time and must live in the runtime stage, not the builder.
+
 ## DATABASE_URL vs TEST_DATABASE_URL — IMPORTANT
 
 **In this project's `.env`, `DATABASE_URL` points at the Neon prod database, NOT local Postgres.** The local Docker Postgres is addressed by `TEST_DATABASE_URL`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,46 @@
 # syntax=docker/dockerfile:1
-
-# SEC Filings Analysis Pipeline
-# This container runs batch extraction scripts and tests for analyzing S-1/F-1 filings.
+#
+# Multi-stage build:
+#   - builder: installs gcc + libpq-dev so psycopg etc. can compile wheels,
+#     then puts everything into /opt/venv.
+#   - runtime: installs only libpq5 (the runtime shared library) and copies
+#     the venv from the builder. ~250 MB of build toolchain stays out of
+#     the final image, which speeds Render's image pull on every deploy.
 
 ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION}-slim AS base
 
-# Prevents Python from writing pyc files.
-ENV PYTHONDONTWRITEBYTECODE=1
+# ---------- builder ----------
+FROM python:${PYTHON_VERSION}-slim AS builder
 
-# Keeps Python from buffering stdout and stderr to avoid situations where
-# the application crashes without emitting any logs due to buffering.
-ENV PYTHONUNBUFFERED=1
-
-# Set the Python path to include src directory
-ENV PYTHONPATH=/app
-
-WORKDIR /app
-
-# Install system dependencies for psycopg and other packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a non-privileged user that the app will run under.
-# See https://docs.docker.com/go/dockerfile-user-best-practices/
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.lock,target=requirements.lock \
+    pip install -r requirements.lock
+
+# ---------- runtime ----------
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    PATH="/opt/venv/bin:${PATH}"
+
+# libpq5 is the runtime shared library that psycopg links against.
+# libpq-dev (with headers) is only needed at build time and stays in the
+# builder stage.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
 ARG UID=10001
 RUN adduser \
     --disabled-password \
@@ -35,12 +50,7 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
-# Download dependencies as a separate step to take advantage of Docker's caching.
-# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
-# Install from pinned lockfile for reproducible production builds.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,source=requirements.lock,target=requirements.lock \
-    python -m pip install -r requirements.lock
+COPY --from=builder /opt/venv /opt/venv
 
 # Copy only the dirs read at runtime. Keeping this list explicit prevents
 # unrelated tree changes (docs, tests, .claude/) from busting the layer cache.
@@ -49,18 +59,11 @@ COPY --chown=appuser:appuser scripts/ ./scripts/
 COPY --chown=appuser:appuser sql/ ./sql/
 COPY --chown=appuser:appuser config/ ./config/
 
-# Create directories for logs, data, and coverage with proper permissions
 RUN mkdir -p /app/logs /app/data /app/filings_cache /app/htmlcov && \
     touch /app/.coverage && \
     chown -R appuser:appuser /app/logs /app/data /app/filings_cache /app/htmlcov /app/.coverage
 
-# Switch to the non-privileged user to run the application.
 USER appuser
 
-# Default command starts the production web server.
 # PORT env var is set by Render; falls back to 8080 locally.
-# Examples:
-#   docker run -e DATABASE_URL=... -e SECRET_KEY=... filings-reviewer  # Start server
-#   docker run filings-reviewer python -m pytest tests/unit/            # Run tests
-#   docker run -it filings-reviewer bash                                # Interactive shell
 CMD python3 scripts/run_review_server.py --host 0.0.0.0 --port ${PORT:-8080}

--- a/Dockerfile.nightly-sweep
+++ b/Dockerfile.nightly-sweep
@@ -5,9 +5,12 @@
 # Differences vs. the main Dockerfile:
 #   - Adds the Claude Code CLI (`claude`) and GitHub CLI (`gh`) — both PINNED
 #     to specific versions so Render rebuilds are reproducible.
-#   - Installs git (the base `python:slim` image lacks it)
+#   - Installs git (the base `python:slim` image lacks it).
 #   - Keeps the same Python + pip layer so /commit's `pytest -x -q` can run
 #     inside worktrees.
+#
+# Multi-stage shape mirrors the main Dockerfile: builder compiles wheels into
+# /opt/venv, runtime drops the build toolchain and keeps only libpq5.
 #
 # Entrypoint is the orchestrator shell script; the Render cron service
 # overrides with its own command if needed.
@@ -17,24 +20,45 @@
 #   claude: update CLAUDE_VERSION below (check https://github.com/anthropics/claude-code/releases)
 
 ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION}-slim AS base
 
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/app
+# ---------- builder ----------
+FROM python:${PYTHON_VERSION}-slim AS builder
+
 ENV DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# System deps: git (for worktrees + push), curl (to fetch CLIs), build deps
-# for psycopg/cffi wheels that the repo pulls in via requirements.lock.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.lock,target=requirements.lock \
+    pip install -r requirements.lock
+
+# ---------- runtime ----------
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    DEBIAN_FRONTEND=noninteractive \
+    PATH="/home/appuser/.local/bin:/opt/venv/bin:${PATH}"
+
+# Runtime system deps:
+#   libpq5    — psycopg's runtime shared library (matches main Dockerfile).
+#   git, curl — needed by the sweeper for worktree checkout + CLI installs.
+#   ca-certificates — for HTTPS to GitHub Releases.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
-    gcc \
-    libpq-dev \
+    libpq5 \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 # GitHub CLI (gh) — pinned to a specific release via the official .deb from
 # GitHub Releases. Bypasses the apt repo entirely so the version is explicit.
@@ -54,12 +78,8 @@ ARG UID=10001
 RUN adduser --disabled-password --gecos "" \
         --home "/home/appuser" --shell "/bin/bash" --uid "${UID}" appuser
 
-# Python dependencies — same lockfile as the main image so pytest works inside
-# sweep worktrees without a separate install step. Installed as root into the
-# system site-packages so both root and appuser can import them.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,source=requirements.lock,target=requirements.lock \
-    python -m pip install -r requirements.lock
+# Pull the venv (with all Python deps) from the builder stage.
+COPY --from=builder /opt/venv /opt/venv
 
 # Claude Code CLI — pinned to a specific release via the versioned tarball on
 # GitHub Releases (https://github.com/anthropics/claude-code/releases).
@@ -68,7 +88,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # fetch the binary directly instead.
 # Architecture is detected at build time; dpkg's "amd64" is mapped to claude's
 # "x64" naming convention. arm64 stays "arm64" in both.
-# Binary lands at /home/appuser/.local/bin/claude; PATH is prepended below so
+# Binary lands at /home/appuser/.local/bin/claude; PATH is prepended above so
 # `scripts/run_nightly_sweep.sh` (runs as appuser) can resolve it.
 #
 # SHA-256 verification: hashes are taken from the published SHASUMS256.txt at
@@ -81,7 +101,6 @@ ARG CLAUDE_VERSION=2.1.119
 ARG CLAUDE_SHA256_X64=0fb5e308c067783997937cef72d020948a863c3838b22251947a110f696d47e8
 # SHA-256 of claude-linux-arm64.tar.gz for v2.1.119 (from SHASUMS256.txt)
 ARG CLAUDE_SHA256_ARM64=866de49f3a308d3f199772f22df3c2b262ee0350353127e0b0d82e86dfd28503
-ENV PATH="/home/appuser/.local/bin:${PATH}"
 RUN ARCH=$(dpkg --print-architecture) \
     && CLAUDE_ARCH=$([ "$ARCH" = "amd64" ] && echo "x64" || echo "$ARCH") \
     && CLAUDE_SHA256=$([ "$ARCH" = "amd64" ] && echo "${CLAUDE_SHA256_X64}" || echo "${CLAUDE_SHA256_ARM64}") \


### PR DESCRIPTION
Splits both Dockerfiles into builder/runtime stages so the build toolchain
(gcc, libpq-dev headers, transient pip cache) stays out of the final image.
Runtime stages install only libpq5 (the shared library psycopg links
against) and copy the prepared /opt/venv from the builder.

Local build: main image 1.59 GB -> 1.38 GB. Verified:
- /health returns 200 against a real DB
- import src.web; psycopg 3.3.3
- batch_v2_extraction --help, onboarding_runner --help, apply_migrations --help
- nightly-sweep image: claude 2.1.119, gh 2.91.0, git, psycopg all resolve

On Render the visible deploy phases that scale with image size are: cache
download (12s), cached layer extraction (15.5s on the 265 MB pip layer),
pre-deploy container boot (4.8s), and deploy container boot (6.7s). PR1
addressed build-context bloat; this PR addresses the runtime layer.

PR2 of the deploy-speed plan. PR3 (GHCR base image) remains deferred.
