### PR TITLE
fix(review-ui): consolidate image-tab typeahead onto server-rendered datalist (closes gh-291)

### DIFF
--- a/docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md
+++ b/docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md
@@ -3,15 +3,15 @@ id: 291
 source: gh
 slug: image-tab-typeahead-consolidate-datalist
 title: Drop redundant /api/v2/metrics/list AJAX from image-tab typeahead
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches: []
 discovered: 2026-04-28
 updated: 2026-04-28
 gh_issue: 291
-note: Point image-tab metric inputs at server-rendered all-metrics-datalist; drop loadMetricsList JS and the now-unused detected-metrics-datalist.
+note: Image-tab metric inputs now point at the server-rendered all-metrics-datalist; loadMetricsList JS and detected-metrics-datalist removed.
 ---
 
 ### Problem
@@ -25,12 +25,13 @@ in `src/web/templates/unified_review.html` use
 round-trip causes a brief flicker and adds a silent failure mode where a
 JS error in `init()` leaves the datalist empty.
 
-### Next Steps
+### Resolution
 
-- `unified_review.html`: switch `list="detected-metrics-datalist"` ->
-  `"all-metrics-datalist"` on the two inputs; delete the empty
-  `<datalist id="detected-metrics-datalist">`.
-- `review_images_v2.js`: remove `DATALIST_ID`, `loadMetricsList()`,
-  `populateDatalist()`, the call from `init()`, and the unused
-  `state.metricsList` field.
-- Leave `/api/v2/metrics/list` in place — referenced by integration / UI tests.
+Both image-tab inputs now reference `all-metrics-datalist`, the empty
+`<datalist id="detected-metrics-datalist">` element is removed, and the
+JS `DATALIST_ID` constant, `loadMetricsList()` / `populateDatalist()`
+functions, the `loadMetricsList()` call in `init()`, and the unused
+`state.metricsList` field are deleted. `/api/v2/metrics/list` is left in
+place per the original plan (still referenced by integration / UI tests
+and by the bulk image-tagging script). UI suite (137/137) and web unit
+tests (158/158) pass on the resulting branch.

--- a/docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md
+++ b/docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md
@@ -12,6 +12,8 @@ discovered: 2026-04-28
 updated: 2026-04-28
 gh_issue: 291
 note: Image-tab metric inputs now point at the server-rendered all-metrics-datalist; loadMetricsList JS and detected-metrics-datalist removed.
+pr_refs:
+  - 310
 ---
 
 ### Problem

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -315,7 +315,6 @@
 
     const CARD_ID = 'detected-metrics-card';
     const ROW_SELECTOR = '.detected-metric-row';
-    const DATALIST_ID = 'detected-metrics-datalist';
 
     const state = {
         imgId: null,
@@ -324,7 +323,6 @@
         confirmationIds: {}, // same keys, maps → server-assigned confirmation id
         submitting: false,
         focusedRow: null,
-        metricsList: [],
         imageStatus: 'all',
         textPending: 0,
         nextFilingUrl: null,
@@ -355,7 +353,6 @@
             console.warn('Failed to parse confirmations:', e);
         }
 
-        loadMetricsList();
         applyInitialDecisionState();
         bindCardEvents(card);
         document.addEventListener('keydown', handleRowKeydown, true);
@@ -385,37 +382,6 @@
 
     function addKey(metricId) {
         return `__add__${metricId}`;
-    }
-
-    async function loadMetricsList() {
-        try {
-            const resp = await fetch('/api/v2/metrics/list', {
-                headers: { 'Accept': 'application/json' },
-            });
-            if (!resp.ok) return;
-            const data = await resp.json();
-            if (Array.isArray(data)) {
-                state.metricsList = data;
-                populateDatalist(data);
-            }
-        } catch (err) {
-            console.warn('Failed to load metrics list:', err);
-        }
-    }
-
-    function populateDatalist(metrics) {
-        const dl = document.getElementById(DATALIST_ID);
-        if (!dl) return;
-        dl.innerHTML = '';
-        metrics.forEach(m => {
-            const opt = document.createElement('option');
-            opt.value = m.metric_id;
-            if (m.display_name && m.display_name !== m.metric_id) {
-                opt.label = m.display_name;
-                opt.textContent = m.display_name;
-            }
-            dl.appendChild(opt);
-        });
     }
 
     function applyInitialDecisionState() {

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -970,7 +970,7 @@
                     <label class="form-label small mb-1">Correct to</label>
                     <input type="text"
                            class="form-control form-control-sm metric-correct-input"
-                           list="detected-metrics-datalist"
+                           list="all-metrics-datalist"
                            placeholder="Search metrics…">
                   </div>
                   <div class="metric-state-indicator small mt-1 text-muted"
@@ -988,7 +988,7 @@
                   <input type="text"
                          id="add-missed-detected-input"
                          class="form-control form-control-sm"
-                         list="detected-metrics-datalist"
+                         list="all-metrics-datalist"
                          placeholder="Search metrics…">
                   <button type="button" class="btn btn-outline-primary btn-sm mt-2"
                           id="btn-add-missed-detected-confirm">
@@ -1004,7 +1004,6 @@
               </div>
             </div>
           </div>
-          <datalist id="detected-metrics-datalist"></datalist>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Image-tab inputs `add-missed-detected-input` and `metric-correct-input` now reference the server-rendered `<datalist id="all-metrics-datalist">` that already exists for the text tab
- Removes the runtime `fetch('/api/v2/metrics/list')` from `loadMetricsList()` and the empty `detected-metrics-datalist` it populated
- `/api/v2/metrics/list` route stays in place — still referenced by integration / UI tests and by the bulk image-tagging script

## Changes

**`src/web/templates/unified_review.html`**
- Two `list="..."` attribute swaps (`detected-metrics-datalist` → `all-metrics-datalist`)
- Deletion of the empty `<datalist id="detected-metrics-datalist"></datalist>` element

**`src/web/static/js/review_images_v2.js`**
- Removes `DATALIST_ID`, `loadMetricsList()`, `populateDatalist()`, the `loadMetricsList()` call in `init()`, and the unused `state.metricsList` field

**`docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md`**
- Status flipped `open` → `resolved`, `autonomy: skip` → `n/a`, Resolution section appended

## Why

Eliminates a brief flicker on the image tab and a silent failure mode (JS error in `init()` leaves the datalist empty). Server-rendered datalist has the same content and zero runtime cost.

## Test plan

- [x] UI suite passes: `npx playwright test review.spec.js` — 137/137 in 57.7s
- [x] Web unit tests pass: `pytest tests/unit/web/` — 158/158 in 2.16s
- [x] No remaining references to deleted symbols (`detected-metrics-datalist`, `DATALIST_ID`, `loadMetricsList`, `populateDatalist`, `state.metricsList`) in `src/` or `tests/`
- [x] Pre-commit and pre-push hooks passed

## Coordination check

`gh-293` (#302) and `gh-294` (#297) — the two PRs that were in flight on these same UI files at draft time — both merged earlier today. No race risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)