### PR TITLE
chore(known-issues): close legacy-024 — img_id orphans cleared, promote Class (B) to blocking

### DIFF
--- a/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
+++ b/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
@@ -7,6 +7,8 @@ note: 'Resolved 2026-04-28 as fragment-only closure: dev (Neon prod) and local
   Docker test DB both report 0 Class (B) orphans against
   scripts/check_image_referential_integrity.py. Class (B) promoted from
   warning-only to blocking in the same PR to lock against regression.'
+pr_refs:
+  - 318
 severity: low
 slug: v2-metric-facts-source-locator-img-id-has-no-referential-int
 source: legacy

--- a/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
+++ b/docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md
@@ -1,19 +1,20 @@
 ---
-autonomy: skip
+autonomy: n/a
 discovered: '2026-04-18'
 estimated: M
 id: 24
-note: 'Scope reduced to historical advisory-fact hygiene after 2026-04-24
-  presence-first pivot: presence rows (v2_text_metric_presence,
-  v2_image_metric_presence) do not rely on source_locator.img_id; orphans live only
-  in legacy advisory v2_metric_facts. Not on the presence-pivot critical path.'
+note: 'Resolved 2026-04-28 as fragment-only closure: dev (Neon prod) and local
+  Docker test DB both report 0 Class (B) orphans against
+  scripts/check_image_referential_integrity.py. Class (B) promoted from
+  warning-only to blocking in the same PR to lock against regression.'
 severity: low
 slug: v2-metric-facts-source-locator-img-id-has-no-referential-int
 source: legacy
-status: open
+status: resolved
 title: '`v2_metric_facts.source_locator.img_id` Has No Referential Integrity'
-touches: []
-updated: '2026-04-24'
+touches:
+  - scripts/check_image_referential_integrity.py
+updated: '2026-04-28'
 ---
 
 ### Problem
@@ -37,3 +38,16 @@ The script now reports three classes and is wired into the integration-tests CI 
 - **Class (C)** — asset rows with `file_path` outside `data/` or missing on disk. Warning-only; tracked under Issue #34.
 
 `tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py` locks the Class (A) invariant at unit-test level.
