### PR TITLE
feat: 10-K/A supersedes same-fiscal-year 10-K (legacy-040)

### DIFF
--- a/docs/known-issues/legacy-040-10-k-a-supersession-semantics-undefined.md
+++ b/docs/known-issues/legacy-040-10-k-a-supersession-semantics-undefined.md
@@ -3,14 +3,14 @@ autonomy: skip
 discovered: '2026-04-19'
 estimated: —
 id: 40
-note: Stakeholder decision (supersession semantics)
+note: Stakeholder confirmed restatement-supersedes-original; 10-K/A demotes same-fiscal-year 10-K via period_end_date partition
 severity: low
 slug: 10-k-a-supersession-semantics-undefined
 source: legacy
-status: open
+status: resolved
 title: 10-K/A Supersession Semantics Undefined
 touches: []
-updated: '2026-04-19'
+updated: '2026-04-28'
 ---
 
 ### Problem

--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -250,9 +250,18 @@ Practical notes:
 - A year's worth of 10-Ks is ~5–10k filings (every public US company files
   one annually). `populate` has no `--limit`; plan for ~15 minutes at SEC's
   10 req/s rate limit for metadata + per-CIK SIC lookups.
-- 10-K/A amendments are distinct fiscal-year filings — the
-  `mark_superseded_filings()` logic only scopes to S-1/S-1/A/F-1/F-1/A, so
-  10-K rows are preserved independently.
+- 10-K/A amendments **supersede** the same-fiscal-year 10-K. After
+  `populate`, `UniverseBuilder` calls `mark_superseded_filings()`, which
+  demotes (`is_in_scope_phase1 = FALSE`) any 10-K whose
+  `(company_id, period_end_date)` pair has a later filing — so a FY2022
+  10-K/A filed in 2024 demotes the FY2022 10-K but leaves FY2023's 10-K
+  in scope. Cross-fiscal-year analytics is preserved; per-fiscal-year
+  the latest filed wins (legacy-040). Rows with NULL `period_end_date`
+  are conservatively skipped — the supersession step needs the fiscal
+  period to pair an amendment with its original. `period_end_date` is
+  populated for 10-K / 10-K/A from EDGAR submissions JSON
+  (`SECClient.get_filing_period_of_report`); S-1/F-1 retain their
+  existing per-company "latest filing wins" semantics.
 - The IPO-era SGML SPAC re-check (which fetches `txt_url` to look for
   "BLANK CHECKS [6770]" in the SGML header) is skipped for non-S-1/F-1
   forms — it's a per-filing HTTP call that adds no signal for 10-Ks.

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -521,19 +521,27 @@ class DatabaseAdapter:
 
     def mark_superseded_filings(self) -> int:
         """
-        Mark non-latest S-1/S-1/A/F-1/F-1/A filings as out of scope.
+        Mark superseded filings as out of scope.
 
-        For each company, keeps only the most recently filed registration
-        statement as is_in_scope_phase1=TRUE. Earlier filings (original S-1
-        and interim amendments) are marked FALSE so they are not fetched,
-        extracted, or surfaced in the review UI.
+        Two scopes, run as separate UPDATEs in a single transaction:
+
+        1. S-1/S-1/A/F-1/F-1/A — registration-statement chain. Per company,
+           keep only the most recently filed; demote earlier originals and
+           interim amendments. (Existing semantics, unchanged.)
+        2. 10-K/10-K/A — annual-report restatement chain. Per
+           (company, fiscal year as ``period_end_date``), keep only the
+           most recently filed; demote earlier originals or amendments
+           for the same fiscal year. Different fiscal years remain in
+           scope so multi-year analytics are preserved. Rows with NULL
+           ``period_end_date`` are conservatively skipped — they cannot
+           be safely paired with an amendment.
 
         All filings are retained in the database for historical reference.
 
         Returns:
-            Number of filings marked out of scope.
+            Total number of filings marked out of scope.
         """
-        sql = """
+        s1f1_sql = """
             UPDATE filings
             SET is_in_scope_phase1 = FALSE
             WHERE form_type IN ('S-1', 'S-1/A', 'F-1', 'F-1/A')
