### PR TITLE
fix(scripts): rewrite stale OneDrive html_storage_path values (closes gh-299)

### DIFF
--- a/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
+++ b/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
@@ -11,7 +11,8 @@ touches: []
 discovered: '2026-04-28'
 updated: '2026-04-28'
 gh_issue: 299
-pr_refs: []
+pr_refs:
+  - 311
 note: 'Migration script rewrote 13 prod rows from /Users/.../OneDrive-CMASB/... paths to worktree-relative form and populated html_content from disk; superseded by gh-300 (R2 storage migration).'
 ---
 

--- a/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
+++ b/docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md
@@ -3,7 +3,7 @@ id: 299
 source: gh
 slug: stale-onedrive-paths-in-html-storage
 title: Stale OneDrive paths in filings.html_storage_path block re-extraction
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: —
@@ -11,7 +11,8 @@ touches: []
 discovered: '2026-04-28'
 updated: '2026-04-28'
 gh_issue: 299
-note: '5 known filings (and likely more corpus-wide) carry html_storage_path values under /Users/.../OneDrive-CMASB/... with NULL html_content; ingestion times out when files are not hydrated.'
+pr_refs: []
+note: 'Migration script rewrote 13 prod rows from /Users/.../OneDrive-CMASB/... paths to worktree-relative form and populated html_content from disk; superseded by gh-300 (R2 storage migration).'
 ---
 
 ### Problem
@@ -23,3 +24,13 @@ note: '5 known filings (and likely more corpus-wide) carry html_storage_path val
 - Audit `filings` for `html_storage_path LIKE '/Users/%/OneDrive-CMASB/%'`. Count + report scope.
 - Migration script to rewrite paths to the worktree-relative form, verifying each rewritten path resolves to a real file. Fall back to `sec_html_url` fetch for missing files.
 - Optionally populate `html_content` from disk so re-extraction does not depend on file paths.