+
+### Resolution (2026-04-28)
+
+Closed as a fragment-only resolution per `project_fragment_only_closure_pattern`. No data migration required.
+
+**Verification.** `scripts/check_image_referential_integrity.py` was rerun after the 2026-04-23 chart-presence pivot (#147), which removed the per-value chart `v2_metric_facts` emission path that historically wrote `source_locator.img_id`-bearing rows. Counts now:
+
+- **Neon prod (`DATABASE_URL` in `.env`)**: 0 Class (B) orphans (down from 9 across 4 docs at the 2026-04-19 baseline). The 4 affected docs (1539, 1545, 1546, 1551) appear to have washed through normal re-extraction or DB churn between 2026-04-19 and 2026-04-28.
+- **Local Docker test DB (`TEST_DATABASE_URL`)**: 0 Class (B) orphans (test DB carries no fact data of its own).
+
+**Lock-in.** Class (B) promoted from warning-only to blocking in `scripts/check_image_referential_integrity.py` so a single regression on any DB the script is pointed at fails CI's integration-tests job. Class (A) blocking semantics and the unit-level invariant in `tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py` are unchanged. Class (C) remains warning-only and continues to track separately under issue #34.
+
+**Why no migration.** The chart-presence pivot eliminated the upstream code path that wrote chart facts with `source_locator.img_id`. Future chart presence flows through `v2_image_metric_presence` and `v2_image_metric_confirmations`, neither of which depends on `source_locator`. With both observed populations already at 0 and no upstream writer remaining, the remaining cleanup options (delete vs. NULL-out vs. promote to FK column) are all no-ops on a no-orphan dataset.

--- a/scripts/check_image_referential_integrity.py
+++ b/scripts/check_image_referential_integrity.py
@@ -11,9 +11,13 @@ in the review UI (`unified_review.html` "Chart Evidence" block):
         fact (chart_fact_bridge.py:134, 185, 244). A non-zero count here is
         a persistence-layer regression and fails CI.
 
-    (B) WARNING: img_id present but does not resolve to any v2_image_assets
-        row. Typically caused by image deletion/dedup migrations. Not a CI
-        blocker today — flip to blocking once baseline reaches zero.
+    (B) BLOCKING: img_id present but does not resolve to any v2_image_assets
+        row. Typically caused by image deletion/dedup migrations. Promoted
+        from warning-only to blocking on 2026-04-28 (legacy-024 closure)
+        after both prod and the local Docker test DB reached 0 orphans —
+        the chart-presence pivot (#147) removed the upstream writer that
+        used to emit chart facts with `source_locator.img_id`, so any new
+        orphan signals a regression.
 
     (C) WARNING: asset row exists but the on-disk file is missing or lives
         outside the project data/ directory. Common with extraction caches
@@ -24,7 +28,6 @@ in the review UI (`unified_review.html` "Chart Evidence" block):
 Scope:
     - Read-only. No schema changes, no writes.
     - Does NOT modify facts, images, or files — diagnosis only.
-    - Promoting img_id to a FK column is a separate workstream (Issue #24).
 
 Usage:
     python3 scripts/check_image_referential_integrity.py              # report
@@ -33,7 +36,7 @@ Usage:
 
 Exit codes:
     0  no blocking violations
-    1  blocking violation (class A) found OR DATABASE_URL unset / other failure
+    1  blocking violation (class A or B) found OR DATABASE_URL unset / other failure
 """
 
 from __future__ import annotations
@@ -96,9 +99,7 @@ ASSET_FILE_PATH_SQL = """
 """
 
 
-def _load_missing_files(
-    db: DatabaseAdapter, data_dir: Path | None
-) -> tuple[int, list[dict]]:
+def _load_missing_files(db: DatabaseAdapter, data_dir: Path | None) -> tuple[int, list[dict]]:
     """Class (C): image rows whose file_path key is invalid or absent in storage.
 
     ``data_dir`` is retained as a parameter for CLI compatibility but is no longer
@@ -187,7 +188,7 @@ def main() -> int:
 
     # (A) — blocking
     null_img_rows = db.query(NULL_IMG_ID_SQL)
-    # (B) — warning
+    # (B) — blocking (promoted 2026-04-28)
     orphan_rows = db.query(ORPHAN_SQL)
     # (C) — warning
     file_checked, file_missing = _load_missing_files(db, data_dir)
@@ -215,20 +216,21 @@ def main() -> int:
     else:
         logger.info("(A) OK: no chart-sourced facts with null img_id.")
 
-    # Class B — warning
+    # Class B — blocking (promoted from warning on 2026-04-28, legacy-024 closure)
     if orphan_rows:
         by_doc = Counter(r["doc_id"] for r in orphan_rows)
         by_source = Counter(r["source_type"] for r in orphan_rows)
-        logger.warning(
-            "(B) WARN: %d fact(s) reference img_id values with no matching asset row "
+        logger.error(
+            "(B) BLOCKING: %d fact(s) reference img_id values with no matching asset row "
             "(across %d doc(s), source_types=%s)",
             len(orphan_rows),
             len(by_doc),
             dict(by_source),
         )
         for doc_id, count in sorted(by_doc.items(), key=lambda x: (-x[1], x[0])):
-            logger.warning("  doc_id=%s: %d fact(s)", doc_id, count)
+            logger.error("  doc_id=%s: %d fact(s)", doc_id, count)
         _print_samples("(B)", orphan_rows, args.sample)
+        exit_code = 1
     else:
         logger.info("(B) OK: no orphaned img_id references.")
 


### PR DESCRIPTION
Both Neon prod and the local Docker test DB now report 0 Class (B) orphans
under scripts/check_image_referential_integrity.py, down from the 2026-04-19
baseline of 9 orphans across 4 docs. The chart-presence pivot (#147) removed
the upstream code path that wrote chart facts with source_locator.img_id, so
no migration is needed — the legacy historical orphans appear to have washed
through normal re-extraction since.

Promote Class (B) from warning-only to blocking in the integrity script (and
therefore in the integration-tests CI job) to lock the now-zero baseline
against regression. Class (A) and Class (C) semantics unchanged; Class (C)
continues to track under issue #34.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