@@ -545,10 +553,28 @@ class DatabaseAdapter:
                   ORDER BY company_id, filing_date DESC NULLS LAST
               )
         """
+        tenk_sql = """
+            UPDATE filings
+            SET is_in_scope_phase1 = FALSE
+            WHERE form_type IN ('10-K', '10-K/A')
+              AND is_in_scope_phase1 = TRUE
+              AND period_end_date IS NOT NULL
+              AND filing_id NOT IN (
+                  SELECT DISTINCT ON (company_id, period_end_date) filing_id
+                  FROM filings
+                  WHERE form_type IN ('10-K', '10-K/A')
+                    AND period_end_date IS NOT NULL
+                  ORDER BY company_id, period_end_date,
+                           filing_date DESC NULLS LAST
+              )
+        """
+        affected = 0
         with self.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(sql)
-                affected = cur.rowcount
+                cur.execute(s1f1_sql)
+                affected += cur.rowcount
+                cur.execute(tenk_sql)
+                affected += cur.rowcount
                 conn.commit()
         return affected
 

--- a/src/infra/sec_client.py
+++ b/src/infra/sec_client.py
@@ -128,6 +128,9 @@ class FilingMetadata:
         primary_doc_url: URL to primary HTML document
         txt_url: URL to complete text filing
         ticker: Stock ticker (if available)
+        period_of_report: Reporting period end date (ISO format) — populated
+            for 10-K / 10-K/A from EDGAR submissions API; None for S-1/F-1
+            (registration statements have no fiscal period).
     """
 
     cik: str
@@ -138,6 +141,7 @@ class FilingMetadata:
     primary_doc_url: str
     txt_url: str | None = None
     ticker: str | None = None
+    period_of_report: str | None = None
 
 
 class SECClient:
@@ -205,6 +209,11 @@ class SECClient:
         self.session.headers.update({"User-Agent": user_agent})
 
         self._last_request_time = 0.0
+
+        # Per-CIK cache of accession -> reportDate, populated lazily on first
+        # period_of_report lookup for a given CIK. Bounded by company count
+        # within a single universe-build run.
+        self._period_of_report_cache: dict[str, dict[str, str | None]] = {}
 
     def _rate_limit(self):
         """Enforce rate limiting between requests."""
@@ -635,10 +644,7 @@ class SECClient:
         if bare is None:
             return None
         accession_no_dashes = bare.replace("-", "")
-        index_url = (
-            f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
-            f"{accession_no_dashes}/index.json"
-        )
+        index_url = f"{self.BASE_URL}/Archives/edgar/data/{cik}/{accession_no_dashes}/index.json"
         try:
             data = self._make_request(index_url)
         except Exception:
@@ -658,10 +664,50 @@ class SECClient:
         chosen = html_match or pdf_match
         if chosen is None:
             return None