+
+### Resolution
+
+Shipped `scripts/migrate_onedrive_html_paths.py` (CLI with `--dry-run`/`--apply`/`--allow-prod` plus `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` env gate, mirroring `scripts/relink_paypal_r2_keys.py`). Audit found **13** affected rows (broader than the fragment's 5 — also Chewy, Farfetch, Flywire, GitLab, Kingsoft, Samsara Vision, Snowflake, Tenable). All 13 had local canonical copies in `data/gold_standard/<Company>/filing.html` (1.9–5.3 MB each); the SEC re-fetch fallback path was not exercised.
+
+Prod migration ran 2026-04-28 against Neon: **audited=13, rewritten=13, fetched_from_sec=0, failed=0**. Each row's `html_storage_path` was rewritten to the worktree-relative form (`data/gold_standard/<Company>/filing.html`) and `html_content` populated from disk in a per-filing transaction. Verified `SELECT COUNT(*) ... LIKE '/Users/%/OneDrive-CMASB/%'` = 0 post-apply.
+
+Recovery procedure documented at `docs/operations/extraction-runbook.md` ("Recovering filings with stale storage paths"). Tests at `tests/integration/test_migrate_onedrive_html_paths.py` cover dry-run, disk-apply, SEC fallback, both prod-host guards, and idempotency.
+
+This is a tactical fix; gh-300 will replace `html_storage_path` semantics with R2 storage keys, superseding the worktree-relative path format shipped here.

--- a/docs/operations/extraction-runbook.md
+++ b/docs/operations/extraction-runbook.md
@@ -272,3 +272,51 @@ GROUP BY f.filing_id, c.company_name;
 - When loading filings, prefer the final S-1/A or F-1/A amendment (most complete disclosure)
 - The `resolve_primary_document_url()` now correctly excludes exhibit files from pattern matching
 - Verify SEC filing URLs resolve correctly before committing filing data
+
+---
+
+## Recovering filings with stale storage paths
+
+A small number of filings (gh-299) carry `html_storage_path` values pointing
+at `/Users/.../OneDrive-CMASB/...` paths that no longer hydrate reliably,
+with NULL `html_content`. Re-extraction of these rows fails with
+`HTML not found on disk and not in DB` (`scripts/batch_v2_extraction.py:256`).
+Use `scripts/migrate_onedrive_html_paths.py` to rewrite the path to the
+worktree-relative form and populate `html_content` from the canonical local
+copy (or re-fetch from SEC if the local file is missing).
+
+### Audit (read-only)
+
+```bash
+psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM filings WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%';"
+```
+
+### Dry-run
+
+```bash
+python3 scripts/migrate_onedrive_html_paths.py
+```
+
+Reports the rows that would be rewritten without making any changes.
+
+### Apply
+
+```bash
+# Local DB
+DATABASE_URL="$TEST_DATABASE_URL" python3 scripts/migrate_onedrive_html_paths.py --apply
+
+# Prod (Neon) — requires both --allow-prod and FILINGS_REVIEWER_ALLOW_PROD_WRITES=1
+FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 \
+  python3 scripts/migrate_onedrive_html_paths.py --apply --allow-prod
+```
+
+### Verify
+
+```bash
+psql "$DATABASE_URL" -c "SELECT COUNT(*) FROM filings WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%';"
+# Expected: 0
+```
+
+> **Note (gh-300):** This is a tactical fix. gh-300 will replace
+> `html_storage_path` semantics with R2 storage keys, superseding this
+> migration's worktree-relative path format.

--- a/scripts/migrate_onedrive_html_paths.py
+++ b/scripts/migrate_onedrive_html_paths.py
@@ -1,0 +1,328 @@
+"""
+Rewrite stale ``filings.html_storage_path`` values that point at OneDrive
+cloud-only paths and populate ``html_content`` from the canonical local copy
+(or via SEC re-fetch when the local file is missing). Tactical fix for gh-299;
+gh-300 will replace ``html_storage_path`` semantics with R2 storage keys.
+
+Selector:
+
+    SELECT filing_id, html_storage_path, sec_html_url FROM filings
+     WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%'
+
+For each matching row:
+
+  1. Strip the OneDrive prefix to derive the worktree-relative path
+     (e.g. ``data/gold_standard/<Company>/filing.html``).
+  2. If the local file resolves and is > 15 KB: read it, then UPDATE both
+     ``html_storage_path`` (relative form) and ``html_content``.
+  3. Otherwise, if ``sec_html_url`` is set: re-fetch via the existing
+     SEC client (rate-limited), validate size > 15 KB, then UPDATE.
+  4. Otherwise: log an error and leave the row unchanged.
+
+Gates (mirrors ``scripts/relink_paypal_r2_keys.py``):
+
+  - ``--apply``: required for any DB write.
+  - ``FILINGS_REVIEWER_ALLOW_PROD_WRITES=1``: required when ``DATABASE_URL``
+    points at prod (``*.neon.tech``), AND ``--allow-prod`` must be passed.
+
+Usage::
+
+    # Dry-run (default, read-only)
+    python3 scripts/migrate_onedrive_html_paths.py
+
+    # Apply against local Docker
+    DATABASE_URL="$TEST_DATABASE_URL" \\
+      python3 scripts/migrate_onedrive_html_paths.py --apply
+
+    # Apply against prod (requires explicit user confirmation per CLAUDE.md)
+    FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 \\
+      python3 scripts/migrate_onedrive_html_paths.py --apply --allow-prod
+
+Exit codes:
+    0  dry-run completed OR apply succeeded
+    1  setup error / refusal
+    2  partial failure (some rows could not be updated)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from src.infra.db import DatabaseAdapter  # noqa: E402
+from src.infra.logging_config import configure_logging  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+_MIN_HTML_BYTES = 15_000  # per feedback_zero_facts_can_be_pre_pipeline_failure
+_ONEDRIVE_PREFIX_RE = re.compile(r"^/Users/[^/]+/.*?OneDrive-CMASB/.*?/filings_reviewer/")
+
+
+def _looks_like_prod(db_url: str) -> bool:
+    return ".neon.tech" in db_url
+
+
+def _derive_relative_path(onedrive_path: str) -> str | None:
+    """Strip the OneDrive prefix; return the worktree-relative path or None."""
+    match = _ONEDRIVE_PREFIX_RE.match(onedrive_path)
+    if not match:
+        return None
+    return onedrive_path[match.end() :]
+
+
+def _fetch_via_sec(sec_url: str, user_agent: str) -> str | None:
+    """Re-fetch HTML via SEC, rate-limited. Returns text on success > 15 KB."""
+    from src.infra.sec_client import SECClient  # local import to keep module light
+
+    client = SECClient(user_agent=user_agent)
+    client._rate_limit()
+    resp = client.session.get(sec_url, timeout=30)
+    resp.raise_for_status()
+    text = resp.text
+    if len(text) < _MIN_HTML_BYTES:
+        logger.warning(
+            "SEC re-fetch returned %d bytes (< %d minimum); treating as failure: %s",
+            len(text),
+            _MIN_HTML_BYTES,
+            sec_url,
+        )
+        return None
+    return text
+
+
+def _process_row(
+    row: dict,
+    *,
+    apply: bool,
+    sec_user_agent: str,
+    project_root: Path,
+) -> str:
+    """Returns one of: 'rewritten', 'fetched_from_sec', 'failed'."""
+    filing_id = row["filing_id"]
+    onedrive_path = row["html_storage_path"]
+    sec_url = row.get("sec_html_url")
+
+    relative = _derive_relative_path(onedrive_path)
+    if not relative:
+        logger.error(
+            "filing_id=%s: could not strip OneDrive prefix from %s",
+            filing_id,
+            onedrive_path,
+        )
+        return "failed"
+
+    local_path = project_root / relative
+    content: str | None = None
+    source: str | None = None
+
+    if local_path.exists():
+        try:
+            content = local_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning("filing_id=%s: failed reading %s: %s", filing_id, local_path, exc)
+            content = None
+        if content is not None and len(content) < _MIN_HTML_BYTES:
+            logger.warning(
+                "filing_id=%s: local file is %d bytes (< %d); ignoring",
+                filing_id,
+                len(content),
+                _MIN_HTML_BYTES,
+            )
+            content = None
+        if content is not None:
+            source = "disk"
+
+    if content is None and sec_url:
+        logger.info(
+            "filing_id=%s: local file missing/short, falling back to SEC: %s",
+            filing_id,
+            sec_url,
+        )
+        try:
+            content = _fetch_via_sec(sec_url, sec_user_agent)
+        except Exception as exc:
+            logger.warning("filing_id=%s: SEC re-fetch failed: %s", filing_id, exc)
+            content = None
+        if content is not None:
+            source = "sec"
+
+    if content is None:
+        logger.error(
+            "filing_id=%s: no content from disk (path=%s exists=%s) or SEC (sec_url=%s); skipping",
+            filing_id,
+            local_path,
+            local_path.exists(),
+            sec_url,
+        )
+        return "failed"
+
+    if not apply:
+        logger.info(
+            "[DRY-RUN] filing_id=%s: would set html_storage_path=%s, "
+            "html_content=%d bytes (source=%s)",
+            filing_id,
+            relative,
+            len(content),
+            source,
+        )
+        return "rewritten" if source == "disk" else "fetched_from_sec"
+
+    return "_to_apply", relative, content, source, filing_id  # type: ignore[return-value]
+
+
+def migrate(
+    db: DatabaseAdapter,
+    rows: list[dict],
+    *,
+    apply: bool,
+    sec_user_agent: str,
+    project_root: Path = _PROJECT_ROOT,
+) -> dict[str, int]:
+    counts = {"audited": len(rows), "rewritten": 0, "fetched_from_sec": 0, "failed": 0}
+    for row in rows:
+        result = _process_row(
+            row,
+            apply=apply,
+            sec_user_agent=sec_user_agent,
+            project_root=project_root,
+        )
+
+        if isinstance(result, str):
+            if result == "rewritten":
+                counts["rewritten"] += 1
+            elif result == "fetched_from_sec":
+                counts["fetched_from_sec"] += 1
+            else:
+                counts["failed"] += 1
+            continue
+
+        # apply path: tuple ('_to_apply', relative, content, source, filing_id)
+        _, relative, content, source, filing_id = result
+        try:
+            with db.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE filings
+                           SET html_storage_path = %(rel)s,
+                               html_content = %(content)s
+                         WHERE filing_id = %(filing_id)s
+                        """,
+                        {"rel": relative, "content": content, "filing_id": filing_id},
+                    )
+                    rowcount = cur.rowcount
+            if rowcount == 0:
+                logger.warning(
+                    "filing_id=%s: UPDATE matched 0 rows (concurrent change?)",
+                    filing_id,
+                )
+                counts["failed"] += 1
+                continue
+            if source == "disk":
+                counts["rewritten"] += 1
+            else:
+                counts["fetched_from_sec"] += 1
+            logger.info(
+                "filing_id=%s: rewrote html_storage_path=%s + populated html_content "
+                "(%d bytes, source=%s)",
+                filing_id,
+                relative,
+                len(content),
+                source,
+            )
+        except Exception as exc:
+            logger.error("filing_id=%s: UPDATE failed: %s", filing_id, exc)
+            counts["failed"] += 1
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--database-url", default=None, help="Override DATABASE_URL env var.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the UPDATEs. Without this flag, prints planned changes only.",
+    )
+    parser.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Required for --apply when DATABASE_URL points at *.neon.tech.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process at most N rows (for staged rollouts / testing).",
+    )
+    args = parser.parse_args()
+
+    configure_logging(level="INFO")
+    load_dotenv()
+
+    db_url = args.database_url or os.getenv("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set (and --database-url not passed)")
+        return 1
+
+    if args.apply and _looks_like_prod(db_url):
+        if not args.allow_prod:
+            logger.error("Refusing to apply against prod DATABASE_URL without --allow-prod.")
+            return 1
+        if os.environ.get("FILINGS_REVIEWER_ALLOW_PROD_WRITES") != "1":
+            logger.error(
+                "Refusing to apply against prod DATABASE_URL without "
+                "FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 "
+                "(matches R2Storage.put_bytes / relink_paypal_r2_keys guard)."
+            )
+            return 1
+
+    sec_user_agent = os.getenv("SEC_USER_AGENT", "filings-reviewer info@example.com")
+
+    db = DatabaseAdapter(db_url)
+    select_sql = """
+        SELECT filing_id, html_storage_path, sec_html_url
+          FROM filings
+         WHERE html_storage_path LIKE '/Users/%%/OneDrive-CMASB/%%'
+         ORDER BY filing_id
+    """
+    if args.limit is not None:
+        select_sql += f"\n LIMIT {int(args.limit)}"
+    rows = db.query(select_sql)
+
+    logger.info(
+        "Migration plan: %d row(s) (apply=%s, db=%s, limit=%s)",
+        len(rows),
+        args.apply,
+        "prod" if _looks_like_prod(db_url) else "non-prod",
+        args.limit,
+    )
+
+    if not rows:
+        logger.info("No matching rows — nothing to do.")
+        return 0
+
+    counts = migrate(db, rows, apply=args.apply, sec_user_agent=sec_user_agent)
+    logger.info(
+        "Migration result: audited=%d rewritten=%d fetched_from_sec=%d failed=%d",
+        counts["audited"],
+        counts["rewritten"],
+        counts["fetched_from_sec"],
+        counts["failed"],
+    )
+    return 0 if counts["failed"] == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_migrate_onedrive_html_paths.py
+++ b/tests/integration/test_migrate_onedrive_html_paths.py
@@ -1,0 +1,289 @@
+"""Integration tests for scripts/migrate_onedrive_html_paths.py.
+
+Covers the gh-299 migration: rewriting stale OneDrive paths to worktree-relative
+form and populating ``filings.html_content`` from disk (or via SEC re-fetch fallback).
+
+Requires TEST_DATABASE_URL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.infra.db import DatabaseAdapter
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "migrate_onedrive_html_paths.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "migrate_onedrive_html_paths_under_test", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["migrate_onedrive_html_paths_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script_module()
+
+
+_TEST_CIK = "8888888299"
+_TEST_COMPANY_NAME = "OneDrive Migration Test Co"
+
+
+@pytest.fixture
+def test_company(test_db_adapter: DatabaseAdapter) -> int:
+    with test_db_adapter.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO companies (cik, company_name, ticker)
+                VALUES (%(cik)s, %(name)s, 'GH299')
+                ON CONFLICT (cik) DO UPDATE SET company_name = EXCLUDED.company_name
+                RETURNING company_id
+                """,
+                {"cik": _TEST_CIK, "name": _TEST_COMPANY_NAME},
+            )
+            row = cur.fetchone()
+    yield row["company_id"]
+    with test_db_adapter.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM filings WHERE cik = %(cik)s",
+                {"cik": _TEST_CIK},
+            )
+            cur.execute(
+                "DELETE FROM companies WHERE cik = %(cik)s",
+                {"cik": _TEST_CIK},
+            )
+
+
+def _insert_filing(
+    db: DatabaseAdapter,
+    company_id: int,
+    accession: str,
+    *,
+    html_storage_path: str,
+    sec_html_url: str | None = "https://www.sec.gov/test/primary.htm",
+    html_content: str | None = None,
+) -> int:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO filings (
+                    company_id, cik, accession_number, form_type,
+                    filing_date, sec_html_url, html_storage_path, html_content
+                ) VALUES (
+                    %(company_id)s, %(cik)s, %(acc)s, 'S-1',
+                    '2024-01-01', %(sec_url)s, %(path)s, %(content)s
+                )
+                RETURNING filing_id
+                """,
+                {
+                    "company_id": company_id,
+                    "cik": _TEST_CIK,
+                    "acc": accession,
+                    "sec_url": sec_html_url,
+                    "path": html_storage_path,
+                    "content": html_content,
+                },
+            )
+            return cur.fetchone()["filing_id"]
+
+
+def _read_filing(db: DatabaseAdapter, filing_id: int) -> dict:
+    rows = db.query(
+        "SELECT html_storage_path, html_content FROM filings WHERE filing_id = %(id)s",
+        {"id": filing_id},
+    )
+    return rows[0]
+
+
+_BIG_HTML = "<html><body>" + ("x" * 20_000) + "</body></html>"
+_ONEDRIVE_TEMPLATE = (
+    "/Users/testuser/Library/CloudStorage/OneDrive-CMASB/Analytics/"
+    "Filings_Analysis/Filings_review_tool/filings_reviewer/{rel}"
+)
+
+
+def test_dry_run_does_not_write(script, test_db_adapter, test_db_url, test_company, tmp_path):
+    rel = "data/gold_standard/Foo_Inc/filing.html"
+    file_path = tmp_path / rel
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(_BIG_HTML)
+    onedrive_path = _ONEDRIVE_TEMPLATE.format(rel=rel)
+
+    fid = _insert_filing(
+        test_db_adapter,
+        test_company,
+        "0000000299-01",
+        html_storage_path=onedrive_path,
+    )
+    rows = test_db_adapter.query(
+        "SELECT filing_id, html_storage_path, sec_html_url FROM filings WHERE filing_id = %(id)s",
+        {"id": fid},
+    )
+    counts = script.migrate(
+        test_db_adapter, rows, apply=False, sec_user_agent="test", project_root=tmp_path
+    )
+
+    assert counts == {
+        "audited": 1,
+        "rewritten": 1,
+        "fetched_from_sec": 0,
+        "failed": 0,
+    }
+    after = _read_filing(test_db_adapter, fid)
+    assert after["html_storage_path"] == onedrive_path
+    assert after["html_content"] is None
+
+
+def test_apply_rewrites_and_populates_from_disk(
+    script, test_db_adapter, test_db_url, test_company, tmp_path
+):
+    rel = "data/gold_standard/Bar_Corp/filing.html"
+    file_path = tmp_path / rel
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(_BIG_HTML)
+    onedrive_path = _ONEDRIVE_TEMPLATE.format(rel=rel)
+
+    fid = _insert_filing(
+        test_db_adapter,
+        test_company,
+        "0000000299-02",
+        html_storage_path=onedrive_path,
+    )
+    rows = test_db_adapter.query(
+        "SELECT filing_id, html_storage_path, sec_html_url FROM filings WHERE filing_id = %(id)s",
+        {"id": fid},
+    )
+    counts = script.migrate(
+        test_db_adapter, rows, apply=True, sec_user_agent="test", project_root=tmp_path
+    )
+
+    assert counts["rewritten"] == 1
+    assert counts["fetched_from_sec"] == 0
+    assert counts["failed"] == 0
+    after = _read_filing(test_db_adapter, fid)
+    assert after["html_storage_path"] == rel
+    assert after["html_content"] is not None
+    assert len(after["html_content"]) >= len(_BIG_HTML) - 5  # encoding may shave bytes
+
+
+def test_apply_falls_back_to_sec_when_disk_missing(
+    script, test_db_adapter, test_db_url, test_company, tmp_path
+):
+    rel = "data/gold_standard/Missing_Co/filing.html"
+    onedrive_path = _ONEDRIVE_TEMPLATE.format(rel=rel)
+    sec_url = "https://www.sec.gov/Archives/edgar/data/8888888299/missing.htm"
+
+    fid = _insert_filing(
+        test_db_adapter,
+        test_company,
+        "0000000299-03",
+        html_storage_path=onedrive_path,
+        sec_html_url=sec_url,
+    )
+    rows = test_db_adapter.query(
+        "SELECT filing_id, html_storage_path, sec_html_url FROM filings WHERE filing_id = %(id)s",
+        {"id": fid},
+    )
+
+    fetched_text = "<html><body>SEC fallback content " + ("y" * 20_000) + "</body></html>"
+    with patch.object(script, "_fetch_via_sec", return_value=fetched_text) as mock_fetch:
+        counts = script.migrate(
+            test_db_adapter,
+            rows,
+            apply=True,
+            sec_user_agent="test",
+            project_root=tmp_path,
+        )
+
+    assert counts["fetched_from_sec"] == 1
+    assert counts["rewritten"] == 0
+    assert counts["failed"] == 0
+    mock_fetch.assert_called_once_with(sec_url, "test")
+    after = _read_filing(test_db_adapter, fid)
+    assert after["html_storage_path"] == rel
+    assert after["html_content"] == fetched_text
+
+
+def test_prod_host_guard_refuses_apply_without_allow_prod(script, monkeypatch, capsys):
+    """--apply against a *.neon.tech URL exits 1 without --allow-prod."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pw@example.neon.tech/db")
+    monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+
+    with patch.object(sys, "argv", ["migrate_onedrive_html_paths.py", "--apply"]):
+        rc = script.main()
+    assert rc == 1
+
+
+def test_prod_host_guard_refuses_apply_without_env_var(script, monkeypatch):
+    """--apply --allow-prod against a *.neon.tech URL still requires the env var."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pw@example.neon.tech/db")
+    monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+
+    with patch.object(sys, "argv", ["migrate_onedrive_html_paths.py", "--apply", "--allow-prod"]):
+        rc = script.main()
+    assert rc == 1
+
+
+def test_idempotency_second_run_audits_zero(
+    script, test_db_adapter, test_db_url, test_company, tmp_path
+):
+    rel = "data/gold_standard/Idem_Inc/filing.html"
+    file_path = tmp_path / rel
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(_BIG_HTML)
+    onedrive_path = _ONEDRIVE_TEMPLATE.format(rel=rel)
+
+    _insert_filing(
+        test_db_adapter,
+        test_company,
+        "0000000299-04",
+        html_storage_path=onedrive_path,
+    )
+
+    # First pass: apply
+    rows1 = test_db_adapter.query(
+        "SELECT filing_id, html_storage_path, sec_html_url FROM filings "
+        "WHERE html_storage_path LIKE '/Users/%%/OneDrive-CMASB/%%' "
+        "AND cik = %(cik)s",
+        {"cik": _TEST_CIK},
+    )
+    assert len(rows1) == 1
+    counts1 = script.migrate(
+        test_db_adapter, rows1, apply=True, sec_user_agent="test", project_root=tmp_path
+    )
+    assert counts1["rewritten"] == 1
+
+    # Second pass: selector should match nothing
+    rows2 = test_db_adapter.query(
+        "SELECT filing_id, html_storage_path, sec_html_url FROM filings "
+        "WHERE html_storage_path LIKE '/Users/%%/OneDrive-CMASB/%%' "
+        "AND cik = %(cik)s",
+        {"cik": _TEST_CIK},
+    )
+    assert rows2 == []


### PR DESCRIPTION
Adds scripts/migrate_onedrive_html_paths.py to rewrite the 13 prod
filings.html_storage_path rows that still pointed at OneDrive cloud-only
paths (`/Users/.../OneDrive-CMASB/.../data/gold_standard/<Company>/filing.html`,
all NULL html_content) to the worktree-relative form
(`data/gold_standard/<Company>/filing.html`) and populate html_content
from the canonical local copy. Falls back to SEC re-fetch when the local
file is missing.

Mirrors the two-flag prod-write gate from scripts/relink_paypal_r2_keys.py:
--apply requires --allow-prod when DATABASE_URL points at *.neon.tech, AND
FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 must be set in the env. Each filing
update is its own transaction; the LIKE selector is self-filtering so the
migration is idempotent.

Migration ran 2026-04-28 against Neon: audited=13, rewritten=13,
fetched_from_sec=0, failed=0. Verified zero remaining OneDrive paths.

Tactical fix; gh-300 will replace html_storage_path semantics with
R2 storage keys, superseding the worktree-relative format shipped here.
