### PR TITLE
test(ui): image-queue cross-filing auto-advance E2E (closes legacy-075)

### DIFF
--- a/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
+++ b/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
@@ -6,6 +6,7 @@ id: 75
 note: Text-queue variant landed in PR #178; image-queue variant landed in follow-up PR
 pr_refs:
   - 178
+  - 309
 severity: low
 slug: missing-playwright-e2e-for-cross-filing-auto-advance
 source: legacy

--- a/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
+++ b/docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md
@@ -1,15 +1,15 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-21'
 estimated: S
 id: 75
-note: Text-queue variant landed in PR #178; image-queue variant remains open
+note: Text-queue variant landed in PR #178; image-queue variant landed in follow-up PR
 pr_refs:
   - 178
 severity: low
 slug: missing-playwright-e2e-for-cross-filing-auto-advance
 source: legacy
-status: partially-resolved
+status: resolved
 title: Missing Playwright E2E for image-queue cross-filing auto-advance
 touches:
 - tests/ui/*.spec.js
@@ -29,7 +29,12 @@ PR #178 (commit `ecc8b30`, 2026-04-24) added `tests/ui/review.spec.js` test 19 (
 
 The image-queue completion variant is still missing. `tests/ui/review.spec.js:1136` carries an explicit `// Image-queue completion variant deferred` stub. Implementing it requires extending the stub-server XHR catch-all in `tests/ui/test_server.py` to handle the image confirmation endpoints; PR #178's scope cut left this undone.
 
-### Next steps
+### Resolution (image-queue variant)
 
-- Implement the image-queue variant: seed two filings with pending image confirmations, confirm the last image in filing A (relevant → non-relevant → skip), and assert the browser lands on filing B preserving sort order.
-- Extend the stub-server XHR catch-all in `tests/ui/test_server.py` to handle the `/api/v2/image-confirmation/*` endpoints.
+The image-queue variant landed as test 19 ("image-queue completion navigates to next filing") in `tests/ui/review.spec.js`. Implementation differed slightly from the original "Next steps" sketch:
+
+- The test mirrors the text-queue test pattern by intercepting the API call (`/api/v2/image-candidates/*/skip`) via `page.route` rather than extending the stub server's XHR catch-all. The fixture routes `/filing-a-images-last-pending` and `/filing-b-images-pending` (and their template-vars helpers `_cross_filing_template_vars_a_images` / `_cross_filing_template_vars_b_images`) were already in place from a prior preparatory PR.
+- The `relevant → non-relevant → skip` sequence in the original sketch was reduced to a single `#btn-skip` click, which is the simplest reliable trigger of `navigateAfterQueueEmpty()` from the images tab. The "Reject all (no relevant metrics)" affordance has its own coverage; this test specifically exercises the queue-empty cross-filing branch in `submitSkip` → `navigateAfterQueueEmpty` → `window.location.href = NEXT_FILING_URL`.
+- Init-time XHR (`/api/v2/metrics/list`) is already stubbed in `test_server.py` (added since the deferral comment was written), so `page.goto` no longer hangs on `load`.
+
+The earlier deferral comment at `tests/ui/review.spec.js:1137` is removed.

--- a/tests/ui/review.spec.js
+++ b/tests/ui/review.spec.js
@@ -1134,8 +1134,44 @@ test.describe('Cross-Filing Auto-Advance', () => {
     await expect(page.locator('h4.mb-0')).toContainText('Acme Corp B');
   });
 
-  // Image-queue completion variant deferred — the images tab's init JS fires an
-  // XHR that is not routed by the stub server, causing page.goto to hang on
-  // the `load` event. Tracked as a follow-up to #75; re-enable once the
-  // stub-server XHR catch-all lands.
+  test('image-queue completion navigates to next filing', async ({ page }) => {
+    // Intercept the image-skip API to return no next_candidate (queue exhausted).
+    // submitSkip() in review_images_v2.js then calls navigateAfterQueueEmpty(),
+    // which (since TEXT_PENDING=0 on the fixture) shows a toast and navigates
+    // to NEXT_FILING_URL = /filing-b-images-pending after a 1500ms delay.
+    await page.route('**/api/v2/image-candidates/*/skip*', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            status: 'success',
+            skipped_img_id: 'img-a-last-20',
+            next_candidate: null,
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Filing A images tab: one pending image, image_pending=1, text pending=0,
+    // next_filing_url=/filing-b-images-pending.
+    await page.goto('/filing-a-images-last-pending');
+
+    // Verify we're on filing A
+    await expect(page.locator('h4.mb-0')).toContainText('Acme Corp');
+    await expect(page.locator('h4.mb-0')).not.toContainText('Acme Corp B');
+
+    // Skip the last pending image — should trigger auto-advance to next filing
+    await page.locator('#btn-skip').click();
+
+    // Wait for navigation to filing B (JS waits 1500ms toast then navigates to
+    // NEXT_FILING_URL = /filing-b-images-pending).
+    await page.waitForURL('**/filing-b-images-pending', { timeout: 10000 });
+
+    // Assert we landed on filing B
+    expect(page.url()).toContain('/filing-b-images-pending');
+    await expect(page.locator('h4.mb-0')).toContainText('Acme Corp B');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds the deferred image-queue variant of the cross-filing auto-advance Playwright test (text-queue variant landed in PR #178)
- Mirrors the text-queue test pattern by intercepting `/api/v2/image-candidates/*/skip` via `page.route` and asserting browser navigates from filing A to filing B via `NEXT_FILING_URL`
- Flips `legacy-075` fragment from `partially-resolved` to `resolved`

## Why this implementation differs slightly from the original "Next steps"

- The fragment's "Next steps" sketched `relevant → non-relevant → skip` against the stub server's XHR catch-all. In practice the `relevant/non-relevant` flow has its own coverage — the queue-empty branch in `submitSkip` → `navigateAfterQueueEmpty` is what this test specifically targets, and a single `#btn-skip` click is the simplest reliable trigger.
- The fixture routes (`/filing-a-images-last-pending`, `/filing-b-images-pending`) and template-vars helpers were already in place from a prior preparatory PR, so no `test_server.py` changes were needed.
- The init-time XHR (`/api/v2/metrics/list`) that originally caused `page.goto` to hang is already stubbed in `test_server.py`, so the deferral comment's premise no longer holds.
- Used `page.route` interception (matching the text-queue test) rather than extending the stub server — smaller diff, lower regression surface.

## Test plan

- [x] New test passes in isolation: `npx playwright test review.spec.js -g "image-queue completion"` (1 passed, 4.4s)
- [x] Full review.spec.js suite passes: 137/137 in 53.9s
- [x] Pre-push pytest unit tests passed
- [x] Pre-commit hooks passed (frontmatter validator + docs guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)