### PR TITLE
fix(migrations): numeric-aware sort so legacy 00-47 files precede timestamp migrations (gh-333)

### DIFF
--- a/docs/known-issues/gh-333-definition-persistence-delete-wrong-column.md
+++ b/docs/known-issues/gh-333-definition-persistence-delete-wrong-column.md
@@ -12,6 +12,8 @@ touches:
 discovered: '2026-04-29'
 updated: '2026-04-29'
 gh_issue: 333
+pr_refs:
+  - 336
 ---
 
 ### Root cause

--- a/docs/known-issues/gh-333-definition-persistence-delete-wrong-column.md
+++ b/docs/known-issues/gh-333-definition-persistence-delete-wrong-column.md
@@ -2,32 +2,47 @@
 id: 333
 source: gh
 slug: definition-persistence-delete-wrong-column
-title: test_definition_persistence fails — DELETE references non-existent doc_id on v2_metric_facts
-status: open
+title: Migration sort order broke test_definition_persistence and fresh-DB setup
+status: resolved
 severity: medium
-autonomy: skip
-estimated: —
+autonomy: n/a
+estimated: S
 touches:
-  - tests/integration/extraction_v2/test_definition_persistence.py
-discovered: 2026-04-29
-updated: 2026-04-29
+  - src/infra/migrations.py
+discovered: '2026-04-29'
+updated: '2026-04-29'
 gh_issue: 333
-note: Test setup DELETE uses doc_id which does not exist on v2_metric_facts; blocks full-suite pytest locally
 ---
 
-### Problem
+### Root cause
 
-`tests/integration/extraction_v2/test_definition_persistence.py::TestDefinitionPersistence::test_persist_single_definition` fails on the local test DB:
+`migration_files()` in `src/infra/migrations.py` used pure lexicographic sort.  The
+rename migration `202604282225_rename_v2_metric_facts_doc_id_to_filing_id.sql` sorted
+**before** legacy migrations `23_chart_source_dedup.sql`, `33_fix_identity_index.sql`,
+and `38_create_analytics_views.sql` on a fresh database — because `'23_' > '20260...'`
+string-wise (`'3' > '0'` at position 1).
 
-```
-psycopg.errors.UndefinedColumn: column "doc_id" does not exist
-LINE 1: DELETE FROM v2_metric_facts WHERE doc_id = $1
-```
+On a fresh database the rename ran first, so those three migrations failed with
+`column "doc_id" does not exist` when they tried to reference `v2_metric_facts.doc_id`.
+The symptom surfaced as `test_definition_persistence` failures during fresh integration
+test runs (gh-333 was filed by the gh-289 worker agent after it hit this state).
 
-The correct column name on `v2_metric_facts` is not `doc_id`. This predates the gh-289 Scope B work and blocks `pytest -x -q` from completing end-to-end locally (integration tests run after unit tests with `-x`).
+The original issue body misidentified the fix as changing the test fixture column name
+(`fact_id` or `document_id`); both suggestions were wrong.  The actual rename was
+`doc_id` → `filing_id` (PR #326) and the test fixture already had the correct column
+name — the failure was in the migration runner ordering, not the test code.
 
-### Next Steps
+Existing databases were unaffected: migration tracking (`schema_migrations`) records
+applied filenames and skips them on re-run, so the out-of-order rename was a no-op on
+databases that had already applied migrations 23–38 before the rename migration existed.
 
-- Find the DELETE in the test setup fixture or persistence adapter that references `doc_id` on `v2_metric_facts`
-- Correct the column name to match the actual schema (`document_id` or the appropriate FK column)
-- Verify the fix does not break other integration tests
+### Fix
+
+Added `_migration_sort_key()` to `src/infra/migrations.py`.  It zero-pads the leading
+digit-run to 12 characters so both groups compare correctly:
+- `23_chart_source_dedup.sql` → sort key `000000000023_chart_source_dedup.sql`
+- `202604282225_rename_...sql` → sort key `202604282225_rename_...sql` (unchanged)
+
+`migration_files()` now passes this key to `sorted()`.  All 54 migrations apply cleanly
+on a fresh DB; `TestDefinitionPersistence` (7 tests) and the full integration suite
+(316 tests) pass.

--- a/src/infra/migrations.py
+++ b/src/infra/migrations.py
@@ -14,6 +14,7 @@ and legacy-046 (recurring "MIGRATION_ORDER stale at NN" issues), legacy-095
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
@@ -33,11 +34,29 @@ KNOWN_SKIPS: frozenset[str] = frozenset(
 )
 
 
-def migration_files(sql_dir: Path = SQL_DIR) -> list[str]:
-    """Return the canonical, alpha-sorted list of schema migrations.
+def _migration_sort_key(name: str) -> str:
+    """Numeric-aware sort key so legacy short prefixes (e.g. ``23_``) sort
+    before timestamp prefixes (e.g. ``202604282225_``).
 
-    Every sql/*.sql filename in `sql_dir` except those in KNOWN_SKIPS.
-    Order is filename-lexicographic — every duplicate-prefix pair has been
-    audited as either independent or correctly ordered under alpha sort.
+    Pure alpha-sort breaks because ``'23_' > '2026...'`` (``'3' > '0'`` at
+    position 1), causing a rename migration timestamped in 2026 to run before
+    legacy migrations 20–47 on a fresh database.  Padding the leading digit-run
+    to 12 characters makes both groups compare correctly.
     """
-    return sorted(p.name for p in sql_dir.glob("*.sql") if p.name not in KNOWN_SKIPS)
+    m = re.match(r"^(\d+)", name)
+    if m:
+        return m.group(1).zfill(12) + name[m.end() :]
+    return name
+
+
+def migration_files(sql_dir: Path = SQL_DIR) -> list[str]:
+    """Return the canonical, numerically-ordered list of schema migrations.
+
+    Every sql/*.sql filename in `sql_dir` except those in KNOWN_SKIPS,
+    ordered by ``_migration_sort_key`` so that short legacy numeric prefixes
+    (``09_``, ``47_``) sort before 12-digit timestamp prefixes (``YYYYMMDDHHMM_``).
+    """
+    return sorted(
+        (p.name for p in sql_dir.glob("*.sql") if p.name not in KNOWN_SKIPS),
+        key=_migration_sort_key,
+    )


### PR DESCRIPTION
## Summary

- `migration_files()` used pure lexicographic sort; `'23_' > '2026...'` because `'3' > '0'` at position 1, placing the `doc_id` → `filing_id` rename migration before legacy migrations 23, 33, and 38 on a fresh DB
- Those three migrations failed with `column "doc_id" does not exist` on a fresh database, breaking `test_definition_persistence` and fresh CI-DB setup
- Added `_migration_sort_key()` that zero-pads the leading digit-run to 12 chars; 54 migrations now apply cleanly on a fresh DB

## Test plan

- [x] `dropdb + createdb + apply_all_migrations.py` on fresh DB: 54 applied, 0 failed
- [x] `TestDefinitionPersistence` (7 tests): all pass
- [x] Full integration suite (316 tests): all pass
- [x] Unit tests (4047): all pass
- [x] Fragment `gh-333-definition-persistence-delete-wrong-column.md` updated to `status: resolved`; GH issue #333 closed

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)