### PR TITLE
docs(known-issues): close gh-280 stale fragment (sentinel-row already shipped in #284)

### DIFF
--- a/docs/known-issues/gh-280-image-level-rejection-signal-ml-training.md
+++ b/docs/known-issues/gh-280-image-level-rejection-signal-ml-training.md
@@ -3,9 +3,9 @@ id: 280
 source: gh
 slug: image-level-rejection-signal-ml-training
 title: Image-level rejection signal for ML training (zero-detected-metric images leave no row)
-status: open
+status: resolved
 severity: medium
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches: []
 discovered: 2026-04-28
@@ -23,3 +23,16 @@ When a reviewer dismisses an image with zero detected metrics via "Reject all (n
 - Decide between (a) adding `decision='reject_image'` enum value with `detected_metric_id=NULL` written for every "Reject all" press, or (b) splitting `review_status='skipped'` into `skipped_rejected` / `skipped_parked`.
 - Update the "Reject all" handler to write the new signal in addition to `/skip`.
 - Plan backfill for historical `skipped` rows where intent is recoverable (presence of per-metric reject rows ⇒ `skipped_rejected`).
+
+### Resolution
+
+Discovered already-fixed during /pick-issues triage. The sentinel-row write was implemented in commit `d855f8e` (PR #284, "feat(review-ui): visible 'no relevant metrics' rejection on image review").
+
+End-to-end path as verified:
+
+- **JS** (`src/web/static/js/review_images_v2.js:856-910`): when `state.detectedMetrics.length === 0`, `rejectAllUnreviewed()` composes `decisions = [{detected_metric_id: null, confirmed_metric_id: null, decision: 'reject', rejection_reason: 'no_relevant_metrics'}]` and POSTs to `/api/v2/image-metric-confirmations`.
+- **API** (`src/web/routes/api_unified.py:685-690`): the `decision == "reject"` validator allows `detected_metric_id=None` only when `rejection_reason == "no_relevant_metrics"` — exactly the sentinel case.
+- **DB** (`src/infra/db.py:2281-2325`): `insert_image_metric_confirmations` upserts with conflict key `COALESCE(detected_metric_id, confirmed_metric_id, '')`, admitting one sentinel row per `(img_id, reviewer_id)`.
+- **`_promote_chart_fact`** (`src/infra/db.py:2368`): early-returns on `if not metric_id`, so sentinel rows never spuriously promote a fact row.
+
+The behavior is authoritatively documented in `CLAUDE.md` Core Design Principles §4. The fragment's described gap was already closed before this issue was filed; this PR closes the tracking fragment.


### PR DESCRIPTION
## Summary

- Flips `gh-280-image-level-rejection-signal-ml-training.md` from `status: open` to `status: resolved`
- Changes `autonomy: skip` to `autonomy: n/a`
- Appends a `### Resolution` section tracing the full implementation path that was already shipped in PR #284

## Verification

The fragment's stated gap ("zero-detected-metric 'Reject all' leaves no row") was already resolved by commit `d855f8e` (PR #284). Code trace confirmed end-to-end:

1. `review_images_v2.js:868-874` — zero-detected-metrics branch constructs sentinel `{detected_metric_id: null, confirmed_metric_id: null, decision: 'reject', rejection_reason: 'no_relevant_metrics'}` and POSTs to `/api/v2/image-metric-confirmations`
2. `api_unified.py:685-690` — validator allows `detected_metric_id=None` only when `rejection_reason == 'no_relevant_metrics'` (all other null-id rejects return HTTP 400)
3. `db.py:2281-2325` — `insert_image_metric_confirmations` upserts with conflict key `COALESCE(detected_metric_id, confirmed_metric_id, '')`, admitting one sentinel row per `(img_id, reviewer_id)`
4. `db.py:2368` — `_promote_chart_fact` early-returns on `if not metric_id`, so sentinel rows never spuriously promote a fact row

Behavior is documented in `CLAUDE.md` Core Design Principles §4.

## Test plan

- [x] Pre-commit hooks: all passed (fragment frontmatter validator, YAML, docs guard)
- [x] Pre-push unit tests: passed
- Docs-only PR — no code changes, no new tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)