### PR TITLE
docs(known-issues): close gh-294 — image-tab shortcuts shipped in #297

### DIFF
--- a/docs/known-issues/gh-294-image-tab-keyboard-shortcut-audit.md
+++ b/docs/known-issues/gh-294-image-tab-keyboard-shortcut-audit.md
@@ -3,9 +3,11 @@ id: 294
 source: gh
 slug: image-tab-keyboard-shortcut-audit
 title: "Image tab: keyboard-shortcut audit + parity with text tab"
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
+pr_refs:
+  - 297
 estimated: S
 touches:
   - src/web/templates/unified_review.html
@@ -38,3 +40,12 @@ between tabs lose muscle memory.
   on the same key.
 - Document the final mapping in `.claude/rules/web.md` so future buttons
   are added with shortcuts from day one.
+
+### Resolution
+
+Shipped in PR #297 (merged 2026-04-28):
+
+- Added `Shift+R` chord for "Reject all (no relevant metrics)" — chord guards against accidental bulk rejection.
+- Added `N` / `P` image-level navigation aliases (parity with text tab's next/prev). Guarded so per-row `N` (focusNextUnreviewed) still wins when a row is focused.
+- Updated help bar in `unified_review.html`: dropped stale `Y` / `1-7` / "Not Relevant" entries; surfaced `N/P` and `Shift+R`.
+- Documented canonical shortcut mapping + single-letter vs chord policy in `.claude/rules/web.md`.


### PR DESCRIPTION
## Summary

- Stale fragment closure only: implementation was already merged to `main` as PR #297 (2026-04-28).
- Flips `status: open` → `resolved`, `autonomy: skip` → `n/a`, adds `pr_refs: [297]`, and appends `### Resolution` section.

## What shipped in #297

- `Shift+R` chord at image-level for "Reject all (no relevant metrics)" (fires regardless of per-metric row focus; per-row `R` handler early-returns on `shiftKey`).
- `N` / `P` image-level navigation aliases (parity with text tab), guarded so per-row `N` (focusNextUnreviewed) still wins when a row is focused.
- Help bar refreshed: dropped stale `Y` / `1-7` / "Not Relevant" entries; surfaced `N/P` and `Shift+R`.
- Canonical shortcut mapping + single-letter vs chord policy documented in `.claude/rules/web.md`.

## Test plan

- [ ] Fragment validator passes (confirmed by pre-commit hook on commit).
- [ ] No code changes — docs-only PR, no functional tests needed.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)