### PR TITLE
docs(worker-prompts): archive 17 completed PICK prompts

### DIFF
--- a/docs/archive/worker-prompts/PICK_gh-258_fix-pr-not-setting-pr-refs-on-resolved-fragment.md
+++ b/docs/archive/worker-prompts/PICK_gh-258_fix-pr-not-setting-pr-refs-on-resolved-fragment.md
@@ -1,0 +1,79 @@
+You are working gh-258: Fix-PR Authors Don't Set pr_refs on the Fragment They Resolve.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-258-fix-pr-not-setting-pr-refs-on-resolved-fragment.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- Related context (read for shape, do not modify unless implementation requires): `scripts/validate_known_issues_fragments.py`, `.claude/commands/commit-proj.md`, `scripts/sync_known_issue_status.py` (the auto-closer — **do not modify**), and `docs/development/CONTRIBUTING.md` for the existing fix-PR flow.
+
+## The problem (summary — fragment is canonical)
+The auto-closer (legacy-84 / PR #177, in `scripts/sync_known_issue_status.py`) flips a fragment from `status: open` → `status: resolved` once every PR in its `pr_refs` field is `MERGED`. It runs nightly. It only fires when `pr_refs` is populated.
+
+In practice fix-PR authors rarely populate `pr_refs` at fix-PR time, so the auto-closer is dead-ended on most fragments and every closure ends up manual. **A live example exists right now**: PR #272 merged this morning closing gh-263, but the gh-263 fragment on `origin/main` still has `status: open` and empty `pr_refs`. Do not fix gh-263 as part of this work — let your nudge prevent the next instance.
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm:
+   ```bash
+   git fetch origin main --quiet
+   grep -nE "pr_refs" scripts/validate_known_issues_fragments.py
+   grep -nE "pr_refs" .claude/commands/commit-proj.md
+   ```
+   At brief time, neither file references `pr_refs` enforcement. If a check has appeared since `updated: 2026-04-27`, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+   Also confirm gh-263 is the live example: `git show origin/main:docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md | head -20` — expect `status: open`, no `pr_refs`, despite PR #272 having merged.
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include the **Documentation** step required by global `Planning Rules` — at minimum, a `docs/development/CONTRIBUTING.md` entry mentioning the new validator nudge so authors know to expect it.
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-258-pr-refs-validator-nudge`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:** confirm `scripts/validate_known_issues_fragments.py` is the right place to add the nudge (it is the existing fragment validator wired into pre-commit; check `.pre-commit-config.yaml` to verify the hook id). Confirm `pr_refs` schema is "list of ints" per `feedback_known_issues_pr_refs_int_not_string`. Confirm the auto-closer's contract: it fires when **every** PR in `pr_refs` is MERGED, **not** when at least one is — the warning text needs to match the actual semantic.
+   - **SCOPE CHECK:** the fragment recommends Option C first (pre-commit nudge) and Option B second (skill hint). **Default to Option C only.** Option B (`/commit-proj` skill `resolves: #N` field) is a separate, larger change — surface to the user before expanding.
+   - **RULES COMPLIANCE:**
+     - The nudge must be **non-blocking** (warning only). A blocking check would block legitimate fix-PR commits where `pr_refs` is still empty during draft.
+     - Per `project_extraction_guard_hook_scope`, pre-commit hooks have a **scope** — make sure the nudge fires when the staged diff includes a known-issue fragment, not on every commit. Don't accidentally nudge on commits that don't touch fragments.
+     - Per `feedback_known_issues_validator_optional_fields`, the validator's `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}` — don't introduce a new field as part of this fix.
+   - **RISK ASSESSMENT:** false positives — many fragment edits are status-flip closures, sweeper edits, or `note:` updates that don't need a `pr_refs` change. The nudge must only fire on fragments that are still `status: open` AND have empty/missing `pr_refs` AND were edited in the staged diff. Otherwise it'll cry wolf on every fragment touch and reviewers will train themselves to ignore it.
+   - **MINIMAL PATH:** add a function in `scripts/validate_known_issues_fragments.py` that walks staged-modified fragments, checks `(status == 'open') AND (pr_refs is empty or missing)`, and prints a non-blocking WARNING with the suggested fix (`Add 'pr_refs: [<this PR #>]' before commit. Auto-closer can't see this fragment otherwise.`). Wire it into the pre-commit hook entry point that already exists.
+
+5. **Implementation** (Option C path):
+   - Locate the existing pre-commit entry point in `scripts/validate_known_issues_fragments.py` (the script already runs as a hook).
+   - Add a new check function: detect staged-modified `docs/known-issues/*.md` files where the fragment's parsed `status == 'open'` AND `pr_refs` is missing/empty.
+   - Emit a non-blocking warning to stderr with the file path and the recommended one-line fix. Do not exit non-zero.
+   - If the validator framework already has a "warnings vs errors" split, use the warnings channel. If not, the smallest viable change is a print-to-stderr that returns 0.
+   - If `.pre-commit-config.yaml` needs a stage adjustment (e.g., to ensure the hook fires on `commit-msg` so the user sees the warning before the commit lands), make that change here.
+
+6. **Tests.**
+   - Add a unit test in `tests/scripts/` (or wherever the existing validator tests live — `rg -l "validate_known_issues_fragments" tests/`) covering: (i) fragment with `status: open` and missing `pr_refs` triggers the warning; (ii) fragment with `status: open` and `pr_refs: [123]` does not; (iii) fragment with `status: resolved` and missing `pr_refs` does not; (iv) fragment with `status: open` and `pr_refs: []` (empty list) triggers the warning (because the auto-closer can't see it).
+   - Run: `pytest tests/scripts -x -q --tb=short` (or the appropriate path).
+   - Run the validator manually against `origin/main` to confirm it doesn't go off on the existing fragment corpus. The current open fragments without `pr_refs` (gh-258 itself, gh-262, gh-273, gh-280, several legacy-* — see your earlier audit) **should** trigger the warning by design — that's the feature, not a bug. Verify the output volume is acceptable.
+
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, `autonomy: review` (already), set `pr_refs: [<this PR #>]` (eat your own dog food — the new validator should be silent on this fragment). Append a `### Resolution` section describing the new pre-commit warning and where authors will see it. Per `feedback_known_issues_pr_refs_int_not_string`, write `- 287`, not `- '#287'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`.
+
+8. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill) — **not** the global `/commit`. Run it from your worktree. The skill itself runs the validator you just modified — confirm the new warning fires (or doesn't) on your own fragment as a smoke test of the fix.
+
+9. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Option B (the `/commit-proj` skill `resolves: #N` field) — surface to user, do not implement here. It is a larger change that couples fragment bookkeeping to the skill happy path.
+- Option D (one-shot backfill sweep of closed fix-PRs) — separate, one-time script. Not steady-state.
+- Modifying `scripts/sync_known_issue_status.py` (the auto-closer) — fragment explicitly forbids this.
+- Fixing gh-263's stale fragment as part of this PR. The gh-263 closure should be its own fragment-only closure PR (`project_fragment_only_closure_pattern`). Mention it in the PR description as the live example, but don't conflate.
+- Concurrent in-flight work — do **not** touch:
+  - `src/web/routes/review_unified.py`, `src/web/routes/api_unified.py`, `src/web/templates/unified_review.html` (legacy-089, in flight; PR #284)
+  - `tests/integration/extraction_v2/test_e2e_pipeline.py`, `tests/integration/test_full_page_ocr_pipeline.py`, `src/infra/image_storage.py` (gh-262, in parallel)
+  - `scripts/export_image_training_data.py`, `scripts/retrain_image_triage.py`, `scripts/benchmark_vision.py`, `src/llm/vision_client.py`, `src/gold_standard/image_eval.py` (gh-196, in parallel)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_known_issues_pr_refs_int_not_string` — `- 287`, not `- '#287'`. The validator under change here enforces this — don't break it.
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`; don't widen it without explicit request
+- `project_known_issues_new_fragments_gh_namespace` — new fragments require `gh-N` namespace + real GH issue; the validator already enforces this — preserve that behavior
+- `project_extraction_guard_hook_scope` — pre-commit hooks have a scope; make the nudge fire only when fragments are in the staged diff
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR; this fragment's own closure follows that pattern
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-262_r2-prod-write-guard-blocks-local-pytest.md
+++ b/docs/archive/worker-prompts/PICK_gh-262_r2-prod-write-guard-blocks-local-pytest.md
@@ -1,0 +1,74 @@
+You are working gh-262: R2 prod-write guard fails 10 e2e tests on a clean main during local pytest.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-262-r2-prod-write-guard-blocks-local-pytest.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/infrastructure.md` — **authoritative** for image-storage and R2 prod-write guard semantics. Read before changing the guard or the storage backend.
+- Related context (read for shape): `src/infra/image_storage.py` (the guard lives here), `tests/integration/extraction_v2/test_e2e_pipeline.py`, `tests/integration/test_full_page_ocr_pipeline.py`, and the existing pytest fixtures under `tests/conftest.py` / `tests/integration/conftest.py`.
+
+## The problem (summary — fragment is canonical)
+Sourcing `.env` (which sets `R2_BUCKET` to the prod bucket and matching R2 creds) without also setting `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` causes 10 integration tests on a clean `origin/main` to fail with `Refusing R2 write — set FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 to allow.` The guard is intentional and correct (`.claude/rules/infrastructure.md`); the failure is a local-DX problem. Fixing it removes a recurring source of false-positive `pytest -x -q` failures that mask real regressions during `/commit-proj` flows.
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Reproduce locally:
+   ```bash
+   git fetch origin main --quiet
+   # In a shell where .env (with R2_BUCKET set) has been sourced and FILINGS_REVIEWER_ALLOW_PROD_WRITES is NOT set:
+   pytest tests/integration/extraction_v2/test_e2e_pipeline.py tests/integration/test_full_page_ocr_pipeline.py -x -q --tb=short
+   ```
+   Expect ~10 `Refusing R2 write` failures matching the fragment's list. If reproduction shows a different failure mode, stop and re-scope before planning. If all 10 already pass on clean main (e.g. someone already shipped a fix), abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include the **Documentation** step required by global `Planning Rules` — at minimum, decide whether `.claude/rules/infrastructure.md` and `docs/development/CONTRIBUTING.md` need a "tests use LocalFilesystemStorage automatically" note.
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-262-r2-guard-test-fixture`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:** confirm `LocalFilesystemStorage` is the right swap-in (read `src/infra/image_storage.py` for the `ImageStorage` interface and existing factory). Confirm the guard is keyed on `R2_BUCKET` + `FILINGS_REVIEWER_ALLOW_PROD_WRITES` and not some other env var. Confirm there isn't already a fixture pattern in `tests/conftest.py` you should extend instead of inventing a new one.
+   - **SCOPE CHECK:** the fragment lists two options (test-side fix vs env-side documentation). Per the fragment, the **test-side fix is preferred**; default to that. If the user wants only documentation, surface that as a redirect before writing code.
+   - **RULES COMPLIANCE:** the guard must remain functional in non-test contexts — do not weaken it globally. The fixture should only redirect storage for the duration of the test process. Never write a fix that disables the guard via env-var injection in CI; the guard's presence is what protects prod from CLI scripts.
+   - **RISK ASSESSMENT:** other tests may depend on the prod guard firing (e.g. tests that assert it raises). Grep for `FILINGS_REVIEWER_ALLOW_PROD_WRITES` and `Refusing R2 write` across `tests/` before swapping the default. Any guard-asserting test must continue to use the real backend (or mock it explicitly).
+   - **MINIMAL PATH:** an autouse fixture (or session-scoped fixture) in `tests/integration/conftest.py` that points the test process at `LocalFilesystemStorage` when `R2_BUCKET` is set but `FILINGS_REVIEWER_ALLOW_PROD_WRITES` is not. This avoids editing each test's body.
+
+5. **Implementation** (test-side fix path):
+   - Add a fixture (autouse on the relevant integration scope) in `tests/integration/conftest.py` that overrides image-storage creation to `LocalFilesystemStorage` for the duration of the test, when `R2_BUCKET` is set without `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1`. Document the override in a one-line comment near the fixture so future readers don't assume R2 is always disabled in tests.
+   - If the fixture mechanism needs an injection point in `src/infra/image_storage.py` (e.g., a module-level factory the fixture can monkeypatch), make the smallest change there.
+   - Confirm the fixture is **not** loaded for unit tests (`tests/unit/...`) and **does not** weaken the guard in the production code path.
+
+6. **Tests.**
+   - Re-run the 10 listed cases: `pytest tests/integration/extraction_v2/test_e2e_pipeline.py tests/integration/test_full_page_ocr_pipeline.py -x -q --tb=short`. All 10 must pass.
+   - Run the broader integration suite to confirm no other tests now break (e.g., guard-assertion tests): `pytest tests/integration -x -q --tb=short`.
+   - Add a test that asserts the guard still fires when `LocalFilesystemStorage` is **not** active and `FILINGS_REVIEWER_ALLOW_PROD_WRITES` is unset — this is the regression-protection for "we accidentally disabled the guard everywhere." A simple unit test in `tests/unit/infra/` exercising the guard branch directly is fine.
+   - Pre-existing failures: per project `CLAUDE.md`, do not spend time fixing failures that predate this work. Confirm with `git stash && pytest <case> -x -q && git stash pop`.
+
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, `autonomy: safe` (already), set `pr_refs: [<this PR #>]`, append a `### Resolution` section describing the fixture and which test files now pass cleanly under `R2_BUCKET` set + `FILINGS_REVIEWER_ALLOW_PROD_WRITES` unset. Per `feedback_known_issues_pr_refs_int_not_string`, write `- 285` not `- '#285'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`.
+
+8. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill) — **not** the global `/commit`. Run it from your worktree.
+
+9. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Modifying the prod-write guard's semantics in `src/infra/image_storage.py` beyond what is required to inject the test fixture. The guard must remain on for non-test code paths.
+- Changing `R2_BUCKET` defaults or `.env` templates.
+- The `pyproject.toml` / `CONTRIBUTING.md` documentation-only path (Option B in the fragment) unless the user explicitly redirects there.
+- Any refactor of `LocalFilesystemStorage` or the storage interface.
+- Concurrent in-flight work — do **not** touch:
+  - `src/web/routes/review_unified.py`, `src/web/routes/api_unified.py`, `src/web/templates/unified_review.html` (legacy-089, in flight; PR #284 also touches these)
+  - `scripts/export_image_training_data.py`, `scripts/retrain_image_triage.py`, `scripts/benchmark_vision.py`, `src/llm/vision_client.py`, `src/gold_standard/image_eval.py` (gh-196, in parallel)
+  - `.claude/commands/commit-proj.md`, `scripts/validate_known_issues_fragments.py` (gh-258, in parallel)
+  - `src/infra/db.py` (open PR #284)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_known_issues_pr_refs_int_not_string` — `- 285`, not `- '#285'`
+- `feedback_known_issues_validator_optional_fields` — don't add frontmatter fields outside the allowlist
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `project_render_env_invisible_to_git_audit` — Render env-group config is invisible to PR review; default new safety controls to code, not env. The R2 guard's strength comes from being in code — preserve that.
+- `feedback_run_recovery_before_verification` — when removing or weakening masking scaffolding (e.g., guard-skipping fixtures), confirm the underlying state is clean before declaring success.
+- `feedback_scan_adjacent_defensive_code` — pre-existing test scaffolding may already mask the issue (e.g., a conftest that sets `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` for CI). Grep for env-var setters in `tests/` and `.github/` before adding new ones.
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-263_fragment-only-closure.md
+++ b/docs/archive/worker-prompts/PICK_gh-263_fragment-only-closure.md
@@ -1,0 +1,91 @@
+You are working gh-263: fragment-only closure PR. The code work already shipped in PR #272.
+
+This is a tiny housekeeping task — a 1-file diff that flips the fragment to `resolved` and sets `pr_refs: [272]`. No code changes. No tests. ~5 minutes end-to-end.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md` (read in full from `origin/main`)
+- `CLAUDE.md` (project root) — read; obey **Implementation Rules**
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply (especially `project_fragment_only_closure_pattern`, `feedback_known_issues_pr_refs_int_not_string`, `feedback_known_issues_validator_optional_fields`)
+
+## Status
+- Fragment on `origin/main` is `status: open` with no `pr_refs`.
+- The proposed refactor (`_maybe_append_exhibit_991` helper extraction) **already shipped in PR #272** ("refactor(filing-fetcher): extract _maybe_append_exhibit_991 helper (closes #263)", merged 2026-04-28 06:33 UTC).
+- Verified: `grep -n "_maybe_append_exhibit_991" src/filing_fetcher/filing_fetcher.py` shows the helper at line 272 with two callsites (lines 380 and 394).
+- The fragment author of PR #272 forgot to set `pr_refs` on the fragment, so the auto-closer can't see it. This is exactly the symptom gh-258 (now resolved, PR #286) addresses going forward — but PR #272 merged before that warning landed.
+
+This PR is the closure half. It's also a small real-world test of the gh-258 warning *not* firing on a fragment whose `pr_refs` is now populated.
+
+## Workflow
+
+1. **Verify the work is done.**
+   ```bash
+   git fetch origin main --quiet
+   grep -n "_maybe_append_exhibit_991" src/filing_fetcher/filing_fetcher.py    # expect 3 matches
+   gh pr view 272 --json state,mergedAt,title                                   # expect MERGED, "(closes #263)"
+   git show origin/main:docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md | head -20
+   ```
+   If the fragment on origin/main has already been flipped to `resolved` (e.g. the auto-closer somehow picked it up overnight), abort — there's nothing to do.
+
+2. **Worktree-first.** `EnterWorktree fix/gh-263-fragment-closure`. Verify you're NOT in any of the in-flight worktrees.
+
+3. **Pre-Implementation Gate** (abbreviated, this is a 1-file edit).
+   - **ASSUMPTION AUDIT:** confirm `_maybe_append_exhibit_991` is at `src/filing_fetcher/filing_fetcher.py:272` with callsites at ~380 and ~394 (don't need to verify the implementation — that's PR #272's job). Confirm PR #272 is MERGED in `gh pr view 272`.
+   - **SCOPE CHECK:** in: edit `docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md` only. Out: anything else.
+   - **RULES COMPLIANCE:**
+     - `feedback_known_issues_pr_refs_int_not_string` — `pr_refs:` must be `- 272`, not `- '#272'` (string). The validator rejects strings.
+     - `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`. Don't add other frontmatter fields. The fragment already has `gh_issue: 263`; preserve it.
+     - The pre-commit hook from gh-258 (PR #286) now warns when a `status: open` fragment is staged without `pr_refs`. Your edit is *flipping* status to `resolved` AND adding `pr_refs`, so the warning should NOT fire — if it does, that's a real bug in PR #286's logic and you should surface it (don't suppress).
+   - **MINIMAL PATH:** edit the fragment frontmatter + append `### Resolution`. That's it.
+   - **WORKTREE CHECK:** yes (step 2).
+
+   No need for explicit user approval on this one — the scope is trivial and the precedent (`project_fragment_only_closure_pattern`, e.g. PRs #232–#234, #240) is well-established.
+
+4. **Implementation.** Edit `docs/known-issues/gh-263-filing-fetcher-8k-exhibit-branch-duplication.md`:
+   - Flip `status: open` → `status: resolved`.
+   - Add `pr_refs:` block with `- 272` (single integer, no `#`, no quotes).
+   - Append a new `### Resolution` section at the end, roughly:
+     ```markdown
+     ### Resolution
+
+     PR #272 (merged 2026-04-28) extracted `_maybe_append_exhibit_991`
+     in `src/filing_fetcher/filing_fetcher.py` and routes both the
+     cold-fetch and cached-backfill branches through it. Both legacy-058's
+     `get_exhibit_99_1_url` fetch logic and legacy-115's PDF skip+warn
+     guard now live in the helper, removing the matched-edits hazard
+     this fragment flagged.
+
+     The fragment was not flipped at PR #272 merge time because `pr_refs`
+     was not set on the fragment in that PR — the same drift gh-258
+     (PR #286) now warns against. This closure PR is the bookkeeping
+     half.
+     ```
+
+5. **Tests.** None — this is a docs-only change. Per project `CLAUDE.md`: "Docs-only and `.claude/`-only commits may skip lint and tests." Confirm by running `git diff --name-only origin/main..HEAD` before commit and verifying only the one fragment file is changed.
+
+6. **Commit + PR.** Use the **project-local** `/commit-proj` skill. The pre-commit framework's gh-258 nudge should pass cleanly on this edit.
+
+7. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Required CI checks should be light (Lint + Vulnerability Scan only — no tests for docs-only PRs in some configurations; let CI guide you).
+
+## Out of scope (do NOT expand into)
+- Any change to `src/filing_fetcher/filing_fetcher.py`. The refactor already shipped.
+- Adding tests for the helper. Existing integration tests in `tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` already cover both branches and pass — they were verified by PR #272.
+- Editing other known-issue fragments that may also be stuck-pending-closure (the gh-263 fragment is the documented live example for the gh-258 PR; other stuck fragments are out of scope here).
+- Adjusting the gh-258 warning logic if it fires unexpectedly — flag to user, do not patch in this PR.
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097, in flight)
+  - `src/universe/onboarding_runner.py`, `docs/operations/*` (legacy-062, in flight)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293, in flight)
+  - `.claude/rules/web.md` (gh-294, in flight; PR #297)
+  - `src/gold_standard/baseline.py`, `src/gold_standard/v2_validator.py` (gh-273, in parallel)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after `/commit-proj`
+- `feedback_known_issues_pr_refs_int_not_string` — write `- 272`, not `- '#272'`. **The whole point of this PR is correct `pr_refs` shape.**
+- `feedback_known_issues_validator_optional_fields` — don't add frontmatter fields outside the allowlist
+- `project_fragment_only_closure_pattern` — this is the canonical pattern; ship the closure, append Resolution, set pr_refs
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_known_issues_new_fragments_gh_namespace` — gh-263 already follows the namespace; nothing to change
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-273_gs-gate-cache-turnover-tolerance.md
+++ b/docs/archive/worker-prompts/PICK_gh-273_gs-gate-cache-turnover-tolerance.md
@@ -1,0 +1,125 @@
+You are working gh-273: GS gate has no tolerance band for LLM cache-turnover noise.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-273-gs-gate-cache-turnover-tolerance.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**. Pay attention to "Metric Priority Tiers" — the gate you are softening is the Tier-1 must-not-miss gate, so the change has direct policy implications.
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- Related context (read for shape): `src/gold_standard/baseline.py` (`compare_to_baseline` — the gate function), `src/gold_standard/v2_validator.py` (`--fail-on-regression` entrypoint), `data/gold_standard/v2_baseline.json` (baseline shape; do not edit), `docs/operations/text-pipeline-presence-pivot-plan.md` (rationale for why `tier1_presence_recall` is the gate metric).
+
+## The problem (summary — fragment is canonical)
+The Tier-1 presence-recall gate in `compare_to_baseline` is zero-tolerance: any negative delta on `tier1_presence_recall` flips `has_regression=True`. With ~176 Tier-1 cells in the corpus, LLM responses can vary by 1–2 cells on cache miss even at `temperature=0` — ~1pp recall noise, enough to trip a zero-tolerance gate. **It has tripped twice with no production code change** (PR #87, legacy-111). The structural risk is independent of either resolution.
+
+## The decision (resolve in plan mode)
+Fragment lists three durable-fix options:
+
+1. **Widen tolerance band** — accept ~0.5–1pp negative delta. Trade: small false-negative window for shallow real regressions.
+2. **Re-run-on-fail retry** — on first fail, re-run validation once; consistent fail = real regression. Trade: ~3 min cost on every gate-trip; needs careful fixture isolation.
+3. **Pin cache contents** — capture LLM cache rows into a fixture for reproducibility. Trade: ongoing maintenance burden as prompts evolve.
+
+**Recommended shape: Option B (Re-run-on-fail retry).** Rationale:
+- The fragment's "Operator workaround (current)" section already documents a manual re-run-once protocol; Option B just automates the existing operator habit.
+- Memory `feedback_reproduce_before_bisect_transient_regression` confirms the protocol is the right empirical primitive ("~3 min re-run beats hours of wasted bisect planning").
+- Option A (tolerance band) opens a real false-negative window for shallow regressions on Tier-1 must-not-miss metrics — that conflicts with `CLAUDE.md` "Tier 1 presence-recall regression = blocker" policy.
+- Option C (pin cache) creates a maintenance liability that grows as prompts evolve, and the LLM cache key already includes the prompt — so any prompt change invalidates the pin anyway.
+
+**Surface the recommendation in plan mode** and let the user redirect to A or C if they prefer. Do NOT silently ship a different option than the user agrees to.
+
+## Workflow
+
+1. **Verify the issue is still relevant.**
+   ```bash
+   git fetch origin main --quiet
+   grep -nE "tier1_presence_recall|has_regression|compare_to_baseline" src/gold_standard/baseline.py | head -20
+   ```
+   Confirm `compare_to_baseline` still implements zero-tolerance on `tier1_presence_recall`. If a tolerance band or retry mechanism has appeared since `updated: 2026-04-28`, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+   Sanity-check the gate currently fires by mental walk-through: pick the function in `src/gold_standard/baseline.py` that takes the current run + baseline and returns the regression decision. Confirm it does not retry, does not allow tolerance, and reads `tier1_presence_recall` from baseline JSON.
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include:
+   - **Decision: which of the three options ships.** Default recommendation: Option B. Surface to user in plan-review with the rationale above.
+   - **Documentation step** (per global Planning Rules):
+     - Update `CLAUDE.md` "Metric Priority Tiers > Rules" to describe the new retry behavior so the policy doc reflects ground truth.
+     - Update `docs/operations/text-pipeline-presence-pivot-plan.md` if it claims zero-tolerance semantics anywhere.
+     - Update memory `project_zero_tolerance_gate_fragility` post-merge — replace "tripped twice with no code change" with "tripped twice; durable fix is Option B (re-run-on-fail retry)" and reference the resolution PR. (The worker can flag this in PR description; a separate memory edit is fine if the worker doesn't have memory write access.)
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-273-gs-gate-rerun-on-fail`. The PreToolUse hook denies HEAD-moving git ops in the primary tree. **Verify** you are NOT in any of the in-flight worktrees (`fix+legacy-097-chart-only-backfill`, `claude/feat-gh-294-image-tab-shortcuts`, or any gh-293 worktree).
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:**
+     - Confirm `compare_to_baseline` is the right function and is the sole gate trigger (grep `has_regression` across `src/gold_standard/`).
+     - Confirm `tier1_presence_recall` is what the baseline JSON keys on (read the relevant entry of `data/gold_standard/v2_baseline.json` — do not edit).
+     - Confirm there is a clean re-entry point for "re-run validation": you'll need to re-execute the corpus run that produced the failing comparison. Find that callsite (likely `src/gold_standard/v2_validator.py::main` or similar). The retry must produce a fresh validation result, not a cached one — make sure the LLM cache invalidation semantics aren't making this trivial in a misleading way.
+   - **SCOPE CHECK:**
+     - In: retry logic in `compare_to_baseline` (or wherever the gate decision lives), wired into `--fail-on-regression`. Test coverage. Doc updates.
+     - Out: changing the corpus, changing baseline values, changing what counts as Tier-1, touching `data/gold_standard/v2_baseline.json`, modifying the LLM cache primitives.
+   - **RULES COMPLIANCE:**
+     - Per `CLAUDE.md` "Tier 1 presence-recall regression = blocker": the retry must NOT silently swallow real regressions. The contract is "first fail → retry once → consistent fail = regression". A flaky-but-real regression that flips between trips and clears would be hidden. Document this loophole explicitly in the docstring + plan, and surface to user.
+     - Per `project_extraction_guard_hook_scope` (memory): the local pre-commit hook fires on changes to `src/extraction*`, `config/metric_keywords.yaml`, `src/review/keyword_matching|false_positive_filter`. Changes to `src/gold_standard/` **bypass** the gate locally — meaning your retry change won't be self-tested by the very gate it's modifying during the commit. CI will run it. Plan accordingly.
+   - **RISK ASSESSMENT:**
+     - The retry doubles the worst-case CI runtime when the gate trips. Acceptable (it only doubles on failure, and "trip then clear" is cheap).
+     - Fixture isolation: if the retry runs in the same Python process, in-memory state from the first run could leak (caches, monkeypatches, environment). Verify the retry creates a fresh `V2Pipeline` / fresh validator state.
+     - There is no rollback complication: the change is in the gate decision, not in any data path. Reverting is safe.
+   - **MINIMAL PATH:** confirmed above.
+   - **WORKTREE CHECK:** yes (step 3).
+
+   Show the completed checklist and **get user approval** before writing code.
+
+5. **Implementation (Option B — recommended path):**
+   - In `src/gold_standard/baseline.py`, modify `compare_to_baseline` (or the calling site in `v2_validator.py` if cleaner) to support a retry-on-fail wrapper. Sketch:
+     ```python
+     # First run already produced `result`. If the Tier-1 presence-recall
+     # delta is negative, re-run validation once and use the second result
+     # as the gate signal.
+     ```
+   - Wire into `--fail-on-regression` so retry fires only when invoked from the gate path (not from informational `python3 -m src.gold_standard.v2_validator` runs without the flag).
+   - Add a clear log line on the retry: e.g. `tier1 presence-recall regression detected (delta=<X>); re-running once to discriminate cache-turnover vs real regression`.
+   - On consistent fail: emit the regression with both runs' deltas in the message.
+   - On retry-clears: emit a one-liner noting the retry cleared and the suspected cause (cache turnover); proceed with `has_regression=False`.
+   - Keep all retry logic synchronous and within the existing process — no async, no subprocess fork. Fixture isolation is a code-organization problem, not a process problem.
+
+6. **Tests.** Add tests under `tests/gold_standard/` (find with `rg -l "compare_to_baseline" tests/`):
+   - **Real regression: both runs fail.** Mock validator output to return `tier1_presence_recall_delta = -0.05` on both calls. Assert: `has_regression=True`, regression includes both deltas in the message.
+   - **Cache turnover: first fail, second clears.** Mock validator output: first call delta=-0.01, second call delta=0.0. Assert: `has_regression=False`, retry log line emitted.
+   - **No retry when delta non-negative on first call.** Mock validator output: first call delta=0.0. Assert: validator called exactly once, no retry, `has_regression=False`.
+   - **Retry only fires under `--fail-on-regression`.** Without the flag, retry must not run (informational invocations stay single-run).
+   - **Retry creates fresh state.** Verify retry doesn't reuse in-memory state from the first call (asserts on the call to whatever validation entrypoint you use — could be a spy/mock).
+   Run: `pytest tests/gold_standard -x -q --tb=short`. Pre-existing failures: `git stash && pytest <case> -x -q && git stash pop` per project `CLAUDE.md`.
+
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section that:
+   - States which option shipped (Option B, with the chosen variant if redirected).
+   - Notes the trade-off explicitly: "real flaky regressions that intermittently clear are hidden by this retry. The bet is that production code regressions are stable across two runs; cache-turnover regressions are not."
+   - Lists test coverage.
+   Per `feedback_known_issues_pr_refs_int_not_string`, write `- 298` (or whichever PR # lands), not `- '#298'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`. Update `note:` to summarize the chosen option (drop "needs decision" qualifier).
+
+8. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill) — **not** the global `/commit-user`. Run from your worktree. Note: per `project_extraction_guard_hook_scope`, the local extraction-guard hook does not gate this change — CI will be the first place the new retry mechanism runs end-to-end. Don't be surprised if a CI run trips the new retry on its first fire; that's the feature.
+
+9. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Implementing Options A or C as fallbacks ("just in case Option B isn't enough"). One option ships per PR. If Option B proves insufficient over time, file a follow-up.
+- Touching `data/gold_standard/v2_baseline.json` (baseline values), the corpus, the LLM cache, or any extraction stage.
+- Re-tuning Tier-1 metric tier definitions in `config/metric_keywords.yaml`.
+- Changing the validator's informational outputs (fact-recall, per-company drops, chart presence_f1) — they remain advisory per the text-presence pivot.
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097, in flight)
+  - `src/universe/onboarding_runner.py`, `docs/operations/*` (legacy-062, in flight)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293, in flight)
+  - `.claude/rules/web.md` (gh-294, in flight; PR #297)
+  - `src/filing_fetcher/filing_fetcher.py` and `docs/known-issues/gh-263-...md` (gh-263 closure, in parallel)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after `/commit-proj`
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_known_issues_pr_refs_int_not_string` — write `- 298`, not `- '#298'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_reproduce_before_bisect_transient_regression` — the manual re-run-once protocol that Option B automates
+- `project_zero_tolerance_gate_fragility` — both prior trips; update post-merge to reference the resolution PR
+- `project_extraction_guard_hook_scope` — local pre-commit hook does NOT cover `src/gold_standard/`; CI is the first end-to-end run
+- `feedback_gs_analysis_doc_baseline_age` — if you reproduce the existing gate trip during testing, re-run validator output before drawing conclusions; baseline can move within hours
+- `project_gs_baseline_schema_corpus_only` — `tier1/tier2_presence_recall` in baseline JSON are corpus-only; per-company is P/R/F1 only. Subset-aware retry isn't possible without schema migration first — keep retry at the corpus-level decision.
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-280_image-level-rejection-signal-ml-training.md
+++ b/docs/archive/worker-prompts/PICK_gh-280_image-level-rejection-signal-ml-training.md
@@ -1,0 +1,68 @@
+You are working gh-280: Image-level rejection signal for ML training. **Read the full prompt before starting** — this is a verify-then-decide task, not a feature build.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-280-image-level-rejection-signal-ml-training.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey Implementation Rules and Pre-Implementation Gate. Note especially the design principle 4 paragraph that documents the existing sentinel-row behavior for "Reject all (no relevant metrics)".
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+
+## Why this prompt is different
+
+Spot-check before /pick-issues drafted this: `src/web/routes/api_unified.py:672` already contains the branch `if not detected_metric_id and rejection_reason != "no_relevant_metrics":` and `src/infra/db.py:2234` has a comment referencing "the NULL/NULL 'no relevant metrics' sentinel reject". CLAUDE.md (Core Design Principles §4) describes this behavior as already shipped: a sentinel `v2_image_metric_confirmations` row with NULL `detected_metric_id` and NULL `confirmed_metric_id` is written when "Reject all" is pressed on a zero-detected-metric image.
+
+So the fragment's stated gap ("zero-detected-metric images leave no row") **looks already-resolved**. The work is to confirm that, then either:
+- **Path A (most likely):** Produce a fragment-only closure PR — flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]` after creation, append a `### Resolution` section pointing to the resolving commit (find via `git log -S 'no_relevant_metrics' src/web/routes/api_unified.py`), and close GH issue #280 with a note. Per `project_fragment_only_closure_pattern` and `feedback_investigate_then_fix_under_30min` and `feedback_shipped_not_effective`.
+- **Path B (fallback):** If reproduction shows the sentinel row is **NOT actually written** end-to-end (e.g. the branch in `api_unified.py:672` is reachable but the upstream caller never enters it for the zero-detected case), implement the missing piece per the fragment's "Next Steps".
+
+Do not skip the verification step. `feedback_verify_issue_status` and `feedback_fragment_fix_is_hypothesis` apply directly here.
+
+## Workflow
+1. **Reproduce the claimed gap.** Without making any code changes:
+   - Find a `v2_image_assets` row with no detected_metrics (`SELECT img_id FROM v2_image_assets WHERE detected_metrics IS NULL OR detected_metrics = '[]' LIMIT 5;`). Use a dev DB, not prod.
+   - Trace the "Reject all (no relevant metrics)" code path in `src/web/static/js/review_images_v2.js` (search for the button handler) → the API endpoint it calls in `src/web/routes/api_unified.py` → the DB write. Confirm whether a `v2_image_metric_confirmations` row is written for the zero-detected case.
+   - If you can run a local server, exercise the button against a zero-detected image and `SELECT * FROM v2_image_metric_confirmations WHERE img_id = <that one>` to confirm. If you cannot run a local server, trace the code path carefully and document the sentinel-row INSERT site explicitly.
+   - Record findings in the plan: file:line of the INSERT, file:line of the call site, conditions under which the row is or isn't written.
+2. **Decide Path A vs Path B.** If the sentinel row is written for zero-detected "Reject all" presses (matching CLAUDE.md §4), you are on **Path A**. Otherwise **Path B**. Surface the decision to the user before implementing.
+
+### Path A — fragment-only closure
+3A. **Worktree-first.** `EnterWorktree fix/gh-280-fragment-closure-stale`.
+4A. Edit `docs/known-issues/gh-280-image-level-rejection-signal-ml-training.md`:
+    - `status: open` → `status: resolved`
+    - `autonomy: skip` → `autonomy: n/a`
+    - Add `pr_refs: [<this PR #>]` after PR creation (write `- <int>`, never `- '#<int>'` per `feedback_known_issues_pr_refs_int_not_string`)
+    - Append a `### Resolution` section explaining: discovered already-fixed during /pick-issues triage; cite the resolving commit (`git log -S 'no_relevant_metrics' src/web/routes/api_unified.py` should narrow it) and CLAUDE.md §4 as the authoritative description.
+    - Do **not** add any frontmatter fields outside the validator allowlist (`pr_refs`, `gh_issue`, `note`) per `feedback_known_issues_validator_optional_fields`.
+5A. Commit + PR via `/commit-proj`. Pre-existing test failures are acceptable to ignore on a docs-only PR per CLAUDE.md "Testing Standards" (docs-only commits may skip lint and tests).
+6A. After merge, close GH issue #280 with a comment referencing the resolving commit and this closure PR.
+7A. Verify auto-merge per `feedback_verify_auto_merge_after_commit`.
+
+### Path B — implement the missing signal
+3B. **Plan mode** required. Decide between fragment options (a) `decision='reject_image'` enum value or (b) splitting `review_status='skipped'` into `skipped_rejected` / `skipped_parked`. Surface tradeoffs to the user. Do not pick unilaterally — this is a schema change either way.
+4B. **Worktree-first.** `EnterWorktree fix/gh-280-image-level-rejection-signal`.
+5B. **Pre-Implementation Gate** with full ASSUMPTION AUDIT — the fragment is recent (2026-04-28) but the codebase moves fast around image confirmations (PR #284 shipped "Reject all" recently, and `claude/feat-gh-293-reopen-reviewed-image` is currently in flight on `api_unified.py`). Verify every assumption. Risk row must explicitly check the in-flight gh-293 worktree's diff against `api_unified.py` to avoid merge-conflict-by-implementation.
+6B. Implement. Add a migration if schema changes; update the "Reject all" handler; update the fragment status as part of the same PR per `project_fragment_only_closure_pattern`.
+7B. Tests: `pytest -x -q --tb=short`. Add unit coverage for the new signal path.
+8B. Commit + PR via `/commit-proj`. Verify auto-merge.
+
+## Out of scope (do NOT expand into)
+- Do **not** backfill historical `v2_image_assets.review_status='skipped'` rows. The fragment mentions backfill as optional/future ("Plan backfill for historical skipped rows where intent is recoverable") — skip it. If backfill matters, file a follow-up fragment.
+- Do **not** modify the ML triage training pipeline or anything in `scripts/export_image_training_data.py` / `scripts/retrain_image_triage.py` / `scripts/benchmark_vision.py` — those are gh-196's scope (still partially-resolved).
+- Do **not** redesign the per-metric confirmation schema or rename fields.
+- Do **not** edit `src/web/templates/unified_review.html` or `src/web/static/js/review_images_v2.js` while gh-293 and gh-294 worktrees are locked on them.
+- Do **not** touch chart/image classifier scoring (`src/extraction_v2/chart/*`) — that's gh-289's scope.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — known-issue fragments go stale; check git/code state before recommending action **(critical for this prompt)**
+- `feedback_fragment_fix_is_hypothesis` — reproduce and rule out the proposed cause before implementing the proposed fix
+- `feedback_investigate_then_fix_under_30min` — if diagnosis+fix is faster than writing a thorough fragment, do the work now; especially relevant for documented-but-broken safety controls
+- `feedback_shipped_not_effective` — closure ≠ outcome; verify upstream preconditions are met before believing an issue is solved
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_known_issues_pr_refs_int_not_string` — `pr_refs` must be a list of ints
+- `feedback_known_issues_validator_optional_fields` — frontmatter optional fields are limited to `pr_refs`, `gh_issue`, `note` (CI Lint enforces; local pre-commit doesn't catch)
+- `feedback_close_partially_resolved_cleanly` — close cleanly; don't leave indefinitely partially-resolved
+- `project_image_review_decisions_for_ml_training` — preserve per-(image, metric) decision trail; the sentinel design exists precisely to fill the zero-detected-metric gap
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after PR opens
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+
+## Return
+The PR URL when done. State explicitly which path (A or B) you took, and which commit resolves the original gap.

--- a/docs/archive/worker-prompts/PICK_gh-291_image-tab-typeahead-consolidate-datalist.md
+++ b/docs/archive/worker-prompts/PICK_gh-291_image-tab-typeahead-consolidate-datalist.md
@@ -1,0 +1,40 @@
+You are working gh-291: Drop redundant `/api/v2/metrics/list` AJAX from image-tab typeahead (consolidate datalist).
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-291-image-tab-typeahead-consolidate-datalist.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey Implementation Rules and Pre-Implementation Gate
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm the duplicate datalist still exists by grepping for `detected-metrics-datalist` in `src/web/templates/unified_review.html` and `src/web/static/js/review_images_v2.js`. As of session start, the inputs at `unified_review.html:973` and `:991` still bind `list="detected-metrics-datalist"`, the empty datalist still lives at `:1007`, and `loadMetricsList()` / `DATALIST_ID` / `populateDatalist()` still exist in `review_images_v2.js:297,337,369,386`. If the consolidation has already shipped, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+2. **Wait-or-coordinate check.** Two locked worktrees touch the same two UI files: `claude/feat-gh-293-reopen-reviewed-image` and `claude/feat-gh-294-image-tab-shortcuts`. Before starting, run `gh pr list --search 'gh-293 OR gh-294' --state all --json number,state,headRefName` and verify both have either merged to `main` or have no in-progress edits to `unified_review.html` lines around the image-tab inputs (~970–1010) and to `review_images_v2.js` `init()` / `state.metricsList`. If either is still in flight, **stop and report** — do not race them. Per `feedback_subagent_midstream_stops` and the skill's parallel-safety rule, the right move is to wait for them to merge then rebase.
+3. **Plan mode.** Use plan mode for this change. Run `/plan-review` before exiting plan mode. The change is mechanical but touches a hot UI file — a plan is still warranted because of the in-flight collision risk.
+4. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-291-image-tab-datalist-consolidation`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+5. **Pre-Implementation Gate** (per global CLAUDE.md). Show the completed checklist and get user approval before writing code. Pay special attention to the Risk Assessment row: `loadMetricsList()` may be called from anywhere in `review_images_v2.js` — grep for all references before deleting.
+6. **Implement.** Per the fragment "Next Steps":
+   - `unified_review.html`: switch `list="detected-metrics-datalist"` → `list="all-metrics-datalist"` on the two image-tab inputs (`add-missed-detected-input` ~line 973, `metric-correct-input` ~line 991). Delete the empty `<datalist id="detected-metrics-datalist">` element (~line 1007).
+   - `review_images_v2.js`: remove `DATALIST_ID` (line 297), the `loadMetricsList()` call from `init()` (line 337), the `loadMetricsList()` definition (lines 369–390 area), the unused `populateDatalist()` helper, and any `state.metricsList` assignment.
+   - **Leave `/api/v2/metrics/list` route in place** — referenced by integration / UI tests (per fragment).
+7. **Tests.** Per project CLAUDE.md testing standards — `pytest -x -q --tb=short`. Plus run the UI suite: `cd tests/ui && npx playwright test review.spec.js` (or the project's documented command). The image-tab typeahead behavior is exercised by Playwright; both inputs should still resolve metric IDs against the datalist.
+8. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, `autonomy: n/a`, set `pr_refs: [<this PR #>]` (after PR creation), append a short `### Resolution` section. Per `project_fragment_only_closure_pattern` and `feedback_known_issues_pr_refs_int_not_string` (write `- 291`, not `- '#291'`).
+9. **Commit + PR.** Use the **project-local** `/commit-proj` skill.
+10. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
+
+## Out of scope (do NOT expand into)
+- Do **not** delete or modify the `/api/v2/metrics/list` Flask route (`src/web/routes/api_unified.py`) — integration / UI tests still hit it.
+- Do **not** modify the text-tab `<datalist id="all-metrics-datalist">` block (~line 1505) — it's the canonical server-rendered datalist this PR is consolidating onto.
+- Do **not** rebind any keyboard shortcuts or buttons on the image tab — that's gh-294's scope, currently in flight on `claude/feat-gh-294-image-tab-shortcuts`.
+- Do **not** add an "Undo review" affordance — that's gh-293's scope, currently in flight on `claude/feat-gh-293-reopen-reviewed-image`.
+- Do **not** touch any chart/image classifier code, OCR, or extraction stages.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on `origin/main` and grep current code first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after PR opens
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_known_issues_pr_refs_int_not_string` — `pr_refs` must be a list of ints
+- `project_web_route_doc_authority` — if behavior docs need updating, the canonical surface is `.claude/rules/web.md`, not `HUMAN_REVIEW_SYSTEM.md`
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-298_chart-only-drain-branch-unreachable.md
+++ b/docs/archive/worker-prompts/PICK_gh-298_chart-only-drain-branch-unreachable.md
@@ -1,0 +1,126 @@
+You are working gh-298: `chart_only=True` drain branch is unreachable post-presence-pivot.
+
+This is a small, surgical fix. The fragment is `autonomy: skip` because it was filed without an autonomous-runner contract, but the work is well-bounded and the user has directed it for a worker prompt.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-298-chart-only-drain-branch-unreachable.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**. Pay attention to design principle 6 (reviewed-filing guard).
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/v2-pipeline.md` — section "Chart-only re-extraction (`chart_only=True`)" — the documented behavior the fix realigns code with
+- Related context (read for shape): `src/extraction_v2/persistence.py` (specifically `_persist_facts_in_tx` lines ~1015–1167), legacy-097's worker prompt at `docs/worker-prompts/PICK_legacy-097_chart-only-backfill-with-lifted-budget.md` (the live drain that surfaced this bug — operator had to fall back to direct SQL DELETE)
+
+## The bug (canonical from fragment)
+`_persist_facts_in_tx` at `src/extraction_v2/persistence.py:1038-1042`:
+```python
+if chart_only:
+    facts = [f for f in facts if f.source_type == SourceType.CHART]
+
+if not facts:
+    return 0
+```
+Under the chart-presence pivot (#86), `enable_chart_candidate_emission=False` means the pipeline never produces chart facts, so the filter always yields an empty list, so the early-return always fires — **before** the reviewed-filing guard and the DELETE block. The drain semantics documented in `.claude/rules/v2-pipeline.md` are unreachable.
+
+Discovered 2026-04-28: legacy-097's `--chart-only --force-reextract` ran on 7 reviewed filings and produced **zero** `force-reextract purging reviewed filing` log lines. The 30 chart facts and their 28 reviewer decisions sat unchanged; the drain had to be done via direct SQL.
+
+## The fix (canonical from fragment "Next Steps")
+Move the `if not facts: return 0` early-return *below* the chart-decision guard + DELETE block when `chart_only=True`. Under chart-only mode, an empty filtered list means "no new chart facts to insert, but still drain existing ones" — emptiness is the expected post-pivot state, not a no-op signal.
+
+## Workflow
+
+1. **Verify the bug is still present.**
+   ```bash
+   git fetch origin main --quiet
+   sed -n '1015,1170p' src/extraction_v2/persistence.py | head -160
+   ```
+   Confirm the early-return at lines ~1041–1042 still fires before the guard+DELETE block. If the structure has changed since `updated: 2026-04-28`, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+   Also verify the integration test gap:
+   ```bash
+   rg -n "chart_only.*force.*True|chart_only=True.*facts=\[\]" tests/
+   ```
+   Expect no test that exercises `chart_only=True` with an empty facts list. That gap is what let the bug ship.
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include:
+   - **Documentation step** (per global Planning Rules): no `.claude/rules/*` change needed (the rule doc already describes the *intended* behavior; the fix realigns code with the doc). Update the fragment's `### Resolution` section as part of the same PR.
+   - **The exact restructure**: separate `chart_only=False` (current behavior — return 0 on empty inbound) from `chart_only=True` (drain-only mode — proceed to guard+DELETE even when inbound facts is empty, then skip the INSERT).
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-298-chart-only-drain-reachable`. The PreToolUse hook denies HEAD-moving git ops in the primary tree. **Verify** you are NOT in any of the in-flight worktrees (`fix+legacy-097-chart-only-backfill`, `fix-gh-273-gs-gate-rerun-on-fail`, `fix-gh-263-fragment-closure`, `claude/feat-gh-293-...`, `claude/feat-gh-294-...`, `feat-render-deploy-speed-pr2`).
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:**
+     - Confirm the early-return is at the location the fragment claims (lines ~1041–1042 at brief time). The DELETE on line 1118 must currently be unreachable when `facts=[]` and `chart_only=True`.
+     - Confirm `_persist_facts_in_tx` is called from both `persist_facts` and `persist_pipeline_result` with `chart_only` threaded through (grep `chart_only` across `src/extraction_v2/persistence.py`).
+     - Confirm `executemany(sql, deduped)` in the INSERT block at ~line 1166 tolerates an empty list (it does — `executemany([])` is a no-op in psycopg). If not, an explicit early-return after DELETE is required for chart_only.
+   - **SCOPE CHECK:**
+     - In: restructure of the early-return logic in `_persist_facts_in_tx`. New unit/integration test for `chart_only=True` with empty inbound facts. Fragment closure.
+     - Out: changes to `chart_only` semantics elsewhere (call sites, CLI flags, persistence layer outside `_persist_facts_in_tx`); changes to `presence_only`; touching the warning-text "purging image-metric confirmations" in the secondary guard (separate cleanup, not in scope).
+   - **RULES COMPLIANCE:**
+     - Per `CLAUDE.md` design principle 6 (reviewed-filing guard): the fix MUST preserve the existing guard semantics. Specifically: with `chart_only=True, facts=[], force=False, decisions_exist=True` → still raise `ReviewedFilingError`. With `force=True` → proceed to DELETE and CASCADE. The bug is that the guard never runs; the fix must NOT bypass it.
+     - The `v2_image_metric_confirmations` secondary guard (~lines 1083–1114) must continue to fire under `chart_only=True` (its query is not scoped by chart_only — confirmed by reading the SQL).
+   - **RISK ASSESSMENT:**
+     - Minor: the fix changes drain timing for production callers using `chart_only=True`. Today they're no-ops; after the fix they will actually delete. Search for in-tree callers of `chart_only=True`:
+       ```bash
+       rg -n "chart_only\s*=\s*True" --type py
+       ```
+       At brief time these are in `scripts/batch_v2_extraction.py` (the `--chart-only` CLI), `src/extraction_v2/persistence.py` (the function under change), and tests. The CLI is operator-invoked; no surprise on next operator run is expected.
+     - The legacy-097 drain has already been resolved via direct SQL; the post-fix drain becomes idempotent on the empty result set.
+   - **MINIMAL PATH:** confirmed above.
+   - **WORKTREE CHECK:** yes (step 3).
+
+   Show the completed checklist and **get user approval** before writing code.
+
+5. **Implementation.**
+   a. In `_persist_facts_in_tx`, restructure as:
+      ```python
+      if chart_only:
+          facts = [f for f in facts if f.source_type == SourceType.CHART]
+          # Don't return early — drain semantics still need the guard + DELETE.
+      elif not facts:
+          return 0
+      ```
+      Keep the existing guard + DELETE flow. After the DELETE, if `facts` is empty, skip the INSERT (`executemany` of an empty list is fine, but a guard before `_fact_to_params` may save a tiny bit of work).
+   b. Add a one-line comment near the DELETE explaining why empty inbound is valid under chart_only:
+      `# chart_only=True with empty inbound is the expected post-pivot drain shape: DELETE existing chart facts; INSERT no new ones.`
+
+6. **Tests.** Add tests in `tests/extraction_v2/` (or wherever the existing persistence tests live — `rg -l "_persist_facts_in_tx\|persist_facts" tests/`):
+   - **Drain reaches DELETE under chart_only=True with empty facts.** Set up a filing with 2 existing chart `v2_metric_facts` rows and 1 reviewer decision on each. Call `persist_facts(facts=[], filing_id=X, chart_only=True, force=True)`. Assert: chart facts deleted, decisions CASCADE-removed, function returns 0, log line `force-reextract purging reviewed filing: ... chart_only=True` emitted.
+   - **Guard fires under chart_only=True with reviewed filing and force=False.** Same setup. Call without `force`. Assert: `ReviewedFilingError` raised.
+   - **Existing non-chart facts and decisions untouched.** Same setup but also seed text-fact rows and decisions. After the chart-only drain, assert text-fact rows and decisions still present.
+   - **chart_only=False with empty facts still early-returns.** Regression-protect the original behavior (no surprise drain on text facts when caller didn't ask for chart_only).
+   Run: `pytest tests/extraction_v2 -x -q --tb=short` (and any integration tests the persistence layer has). Pre-existing failures: `git stash && pytest <case> -x -q && git stash pop`.
+
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section that:
+   - Names the restructure in `_persist_facts_in_tx`.
+   - Cross-references the legacy-097 drain (which had to use direct SQL because of this bug).
+   - Notes that future `--chart-only --force-reextract` invocations will now actually drain (idempotent on already-drained corpora).
+   Per `feedback_known_issues_pr_refs_int_not_string`, write `- 305` (or whichever PR # lands), not `- '#305'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`. Update `note:` to summarize the fix (drop the "early-return blocks drain" wording).
+
+8. **Commit + PR.** Use the **project-local** `/commit-proj` skill. Run from your worktree.
+
+9. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Changing `chart_only` semantics in `persist_facts` / `persist_pipeline_result` public API.
+- Cleaning up the misleading "purging image-metric confirmations" warning text in the secondary guard. Separate small follow-up — file a fragment if you want, don't conflate.
+- Re-running legacy-097's drain with the fixed code path. The drain is already done (direct SQL); a post-fix run would be a no-op.
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097, in flight)
+  - `src/universe/onboarding_runner.py`, `docs/operations/*` (legacy-062, in flight)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293, in flight)
+  - `.claude/rules/web.md` (gh-294 PR #297)
+  - `src/gold_standard/baseline.py`, `src/gold_standard/v2_validator.py` (gh-273, in flight)
+  - `docs/known-issues/gh-263-...md` (gh-263 PR #304)
+- gh-299 / gh-300 work (filing HTML storage migration). Different code path.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_known_issues_pr_refs_int_not_string` — write `- 305`, not `- '#305'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_shipped_not_effective` — closure PR + working tool ≠ outcome; this fragment is the canonical example (chart_only mode "shipped" but never actually drained anything)
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_gh-299_stale-onedrive-paths-in-html-storage.md
+++ b/docs/archive/worker-prompts/PICK_gh-299_stale-onedrive-paths-in-html-storage.md
@@ -1,0 +1,176 @@
+You are working gh-299: Stale OneDrive paths in `filings.html_storage_path` block re-extraction.
+
+This is a **tactical** data-hygiene fix. The fragment is `autonomy: skip` because it requires prod data writes; the user has directed it for a worker prompt with explicit prod-write checkpoints.
+
+**Important relationship to gh-300:** gh-300 ("Migrate filing HTMLs to R2") is the architectural follow-up that **supersedes** gh-299 by changing `html_storage_path` semantics from "filesystem path" to "opaque R2 storage key." If gh-300 ships first, gh-299 becomes moot. If gh-299 ships first, gh-300 will need to migrate again from the rewritten worktree-relative paths to R2 keys. **The user's stated intent is to ship both** — gh-299 first as a quick-fix to unstick re-extraction, then gh-300 as the medium-term architecture. Treat the work in this PR as known-temporary.
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md` (read in full from `origin/main` before planning)
+- Cross-fragment: `docs/known-issues/gh-300-migrate-filing-htmls-to-r2.md` (read for awareness; do NOT implement here)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Git Operations" (destructive-action confirmation rules apply to prod data UPDATEs)
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/infrastructure.md` — `DATABASE_URL` is **Neon prod** in this project's `.env`. Test with `TEST_DATABASE_URL` first.
+- Related context: `src/extraction_v2/stages/ingestion.py` (the consumer of `filings.html_storage_path`), `data/gold_standard/<Company>/filing.html` (the canonical local copies), schema definition for `filings` table in `sql/`.
+
+## The bug (canonical from fragment)
+5 known filings (`filing_ids` 1539, 1544, 1546, 1548, 1551 — Datadog, Maplebear, Samsara, Slack, Torrid) carry `filings.html_storage_path` values under `/Users/.../OneDrive-CMASB/.../data/gold_standard/<Company>/filing.html` with `NULL html_content`. OneDrive cloud-only files no longer hydrate reliably; 3 of 5 timed out during a 2026-04-28 backfill. Canonical local copies all exist at `data/gold_standard/<Company>/filing.html` (2–5 MB each). **Likely broader corpus-wide** — any filing ingested before the OneDrive→local migration may share the pattern.
+
+## The fix shape (canonical from fragment "Next Steps")
+1. **Audit** `filings` for `html_storage_path LIKE '/Users/%/OneDrive-CMASB/%'`. Count + report scope.
+2. **Migration script** to rewrite paths to worktree-relative form, verifying each rewritten path resolves to a real file. Fall back to `sec_html_url` re-fetch for missing files.
+3. **Optionally** populate `html_content` from disk so re-extraction does not depend on filesystem state.
+
+## Workflow
+
+1. **Verify the bug is still present + measure full scope.**
+   ```bash
+   git fetch origin main --quiet
+   set -a && source .env && set +a
+   psql "$DATABASE_URL" -c "
+     SELECT COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%') AS onedrive_paths,
+            COUNT(*) FILTER (WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%' AND html_content IS NOT NULL) AS onedrive_with_content,
+            COUNT(*) FILTER (WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%' AND html_content IS NULL) AS onedrive_null_content
+       FROM filings;"
+   ```
+   Read-only; OK against prod. Capture the actual scope. Fragment names 5; expect more. If 0 rows match, the bug is already fixed — abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include:
+   - **Decision: rewrite paths only, populate `html_content`, or both?** Recommended shape:
+     - **Rewrite paths to worktree-relative form** (e.g. strip `/Users/.../OneDrive-CMASB/` prefix, resulting in `data/gold_standard/<Company>/filing.html`). Required.
+     - **Populate `html_content` from disk in the same migration.** Recommended — removes filesystem dependency entirely so re-extraction works from DB alone. Skip only if `html_content` blob size becomes a Neon-storage concern (current corpus: ~5 MB × N filings, low).
+     - **Fall back to `sec_html_url` re-fetch only for missing files** — fragments names this; necessary for paths that don't resolve to a real file post-rewrite. Throttle the SEC fetcher (existing 100ms minimum is fine for ≤100 filings).
+   - **Documentation step** (per global Planning Rules):
+     - Append a `### Recovering filings with stale storage paths` subsection under the existing operations docs (likely `docs/operations/` — find the right home; `TICKER_ONBOARDING.md` is plausible). Show the audit command, dry-run + apply, verification SQL.
+     - Add a one-line cross-reference to gh-300 noting this is a tactical fix superseded by R2 migration.
+   - **Migration script shape** (recommended): `scripts/migrate_onedrive_html_paths.py` with `--dry-run` (default), `--apply`, `--limit N` (process N filings), `--allow-prod` (refuse `--apply` against `*.neon.tech` without it).
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-299-onedrive-html-paths`. The PreToolUse hook denies HEAD-moving git ops in the primary tree. **Verify** you are NOT in any of the in-flight worktrees.
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:**
+     - Confirm `data/gold_standard/<Company>/filing.html` exists for the 5 named filings: `ls -la data/gold_standard/{Datadog,Maplebear,Samsara,Slack,Torrid}/filing.html` (or whatever directory naming convention is used — check `data/gold_standard/`).
+     - Confirm the schema for `filings.html_content`: BYTEA / TEXT / something else? Read the migration that created the column.
+     - Confirm there is no other consumer of `html_storage_path` that hard-codes the OneDrive prefix (grep `OneDrive-CMASB` across the repo — should be zero non-fragment hits).
+     - Confirm the `filings.sec_html_url` column exists and is populated for these rows (the fallback path depends on it).
+   - **SCOPE CHECK:**
+     - In: new `scripts/migrate_onedrive_html_paths.py`, docs append, fragment closure.
+     - Out: any change to `src/extraction_v2/stages/ingestion.py`, the `filings` schema, `image_storage.py`, or any other consumer of `html_storage_path`. Those are gh-300 territory.
+     - Out: gh-300's `src/infra/filing_storage.py` abstraction. **Specifically out** — the worker MUST NOT introduce that file as part of this PR. gh-300 is its own PR.
+   - **RULES COMPLIANCE:**
+     - Per `.claude/rules/infrastructure.md`: `DATABASE_URL` is Neon prod. The migration's `--apply` mode must refuse to run against `*.neon.tech` without an explicit `--allow-prod` flag. Dry-run mode is OK against prod (read-only).
+     - Per `feedback_run_recovery_before_verification`: docs must show `--dry-run` first, `--apply` second.
+     - Per `project_render_env_invisible_to_git_audit`: keep the prod guard in code, not in env.
+   - **RISK ASSESSMENT:**
+     - Wrong rewrite could point to a non-existent file. Mitigation: per-row file existence check; SEC fallback for missing.
+     - Mid-migration interruption could leave the table in mixed state. Mitigation: each filing's UPDATE is its own transaction; resumable via `--limit` + already-rewritten rows being filtered out by the `LIKE '/Users/%/OneDrive-CMASB/%'` selector.
+     - Concurrent `--watch` worker could pick up filings during migration. Low risk (re-extraction cycle is slow), but make migration idempotent: re-running on a clean corpus is a no-op.
+     - **gh-300 will rewrite this column again** — the worktree-relative paths shipped here become an intermediate state. Make sure the worktree-relative format is unambiguous and recognizable so gh-300's migration can target them cleanly. Recommended format: bare relative path (`data/gold_standard/Datadog/filing.html`), no leading `./` or `/`.
+   - **MINIMAL PATH:** confirmed above.
+   - **WORKTREE CHECK:** yes (step 3).
+
+   Show the completed checklist and **get user approval** before writing code.
+
+5. **Implementation.**
+   a. Create `scripts/migrate_onedrive_html_paths.py`:
+      - Argparse: `--dry-run` (default), `--apply`, `--limit N` (default: no limit), `--allow-prod` (required for `--apply` against `*.neon.tech`), `--database-url` (default `$DATABASE_URL`).
+      - Connect via `src.infra.db.DatabaseAdapter`.
+      - Query: `SELECT filing_id, html_storage_path, sec_html_url FROM filings WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%' [LIMIT N]`.
+      - For each row:
+        - Strip the OneDrive prefix to get the worktree-relative path.
+        - Check if the file exists at that path.
+        - If yes: rewrite `html_storage_path` to the relative form; read file, populate `html_content` (bytes or text — match column type).
+        - If no: log a warning; if `sec_html_url` is set, fetch via `SECClient` (respect 100ms rate limit), validate size > 15 KB (per memory `feedback_zero_facts_can_be_pre_pipeline_failure`), populate `html_content`, set `html_storage_path` to a deterministic format (e.g. the relative path for consistency).
+        - If both fail: log an error; do not UPDATE; report at end.
+      - Print a summary at the end: `audited=N rewritten=M fetched_from_sec=K failed=L`.
+   b. Append a `### Recovering filings with stale storage paths` section to the appropriate operations doc (recommend `docs/operations/TICKER_ONBOARDING.md` since it's the existing home for this kind of recovery procedure — or create a new `docs/operations/onedrive-html-recovery.md` if the runbook prefers separation). Show the dry-run + apply commands, the prod-guard message, and a one-line note that gh-300 will supersede this with R2 storage.
+
+6. **Tests.** Add tests in `tests/scripts/` (or wherever existing migration-script tests live):
+   - **Dry-run does not write.** Fixture filing with OneDrive path. `--dry-run`. Assert: row unchanged, audit summary correct.
+   - **Apply rewrites + populates content.** Same fixture + a real local file. `--apply`. Assert: `html_storage_path` is the relative form, `html_content` populated, byte length > 0.
+   - **Missing file falls back to SEC.** Fixture with OneDrive path, no local file, `sec_html_url` set. Mock SEC fetch. Assert: `html_content` populated from mocked fetch.
+   - **Prod-host guard.** `DATABASE_URL` ending in `.neon.tech`. `--apply --allow-prod=False`. Assert: refusal.
+   - **Idempotency.** Run twice. Assert: second run is a no-op (no rows match the selector).
+   Run: `pytest tests/scripts -x -q --tb=short`. Pre-existing failures: `git stash && pytest <case> -x -q && git stash pop`.
+
+7. **PROD MIGRATION — STOP FOR EXPLICIT USER APPROVAL.**
+
+   This step writes to prod. Print:
+   - The exact command you intend to run.
+   - The audit count from step 1 (e.g. "5 rows" or "N rows").
+   - Expected outcome (rewritten paths + populated `html_content`).
+   - Note: irreversible without a backup; original OneDrive paths are gone after the UPDATE.
+
+   Ask: `"This is a prod data migration. Confirm 'yes, run the migration' to proceed."`
+
+   On explicit `yes`:
+   ```bash
+   set -a && source .env && set +a
+   FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 \
+   python3 scripts/migrate_onedrive_html_paths.py --apply --allow-prod 2>&1 | tee /tmp/gh_299_migration.log
+   ```
+   Capture the log. Verify the summary.
+
+8. **Verify the outcome.**
+   ```bash
+   psql "$DATABASE_URL" -c "
+     SELECT COUNT(*) AS remaining_onedrive
+       FROM filings
+      WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%';"
+   ```
+   Expected: 0. If non-zero, surface the failed rows and stop.
+
+   Spot-check one filing:
+   ```bash
+   psql "$DATABASE_URL" -c "
+     SELECT filing_id, html_storage_path, octet_length(html_content) AS content_bytes
+       FROM filings WHERE filing_id = 1544;"
+   ```
+   Expected: relative `html_storage_path`, `content_bytes` > 100000.
+
+9. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section that:
+   - Names the migration (script path, runbook section).
+   - Reports the migration counts (N audited, M rewritten, K fetched from SEC, L failed if any).
+   - Cross-references gh-300 explicitly: "This is a tactical fix; gh-300 will replace `html_storage_path` semantics with R2 storage keys."
+   Per `feedback_known_issues_pr_refs_int_not_string`, write `- 306` (or whichever PR # lands), not `- '#306'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`. Update `note:` to summarize what shipped (drop "skip" qualifier — the migration is now done).
+
+10. **Commit + PR.** Use the **project-local** `/commit-proj` skill. Run from your worktree. The PR contains:
+    - `scripts/migrate_onedrive_html_paths.py` (new)
+    - `docs/operations/<runbook>.md` (append section, or new file)
+    - `docs/known-issues/gh-299-...md` (closure)
+    - Tests under `tests/scripts/`
+
+11. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- gh-300's R2 storage abstraction. Specifically: do NOT create `src/infra/filing_storage.py`. Do NOT modify `src/extraction_v2/stages/ingestion.py` to use a new abstraction. That is gh-300's PR.
+- Modifying the `filings` table schema (adding/removing columns).
+- Re-extracting filings as part of this PR. The migration just rehydrates paths/content; re-extraction is a separate operator step.
+- Applying the same fix to non-filings tables (`v2_image_assets.file_path` is a different concern with its own column-stickiness rules, see `.claude/rules/v2-pipeline.md`).
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097, in flight)
+  - `src/universe/onboarding_runner.py`, `docs/operations/TICKER_ONBOARDING.md` (legacy-062, in flight; **note this is the docs file you'd most naturally append to — coordinate with the user if legacy-062's PR has not yet merged, or use a separate docs file**)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293, in flight)
+  - `.claude/rules/web.md` (gh-294 PR #297)
+  - `src/gold_standard/baseline.py`, `src/gold_standard/v2_validator.py` (gh-273, in flight)
+  - `src/extraction_v2/persistence.py` (gh-298, in parallel)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first; the audit query in step 1 is the verification mechanism
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate the prod migration to a subagent, do **not**. The user-approval gate must be honored synchronously.
+- `feedback_destructive_recovery_workflow` — bundle migration script in fix PR; execute the prod step under explicit approval; frame around ground-truth file resolution rather than abstract risk
+- `feedback_run_recovery_before_verification` — show dry-run before apply in docs; verify post-migration before fragment closure
+- `feedback_known_issues_pr_refs_int_not_string` — `- 306`, not `- '#306'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_zero_facts_can_be_pre_pipeline_failure` — if SEC fallback fetch returns < 15 KB, treat as failure not success
+- `project_render_env_invisible_to_git_audit` — keep the `--allow-prod` guard in code, not env
+- `project_db_query_vs_execute` — use `db.execute` for INSERT/UPDATE/DELETE without RETURNING
+
+## Return
+The PR URL when done, plus:
+- Migration log summary (audited / rewritten / fetched / failed)
+- Verification query output (remaining OneDrive paths = 0)
+- One-line note flagging that gh-300 should be the next pick

--- a/docs/archive/worker-prompts/PICK_gh-300_migrate-filing-htmls-to-r2.md
+++ b/docs/archive/worker-prompts/PICK_gh-300_migrate-filing-htmls-to-r2.md
@@ -1,0 +1,200 @@
+You are working gh-300: Migrate filing HTMLs to R2 long-haul storage.
+
+This is a **medium-large architectural change**, not a quick fix. The fragment is `autonomy: skip` because it requires a real plan-mode design pass; the user has directed it for a worker prompt. Estimate: M-to-L. Plan-mode work is most of the value here.
+
+**Sequencing constraint: gh-299 must ship first.** gh-299 is the tactical OneDrive-path fix that gets the prod data into a known-clean state. gh-300's migration starts from gh-299's worktree-relative paths and uploads the on-disk HTML to R2, replacing `html_storage_path` semantics from "filesystem path" to "opaque R2 storage key" (mirroring `v2_image_assets.file_path`). **Do not start gh-300 implementation until gh-299's PR has merged.**
+
+## Source of truth
+- Fragment: `docs/known-issues/gh-300-migrate-filing-htmls-to-r2.md` (read in full from `origin/main` before planning)
+- Cross-fragment: `docs/known-issues/gh-299-stale-onedrive-paths-in-html-storage.md` (precondition — verify it has merged before implementing)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**. Pay attention to design principles 4 (Conservative classification — analogue here is conservative migration) and 6 (Reviewed-filing guard — re-extraction implications must stay safe).
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules", "Planning Rules", and "Git Operations" (destructive-action rules apply to the prod migration step)
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/infrastructure.md` — **authoritative** for R2 patterns (`R2Storage`, `LocalFilesystemStorage`, `FILINGS_REVIEWER_ALLOW_PROD_WRITES`, `validate_key`). The new `FilingStorage` abstraction must mirror this surface.
+- `.claude/rules/v2-pipeline.md` — `Image Asset Identity` section explains the storage-key + UPSERT pattern that `filing_storage` should mirror
+- Related context (read for shape, modify only as required): `src/infra/image_storage.py` (the canonical reference implementation — your new `filing_storage.py` is the same shape for HTML), `src/extraction_v2/stages/ingestion.py` (the consumer of `filings.html_storage_path` — your refactor target), `tests/integration/test_full_page_ocr_pipeline.py` and other ingestion tests (the regression-protection surface)
+
+## The work (canonical from fragment "Next Steps")
+1. **New `src/infra/filing_storage.py` abstraction** analogous to `image_storage.py`. `R2FilingStorage` (prod) + `LocalFilesystemFilingStorage` (dev), gated by `FILINGS_REVIEWER_ALLOW_PROD_WRITES` env. Identical safety contract: writes refused without the env, reads always allowed. Backend selected at runtime via `R2_BUCKET` env.
+2. **Refactor `src/extraction_v2/stages/ingestion.py`** to fetch HTML via the storage abstraction (opaque storage key in `html_storage_path`) instead of `Path(...).read_text()`. The column changes meaning: filesystem path → R2 storage key (e.g. `filings/<cik>/<accession>/primary.htm`). Other consumers of `html_storage_path` need the same refactor.
+3. **One-time migration script** to upload each filing's HTML bytes to R2 under deterministic keys and rewrite `html_storage_path`. The migration reads from gh-299's worktree-relative paths and `html_content` blobs.
+4. **Update other consumers of `html_storage_path`** — reviewer UI source-rendering, any analytics views, any scripts that resolve the column.
+
+## Workflow
+
+1. **Verify gh-299 has merged.**
+   ```bash
+   git fetch origin main --quiet
+   gh pr list --state merged --search "gh-299" --json number,title,mergedAt | head
+   psql "$DATABASE_URL" -c "
+     SELECT COUNT(*) FILTER (WHERE html_storage_path LIKE '/Users/%/OneDrive-CMASB/%') AS onedrive_paths,
+            COUNT(*) FILTER (WHERE html_storage_path LIKE 'data/gold_standard/%') AS worktree_relative,
+            COUNT(*) FILTER (WHERE html_content IS NOT NULL) AS has_content
+       FROM filings;"
+   ```
+   Expected: 0 OneDrive paths, all eligible filings have either worktree-relative paths or `html_content` populated. If OneDrive paths remain, gh-299 isn't done — STOP and surface to user. Do not begin gh-300 implementation; gh-300 assumes gh-299's clean state.
+
+2. **Verify the issue is still relevant** by spot-checking the consumers.
+   ```bash
+   rg -nE "html_storage_path|html_content" src/extraction_v2/stages/ingestion.py src/web/ scripts/ | head -30
+   ```
+   Confirm `ingestion.py` still reads `html_storage_path` as a filesystem path. List every other file that reads the column — those are your refactor surface.
+
+3. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. **The plan is most of the work for this PR.** It must include:
+
+   - **Storage-key shape decision.** Recommended: `filings/<cik>/<accession>/primary.htm`. Mirrors `pipeline/<cik>/<accession>/<filename>` from image storage. Surface alternatives (e.g. `filings/<filing_id>/primary.htm`) and trade-offs (CIK+accession is human-debuggable; filing_id is opaque) — let user pick.
+   - **Column semantics decision.** Two options:
+     - **A. Reuse `html_storage_path`** with a different semantic (filesystem path → R2 storage key). Smallest schema diff. But the column name becomes a lie.
+     - **B. Add `html_storage_key` column, deprecate `html_storage_path`, drop the latter in a follow-up migration.** Cleaner long-term. Larger schema diff and a deprecation tail.
+     Recommended: **A** with a one-line comment in the schema/migration explaining the semantic shift, plus a follow-up fragment for an eventual rename. Surface to user; let them redirect to B if they prefer.
+   - **Migration parity decision.** Should the migration drop `html_content` after R2 upload? Trade-off: smaller Neon DB; loses the fallback if R2 reads fail. Recommended: **keep `html_content` for now**, file a follow-up fragment to drop it once R2 has been the source of truth for ≥30 days without incident.
+   - **Documentation step** (per global Planning Rules):
+     - Update `.claude/rules/infrastructure.md` "Image Storage" → rename to "Image and Filing Storage" or add a new section explaining the parallel `filing_storage.py` abstraction.
+     - Update `.claude/rules/v2-pipeline.md` if it documents `html_storage_path` semantics anywhere.
+     - Update CLAUDE.md "Database" section to note that filing HTML lives in R2 (analogue to the image-bytes note).
+     - Add a `### Migrating filing HTMLs to R2` runbook under `docs/operations/` with the migration command, dry-run, verification SQL.
+   - **Test plan.**
+     - Unit tests for `LocalFilesystemFilingStorage` and `R2FilingStorage` (both directions: get/put).
+     - Integration test: ingestion reads HTML via the storage abstraction (LocalFilesystemFilingStorage in tests).
+     - Migration script: dry-run + apply tests with a fixture filing.
+     - Reviewer UI source-rendering: spot-check a UI route resolves the column correctly via Playwright (if practical) or assert the route handler reads via the abstraction.
+   - **Stages.** Recommend splitting into 2 PRs:
+     - **PR 1 (this prompt):** abstraction + migration script + ingestion refactor + UI refactor + docs. Migration runs against prod under approval gate.
+     - **PR 2 (follow-up fragment):** drop `html_content` column after a soak window. **Do not include in PR 1.**
+
+4. **Worktree-first.** First step of implementation: `EnterWorktree fix/gh-300-filing-htmls-to-r2`. The PreToolUse hook denies HEAD-moving git ops in the primary tree. **Verify** you are NOT in any of the in-flight worktrees, and that gh-299's PR has merged into `main`.
+
+5. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:**
+     - Confirm `R2_BUCKET` is set on the prod env (`render.yaml`'s `filings-shared-secrets`); confirm `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` is set on the services that need to write filing HTML (extraction, ingestion-runner). If not, the migration won't be able to upload — flag to user as a precondition.
+     - Confirm `boto3` is in `requirements.txt`. (It will be — image_storage uses it.)
+     - Confirm the existing `image_storage.py`'s `validate_key` semantics are appropriate for filing keys (path-traversal rejection, absolute-path rejection). Reuse or replicate.
+     - Confirm the `filings` schema's current column types: `html_storage_path` (TEXT?), `html_content` (BYTEA / TEXT?). The R2 round-trip should match `html_content`'s encoding.
+     - Confirm there is no critical UI feature that needs synchronous local-filesystem access to filing HTML. R2 reads add ~50–200ms latency.
+   - **SCOPE CHECK:**
+     - In: `src/infra/filing_storage.py` (new), `src/extraction_v2/stages/ingestion.py` refactor, migration script, UI consumer refactor, docs, tests, fragment closure.
+     - Out: dropping `html_content` column. Schema column rename (`html_storage_path` → `html_storage_key`). Adding new fields to `filings`. Migrating other table columns. Render service config changes (env vars are out of scope; verify they exist as a precondition).
+     - Out: gh-298 (chart-only drain — separate PR) and gh-299 (already merged precondition).
+   - **RULES COMPLIANCE:**
+     - The new `R2FilingStorage.put_bytes` MUST refuse without `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` (mirror `R2Storage` exactly). Reads remain open.
+     - Per `project_render_env_invisible_to_git_audit`: keep the prod-write guard in code, not in env config.
+     - Per `feedback_run_recovery_before_verification`: docs must show migration dry-run before apply.
+     - Per design principle 6 (reviewed-filing guard): the ingestion refactor must NOT change the contract under which `_persist_facts_in_tx` raises `ReviewedFilingError`. The HTML source change is upstream of fact persistence; verify with an integration test.
+   - **RISK ASSESSMENT:**
+     - **Migration is the highest-risk step.** Each filing's HTML uploaded to R2; `html_storage_path` rewritten in a separate transaction. If the upload succeeds and the UPDATE fails, R2 has an orphan key (cheap, recoverable). If the UPDATE succeeds and the upload failed, the column points to a missing key — re-extraction will fail on read.
+       - Mitigation: verify R2 write succeeded (HEAD on the key) BEFORE the UPDATE; on UPDATE failure, do not delete the R2 key (orphans are cheap, lost data is not).
+     - **Read latency change.** Ingestion now hits R2 instead of local disk. Cache helpfully, but don't over-engineer.
+     - **gh-299's `html_content` blobs are the migration source.** If gh-299 didn't fully populate `html_content` (e.g. the SEC fallback failed for some rows), those rows can't be migrated to R2 from the DB alone — they'd need a fresh SEC fetch. Plan for this: the migration script should detect `html_content IS NULL`, log, and either re-fetch from `sec_html_url` (with the existing SEC throttle) or skip+report.
+     - Concurrent worktree footprints (do NOT touch):
+       - `worktree-fix+legacy-097-chart-only-backfill`: scripts/audit_residual_chart_facts.py, fragment.
+       - `claude/feat-gh-293-...`: web routes + UI templates + JS.
+       - `claude/feat-gh-294-...` (PR #297): UI templates + JS + web rules.
+       - `fix-gh-273-gs-gate-rerun-on-fail`: gold_standard/.
+       - `fix-gh-263-fragment-closure` (PR #304): fragment only.
+       - `feat-render-deploy-speed-pr2`: large grab-bag including Dockerfile and render.yaml — coordinate if you need to touch any deploy config.
+     - **gh-298 may be in parallel** — both touch `src/extraction_v2/persistence.py` only IF gh-300's ingestion refactor incidentally touches persistence. It shouldn't (HTML source is upstream of persistence). Verify your refactor does not change persistence.py.
+   - **MINIMAL PATH:** confirmed above; the PR is bigger than usual, but each piece is required for the abstraction to land cleanly.
+   - **WORKTREE CHECK:** yes (step 4).
+
+   Show the completed checklist and **get user approval** before writing code.
+
+6. **Implementation.**
+   a. **`src/infra/filing_storage.py`** — new file. Mirror `src/infra/image_storage.py` exactly:
+      - Abstract `FilingStorage` protocol: `get_bytes(key) -> bytes`, `put_bytes(key, data) -> None`, `exists(key) -> bool`, `validate_key(key)`.
+      - `LocalFilesystemFilingStorage` rooted at `<repo>/data/filing_cache/` (or new env `FILING_CACHE_DIR`).
+      - `R2FilingStorage` wrapping the same boto3 S3-compatible client. Bucket: `R2_BUCKET` (shared with images is fine; key prefix `filings/` separates).
+      - Factory: `make_filing_storage()` returns R2 if `R2_BUCKET` is set, Local otherwise.
+      - Prod-write guard on `R2FilingStorage.put_bytes`: refuse without `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1`.
+   b. **Refactor `src/extraction_v2/stages/ingestion.py`** to read via the abstraction. Remove direct `Path(...).read_text()` calls on `html_storage_path`. The column now stores opaque storage keys.
+   c. **Refactor other consumers** (from step 2 grep). UI source-rendering routes: read via the abstraction. Analytics views: confirm none JOIN on the column directly (filesystem paths in views were always wrong).
+   d. **`scripts/migrate_filing_html_to_r2.py`** — new file. Argparse: `--dry-run` (default), `--apply`, `--limit N`, `--allow-prod` (required for `--apply` against `*.neon.tech`).
+      - For each `filings` row with `html_storage_path` not yet in R2 storage-key shape:
+        - Source: prefer `html_content` (from gh-299); fall back to `Path(html_storage_path).read_bytes()` if local; fall back to SEC fetch if `sec_html_url` set.
+        - Compute storage key: `filings/<cik>/<accession>/primary.htm` (or whatever shape the plan-mode decision picked).
+        - `R2FilingStorage.put_bytes(key, html_bytes)`.
+        - Verify with `R2FilingStorage.exists(key)` HEAD.
+        - On verified upload: UPDATE `filings SET html_storage_path = %(key)s WHERE filing_id = %(id)s`.
+        - On any failure: log and continue; do NOT update the column for that row.
+      - Print summary: `audited=N migrated=M sec_fetched=K skipped=L failed=F`.
+   e. Update docs (per plan).
+
+7. **Tests.**
+   - Unit tests for both `FilingStorage` backends (round-trip, key validation, prod-write guard, missing key returns False on `exists`).
+   - Integration test: refactored `ingestion.py` reads HTML via `LocalFilesystemFilingStorage`. Existing `tests/integration/extraction_v2/` tests should pass — verify they still do (don't break the gh-262 fixture pattern that redirects to LocalFilesystemStorage in tests).
+   - Migration script: dry-run vs apply, prod-host guard, `html_content` source path, SEC fallback path, idempotency.
+   - Run: `pytest tests/integration tests/unit -x -q --tb=short`. Pre-existing failures: `git stash && pytest <case> -x -q && git stash pop`.
+
+8. **PROD MIGRATION — STOP FOR EXPLICIT USER APPROVAL.**
+
+   This step uploads N filings' HTML to prod R2 and rewrites `filings.html_storage_path` semantics for those rows. It is forward-recoverable (R2 keys can be re-uploaded if state diverges) but the column rewrite is hard to undo without per-row reconciliation.
+
+   Print:
+   - Audit count (N rows about to migrate).
+   - Estimated R2 storage growth (N × avg_html_size; should be small — fragment estimates ~$1/month for full corpus).
+   - Expected outcome (column values change shape; ingestion now reads via R2).
+
+   Ask: `"This is a prod migration that changes filings.html_storage_path semantics. Confirm 'yes, run the migration' to proceed."`
+
+   On explicit `yes`:
+   ```bash
+   set -a && source .env && set +a
+   FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 \
+   python3 scripts/migrate_filing_html_to_r2.py --apply --allow-prod 2>&1 | tee /tmp/gh_300_migration.log
+   ```
+
+9. **Verify.**
+   ```bash
+   psql "$DATABASE_URL" -c "
+     SELECT COUNT(*) FILTER (WHERE html_storage_path LIKE 'filings/%/%/%') AS r2_keys,
+            COUNT(*) FILTER (WHERE html_storage_path NOT LIKE 'filings/%/%/%') AS not_yet_migrated,
+            COUNT(*) AS total
+       FROM filings;"
+   ```
+   Expected: `r2_keys` ≈ migration target count; `not_yet_migrated` matches expected leftovers (e.g. rows with no source).
+   - Spot-check one filing through the refactored ingestion path: re-extract a non-reviewed test filing end-to-end, confirm `process_filing` succeeds reading from R2.
+
+10. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section that:
+    - Names the abstraction (`src/infra/filing_storage.py`), the refactored consumers, the migration script, and the updated docs.
+    - Reports migration counts.
+    - Notes the deferred follow-up: drop `html_content` column after a soak window. File as a separate fragment if not already filed.
+    - Cross-references gh-299: "gh-299's worktree-relative paths and `html_content` populated fields were the migration source."
+    Per `feedback_known_issues_pr_refs_int_not_string`, write `- 312` (or whichever PR # lands), not `- '#312'`. Per `feedback_known_issues_validator_optional_fields`, don't add frontmatter fields outside `{pr_refs, gh_issue, note}`. Update `note:` to summarize what shipped.
+
+11. **Commit + PR.** Use the **project-local** `/commit-proj` skill. Run from your worktree. The PR is medium-large (4–8 source files, 2 docs, tests, plus the migration script) — expect CI to take longer than usual; don't panic if Integration Tests run > 10 min.
+
+12. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Dropping the `html_content` column. **File a follow-up fragment** for it post-soak; do not do it in this PR.
+- Renaming `html_storage_path` to `html_storage_key`. Surface in plan-mode; default to keeping the name.
+- Migrating other tables' filesystem paths to R2 (e.g. gold-standard fixtures, transcript files). Different columns, different decisions.
+- Modifying `image_storage.py` or any image-side logic.
+- Render service config changes (R2 env vars, bucket creation). Verify these as preconditions; flag missing ones to user.
+- gh-299 work. Precondition; if gh-299 hasn't merged, STOP.
+- gh-298 work. Independent track in `src/extraction_v2/persistence.py`.
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097, in flight)
+  - `src/universe/onboarding_runner.py`, `docs/operations/TICKER_ONBOARDING.md` (legacy-062, in flight; if you need to add docs, use a separate file under `docs/operations/`)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293, in flight) — but the UI source-rendering refactor MAY need to touch one of these. **Coordinate with the user** before editing any of these files; gh-293 must merge first OR your PR splits the file with a careful merge plan.
+  - `.claude/rules/web.md` (gh-294 PR #297)
+  - `src/gold_standard/baseline.py`, `src/gold_standard/v2_validator.py` (gh-273, in flight)
+  - Dockerfile, render.yaml (`feat-render-deploy-speed-pr2` worktree)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first; verify gh-299 has merged
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate the prod migration to a subagent, do **not**. The user-approval gate must be honored synchronously.
+- `feedback_destructive_recovery_workflow` — bundle migration script in fix PR; execute under explicit approval; frame around column-semantic change rather than abstract risk
+- `feedback_run_recovery_before_verification` — show dry-run before apply
+- `feedback_known_issues_pr_refs_int_not_string` — `- 312`, not `- '#312'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_zero_facts_can_be_pre_pipeline_failure` — SEC fallback fetch results < 15 KB are failures
+- `project_render_env_invisible_to_git_audit` — keep the prod-write guard in code, not env
+- `project_db_query_vs_execute` — use `db.execute` for INSERT/UPDATE/DELETE without RETURNING
+
+## Return
+The PR URL when done, plus:
+- Migration log summary (audited / migrated / sec_fetched / skipped / failed)
+- Verification query output (R2 keys count vs not_yet_migrated)
+- One-line note on the deferred `html_content` drop follow-up (which fragment file, if filed)

--- a/docs/archive/worker-prompts/PICK_legacy-024_metric-facts-source-locator-img-id-referential-integrity.md
+++ b/docs/archive/worker-prompts/PICK_legacy-024_metric-facts-source-locator-img-id-referential-integrity.md
@@ -1,0 +1,109 @@
+You are working legacy-024: `v2_metric_facts.source_locator.img_id` Has No Referential Integrity.
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-024-v2-metric-facts-source-locator-img-id-has-no-referential-int.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey Implementation Rules and Pre-Implementation Gate. **Note especially Core Design Principle §4** (chart-presence pivot, #86, 2026-04-23): the pipeline no longer auto-emits per-value chart `v2_metric_facts` rows at extraction time. This narrows the scope of "what new orphans could appear" to the legacy advisory facts already on disk.
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+
+## Read this before you start
+The fragment's `note:` field reduces scope explicitly: "Scope reduced to historical advisory-fact hygiene after 2026-04-24 presence-first pivot: presence rows (`v2_text_metric_presence`, `v2_image_metric_presence`) do not rely on `source_locator.img_id`; orphans live only in legacy advisory `v2_metric_facts`. Not on the presence-pivot critical path."
+
+This is a low-severity, M-sized historical-data hygiene task. The fragment lists **three cleanup options** and explicitly says "Cleanup strategy is still open." You are NOT here to ship code unilaterally — you are here to:
+
+1. Confirm the orphan population on the current dev DB and (read-only) on prod;
+2. Surface the three options + tradeoffs to the user with concrete row counts;
+3. Implement the option the user picks;
+4. Close the fragment.
+
+The diagnostic exists already (`scripts/check_image_referential_integrity.py`, wired into CI integration-tests job). The work is **decision + cleanup migration + closing the loop**, not building diagnostics.
+
+## Workflow
+
+### Step 1 — Verify the issue is still relevant
+- Run `scripts/check_image_referential_integrity.py` against the dev DB; record current Class (B) orphan count (baseline 2026-04-19 was 9 orphans across 4 docs: doc_id 1546:4, 1545:2, 1551:2, 1539:1).
+- If the script no longer reports any Class (B) orphans, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`. Cite the script run output and the resolving commit (find via `git log -S 'class_b' scripts/check_image_referential_integrity.py` or similar).
+- Run a **read-only** prod scan (no `--apply` semantics needed; the script is non-destructive). Record prod orphan count separately. Per `project_render_env_invisible_to_git_audit` and `.claude/rules/infrastructure.md`, only run scans against prod if you have explicit authorization in this session — otherwise stop and ask.
+
+### Step 2 — Surface the decision
+The fragment names three cleanup strategies. Present each to the user with concrete row counts and tradeoffs:
+
+- **Option A — Delete orphan facts.** Smallest surface; one-shot SQL migration. Loses the historical record entirely. Reviewer-decision exposure: check whether any orphan fact has a `v2_review_decisions` row (per `feedback_destructive_recovery_workflow`, frame the destructive option around reviewer-decision exposure, not abstract risk).
+- **Option B — Rewrite `source_locator.img_id` to NULL on orphans.** Preserves the fact row and its value/provenance, drops only the broken back-pointer. JSONB `jsonb_set` migration. Schema unchanged.
+- **Option C — Promote `img_id` to a dedicated FK column on `v2_metric_facts`.** The fragment calls this "the more robust fix" but adds: "requires a migration and application-layer changes." Application sites: every reader of `source_locator->>'img_id'` and every writer in `src/extraction_v2/persistence.py` / `src/extraction_v2/stages/chart_fact_bridge.py`. Significantly larger scope; only justifiable if new orphans are still being written (per Principle §4 they should not be).
+
+Recommend B unless prod scan turns up something surprising. Wait for explicit user choice before implementing.
+
+### Step 3 — Plan mode
+Use plan mode. Run `/plan-review` before exiting. The plan must include:
+- The migration filename (timestamp-prefixed per `.claude/rules/sql.md`; use `scripts/new_migration.py`).
+- The exact SQL (parameterized; idempotent; gated on Class (B) orphan signature so a rerun is a no-op).
+- A backfill-validation step: post-migration, the integrity script must report 0 Class (B) orphans on dev (and on prod, if/when applied).
+- Whether the integration-tests CI job should be **promoted** for Class (B) from warning-only to blocking once the cleanup lands. The fragment says Class (A) is blocking, B and C are warning-only. If the cleanup zeros out B, promoting B to blocking is the lock that prevents regression. Surface this as part of the plan and let the user decide.
+- Documentation step (per global CLAUDE.md "Planning Rules"): the fragment itself + any change to `.github/workflows/ci.yml` warning-vs-blocking semantics.
+
+### Step 4 — Worktree-first
+First step of implementation: `EnterWorktree fix/legacy-024-img-id-orphan-cleanup`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+
+### Step 5 — Pre-Implementation Gate (per global CLAUDE.md)
+Show the completed checklist and get user approval before writing code. Specifically:
+- **Assumption audit:** verify the orphan count on dev hasn't shifted between Step 1 and now; verify no other open PR is touching `v2_metric_facts` rows or `source_locator` semantics (`gh pr list --state open --search 'source_locator OR metric_facts'`).
+- **Risk:** if Option C is chosen, the application-layer change set is large and overlaps with extraction code under the extraction-guard pre-commit hook (per `project_extraction_guard_hook_scope`). Plan a separate gold-standard validation if you go that route.
+- **Migration ordering:** new SQL migration must use the timestamp filename convention; do not extend the frozen `00–47` range.
+
+### Step 6 — Implement
+- Add the migration via `python3 scripts/new_migration.py "legacy-024-img-id-orphan-cleanup"` — do not hand-name the file.
+- Migration must be idempotent: run it once, run it again, second run finds 0 rows to fix and exits clean.
+- If promoting Class (B) to blocking in CI: edit `scripts/check_image_referential_integrity.py` (or its CI invocation in `.github/workflows/ci.yml`) so Class (B) > 0 fails the job. Verify Class (A) and (C) semantics are unchanged.
+- For Option C only: add the FK column, the data migration to populate it, the `NOT VALID` → `VALIDATE CONSTRAINT` two-step (so the migration is safe under load), and the application-layer reader/writer updates. Run gold-standard validation if extraction code is touched (`python3 -m src.gold_standard.v2_validator --fail-on-regression`).
+
+### Step 7 — Tests
+- `pytest -x -q --tb=short`.
+- Re-run `scripts/check_image_referential_integrity.py` post-migration; assert 0 Class (B) orphans on dev.
+- Add a regression unit test that round-trips a minimal write/read through the new code path (Option B: `jsonb_set` on a synthetic orphan row; Option C: insert + FK violation check).
+
+### Step 8 — Update fragment status as part of the same PR
+Flip `status: open` → `resolved`, `autonomy: n/a`, set `pr_refs: [<this PR #>]` (after PR creation; ints not strings per `feedback_known_issues_pr_refs_int_not_string`), append a `### Resolution` section noting:
+- which option was chosen and why,
+- final dev orphan count (0),
+- whether prod was migrated in this PR or deferred (prod data migrations are a separate post-merge step per `feedback_destructive_recovery_workflow`),
+- whether Class (B) was promoted to blocking in CI.
+
+Do **not** add frontmatter fields outside the validator allowlist (`pr_refs`, `gh_issue`, `note`) per `feedback_known_issues_validator_optional_fields`.
+
+### Step 9 — Commit + PR
+Use the **project-local** `/commit-proj` skill.
+
+### Step 10 — Verify auto-merge
+After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
+
+### Step 11 — Prod data migration (post-merge, if applicable)
+If the cleanup migration is data-only (Option A or B) and prod still has orphans, run the migration against prod **after merge**, gated by `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` per `.claude/rules/infrastructure.md`. Frame the decision around reviewer-decision exposure per `feedback_destructive_recovery_workflow`. Bundle the audit script and the apply step in this PR; execute against prod only post-merge.
+
+## Out of scope (do NOT expand into)
+- Do **not** redesign `source_locator` more broadly (e.g., normalizing all of its keys into FK columns). The fragment scope is `img_id` only.
+- Do **not** touch the presence-pivot data path: `v2_text_metric_presence` and `v2_image_metric_presence` are explicitly out of scope per the fragment note. They do not depend on `source_locator.img_id`.
+- Do **not** modify `ChartFactBridgeStage` semantics. Class (A) is blocking and locked by `tests/unit/extraction_v2/test_chart_fact_bridge_invariants.py`; do not loosen that.
+- Do **not** modify `v2_image_assets` schema. Image FK targets stay where they are.
+- Do **not** rebuild or modify Class (C) (asset rows with `file_path` outside `data/`) — that's tracked separately under issue #34. Mention any incidental observations to the user; don't fix them in this PR per the global CLAUDE.md "Implementation Rules" (call out adjacent issues, don't silently fix).
+- Do **not** edit the chart classifier, OCR pipeline, vision client, or extraction stages unless Option C is chosen and the change is strictly necessary.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — re-run the integrity script before believing the 2026-04-19 baseline; numbers may have shifted
+- `feedback_fragment_fix_is_hypothesis` — the three options in the fragment are hypotheses; the user picks
+- `feedback_destructive_recovery_workflow` — bundle audit + recovery scripts in fix PR, execute post-merge, frame around reviewer-decision exposure not abstract risk
+- `feedback_investigate_then_fix_under_30min` — if the orphan population is empty on dev and prod, the right move is a fragment-only closure PR, not a migration
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `project_extraction_guard_hook_scope` — extraction-guard pre-commit hook fires on `src/extraction*`, `config/metric_keywords.yaml`, etc.; relevant for Option C
+- `feedback_known_issues_pr_refs_int_not_string` — `pr_refs` must be a list of ints
+- `feedback_known_issues_validator_optional_fields` — frontmatter optional fields are limited to `pr_refs`, `gh_issue`, `note`
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after PR opens
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_scan_adjacent_defensive_code` — don't expand the PR if you find related issues; file follow-up fragments instead
+
+## Return
+The PR URL when done. State explicitly:
+- which option was chosen,
+- final dev orphan count post-migration,
+- whether prod was migrated (and if so, the run output),
+- whether Class (B) was promoted to blocking in CI.

--- a/docs/archive/worker-prompts/PICK_legacy-062_local-dev-stuck-batch-recovery.md
+++ b/docs/archive/worker-prompts/PICK_legacy-062_local-dev-stuck-batch-recovery.md
@@ -1,0 +1,130 @@
+You are working legacy-062: Local-Dev Stuck-Batch Recovery Is Manual — ship the remaining `--cleanup-stuck` admin flag (NS2) plus the SIGTERM log-line update (NS3 trailer).
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-062-local-dev-stuck-batch-recovery-is-manual.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/infrastructure.md` — for `DATABASE_URL` / `TEST_DATABASE_URL` separation. The cleanup tool must not silently fall back to prod.
+- Related context (read for shape, modify only as required): `src/universe/onboarding_runner.py` (the CLI you're extending — see lines ~395–476 for the existing argparse surface, lines ~54–60 for the SIGTERM handler), `docs/operations/TICKER_ONBOARDING.md` (the recovery doc shipped under NS1 — your `--cleanup-stuck` section appends here), and any `tests/integration/universe/` tests that already cover the runner.
+
+## Status note (read first)
+Fragment is **`partially-resolved`**. NS1 (docs) and NS3 (SIGTERM signal-trap) already shipped. **Remaining work, per fragment "Remaining":**
+
+> NS2 (`--cleanup-stuck` admin flag) — `python3 -m src.universe.onboarding_runner --cleanup-stuck` admin mode that scans for batches with `run_lock_until < NOW() - INTERVAL '1 hour'` still in `running` state and either marks them failed or re-claims them. Once shipped, update the SIGTERM log message to point operators at the flag.
+
+The fragment leaves one design call unmade: **mark-failed vs re-claim.** Resolve it in plan mode (see Pre-Implementation Gate below).
+
+## Workflow
+
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm `--cleanup-stuck` is still absent:
+   ```bash
+   git fetch origin main --quiet
+   grep -nE "cleanup-stuck|cleanup_stuck" src/universe/onboarding_runner.py
+   ```
+   At brief time the grep was empty. If a flag has appeared since `updated: 2026-04-28`, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+   Also confirm NS1 and NS3 are still in place (don't re-ship them):
+   - `grep -nE "Shutdown signal received|Recovering a stuck batch" src/universe/onboarding_runner.py docs/operations/TICKER_ONBOARDING.md`
+
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include:
+
+   **Decision: mark-failed vs re-claim.** Recommended shape:
+   - **Default behavior: mark-failed.** Set `status='failed'`, `finished_at=NOW()`, `run_lock_until=NULL` on the matched rows. Why: re-claiming is what `--watch` mode already does (its `claim_next_queued_batch` picks up rows with expired `run_lock_until` automatically). The point of `--cleanup-stuck` is the *opposite* — give the operator a clean way to abandon dead batches that `--watch` won't retry (e.g., the underlying filing is broken, or the operator wants the batch out of the way). Failed rows are visible in the UI; the operator can re-queue manually if needed.
+   - **No re-claim mode.** Don't add an `--reclaim` toggle as part of this PR. If a future use case wants it, ship as a separate fragment.
+   - Surface this recommendation to the user during plan-review and let them redirect to "support both modes" if they prefer. Do NOT ship both modes silently.
+
+   **Documentation step** (per global Planning Rules):
+   - Append a `### Cleaning up stuck batches with --cleanup-stuck` subsection under the existing "Recovering a stuck batch (local dev)" heading in `docs/operations/TICKER_ONBOARDING.md`. Show the dry-run + apply invocations, and the threshold flag.
+   - Update the SIGTERM log message in `_signal_handler` to mention the flag (NS3 trailer).
+   - No changes to `.claude/rules/*` are needed for this work.
+
+   **CLI shape** (recommended, surface in plan-review):
+   - Extend the mutually-exclusive `mode_group` in `main()` with a third option: `--cleanup-stuck`.
+   - Add `--apply` flag (default: dry-run that lists affected `batch_id`s without writing). Operators always see the candidate list before any UPDATE.
+   - Add `--stuck-threshold` (default: `'1 hour'`) for tunability — pass through as a Postgres interval string.
+   - Print a one-line summary on completion: `cleanup-stuck: matched=N marked_failed=M (dry-run | applied)`.
+
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-062-cleanup-stuck-flag`. The PreToolUse hook denies HEAD-moving git ops in the primary tree. **Verify** you are NOT in the `fix+legacy-097-chart-only-backfill` worktree — that's the parallel chart-drain track and must not pick up your changes.
+
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT:**
+     - Confirm `v2_ingest_batches` schema has `status`, `run_lock_until`, `finished_at` columns (read the migration in `sql/` that creates the table).
+     - Confirm `v2_ingest_batch_filings` is FK'd to `v2_ingest_batches.batch_id` and the cleanup behavior on the batch-level UPDATE is what you want — does flipping a batch's `status='failed'` cascade or otherwise affect the per-filing rows? If yes, reflect that in the docs section. The fragment's NS1 docs may already capture the manual recovery shape — mirror it.
+     - Confirm `argparse`'s mutually-exclusive group accepts a third option without breaking `--batch-id` / `--watch`.
+   - **SCOPE CHECK:**
+     - In: NS2 implementation + NS3 trailer (one-line SIGTERM log update) + docs append + tests.
+     - Out: any change to `--watch` mode's claim semantics, any new lock-acquisition logic, any UI surface, any change to how batches are queued.
+   - **RULES COMPLIANCE:**
+     - **`DATABASE_URL` vs `TEST_DATABASE_URL`** (`.claude/rules/infrastructure.md`): the runner already calls `load_dotenv()` and reads `DATABASE_URL`. **In this project's `.env`, `DATABASE_URL` is Neon prod.** A `--cleanup-stuck --apply` run pointing at prod would mark prod batches failed. That's destructive and irreversible. Add a guard: refuse `--apply` mode when `DATABASE_URL` matches a production hostname (`*.neon.tech`) **unless** an explicit `--allow-prod` flag is set. Dry-run mode is fine against prod (no writes). Explain this in the docs section.
+     - Per `feedback_run_recovery_before_verification`, **the docs must show dry-run first, then apply** so operators don't accidentally write before inspecting.
+   - **RISK ASSESSMENT:**
+     - Wrong threshold could mark a still-active batch failed. The 1-hour default + the dry-run-first contract + the prod guard mitigate this.
+     - Concurrent `--watch` running in another process could race the cleanup UPDATE. The existing `run_lock_until` semantics are the right primitive — only target rows where `run_lock_until < NOW() - <threshold>` AND `status='running'`. A live watcher would have a current-or-future `run_lock_until`, so it's filtered out by construction.
+     - Concurrent worktree footprints (do NOT touch):
+       - `worktree-fix+legacy-097-chart-only-backfill`: `scripts/audit_residual_chart_facts.py` + the legacy-097 fragment.
+       - Active gh-293 work (image-card undo affordance): `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js`.
+       - Active gh-294 work (image-tab keyboard shortcuts): `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js`, `.claude/rules/web.md`.
+     - None of those overlap your `touches:` (`docs/operations/*`, `src/universe/onboarding_runner.py`).
+   - **MINIMAL PATH:** confirmed above.
+   - **WORKTREE CHECK:** yes (step 3).
+
+   Show the completed checklist and **get user approval** before writing code. Per global `CLAUDE.md`: "Show the completed checklist and get user approval before proceeding with implementation."
+
+5. **Implementation.**
+   a. Add the `--cleanup-stuck` mode to `main()` in `src/universe/onboarding_runner.py`. Extend `mode_group`, add `--apply`, `--stuck-threshold`, and `--allow-prod` flags. Implement the prod-host guard (refuse `--apply` against `*.neon.tech` without `--allow-prod`).
+   b. Implement a `cleanup_stuck_batches(db, threshold: str, apply: bool) -> dict` helper alongside the existing `claim_*` helpers. The helper:
+      - SELECTs candidates: `WHERE status='running' AND run_lock_until < NOW() - INTERVAL %s` (parameterized — Postgres `make_interval` or formatted at the SQL boundary; **never f-string user input into SQL**).
+      - When `apply=True`: UPDATE matched rows to `status='failed'`, `finished_at=NOW()`, `run_lock_until=NULL`.
+      - Returns `{matched: N, marked_failed: M}` (M == 0 in dry-run).
+   c. Print the candidate `batch_id` list before the UPDATE (so the operator sees what's about to change even in `--apply` mode). Use `logger.info`, not stdout.
+   d. Update `_signal_handler` log line: change "Shutdown signal received (%s); will stop after current filing." to mention the flag, e.g. `"Shutdown signal received (%s); will stop after current filing. To recover stuck batches afterwards, run: python3 -m src.universe.onboarding_runner --cleanup-stuck"`. Keep it one line.
+   e. Update `docs/operations/TICKER_ONBOARDING.md`: append `### Cleaning up stuck batches with --cleanup-stuck` under the existing "Recovering a stuck batch (local dev)" heading. Show:
+      - The dry-run command + sample output.
+      - The `--apply` command + the prod-guard message + how to override with `--allow-prod`.
+      - The threshold tunability with `--stuck-threshold`.
+      - A note that `--cleanup-stuck` is "abandon, don't retry" — `--watch` already re-claims expired rows automatically.
+
+6. **Tests.** Add tests in `tests/integration/universe/` (or wherever the runner's existing tests live — find with `rg -l "onboarding_runner" tests/`):
+   - **Dry-run identifies stuck rows but does not write.** Set up a fixture batch with `status='running'` and `run_lock_until = NOW() - INTERVAL '2 hours'`. Run `cleanup_stuck_batches(db, '1 hour', apply=False)`. Assert: `matched == 1`, `marked_failed == 0`, DB row still `status='running'`.
+   - **Apply mode writes.** Same fixture; `apply=True`. Assert: `matched == 1`, `marked_failed == 1`, DB row now `status='failed'`, `finished_at IS NOT NULL`, `run_lock_until IS NULL`.
+   - **Threshold honored.** Fixture row at `NOW() - INTERVAL '30 minutes'`, threshold `'1 hour'`. Assert: `matched == 0` (too fresh).
+   - **Live watcher not flagged.** Fixture row with `run_lock_until = NOW() + INTERVAL '5 minutes'` and `status='running'`. Assert: `matched == 0`.
+   - **Prod-host guard.** Mock `DATABASE_URL` ending in `.neon.tech`; call with `apply=True, allow_prod=False`. Assert: function refuses (raises a clear error or returns a typed refusal — your choice; surface in plan-review).
+   Run: `pytest tests/integration/universe -x -q --tb=short`. Per project `CLAUDE.md` testing standards. Pre-existing failures: `git stash && pytest <case> -x -q && git stash pop`.
+
+7. **Update fragment status as part of the same PR.** Flip `status: partially-resolved` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section that:
+   - Names what shipped: `--cleanup-stuck` mode (dry-run default + `--apply` + `--stuck-threshold` + prod-host guard with `--allow-prod` override), SIGTERM log update, docs append.
+   - Notes the design call resolution: chose mark-failed as the default (rationale: `--watch` already re-claims expired rows; `--cleanup-stuck` is the abandon path).
+   - Test coverage summary: `<N>` integration tests under `tests/integration/universe/`.
+   Per `feedback_known_issues_pr_refs_int_not_string`, write `- 296` (or whichever PR number lands), not `- '#296'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`. Update `note:` to drop the "needs design call" qualifier; replace with a one-line summary of what shipped.
+
+8. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill) — **not** the global `/commit-user`. Run from your worktree.
+
+9. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Changing `--watch` mode's claim semantics or adding new lock-acquisition primitives.
+- A `--reclaim` mode for `--cleanup-stuck` (separate fragment if anyone wants it).
+- Any UI affordance for stuck-batch cleanup. The fragment scope is CLI + docs only.
+- Cleanup of `v2_ingest_batch_filings` partial rows beyond what flipping the parent batch's status implies. If the existing FK/CASCADE behavior is insufficient, file a follow-up fragment — don't expand here.
+- Changes to `v2_ingest_batches` schema, indexes, or constraints.
+- Any bigger refactor of `onboarding_runner.py` ("the CLI is messy" is not in scope).
+- Concurrent in-flight work — do **not** touch:
+  - `scripts/audit_residual_chart_facts.py`, `docs/known-issues/legacy-097-...md` (legacy-097 in flight, parallel)
+  - `src/web/routes/api_unified.py`, `src/web/routes/review_unified.py`, `src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js` (gh-293 in flight, parallel)
+  - `.claude/rules/web.md` (gh-294 in flight, parallel)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after `/commit-proj`
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `feedback_known_issues_pr_refs_int_not_string` — write `- 296`, not `- '#296'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_run_recovery_before_verification` — show dry-run before apply in the docs; do not let operators write blind
+- `feedback_close_partially_resolved_cleanly` — closing partially-resolved fragments cleanly is the goal; don't leave NS2 deferred again
+- `project_render_env_invisible_to_git_audit` — Render env-group config is invisible to git; default new safety controls (the `--allow-prod` guard) to code, not env vars
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_legacy-075_image-queue-cross-filing-auto-advance.md
+++ b/docs/archive/worker-prompts/PICK_legacy-075_image-queue-cross-filing-auto-advance.md
@@ -1,0 +1,45 @@
+You are working legacy-075: Implement the deferred image-queue variant of the cross-filing auto-advance Playwright E2E test (text-queue variant landed in PR #178; image-queue variant remains).
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-075-missing-playwright-e2e-for-cross-filing-auto-advance.md` (read in full from `origin/main` before planning). Status is `partially-resolved` — only the image-queue variant remains.
+- `CLAUDE.md` (project root) — read fully; obey Implementation Rules and Pre-Implementation Gate
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm the deferred stub still exists at `tests/ui/review.spec.js:1137` (currently a comment block: `// Image-queue completion variant deferred — the images tab's init JS fires an...`). Confirm PR #178's text-queue test ("text-queue completion navigates to next filing") is in `tests/ui/review.spec.js` as the model to mirror. Confirm `tests/ui/test_server.py` does NOT already handle `/api/v2/image-confirmation/*` (or whichever endpoints the image tab posts to). If the image-queue variant has already shipped, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+2. **Reproduce the gap once before planning.** Run the text-queue test and observe its shape (`cd tests/ui && npx playwright test review.spec.js -g "text-queue completion"` — adjust grep to project convention). Read the test source so the image variant mirrors structure exactly — same setup, same assertion style, same fixtures.
+3. **Plan mode.** Use plan mode. Run `/plan-review` before exiting. The plan must include:
+   - the seed strategy (two filings, last image of filing A having pending confirmations);
+   - the precise sequence of clicks/XHRs the test will assert (relevant → non-relevant → skip per fragment text — verify this matches the actual button labels in `unified_review.html` rather than trusting the fragment verbatim);
+   - the stub-server XHR catch-all extension in `tests/ui/test_server.py` (which exact endpoints, what JSON each returns);
+   - assertion that the browser lands on filing B with sort order preserved.
+4. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-075-image-queue-e2e`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+5. **Pre-Implementation Gate** (per global CLAUDE.md). Show the completed checklist and get user approval before writing code. Verify the listed `touches:` paths still exist; check whether any in-flight worktree is editing `tests/ui/test_server.py` (`git worktree list` + scan `.claude/worktrees/*/tests/ui/test_server.py`).
+6. **Implement.**
+   - Add the new Playwright test in `tests/ui/review.spec.js`, replacing the `// Image-queue completion variant deferred` stub at line ~1137.
+   - Extend the stub-server XHR catch-all in `tests/ui/test_server.py` to handle the image-confirmation endpoints the test exercises. Mirror the response shape produced by the real handlers in `src/web/routes/api_unified.py` (read them — don't fabricate). Per `project_web_route_doc_authority`, `.claude/rules/web.md` is the API contract surface; cross-reference if shapes are unclear.
+   - Keep the test deterministic — no real DB, no real network.
+7. **Tests.** Run the new test in isolation first (`npx playwright test review.spec.js -g "image-queue completion"`), then the full UI suite, then `pytest -x -q --tb=short` (to make sure nothing in the stub-server change broke unit tests that import `tests/ui/test_server.py`).
+8. **Update fragment status as part of the same PR.** Flip `status: partially-resolved` → `resolved`, `autonomy: n/a`, append the new PR to `pr_refs` (keep `- 178` and add `- <new>`), append a `### Resolution (image-queue variant)` section. Per `project_fragment_only_closure_pattern` and `feedback_known_issues_pr_refs_int_not_string` (ints, not strings).
+9. **Commit + PR.** Use the **project-local** `/commit-proj` skill.
+10. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
+
+## Out of scope (do NOT expand into)
+- Do **not** modify the text-queue test or its server stubs — PR #178 already covers that path.
+- Do **not** modify any production route handler in `src/web/routes/`. This PR is test-only.
+- Do **not** modify `unified_review.html` or `review_images_v2.js` — the in-flight worktrees `claude/feat-gh-293-reopen-reviewed-image` and `claude/feat-gh-294-image-tab-shortcuts` own those files right now. The test should target the **current** committed behavior on `main`, not anticipated behavior from those PRs.
+- Do **not** add new Playwright fixtures beyond what the image-queue completion test needs. Do not refactor existing fixtures.
+- Do **not** add database integration tests — the fragment scope is browser-layer Playwright only.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on `origin/main` and grep current code first; `partially-resolved` fragments especially drift fast
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after PR opens
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `feedback_known_issues_pr_refs_int_not_string` — `pr_refs` must be a list of ints
+- `project_web_route_doc_authority` — `.claude/rules/web.md` is the canonical web/API contract doc; consult it for endpoint shapes if needed
+- `project_image_review_status_not_flipped_by_per_metric` — relevant if the test simulates the per-metric → image-level transition; chain `/skip` to flip `review_status` (no trigger)
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_legacy-089_image-ocr-segments-not-surfaced.md
+++ b/docs/archive/worker-prompts/PICK_legacy-089_image-ocr-segments-not-surfaced.md
@@ -1,0 +1,114 @@
+You are working **legacy-089 Step B (design-first)**: stale image review decisions when fresh OCR data lands.
+
+This is a **design pass**, not an implementation. The goal is a written design proposal the user can sign off on before any code is written. Do not open a code-change PR. The deliverable is a markdown design doc under `docs/architecture/` plus a fragment-status update.
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-089-image-ocr-segments-not-surfaced-in-review-ui.md` (read in full from `origin/main` — Step A already shipped in PR #285; only Step B remains).
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and the design-principles section, especially principle 6 (reviewed-filing guard semantics).
+- Global `~/.claude/CLAUDE.md` — read **Implementation Rules** and **Planning Rules**.
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully.
+- `.claude/rules/web.md` — authoritative web-route / API contract doc per `project_web_route_doc_authority`. Any new endpoint must be specified here.
+- `.claude/rules/docs.md` — placement rule: design specs live in `docs/architecture/`.
+- Read for shape (do not modify in this pass): `src/web/routes/review_unified.py`, `src/web/routes/api_unified.py`, `src/web/templates/unified_review.html`, `sql/` for `v2_image_assets`, `v2_image_review_decisions`, `v2_image_metric_confirmations`, `v2_audit_log`.
+
+## Why design-first
+The fragment author explicitly deferred Step B because "the right shape needs its own design pass." Two memory entries make this load-bearing:
+
+- `project_image_review_decisions_for_ml_training` — image review decisions are ML training signal; the per-(image, metric) decision trail must be preserved when an image is "unlocked." Naive `UPDATE … SET review_status='pending'` that loses the prior decision is a regression.
+- `project_image_review_status_not_flipped_by_per_metric` — bulk image-level actions don't flip `v2_image_assets.review_status` automatically. So whichever surface a "re-review" affordance touches (image-level vs per-metric), the design has to be explicit about which status it manipulates and what the downstream queue/UI consequences are.
+
+Implementing the wrong shape costs more than designing first.
+
+## Concurrency footing
+The user is also working **legacy-024** (`v2_metric_facts.source_locator.img_id` referential integrity) and **legacy-038** (`v2_metric_facts.doc_id → filing_id` rename). Both touch `v2_metric_facts`. This pass touches **image-decision tables** only — no `v2_metric_facts` reads or writes in the proposed design. If you find an unavoidable touch on `v2_metric_facts`, stop and surface the conflict to the user.
+
+## Workflow
+
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm Step A's resolution section is intact and Step B is still listed as deferred. If someone has already shipped Step B since `updated: 2026-04-28`, abort and propose a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+
+   Spot-check the current state — do any of these surfaces already exist?
+   ```bash
+   grep -rnE "re-review|reopen.*image|invalidate.*ocr|ocr.*decision" src/web/ src/infra/db.py
+   ```
+   If yes, narrow the design scope to only the missing pieces.
+
+2. **Reproduce the problem on filing 1748.** Confirm the symptom is still present:
+   - DB: 18 `v2_segments source_type='image_ocr'` rows for filing 1748 (or substitute fixture if 1748 has been re-extracted).
+   - DB: ≥1 `v2_image_review_decisions` row for an image that now has fresh `ocr_text` post-re-extraction.
+   - UI: load `/v2/review/1748?tab=images`; observe the "already reviewed" UX hides the new OCR data.
+
+   If you cannot reproduce the symptom, that is itself a finding — escalate to the user before designing.
+
+3. **Design pass — write the proposal.** No code, no `EnterWorktree` yet (a docs-only commit doesn't strictly need one, but per the project worktree-first rule you should still enter one if any commit is on the table). Output is a single design doc:
+
+   **Path:** `docs/architecture/image-decision-revalidation-design.md`
+
+   **Required sections:**
+
+   1. **Problem statement** (½ page) — restate Step B's problem in your own words; cite the filing-1748 reproduction; cite the two memory constraints (ML signal preservation, image-level vs per-metric status surface).
+
+   2. **Options considered** (≥2, ideally 3). For each option, document:
+      - Surface (which table(s), which UI affordance, which endpoint).
+      - Mechanism (how staleness is detected; how the prior decision is preserved; how audit-log entries are written).
+      - User flow (what does the reviewer click, what do they see).
+      - Backward compatibility (what happens to existing reviewed images on first deploy — do they all become stale at once? does the comparison need a "decision-time hash" column added retroactively?).
+      - Risks and failure modes.
+      - Effort estimate (XS/S/M/L; ballpark file count and migration count).
+
+      At minimum cover:
+      - **Option A — explicit "re-review" button** on the image-detail panel. Reviewer-driven; new endpoint; writes audit row; flips `review_status` (decide which surface) without deleting the prior decision row.
+      - **Option B — auto-invalidate on hash change**. Compare current `ocr_text`/`chart_data` against a snapshot captured at decision time. Requires a new column (e.g. `v2_image_review_decisions.snapshot_hash` or `decided_against_ocr_hash`) and a backfill story for the existing rows that have no snapshot. Higher blast radius; lower reviewer overhead.
+      - **Option C — hybrid / something else** if a third shape is obvious from the code shape.
+
+   3. **Recommendation** (½ page) — pick one option with a justification grounded in the two memory constraints and the principle-6 "reviewed-filing guard" semantics. Be explicit about why the rejected options were rejected.
+
+   4. **Implementation outline** for the recommended option:
+      - File-by-file change list (route(s), API endpoint(s), DB adapter method(s), template snippet(s), test files). Do not write the code; just enumerate.
+      - Migration plan if a new column is required (timestamp filename per `.claude/rules/sql.md`; backfill semantics; whether `v2_image_review_decisions` is the right home or a sibling table).
+      - Audit-log shape: which `action` value, which JSONB payload fields. Confirm the `action` value passes the `v2_audit_log` CHECK constraint (cite the constraint).
+      - Test plan: unit (DB adapter), integration (route → DB), Playwright (UI affordance if applicable).
+      - Documentation updates required: `.claude/rules/web.md` for any new endpoint, the appropriate runbook under `docs/operations/`, and CLAUDE.md design-principles section if the reviewed-filing-guard semantics are extended.
+
+   5. **Out of scope** — explicitly list what the implementation PR must NOT expand into:
+      - Step A's surfacing work (already shipped in #285).
+      - Tier 1 keyword tuning for PayPal-style prose (separate fact-extraction work).
+      - Cross-filing image-queue auto-advance (`legacy-075`).
+      - Anything touching `v2_metric_facts` (concurrent with legacy-024 / legacy-038).
+      - ML triage feed schema (`gh-196`).
+
+   6. **Open questions** — anything you want the user to decide before implementation starts. Use a numbered list. Don't paper over uncertainty; surface it.
+
+4. **Update fragment status as part of the same docs-only PR.** Do **not** flip to `resolved` — the design pass is design only. Append to the fragment's `note:` field (within the existing allowlist per `feedback_known_issues_validator_optional_fields`): a one-sentence pointer to the new design doc and the date. Add this PR's number to `pr_refs:` once the PR is open (write `- 277` not `- '#277'` per `feedback_known_issues_pr_refs_int_not_string`). Status stays `partially-resolved`.
+
+5. **Worktree + commit.** First step before any docs commit: `EnterWorktree fix/legacy-089-step-b-design`. Use the **project-local** `/commit-proj` skill. Per project `CLAUDE.md`, docs-only commits may skip lint/tests, but `/commit-proj` will handle that decision via its file-type sniff — let it run.
+
+6. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`.
+
+## Hard constraints (do NOT violate)
+- **No code changes.** Output is one markdown design doc + a fragment frontmatter touch. If during the design pass you spot a one-line bug fix, file a separate gh-N fragment per `project_known_issues_new_fragments_gh_namespace` — do not bundle.
+- **No `v2_metric_facts` reads or writes** in the proposed design. Concurrent worktrees own that table this week.
+- **No deletion of existing `v2_image_review_decisions` rows** in any proposed design. The ML decision trail is preserved; "unlock" semantics work by adding rows or adding a status field, not by removing prior decisions.
+- **No new `docs/` subfolders.** Per `.claude/rules/docs.md`, `docs/architecture/` is the canonical home for design specs.
+
+## Out of scope (do NOT expand into)
+- Implementing the recommended option (separate PR after user signs off on the design).
+- Step A re-work (already shipped in #285).
+- Tier-1 keyword tuning for PayPal earnings prose.
+- `legacy-075`, `legacy-097`, `gh-196` — cross-referenced in the fragment but distinct fragments.
+- Concurrent worktree footprints to avoid: `fix+legacy-038-doc-id-rename` (column rename across the codebase), `fix+legacy-097-chart-only-backfill`, anything touching `v2_metric_facts.source_locator.img_id` (legacy-024 territory). If your design proposal needs to touch any of these, stop and surface the conflict to the user.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first.
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set after `/commit-proj`.
+- `feedback_subagent_midstream_stops` — if you delegate the design write-up to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree.
+- `feedback_known_issues_pr_refs_int_not_string` — `- 277`, not `- '#277'`.
+- `feedback_known_issues_validator_optional_fields` — only `{pr_refs, gh_issue, note}` are accepted in frontmatter for closure-style updates.
+- `project_fragment_only_closure_pattern` — pattern for when a design pass turns out to be unnecessary because the issue is already resolved.
+- `project_web_route_doc_authority` — `.claude/rules/web.md` is authoritative for any new endpoint specified in the design.
+- `project_image_review_decisions_for_ml_training` — preserve per-(image, metric) decision trail; do not propose deletes.
+- `project_image_review_status_not_flipped_by_per_metric` — be explicit about which status surface (image-level vs per-metric) the design touches.
+- `project_db_query_vs_execute` — relevant to the implementation outline; `db.execute` for write SQL.
+- `project_known_issues_new_fragments_gh_namespace` — for any incidental bug found during the design pass, file a `gh-N` fragment.
+
+## Return
+The PR URL of the design-doc PR, plus a one-paragraph summary of the recommended option from section 3 of the design.

--- a/docs/archive/worker-prompts/PICK_legacy-091_gemini-pro-empty-content.md
+++ b/docs/archive/worker-prompts/PICK_legacy-091_gemini-pro-empty-content.md
@@ -1,0 +1,42 @@
+You are working legacy-091: gemini-pro Returns Empty Content on vision + response_format=json_object.
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-091-gemini-pro-empty-content-on-vision-json-object.md` (read in full from origin/main before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- Reference doc: `docs/operations/vision-bakeoff-metric-classify-2026-04-23.md` (the bake-off where this was discovered)
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Inspect `src/llm/vision_client.py` and `scripts/benchmark_vision.py` for changes since `updated: 2026-04-23`. Re-run a minimal repro: one image + `gemini-pro` (`gemini-2.5-pro`) via `VisionClient.analyze_image(..., response_format={"type": "json_object"})` and confirm the empty-`content` behavior still reproduces. If already fixed, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+2. **Plan mode.** Use plan mode for any non-trivial change. Run `/plan-review` before exiting plan mode. The plan must include the **Documentation** step required by the global `Planning Rules`.
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-091-gemini-pro-json-mode`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`). Show the completed checklist and get user approval before writing code. This change touches `src/llm/vision_client.py` (provider adapter) — pay attention to ASSUMPTION AUDIT (which Gemini SDK version is pinned, which other callers depend on the JSON-mode hint) and RISK ASSESSMENT (does dropping JSON-mode affect non-vision Gemini callers?).
+5. **Implementation strategy** (from fragment Next Steps; pick after the gate, do not pre-decide):
+   - Either drop the `response_format={"type": "json_object"}` hint on the Gemini Pro vision path and parse free-text back into the four-field classify schema, or
+   - Route Pro through a non-JSON code path when `analyze_image` is the caller, leaving non-vision Gemini callers' JSON-mode intact.
+   - Until resolved, the fragment also calls for omitting `gemini-pro` from `BAKEOFF_PROVIDER_ORDER_METRIC_CLASSIFY` — only do this if you cannot fix in code in this PR.
+6. **Tests.** Per project `CLAUDE.md` testing standards: `pytest -x -q --tb=short`. Add a unit test that exercises the Gemini Pro vision JSON path (mocked SDK response is fine) so this can't regress silently. Don't skip on failures.
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, `autonomy: n/a` (already), set `pr_refs: [<this PR #>]` (added after PR creation), and append a `### Resolution` section describing what changed and why. Per `project_fragment_only_closure_pattern`. Per `feedback_known_issues_pr_refs_int_not_string`, write `- 261` not `- '#261'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}` when closing.
+8. **Commit + PR.** Use the **project-local** `/commit` skill (Safe Commit + PR Skill). Per `feedback_commit_skill_name_collision`, the global skill may load instead — if you see "Safe Commit Skill" without a PR step, follow up manually with `gh pr create` + `gh pr merge --auto --squash`.
+9. **Verify auto-merge.** After `/commit` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`. Note: the project-local `/commit` may rename the branch to `fix/legacy-091-...` — fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push (per `feedback_commit_skill_renames_pr_branch`).
+
+## Out of scope (do NOT expand into)
+- Other Gemini quirks beyond the empty-content-on-JSON-vision bug.
+- Refactoring `VisionClient` provider abstractions.
+- Vision bake-off methodology changes (`docs/operations/vision-bakeoff-*`).
+- Touching the metric-classify pipeline outside the provider adapter.
+- Concurrent worktree footprints: `docs/known-issues/`, `tests/integration/test_db_filings_reviewers.py`, `tests/integration/extraction_v2/`, `sql/` — left to legacy-113 and legacy-116 picks.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_commit_skill_name_collision` — global vs project-local /commit
+- `feedback_commit_skill_renames_pr_branch` — fetch headRefName before follow-up pushes
+- `feedback_known_issues_pr_refs_int_not_string` — `- 261`, not `- '#261'`
+- `feedback_known_issues_validator_optional_fields` — don't add frontmatter fields outside the allowlist
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_legacy-097_chart-only-backfill-with-lifted-budget.md
+++ b/docs/archive/worker-prompts/PICK_legacy-097_chart-only-backfill-with-lifted-budget.md
@@ -1,0 +1,223 @@
+You are working legacy-097: Residual Chart Facts Remain After Chart-Presence Pivot — execute Option 2 (chart-only re-extraction with lifted Vision-OCR budget).
+
+**This is an unusual worker task — it includes a prod-destructive backfill step that CASCADE-destroys 28 reviewer decisions and spends ~$2–$5 on Vision API. Do not skip the explicit user-approval gate before running the backfill.**
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md` (read in full from `origin/main` before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**. Pay special attention to design principle 6 (reviewed-filing guard) and the chart-presence pivot semantics in principle 4.
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules", "Planning Rules", and **"Git Operations"** (destructive-action confirmation rules).
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- `.claude/rules/v2-pipeline.md` — **authoritative** for `chart_only=True` semantics, the reviewed-filing guard, and the `CHART_BUDGET_PER_FILING_USD` env knob
+- `.claude/rules/infrastructure.md` — for `DATABASE_URL` / `TEST_DATABASE_URL` separation and the R2 prod-write guard
+- Audit script (already written in the prior session): `scripts/audit_residual_chart_facts.py` — verify it exists at `HEAD`. If missing, the prior session's work didn't get committed; flag and stop.
+- Related: `src/extraction_v2/persistence.py::_persist_facts_in_tx` (the `chart_only` branch), `src/extraction_v2/stages/ocr_extraction.py` (`CHART_BUDGET_PER_FILING_USD` env override), `scripts/batch_v2_extraction.py` (`--chart-only`, `--force-reextract`, `--filing-ids-file`).
+
+## The decision (already made)
+User picked Option 2 from the legacy-097 triage:
+
+> "Run `chart_only --force-reextract` on the 10 affected filings, but bump `CHART_BUDGET_PER_FILING_USD` for this backfill run only. Get full chart coverage. Higher API spend (~$2–$5). Touches `src/extraction_v2/stages/ocr_extraction.py` env-config — trivial."
+
+The audit (run against prod 2026-04-28) established:
+- 10 filings carry residual chart facts (30 rows)
+- 28 chart-fact reviewer decisions on those rows (will CASCADE-destroy — intentional)
+- 154 chart-classified images across the 10 filings
+- 31 of 154 already have `chart_data` populated (cached Vision OCR)
+- 146 text-fact reviewer decisions on the same 10 filings (must be preserved — `chart_only=True` scopes the DELETE)
+- 3 image-metric confirmations on PYPL filing 1753 (preserved — confirmations are not CASCADE-linked to facts; the "purging" warning text in `_persist_facts_in_tx` is misleading)
+
+The plan is therefore:
+1. Re-run the audit to confirm the numbers haven't shifted.
+2. Generate the filing-ids file from the audit.
+3. **PAUSE FOR EXPLICIT USER APPROVAL** before running the backfill.
+4. Run `CHART_BUDGET_PER_FILING_USD=<lifted> python3 scripts/batch_v2_extraction.py --chart-only --force-reextract --filing-ids-file <path>`.
+5. Re-run the audit; record outcome.
+6. Close the fragment with a Resolution describing the measured outcome.
+
+## Workflow
+
+1. **Verify state on `origin/main`.**
+   ```bash
+   git fetch origin main --quiet
+   ls -la scripts/audit_residual_chart_facts.py            # should exist
+   git show origin/main:docs/known-issues/legacy-097-residual-chart-facts-after-presence-pivot.md | head -20
+   ```
+   Confirm the audit script is committed (or stage it from the local tree if the prior session left it uncommitted — see step 5b). Confirm legacy-097 is still `status: open` with empty `pr_refs`. If anything else has changed (e.g., fragment already closed, audit script absent and untracked locally), stop and re-scope.
+
+2. **Re-run the audit against prod (read-only).**
+   ```bash
+   set -a && source .env && set +a
+   python3 scripts/audit_residual_chart_facts.py
+   ```
+   Capture the output. Compare to expected (28 chart-fact decisions, 146 text-fact decisions, 3 image confirmations on PYPL 1753, 31 images with `chart_data`, 0 with `detected_metrics`). If any of those numbers have shifted by >5%, stop and surface the delta — recent reviewer work or another backfill may have changed the picture.
+
+3. **Plan mode.** Run `/plan-review` before exiting plan mode. The plan must include:
+   - **Documentation step** (per global Planning Rules): a Resolution section in the fragment + optional one-paragraph runbook addition under `docs/operations/` (e.g. `chart-presence-residual-drain.md`, or an inline note in `docs/operations/full-page-ocr-runbook.md`) describing the procedure for future drain-style backfills.
+   - **Backfill parameters**: pick `CHART_BUDGET_PER_FILING_USD` value (recommend `2.00` — gives ~8x headroom over default 0.25, comfortably covers all 154 chart images even if Tier-1-keyword bypass under-fires).
+   - **Verification SQL**: queries to run post-backfill (chart_fact_count → 0, chart-decision count → 0, text-fact decision count unchanged, image-metric confirmation count unchanged, detected_metrics populated on most chart images).
+   - **Rollback plan**: there isn't one. The 28 decisions are gone after the DELETE+CASCADE. State this explicitly so the user is aware before approval.
+
+4. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-097-chart-only-backfill`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+
+5. **Pre-Implementation Gate** (per global `CLAUDE.md`).
+   - **ASSUMPTION AUDIT**:
+     - Confirm `scripts/batch_v2_extraction.py` accepts `--chart-only`, `--force-reextract`, and `--filing-ids-file` (grep already confirmed at brief time).
+     - Confirm `CHART_BUDGET_PER_FILING_USD` is the right env knob (grep `src/extraction_v2/stages/ocr_extraction.py` for the `os.environ` reference at the line that defaults to `DEFAULT_CHART_BUDGET_PER_FILING_USD`).
+     - Confirm `chart_only=True` does NOT delete `v2_image_metric_confirmations` rows (read `_persist_facts_in_tx` lines ~1083–1118 — the secondary guard checks but does not DELETE; the `_persist_images_in_tx` UPSERT preserves `img_id`, so confirmations FK survives).
+     - Confirm `_persist_images_in_tx`'s visible→hidden guard does NOT fire for chart→chart re-runs (it only blocks visible→hidden transitions).
+   - **SCOPE CHECK**: this PR ships:
+     - `scripts/audit_residual_chart_facts.py` (already written; commit only if untracked at HEAD)
+     - The fragment closure (status flip + Resolution + pr_refs)
+     - Optional: a brief runbook section
+     The PR does **NOT** ship code changes to the pipeline, persistence, or `MAX_CHART_CALLS_PER_DOCUMENT` semantics. The budget lift is done via env var at runtime, not as a code change.
+   - **RULES COMPLIANCE**:
+     - The backfill writes to prod Postgres AND prod R2. `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` must be set for the run (per `.claude/rules/infrastructure.md`). Without it, `_persist_images_in_tx`'s downstream R2 writes will fail (gh-262 territory).
+     - The reviewed-filing guard intentionally fires here because of the 28 chart decisions; `--force-reextract` is the documented opt-in.
+   - **RISK ASSESSMENT**:
+     - 28 reviewer decisions destroyed (intentional, the whole point).
+     - 146 text-fact decisions preserved (verified by `chart_only` semantics; verify post-run in step 7).
+     - 3 image confirmations preserved (verified by code inspection; verify post-run).
+     - ~$2–$5 Vision API spend.
+     - Possible re-classification edge: if any chart image gets re-classified into a hidden class on this run, `_persist_images_in_tx` will fire its guard. With `--force-reextract`, it proceeds and logs `force-reextract hiding reviewed images: ...`. Watch for this in the logs and surface to user if it happens.
+   - **MINIMAL PATH**: confirmed above.
+   - **WORKTREE CHECK**: yes (step 4).
+
+   Show the completed checklist and **get user approval before continuing to step 6**.
+
+6. **Implementation — code-side (no prod writes yet).**
+   a. Commit the audit script if it's not yet at HEAD: `git add scripts/audit_residual_chart_facts.py`.
+   b. Generate the filing-ids file:
+      ```bash
+      set -a && source .env && set +a
+      psql "$DATABASE_URL" -A -t -F$'\n' -c \
+        "SELECT DISTINCT doc_id FROM v2_metric_facts WHERE source_type='chart' ORDER BY doc_id" \
+        > /tmp/legacy_097_filing_ids.txt
+      wc -l /tmp/legacy_097_filing_ids.txt        # expect 10
+      cat /tmp/legacy_097_filing_ids.txt
+      ```
+      Do NOT commit this file (it's run-time scratch). Confirm count == 10 and IDs match the audit output.
+   c. Optionally add a one-paragraph note under `docs/operations/` describing the residual-chart-fact drain procedure (so a future operator can repeat it). Keep it short.
+
+7. **PROD BACKFILL — STOP FOR EXPLICIT USER APPROVAL.**
+
+   Print the exact command you intend to run, including:
+   - The `CHART_BUDGET_PER_FILING_USD` value chosen
+   - The 10 filing IDs
+   - The expected outcome (28 decisions destroyed, ~100–130 chart images gain `detected_metrics`, ~$2–$5 spend)
+   - The fact that there is no rollback for the 28 decisions
+
+   Then ask: `"This is a prod-destructive operation. Confirm 'yes, run the backfill' to proceed."`
+
+   Do NOT proceed on ambiguous input. Per global `CLAUDE.md`:
+   > "Never interpret ambiguous input as approval for destructive git operations."
+   The same rule applies here even though this is a script run rather than a git op — the prod-destruction reversibility is the same shape.
+
+   On explicit `yes`:
+   ```bash
+   set -a && source .env && set +a
+   FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 \
+   CHART_BUDGET_PER_FILING_USD=2.00 \
+   python3 scripts/batch_v2_extraction.py \
+     --chart-only \
+     --force-reextract \
+     --filing-ids-file /tmp/legacy_097_filing_ids.txt 2>&1 | tee /tmp/legacy_097_backfill.log
+   ```
+   Capture the log. Watch for:
+   - `force-reextract purging reviewed filing: filing_id=X purged_decision_count=N ... chart_only=True` (expected, ~28 total across filings)
+   - `force-reextract hiding reviewed images: ...` (UNEXPECTED — if you see it, stop and surface)
+   - `chart_budget_usd=2.0` in any per-filing log line (confirms env override took effect)
+   - Per-filing fact_count=0 (correct — chart pipeline emits no per-value facts post-pivot)
+
+8. **Verify the outcome.**
+   ```bash
+   python3 scripts/audit_residual_chart_facts.py 2>&1 | tee /tmp/legacy_097_postaudit.txt
+   ```
+   Expected:
+   - 0 rows returned (no filings carry residual chart facts) — this is the success state
+   - If rows are returned, chart_facts and chart_fact_decisions should be 0; `chart_imgs_with_detected` should be substantially > 0 (target ≥ 100 across the 10 filings, vs 0 before)
+   - Run a separate query to verify text-fact decisions preserved:
+     ```bash
+     psql "$DATABASE_URL" -c "
+       SELECT mf.doc_id, COUNT(*) AS text_decs
+       FROM v2_review_decisions rd
+       JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
+       WHERE mf.source_type <> 'chart' AND mf.doc_id IN (SELECT unnest(string_to_array('$(paste -sd, /tmp/legacy_097_filing_ids.txt)', ',')::int[]))
+       GROUP BY mf.doc_id ORDER BY mf.doc_id;"
+     ```
+     Expected: 146 total across 9 filings (PYPL 1753 has 0 text decisions). If lower, something went wrong — DO NOT proceed to fragment closure; surface to user.
+   - Verify image-metric confirmations preserved:
+     ```bash
+     psql "$DATABASE_URL" -c "
+       SELECT COUNT(DISTINCT (imc.img_id, COALESCE(imc.detected_metric_id, imc.confirmed_metric_id, ''), imc.reviewer_id))
+       FROM v2_image_metric_confirmations imc
+       JOIN v2_image_assets ia ON ia.img_id = imc.img_id
+       WHERE ia.doc_id = 1753;"
+     ```
+     Expected: 3. If lower, surface immediately.
+
+9. **Tests (light).** There's no unit test for this operation — it's an operator script run. But the audit script's SQL should be sanity-checked against the local Docker DB if it's running:
+   ```bash
+   docker compose ps  # check if local Postgres is up
+   # If yes:
+   DATABASE_URL="$TEST_DATABASE_URL" python3 scripts/audit_residual_chart_facts.py
+   # Should run cleanly even if it returns 0 rows (local test DB likely has no chart facts)
+   ```
+   Run `pytest -x -q --tb=short` on any tests that touch `scripts/` if they exist (`rg -l "audit_residual_chart_facts" tests/` — likely none). Pre-existing failures: per project `CLAUDE.md`, do not spend time fixing predates.
+
+10. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, append a `### Resolution` section structured roughly as:
+    ```markdown
+    ### Resolution
+
+    Drained the 30 residual chart `v2_metric_facts` rows via `chart_only=True --force-reextract` on 2026-04-28 with `CHART_BUDGET_PER_FILING_USD=2.00`.
+
+    **Measured outcome (post-run audit):**
+    - Chart facts remaining: 0 (was 30)
+    - Chart-fact reviewer decisions destroyed: 28 (intentional; CASCADE via `v2_review_decisions.fact_id ON DELETE CASCADE`)
+    - Text-fact reviewer decisions: <N> (was 146; should be unchanged)
+    - Image-metric confirmations on PYPL filing 1753: <N> (was 3; should be unchanged)
+    - Chart images with `detected_metrics` populated: <N> / 154 (was 0)
+    - Vision API spend: ~$<actual>
+    - Pipeline runtime: ~<actual> min
+
+    Reviewer follow-up: <N> chart images now surface in the per-(image, metric) review queue across the 10 filings. Estimated reviewer time: ~25 min in bulk-image flow.
+
+    **Why Option 2 was picked over surgical drain:** the surgical-drain path (DELETE chart facts only, no re-extraction) abandons the 28 decisions without producing any new presence signal, since the chart images had `detected_metrics IS NULL` and no fresh classification would be written. Option 2 produces a real reviewable surface.
+
+    See `scripts/audit_residual_chart_facts.py` for the verification mechanism (read-only).
+    ```
+    Per `feedback_known_issues_pr_refs_int_not_string`, write `- 290`, not `- '#290'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`.
+
+11. **Commit + PR.** Use the **project-local** `/commit-proj` skill (Safe Commit + PR Skill) — **not** the global `/commit`. Run from your worktree. The PR contains:
+    - `scripts/audit_residual_chart_facts.py` (new)
+    - `docs/known-issues/legacy-097-...md` (status flip + Resolution)
+    - Optional: brief runbook addition under `docs/operations/`
+
+12. **Verify auto-merge.** After `/commit-proj` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push.
+
+## Out of scope (do NOT expand into)
+- Modifying `MAX_CHART_CALLS_PER_DOCUMENT`, `DEFAULT_CHART_BUDGET_PER_FILING_USD`, or any per-doc cap as a permanent change. The lift is **runtime-only via env var** for this backfill.
+- Changing `chart_only=True` semantics in `src/extraction_v2/persistence.py`. The current behavior is correct; only the warning text "purging image-metric confirmations" is misleading. Do **not** edit it as part of this PR — that's a separate, low-priority cleanup. (If you want to file a follow-up gh-N fragment for it, fine — but don't conflate.)
+- Adding tests for `chart_only=True` or the audit script unless an obviously trivial smoke test is at hand.
+- Reviewing the chart images yourself in the UI. That's reviewer work for RGM; the PR's job is to make those images surface.
+- Concurrent in-flight work — do **not** touch:
+  - `src/web/routes/review_unified.py`, `src/web/routes/api_unified.py`, `src/web/templates/unified_review.html` (legacy-089 + open PR #284)
+  - `tests/integration/extraction_v2/test_e2e_pipeline.py`, `tests/integration/test_full_page_ocr_pipeline.py`, `src/infra/image_storage.py` (gh-262)
+  - `scripts/export_image_training_data.py`, `scripts/retrain_image_triage.py`, `scripts/benchmark_vision.py`, `src/llm/vision_client.py`, `src/gold_standard/image_eval.py` (gh-196)
+  - `.claude/commands/commit-proj.md`, `scripts/validate_known_issues_fragments.py` (gh-258)
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first; the audit's chart-fact-decision count was already stale (fragment said 18, audit measured 28 — re-run before acting)
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_subagent_midstream_stops` — if you delegate the backfill execution to a subagent, do **not**. The user-approval gate must be honored synchronously.
+- `feedback_destructive_recovery_workflow` — bundle audit+recovery in fix PR, frame around reviewer-decision exposure not abstract risk
+- `feedback_run_recovery_before_verification` — do not run the post-audit (step 8) until the backfill (step 7) actually completed cleanly; otherwise the "verification" measures stale state
+- `feedback_known_issues_pr_refs_int_not_string` — `- 290`, not `- '#290'`
+- `feedback_known_issues_validator_optional_fields` — `OPTIONAL_FIELDS` allowlist is `{pr_refs, gh_issue, note}`
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+- `project_image_review_decisions_for_ml_training` — image review decisions are ML training signal; the 28 chart-fact decisions ARE included in that signal. Their abandonment is deliberate (Option 2 was chosen with this trade-off explicit).
+- `project_db_query_vs_execute` — `db.query` is SELECT-only
+
+## Return
+The PR URL when done, plus:
+- Summary of the backfill log (purged_decision_count, chart_budget_usd, chart_call counts)
+- Post-audit numbers (text-fact decisions preserved, image confirmations preserved, detected_metrics populated count)
+- One-line note for RGM on the reviewer follow-up: "<N> chart images now surface in the image queue across <N> filings; estimated review time ~<N> min."

--- a/docs/archive/worker-prompts/PICK_legacy-113_test-db-filings-reviewers-missing-v2-documents.md
+++ b/docs/archive/worker-prompts/PICK_legacy-113_test-db-filings-reviewers-missing-v2-documents.md
@@ -1,0 +1,47 @@
+You are working legacy-113: `test_db_filings_reviewers.py::test_reviewers_aggregates_text_and_image_sources` fails on missing `v2_documents` relation.
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-113-test-db-filings-reviewers-v2-documents-missing.md` (read in full from origin/main before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- Related fragments to cross-reference: `docs/known-issues/legacy-110-*` (migration registry drift — likely shared root cause), `docs/known-issues/legacy-114-*` (recently-resolved checksum self-heal context, PR #254/#255).
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm the failure still reproduces on clean main:
+   ```
+   pytest tests/integration/test_db_filings_reviewers.py::TestReviewerAggregation::test_reviewers_aggregates_text_and_image_sources -x -q
+   ```
+   If it now passes (e.g. legacy-110 was fixed in a way that incidentally fixed this), abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`. Per `feedback_run_recovery_before_verification`: if the test DB looks corrupted, run the documented recovery (e.g. `dropdb` per the integration test runbook) before assuming the test itself is wrong.
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include the **Documentation** step required by the global `Planning Rules`.
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-113-test-db-filings-reviewers-missing-v2-documents`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`). The fragment lists `touches: sql/` which is a wide glob — narrow the **MINIMAL PATH** to the specific files actually needed (likely `tests/integration/conftest.py`'s `_apply_migrations_to_test_db` and possibly a single migration registration), and rule out broad `sql/` edits unless required. ASSUMPTION AUDIT must verify the current registry order and the per-worker DB isolation behavior in `tests/integration/conftest.py::_isolate_xdist_worker_database`.
+5. **Diagnostics first** (per fragment Next Steps):
+   - Run the integration conftest migration step manually and confirm whether `v2_documents` is created (`\dt v2_*` in `psql`).
+   - Cross-reference with legacy-110 (migration registry drift). If that's the underlying bug, fix in the registry rather than papering over here.
+   - Last-resort fallback (only if registry fix is out of scope): make the test skip when V2 schema is absent, with a clear xfail/skip reason linked to the upstream fragment.
+6. **Tests.** `pytest -x -q --tb=short`. The single failing test must pass. Per project `CLAUDE.md` testing standards, run the full integration test file at minimum to ensure no other regressions. Don't skip on failures.
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, set `pr_refs: [<this PR #>]`, and append a `### Resolution` section describing the root cause and fix. Per `feedback_known_issues_pr_refs_int_not_string`, write `- 261` not `- '#261'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}` when closing. If the actual fix is in legacy-110's domain and this fragment is now incidentally fixed, mark it `resolved` and reference the upstream fix in the Resolution section.
+8. **Commit + PR.** Use the **project-local** `/commit` skill (Safe Commit + PR Skill). Per `feedback_commit_skill_name_collision`, the global skill may load instead — if you see "Safe Commit Skill" without a PR step, follow up manually with `gh pr create` + `gh pr merge --auto --squash`.
+9. **Verify auto-merge.** After `/commit` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push (per `feedback_commit_skill_renames_pr_branch`).
+
+## Out of scope (do NOT expand into)
+- Resolving legacy-110 in full (note progress in this PR's description if the fix happens to subsume it, but don't expand scope to chase the registry-drift root cause beyond what's needed to unblock the test).
+- Other failing integration tests not connected to V2 schema setup.
+- Refactoring `tests/integration/conftest.py` beyond the minimum to make the migration step deterministic.
+- Touching unrelated `sql/` migrations.
+- Concurrent worktree footprints: `src/llm/vision_client.py`, `scripts/benchmark_vision.py`, `tests/integration/extraction_v2/` — left to legacy-091 and legacy-116 picks.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_commit_skill_name_collision` — global vs project-local /commit
+- `feedback_commit_skill_renames_pr_branch` — fetch headRefName before follow-up pushes
+- `feedback_known_issues_pr_refs_int_not_string` — `- 261`, not `- '#261'`
+- `feedback_known_issues_validator_optional_fields` — don't add frontmatter fields outside the allowlist
+- `feedback_run_recovery_before_verification` — run recovery before assuming a workaround removal failed
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+
+## Return
+The PR URL when done.

--- a/docs/archive/worker-prompts/PICK_legacy-116_8k-e2e-pipeline-test-for-exhibit-content.md
+++ b/docs/archive/worker-prompts/PICK_legacy-116_8k-e2e-pipeline-test-for-exhibit-content.md
@@ -1,0 +1,44 @@
+You are working legacy-116: Missing E2E Pipeline Test for 8-K Exhibit Metric Extraction.
+
+## Source of truth
+- Fragment: `docs/known-issues/legacy-116-8k-e2e-pipeline-test-for-exhibit-content.md` (read in full from origin/main before planning)
+- `CLAUDE.md` (project root) — read fully; obey **Implementation Rules** and **Pre-Implementation Gate**
+- Global `~/.claude/CLAUDE.md` — read; especially "Implementation Rules" and "Planning Rules"
+- Project memory at `~/.claude/projects/-Users-rgmarkey-CMASB-Coding-filings-reviewer/memory/MEMORY.md` — read fully and apply
+- Related context (read for fixture pattern, do not modify): `tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` (the legacy-058 fix's narrower test), the legacy-058 fragment under `docs/known-issues/`, and existing `tests/integration/extraction_v2/` tests for the E2E pattern.
+
+## Workflow
+1. **Verify the issue is still relevant.** Re-read the fragment from `origin/main`. Confirm no E2E exhibit-content test has been added under `tests/integration/extraction_v2/` since `updated: 2026-04-27` — `grep -r "exhibit" tests/integration/extraction_v2/`. If a test already exists and asserts segment count + metric-fact emission from exhibit content, abort and produce a fragment-only closure PR per `project_fragment_only_closure_pattern`.
+2. **Plan mode.** Use plan mode. Run `/plan-review` before exiting plan mode. The plan must include the **Documentation** step required by the global `Planning Rules` — at minimum, decide whether the fixture's provenance needs a note in `data/gold_standard/README.md` or equivalent.
+3. **Worktree-first.** First step of implementation: `EnterWorktree fix/legacy-116-8k-exhibit-e2e-pipeline-test`. The PreToolUse hook denies HEAD-moving git ops in the primary tree.
+4. **Pre-Implementation Gate** (per global `CLAUDE.md`). ASSUMPTION AUDIT: confirm `process_filing` is the right entry point (check `src/extraction_v2/`), confirm Samsara CIK 1642545 / 2025-08-21 fixture is the correct shape, and verify the existing `data/gold_standard/` fixture pattern still applies. RISK ASSESSMENT: a sanitized exhibit HTML fixture going into `data/gold_standard/` may interact with gold-standard validation — confirm it's stored in a test-only path or otherwise excluded from baseline computation.
+5. **Implementation** (from fragment Next Steps):
+   - Add an E2E test in `tests/integration/extraction_v2/` that feeds a Samsara-shaped 8-K fixture (primary cover page + exhibit 99.1 with known earnings language) through `process_filing`.
+   - Assert: (i) `len(result.segments) > 20`, (ii) at least one `MetricFact` is produced whose source segment text contains exhibit-sourced language (e.g. "total revenue" or "ARR").
+   - Use the existing `data/gold_standard/` fixture pattern. A sanitized copy of Samsara's 2025-08-21 (CIK 1642545) exhibit HTML is the recommended fixture source.
+   - Sanitize the fixture: keep enough structure for the test to be meaningful, strip anything that would inflate the gold-standard corpus or leak production data.
+6. **Tests.** `pytest tests/integration/extraction_v2/<new_test_file>.py -x -q --tb=short`. Per project `CLAUDE.md` testing standards, also run the broader integration suite to confirm no regressions. Don't skip on failures.
+7. **Update fragment status as part of the same PR.** Flip `status: open` → `resolved`, `autonomy: safe` (already), set `pr_refs: [<this PR #>]`, append a `### Resolution` section describing the new test and fixture path. Per `feedback_known_issues_pr_refs_int_not_string`, write `- 261` not `- '#261'`. Per `feedback_known_issues_validator_optional_fields`, do not add frontmatter fields outside `{pr_refs, gh_issue, note}`.
+8. **Commit + PR.** Use the **project-local** `/commit` skill (Safe Commit + PR Skill). Per `feedback_commit_skill_name_collision`, the global skill may load instead — if you see "Safe Commit Skill" without a PR step, follow up manually with `gh pr create` + `gh pr merge --auto --squash`.
+9. **Verify auto-merge.** After `/commit` returns, run `gh pr view --json autoMergeRequest`. If unset, run `gh pr merge <PR#> --auto --squash`. Per `feedback_verify_auto_merge_after_commit`. Fetch the actual head ref via `gh pr view --json headRefName` before any follow-up push (per `feedback_commit_skill_renames_pr_branch`).
+
+## Out of scope (do NOT expand into)
+- Modifying `src/extraction_v2/` (this is a test-only PR — extraction code shipped in legacy-058's PR).
+- Modifying `tests/integration/filing_fetcher/test_8k_exhibit_fetch.py` (legacy-058's narrower test).
+- Adding fixtures for non-Samsara 8-Ks (one canonical fixture is enough; coverage expansion is a separate fragment).
+- Updating `v2_baseline.json` or any gold-standard recalibration.
+- Concurrent worktree footprints: `src/llm/vision_client.py`, `scripts/benchmark_vision.py`, `tests/integration/test_db_filings_reviewers.py`, `sql/` — left to legacy-091 and legacy-113 picks.
+
+## Memory references that apply
+- `feedback_verify_issue_status` — verify on origin/main first
+- `feedback_verify_auto_merge_after_commit` — verify auto-merge is set
+- `feedback_commit_skill_name_collision` — global vs project-local /commit
+- `feedback_commit_skill_renames_pr_branch` — fetch headRefName before follow-up pushes
+- `feedback_known_issues_pr_refs_int_not_string` — `- 261`, not `- '#261'`
+- `feedback_known_issues_validator_optional_fields` — don't add frontmatter fields outside the allowlist
+- `feedback_zero_facts_can_be_pre_pipeline_failure` — when asserting MetricFact emission, also confirm the fetched HTML actually contains the expected content (size > 15 KB, no `html_fetch_error`)
+- `feedback_subagent_midstream_stops` — if you delegate to a subagent and it returns truncated, dispatch a tightly-scoped wrap-up pinned to the existing worktree
+- `project_fragment_only_closure_pattern` — fragment frontmatter flip + Resolution section in the same PR
+
+## Return
+The PR URL when done.


### PR DESCRIPTION
Per .claude/rules/docs.md, completed worker prompts move to
docs/archive/worker-prompts/. Archives the 16 prompts whose fragments
are now resolved (gh-258, gh-262, gh-263, gh-273, gh-280, gh-291,
gh-298, gh-299, gh-300, legacy-024, legacy-062, legacy-075, legacy-091,
legacy-097, legacy-113, legacy-116) plus the legacy-089 design-first
prompt whose work shipped in PR #319. Active prompts (gh-196,
legacy-038, legacy-089 step-b implementation) stay in the working
docs/worker-prompts/ tree.