-        return (
-            f"{self.BASE_URL}/Archives/edgar/data/{cik}/"
-            f"{accession_no_dashes}/{chosen}"
-        )
+        return f"{self.BASE_URL}/Archives/edgar/data/{cik}/{accession_no_dashes}/{chosen}"
+
+    def get_filing_period_of_report(self, cik: str, accession_number: str) -> str | None:
+        """
+        Look up the reporting-period end date for a single filing.
+
+        Reads `recent.reportDate` from the EDGAR submissions JSON. For 10-K
+        and 10-K/A this is the fiscal-year-end the filing reports on; used
+        by `mark_superseded_filings` to pair an amendment with the original
+        it replaces. Registration statements (S-1/F-1) typically return
+        empty string from EDGAR — callers should treat empty as None.
+
+        Per-CIK results are cached on the SECClient instance so multiple
+        filings for the same company within one universe-build run share
+        a single submissions-JSON fetch.
+
+        Returns:
+            ISO date string (e.g. "2023-12-31"), or None if the accession
+            isn't in the recent-filings array, the field is empty, or the
+            submissions fetch fails.
+        """
+        cik_padded = cik.zfill(10)
+
+        cache = self._period_of_report_cache.get(cik_padded)
+        if cache is None:
+            try:
+                url = self.SUBMISSIONS_URL.format(cik=cik_padded)
+                data = self._make_request(url)
+                recent = data.get("filings", {}).get("recent", {})
+                accessions = recent.get("accessionNumber", [])
+                report_dates = recent.get("reportDate", [])
+                cache = {}
+                for i, acc in enumerate(accessions):
+                    rd = report_dates[i] if i < len(report_dates) else ""
+                    cache[acc] = rd or None
+            except requests.HTTPError as e:
+                logger.warning(f"period_of_report lookup failed for CIK {cik}: HTTP {e}")
+                cache = {}
+            except Exception as e:
+                logger.warning(f"period_of_report lookup failed for CIK {cik}: {e}")
+                cache = {}
+            self._period_of_report_cache[cik_padded] = cache
+
+        return cache.get(accession_number)
 
     def get_company_info(self, cik: str) -> dict | None:
         """

--- a/src/universe/universe_builder.py
+++ b/src/universe/universe_builder.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 # Exported as a module constant so callers (e.g. scripts/onboard_tickers.py)
 # share a single source of truth.
 DEFAULT_FORM_TYPES_S1F1 = ["S-1", "S-1/A", "F-1", "F-1/A"]
+FORM_TYPES_10K = ["10-K", "10-K/A"]
 
 
 class UniverseBuilder:
@@ -263,6 +264,16 @@ class UniverseBuilder:
             spac_method, fti_method, offering_method
         )
 
+        # 10a. Look up period_of_report for 10-K / 10-K/A so the post-load
+        # supersession step can pair an amendment with the original 10-K it
+        # replaces (same company + same fiscal year). S-1/F-1 are
+        # registration statements with no fiscal period; skip the lookup.
+        period_of_report: str | None = None
+        if filing.form_type in FORM_TYPES_10K:
+            period_of_report = self.sec_client.get_filing_period_of_report(
+                filing.cik, filing.accession_number
+            )
+
         # 11. Upsert filing
         self.db.upsert_filing(
             company_id=company_id,
@@ -270,6 +281,7 @@ class UniverseBuilder:
             accession_number=filing.accession_number,
             form_type=filing.form_type,
             filing_date=filing.filing_date,
+            period_end_date=period_of_report,
             sec_html_url=filing.primary_doc_url,
             sec_txt_url=filing.txt_url,
             is_in_scope_phase1=in_scope,

--- a/tests/integration/test_mark_superseded_filings.py
+++ b/tests/integration/test_mark_superseded_filings.py
@@ -1,0 +1,144 @@
+"""Integration tests for DatabaseAdapter.mark_superseded_filings (legacy-040).
+
+Two scopes are validated:
+
+1. S-1/F-1 chain: latest by filing_date wins per company.
+2. 10-K/10-K/A chain: latest by filing_date wins per (company, fiscal year),
+   so cross-fiscal-year 10-Ks remain in scope while only the amended-year
+   original is demoted by its 10-K/A.
+"""
+
+from __future__ import annotations
+
+from src.infra.db import DatabaseAdapter
+from tests.integration.conftest import create_test_company
+
+
+def _upsert(
+    db: DatabaseAdapter,
+    company_id: int,
+    cik: str,
+    accession_number: str,
+    form_type: str,
+    filing_date: str,
+    period_end_date: str | None = None,
+) -> int:
+    return db.upsert_filing(
+        company_id=company_id,
+        cik=cik,
+        accession_number=accession_number,
+        form_type=form_type,
+        filing_date=filing_date,
+        period_end_date=period_end_date,
+        sec_html_url=f"https://www.sec.gov/test/{accession_number}",
+        is_in_scope_phase1=True,
+        is_post_combination=False,
+        is_investment_vehicle=False,
+        is_resource_extraction=False,
+    )
+
+
+def _is_in_scope(db: DatabaseAdapter, filing_id: int) -> bool:
+    rows = db.query(
+        "SELECT is_in_scope_phase1 FROM filings WHERE filing_id = %(fid)s",
+        {"fid": filing_id},
+    )
+    return bool(rows[0]["is_in_scope_phase1"])
+
+
+class TestS1F1Supersession:
+    def test_latest_s1_amendment_wins_per_company(self, clean_db: DatabaseAdapter) -> None:
+        """Original S-1 demoted; latest S-1/A kept. Pre-existing semantics."""
+        company_id = create_test_company(clean_db, cik="0000000111", company_name="S1 Co")
+
+        original = _upsert(
+            clean_db,
+            company_id,
+            "0000000111",
+            "0000000111-24-000001",
+            "S-1",
+            "2024-01-10",
+        )
+        amendment = _upsert(
+            clean_db,
+            company_id,
+            "0000000111",
+            "0000000111-24-000002",
+            "S-1/A",
+            "2024-03-15",
+        )
+
+        clean_db.mark_superseded_filings()
+
+        assert _is_in_scope(clean_db, original) is False
+        assert _is_in_scope(clean_db, amendment) is True
+
+
+class TestTenKSupersession:
+    def test_10ka_demotes_same_year_10k_only(self, clean_db: DatabaseAdapter) -> None:
+        """A 10-K/A amending FY2022 demotes the FY2022 10-K but leaves the
+        FY2023 10-K in scope."""
+        company_id = create_test_company(clean_db, cik="0000000222", company_name="K10 Co")
+
+        fy2022_original = _upsert(
+            clean_db,
+            company_id,
+            "0000000222",
+            "0000000222-23-000001",
+            "10-K",
+            "2023-02-15",
+            period_end_date="2022-12-31",
+        )
+        fy2023_original = _upsert(
+            clean_db,
+            company_id,
+            "0000000222",
+            "0000000222-24-000001",
+            "10-K",
+            "2024-02-15",
+            period_end_date="2023-12-31",
+        )
+        fy2022_amendment = _upsert(
+            clean_db,
+            company_id,
+            "0000000222",
+            "0000000222-24-000002",
+            "10-K/A",
+            "2024-06-01",
+            period_end_date="2022-12-31",
+        )
+
+        clean_db.mark_superseded_filings()
+
+        assert _is_in_scope(clean_db, fy2022_original) is False
+        assert _is_in_scope(clean_db, fy2022_amendment) is True
+        assert _is_in_scope(clean_db, fy2023_original) is True
+
+    def test_null_period_end_date_is_skipped(self, clean_db: DatabaseAdapter) -> None:
+        """A 10-K with NULL period_end_date is conservatively left in scope —
+        no amendment can be safely paired without the fiscal-year key."""
+        company_id = create_test_company(clean_db, cik="0000000333", company_name="Null Co")
+
+        no_period = _upsert(
+            clean_db,
+            company_id,
+            "0000000333",
+            "0000000333-23-000001",
+            "10-K",
+            "2023-02-15",
+            period_end_date=None,
+        )
+        later_no_period = _upsert(
+            clean_db,
+            company_id,
+            "0000000333",
+            "0000000333-24-000001",
+            "10-K",
+            "2024-02-15",
+            period_end_date=None,
+        )
+
+        clean_db.mark_superseded_filings()
+
+        assert _is_in_scope(clean_db, no_period) is True
+        assert _is_in_scope(clean_db, later_no_period) is True


### PR DESCRIPTION
Stakeholder-confirmed semantics: only the latest filing for a given
fiscal year stays in scope. mark_superseded_filings now runs a second
UPDATE for 10-K/10-K/A partitioned by (company_id, period_end_date),
preserving multi-year analytics while demoting amended originals.

Threading period_of_report through the SEC pipeline:
- FilingMetadata gains period_of_report (None for S-1/F-1).
- SECClient.get_filing_period_of_report reads recent.reportDate from
  the submissions JSON, with per-CIK in-memory caching.
- UniverseBuilder._process_filing looks it up only for 10-K/10-K/A and
  threads into upsert_filing(period_end_date=...).

NULL period_end_date rows are conservatively skipped from the 10-K
supersession step. S-1/F-1 semantics are unchanged.

Adds integration test covering S-1 regression, 10-K/A demoting only
the same-fiscal-year 10-K, and NULL-period skip. Updates
TICKER_ONBOARDING.md to document the new semantics.
