### PR TITLE
refactor: rename doc_id → filing_id on remaining v2 tables (closes #324, closes #323)

### DIFF
--- a/.claude/rules/v2-pipeline.md
+++ b/.claude/rules/v2-pipeline.md
@@ -82,13 +82,13 @@ verification SQL.
 
 ## Image Asset Identity
 
-`v2_image_assets` is unique on `(doc_id, filename)`; `img_id` is stable across re-extractions because `_persist_images_in_tx` upserts via `ON CONFLICT (doc_id, filename) DO UPDATE` and preserves the existing `img_id` on conflict. `persist_pipeline_result` uses the old→stable img_id map returned by `_persist_images_in_tx` to rewrite in-memory fact `source_locator.img_id` values before fact persistence, keeping metric-fact provenance consistent with the canonical DB row.
+`v2_image_assets` is unique on `(filing_id, filename)`; `img_id` is stable across re-extractions because `_persist_images_in_tx` upserts via `ON CONFLICT (filing_id, filename) DO UPDATE` and preserves the existing `img_id` on conflict. `persist_pipeline_result` uses the old→stable img_id map returned by `_persist_images_in_tx` to rewrite in-memory fact `source_locator.img_id` values before fact persistence, keeping metric-fact provenance consistent with the canonical DB row.
 
 **`file_path` survives a NULL inbound (legacy-103, 2026-04-27):** the upsert clause is `file_path = COALESCE(EXCLUDED.file_path, v2_image_assets.file_path)`, so a force-reextract whose SEC fetch failed (transient outage, malformed URL) preserves the existing R2 storage key. Every other column still refreshes — only `file_path` is sticky against NULL.
 
 **Synthetic accession URL construction (legacy-104, 2026-04-27):** filings ingested via `ingest_presentations.py` / `ingest_transcripts.py` carry synthetic `accession_number` values (`presentation:<cik>/<acc>/<file>`, `transcript:<...>`). EDGAR-URL construction sites (`SECClient.fetch_image`, `_get_image_cache_path`, `resolve_primary_document_url`, `get_filing_by_accession`, `_search_filings_array`, and `web/url_builders.build_image_cache_url`) all run `extract_sec_accession_token` from `src/infra/validation.py` to recover the embedded SEC token before building the URL. New URL-construction sites must do the same — `normalize_sec_accession` deliberately preserves the synthetic prefix for row-identity callers and is the wrong primitive for URLs.
 
-**Detected-metrics invariant (chart-presence pivot, #86):** Every `v2_image_assets` row persists `detected_metrics` (JSONB, default `[]`) alongside the existing `chart_data`, `img_id`, and `file_path`. `ChartFactBridgeStage` populates `image.detected_metrics` from `ChartMetricClassifier.classify_all(...)`; `_persist_images_in_tx` round-trips the JSONB through the `ON CONFLICT (doc_id, filename) DO UPDATE` upsert so re-extraction overwrites cleanly. `scripts/check_image_referential_integrity.py` still runs in CI but is now trivially green (no chart facts → no `img_id` refs to validate); orphaned-asset and missing-on-disk checks still fire. The review UI's Detected-metrics card (`src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js`) surfaces each detected entry for reviewer accept / reject / correct / add via `POST /api/v2/image-metric-confirmations`. As of #86 + 2026-04-28, `ChartFactBridgeStage` scores both `chart_data` (chart path, via `ChartMetricClassifier`) and `ocr_table` (TABLE_IMAGE path, via `score_ocr_table` in `src/extraction_v2/chart/table_metric_classifier.py`). Both write into the same `v2_image_assets.detected_metrics` JSONB column — the review UI's `dataset.detectedMetrics` reader is source-agnostic.
+**Detected-metrics invariant (chart-presence pivot, #86):** Every `v2_image_assets` row persists `detected_metrics` (JSONB, default `[]`) alongside the existing `chart_data`, `img_id`, and `file_path`. `ChartFactBridgeStage` populates `image.detected_metrics` from `ChartMetricClassifier.classify_all(...)`; `_persist_images_in_tx` round-trips the JSONB through the `ON CONFLICT (filing_id, filename) DO UPDATE` upsert so re-extraction overwrites cleanly. `scripts/check_image_referential_integrity.py` still runs in CI but is now trivially green (no chart facts → no `img_id` refs to validate); orphaned-asset and missing-on-disk checks still fire. The review UI's Detected-metrics card (`src/web/templates/unified_review.html`, `src/web/static/js/review_images_v2.js`) surfaces each detected entry for reviewer accept / reject / correct / add via `POST /api/v2/image-metric-confirmations`. As of #86 + 2026-04-28, `ChartFactBridgeStage` scores both `chart_data` (chart path, via `ChartMetricClassifier`) and `ocr_table` (TABLE_IMAGE path, via `score_ocr_table` in `src/extraction_v2/chart/table_metric_classifier.py`). Both write into the same `v2_image_assets.detected_metrics` JSONB column — the review UI's `dataset.detectedMetrics` reader is source-agnostic.
 
 ## Reviewed-Filing Guard
 
@@ -121,7 +121,7 @@ a backup.
 an existing `v2_image_review_decisions` row would be re-classified from a
 visible class (`chart` / `table_image` / `unknown`) into a hidden class
 (`decorative` / `logo` / `signature`). The asset row is preserved by
-`ON CONFLICT (doc_id, filename)`, so the decision survives — but the review
+`ON CONFLICT (filing_id, filename)`, so the decision survives — but the review
 UI's `classification NOT IN ('decorative','logo','signature')` filter would
 make it invisible. `force=True` proceeds and logs
 `force-reextract hiding reviewed images: filing_id=X hidden_image_count=N filenames=[…]`.
@@ -132,7 +132,7 @@ already-hidden image, are not blocked.
 
 `persist_facts` and `persist_pipeline_result` accept `chart_only=True` to
 scope the DELETE-then-INSERT to `source_type='chart'` only. Inbound
-facts are filtered to chart facts; the DELETE is `WHERE doc_id=%s AND
+facts are filtered to chart facts; the DELETE is `WHERE filing_id=%s AND
 source_type='chart'`; the reviewed-filing guard counts decisions on
 chart facts only. Text facts and their reviewer decisions are untouched.
 

--- a/docs/known-issues/gh-323-metricfact-doc-id-field-semantic-confusion.md
+++ b/docs/known-issues/gh-323-metricfact-doc-id-field-semantic-confusion.md
@@ -3,13 +3,13 @@ id: 323
 source: gh
 slug: metricfact-doc-id-field-semantic-confusion
 title: MetricFact.doc_id dataclass field is semantically confused
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches: []
 discovered: '2026-04-28'
-updated: '2026-04-28'
+updated: '2026-04-29'
 gh_issue: 323
 note: Field named doc_id but holds Document UUID; never read, never persisted — misleading comment too.
 ---
@@ -31,3 +31,9 @@ Surfaced while resolving legacy-038.
   actually hold the filing_id; update the misleading `# Filing ID` comment.
 - Sweep `fact.doc_id` and `MetricFact(doc_id=...)` callers (only test
   fixtures and `fact_construction.py:229` populate it).
+
+### Resolution
+
+`MetricFact.doc_id` renamed to `document_uuid` with comment `# Document UUID
+(v2_documents.doc_id; not persisted to DB)`. All callers in `fact_construction.py`
+and test fixtures updated. Bundled with gh-324 rename PR.

--- a/docs/known-issues/gh-324-other-v2-tables-bigint-doc-id-mismatch.md
+++ b/docs/known-issues/gh-324-other-v2-tables-bigint-doc-id-mismatch.md
@@ -3,16 +3,16 @@ id: 324
 source: gh
 slug: other-v2-tables-bigint-doc-id-mismatch
 title: Other v2 tables share v2_metric_facts' BIGINT-named-doc_id mismatch
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: M
 touches:
 - sql/*.sql
 - src/extraction_v2/persistence.py
 - src/infra/db.py
 discovered: '2026-04-28'
-updated: '2026-04-28'
+updated: '2026-04-29'
 gh_issue: 324
 note: v2_segments / v2_tables / v2_image_assets / v2_metric_definitions doc_id columns are all filing_ids — same legacy-038 trap class.
 ---
@@ -38,3 +38,11 @@ for any cross-join with `v2_documents.doc_id`.
   sites, integration tests, and scripts.
 - Postgres views in frozen `sql/09`/`sql/38` resolve via attnums — no
   view recreation needed (proven in legacy-038).
+
+### Resolution
+
+Timestamped migration
+`sql/202604291308_rename_doc_id_to_filing_id_on_v2_segments_tables_image_assets_metric_definitions.sql`
+renames `doc_id → filing_id` on all four tables with idempotent
+`information_schema` guards. All callsites in `persistence.py`, `db.py`,
+stages, scripts, and tests updated in the same PR (bundled with gh-323).

--- a/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
+++ b/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
@@ -1,0 +1,35 @@
+---
+id: 338
+source: gh
+slug: v2-text-metric-presence-doc-id-rename
+title: v2_text_metric_presence.doc_id should be renamed to filing_id
+status: open
+severity: low
+autonomy: skip
+estimated: S
+touches:
+- sql/*.sql
+- src/extraction_v2/persistence.py
+- tests/integration/extraction_v2/test_presence_persistence.py
+discovered: '2026-04-29'
+updated: '2026-04-29'
+gh_issue: 338
+note: doc_id is BIGINT FK to filings(filing_id) — same naming smell fixed in gh-324 for four other v2 tables.
+---
+
+### Problem
+
+`v2_text_metric_presence.doc_id` is a `BIGINT NOT NULL REFERENCES filings(filing_id)`
+column named `doc_id`, the same naming smell that was resolved for
+`v2_segments`, `v2_tables`, `v2_image_assets`, and `v2_metric_definitions`
+in gh-324. It was explicitly out of scope for that PR but should be
+cleaned up for consistency to prevent the same "operator does not exist:
+uuid = bigint" bug class for any future cross-join with `v2_documents.doc_id`.
+
+### Next Steps
+
+- Generate a timestamped migration to rename `doc_id → filing_id` on
+  `v2_text_metric_presence` (idempotency-guarded via `information_schema`).
+- Sweep callsites in `src/extraction_v2/persistence.py`
+  (`_persist_text_metric_presence_in_tx`), tests
+  (`test_presence_persistence.py`), and any scripts querying the table directly.

--- a/scripts/audit_filing_url_mismatch.py
+++ b/scripts/audit_filing_url_mismatch.py
@@ -105,7 +105,7 @@ def _count_downstream(db: DatabaseAdapter, filing_id: int) -> dict:
         SELECT count(*) AS n
         FROM v2_image_review_decisions ird
         JOIN v2_image_assets ia ON ia.img_id = ird.img_id
-        WHERE ia.doc_id = %(id)s
+        WHERE ia.filing_id = %(id)s
         """,
         {"id": filing_id},
     )

--- a/scripts/audit_paypal_r2_orphans.py
+++ b/scripts/audit_paypal_r2_orphans.py
@@ -68,7 +68,7 @@ ROW_QUERY = """
         a.filename,
         a.file_path
       FROM v2_image_assets a
-      JOIN filings f ON f.filing_id = a.doc_id
+      JOIN filings f ON f.filing_id = a.filing_id
      WHERE f.filing_id = ANY(%(filing_ids)s)
      ORDER BY f.filing_id, a.filename
 """

--- a/scripts/audit_residual_chart_facts.py
+++ b/scripts/audit_residual_chart_facts.py
@@ -57,7 +57,7 @@ text_fact_decisions AS (
     GROUP BY mf.filing_id
 ),
 chart_images AS (
-    SELECT doc_id AS filing_id,
+    SELECT filing_id,
            COUNT(*) AS chart_image_count,
            COUNT(*) FILTER (WHERE detected_metrics IS NOT NULL
                             AND jsonb_typeof(detected_metrics) = 'array'
@@ -65,15 +65,15 @@ chart_images AS (
                AS chart_images_with_detected_metrics
     FROM v2_image_assets
     WHERE classification = 'chart'
-    GROUP BY doc_id
+    GROUP BY filing_id
 ),
 image_confirmations AS (
-    SELECT ia.doc_id AS filing_id,
+    SELECT ia.filing_id,
            COUNT(DISTINCT (imc.img_id, COALESCE(imc.detected_metric_id, imc.confirmed_metric_id, ''), imc.reviewer_id))
                AS image_metric_confirmation_count
     FROM v2_image_metric_confirmations imc
     JOIN v2_image_assets ia ON ia.img_id = imc.img_id
-    GROUP BY ia.doc_id
+    GROUP BY ia.filing_id
 )
 SELECT
     f.filing_id,

--- a/scripts/backfill_full_page_ocr.py
+++ b/scripts/backfill_full_page_ocr.py
@@ -90,10 +90,10 @@ WITH per_filing AS (
         f.form_type,
         f.filing_date,
         f.accession_number,
-        (SELECT COUNT(*) FROM v2_image_assets i WHERE i.doc_id = f.filing_id) AS image_count,
+        (SELECT COUNT(*) FROM v2_image_assets i WHERE i.filing_id = f.filing_id) AS image_count,
         COALESCE(
             (SELECT SUM(LENGTH(COALESCE(segment_text, '')))::bigint
-             FROM v2_segments s WHERE s.doc_id = f.filing_id),
+             FROM v2_segments s WHERE s.filing_id = f.filing_id),
             0
         ) AS segment_char_count,
         (SELECT COUNT(*) FROM v2_review_decisions rd

--- a/scripts/backfill_image_cache.py
+++ b/scripts/backfill_image_cache.py
@@ -46,7 +46,7 @@ def get_image_candidates(db: DatabaseAdapter, limit: int | None = None) -> list[
     sql = """
         SELECT DISTINCT v.filename AS image_src, f.cik, f.accession_number
         FROM v2_image_assets v
-        JOIN filings f ON v.doc_id = f.filing_id
+        JOIN filings f ON v.filing_id = f.filing_id
         WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
           AND v.filename IS NOT NULL AND v.filename != ''
         ORDER BY f.cik, f.accession_number, v.filename
@@ -128,7 +128,9 @@ def main() -> None:
 
         # Fetch from SEC EDGAR — SECClient auto-stores in image_cache on success
         logger.info(f"[{i}/{len(candidates)}] Fetching: {cik}/{accession_number}/{filename}")
-        result = sec_client.fetch_image(cik=cik, accession_number=accession_number, filename=filename)
+        result = sec_client.fetch_image(
+            cik=cik, accession_number=accession_number, filename=filename
+        )
 
         if result is not None:
             fetched += 1
@@ -142,7 +144,9 @@ def main() -> None:
     logger.info(f"  Fetched:  {fetched}")
     logger.info(f"  Skipped:  {skipped} (already cached)")
     logger.info(f"  Failed:   {failed}")
-    logger.info(f"  Cache total: {stats['count']} images ({stats['total_bytes'] / 1024 / 1024:.1f} MB)")
+    logger.info(
+        f"  Cache total: {stats['count']} images ({stats['total_bytes'] / 1024 / 1024:.1f} MB)"
+    )
     logger.info("=" * 60)
 
 

--- a/scripts/backfill_text_presence.py
+++ b/scripts/backfill_text_presence.py
@@ -83,9 +83,8 @@ def _resolve_db_url(allow_prod: bool) -> str:
 
 def _select_filings(db: DatabaseAdapter, args: argparse.Namespace) -> list[dict]:
     """Return filings to process."""
-    # v2_image_assets.doc_id is a BIGINT FK to filings.filing_id (despite the
-    # column name) — see sql/09_v2_schema.sql. v2_metric_facts.filing_id was
-    # renamed in legacy-038.
+    # v2_image_assets.filing_id is a BIGINT FK to filings.filing_id.
+    # Renamed from doc_id in migration 202604291308 (gh-324).
     if args.all_filings:
         sql = """
             SELECT f.filing_id, f.cik, f.accession_number, f.html_storage_path,
@@ -103,7 +102,7 @@ def _select_filings(db: DatabaseAdapter, args: argparse.Namespace) -> list[dict]
               JOIN companies c USING (company_id)
               LEFT JOIN v2_metric_facts mf ON mf.filing_id = f.filing_id
               LEFT JOIN v2_review_decisions rd ON rd.fact_id = mf.fact_id
-              LEFT JOIN v2_image_assets ia ON ia.doc_id = f.filing_id
+              LEFT JOIN v2_image_assets ia ON ia.filing_id = f.filing_id
               LEFT JOIN v2_image_metric_confirmations imc ON imc.img_id = ia.img_id
              WHERE rd.decision_id IS NOT NULL OR imc.id IS NOT NULL
         """

--- a/scripts/benchmark_vision.py
+++ b/scripts/benchmark_vision.py
@@ -220,7 +220,7 @@ SELECT
     v.relevance_score                            AS relevance_score
 FROM v2_image_review_decisions d
 JOIN v2_image_assets           v ON v.img_id = d.img_id
-JOIN filings                   f ON v.doc_id = f.filing_id
+JOIN filings                   f ON v.filing_id = f.filing_id
 JOIN companies                 c ON f.company_id = c.company_id
 ORDER BY d.created_at
 """
@@ -253,7 +253,7 @@ SELECT
     v.relevance_score                            AS relevance_score
 FROM v2_image_metric_confirmations imc
 JOIN v2_image_assets               v ON v.img_id = imc.img_id
-JOIN filings                       f ON v.doc_id = f.filing_id
+JOIN filings                       f ON v.filing_id = f.filing_id
 JOIN companies                     c ON f.company_id = c.company_id
 GROUP BY v.img_id, v.filename, v.file_path, v.relevance_score,
          f.accession_number, c.cik, c.company_name

--- a/scripts/check_image_referential_integrity.py
+++ b/scripts/check_image_referential_integrity.py
@@ -93,7 +93,7 @@ ORPHAN_SQL = """
 # (C) helper — every asset row with a declared file_path; existence is tested
 # in Python because the DB has no visibility into the local filesystem.
 ASSET_FILE_PATH_SQL = """
-    SELECT img_id, doc_id, filename, file_path, classification
+    SELECT img_id, filing_id, filename, file_path, classification
       FROM v2_image_assets
      WHERE file_path IS NOT NULL
 """

--- a/scripts/diagnostic_chart_evidence_coverage.py
+++ b/scripts/diagnostic_chart_evidence_coverage.py
@@ -103,7 +103,7 @@ def _check_missing_image_files(db: DatabaseAdapter) -> tuple[int, int, list[dict
     """
     rows = db.query(
         """
-        SELECT img_id, doc_id, filename, file_path
+        SELECT img_id, filing_id, filename, file_path
           FROM v2_image_assets
          WHERE file_path IS NOT NULL
         """
@@ -137,23 +137,23 @@ def _chart_image_vs_fact_rate(db: DatabaseAdapter) -> list[dict]:
     """Class (E): filings with chart-class images but zero chart-sourced facts."""
     sql = """
         WITH chart_imgs AS (
-            SELECT doc_id, COUNT(*) AS n_chart_imgs
+            SELECT filing_id, COUNT(*) AS n_chart_imgs
               FROM v2_image_assets
              WHERE classification = 'chart'
-             GROUP BY doc_id
+             GROUP BY filing_id
         ),
         chart_facts AS (
-            SELECT filing_id AS doc_id, COUNT(*) AS n_chart_facts
+            SELECT filing_id, COUNT(*) AS n_chart_facts
               FROM v2_metric_facts
              WHERE source_type = 'chart'
              GROUP BY filing_id
         )
         SELECT
-            ci.doc_id,
+            ci.filing_id,
             ci.n_chart_imgs,
             COALESCE(cf.n_chart_facts, 0) AS n_chart_facts
           FROM chart_imgs ci
-          LEFT JOIN chart_facts cf USING (doc_id)
+          LEFT JOIN chart_facts cf USING (filing_id)
          WHERE COALESCE(cf.n_chart_facts, 0) = 0
          ORDER BY ci.n_chart_imgs DESC
     """
@@ -264,9 +264,9 @@ def main() -> int:
     logger.info("checked=%d missing=%d", c_checked, c_missing_count)
     for row in c_missing_rows[: args.sample]:
         logger.info(
-            "  img_id=%s doc_id=%s filename=%s path=%s",
+            "  img_id=%s filing_id=%s filename=%s path=%s",
             row["img_id"],
-            row["doc_id"],
+            row["filing_id"],
             row["filename"],
             row["file_path"],
         )
@@ -298,8 +298,8 @@ def main() -> int:
     logger.info("affected filings: %d", len(e_rows))
     for row in e_rows[: args.sample]:
         logger.info(
-            "  doc_id=%s n_chart_imgs=%d n_chart_facts=%d",
-            row["doc_id"],
+            "  filing_id=%s n_chart_imgs=%d n_chart_facts=%d",
+            row["filing_id"],
             row["n_chart_imgs"],
             row["n_chart_facts"],
         )

--- a/scripts/export_image_decisions.py
+++ b/scripts/export_image_decisions.py
@@ -121,7 +121,7 @@ def export_decisions(
             conditions.append("d.decision = 'not_relevant'")
 
     if filing_id:
-        conditions.append("v.doc_id = %(filing_id)s")
+        conditions.append("v.filing_id = %(filing_id)s")
         params["filing_id"] = filing_id
 
     if detection_tier:
@@ -141,7 +141,7 @@ def export_decisions(
             d.reviewer_id,
             d.review_time_seconds,
             d.created_at AS decision_created_at,
-            v.doc_id AS filing_id,
+            v.filing_id,
             v.filename AS image_src,
             'https://www.sec.gov/Archives/edgar/data/'
                 || COALESCE(NULLIF(REGEXP_REPLACE(c.cik, '^0+', ''), ''), '0')
@@ -155,7 +155,7 @@ def export_decisions(
             c.company_name
         FROM v2_image_review_decisions d
         JOIN v2_image_assets v ON v.img_id = d.img_id
-        JOIN filings f ON v.doc_id = f.filing_id
+        JOIN filings f ON v.filing_id = f.filing_id
         JOIN companies c ON f.company_id = c.company_id
         {where_clause}
         ORDER BY c.company_name, d.created_at

--- a/scripts/export_image_training_data.py
+++ b/scripts/export_image_training_data.py
@@ -106,7 +106,7 @@ LEGACY_SEC_QUERY = f"""
         {_IMAGE_URL_FRAGMENT}
     FROM v2_image_review_decisions d
     JOIN v2_image_assets v ON v.img_id = d.img_id
-    JOIN filings f ON v.doc_id = f.filing_id
+    JOIN filings f ON v.filing_id = f.filing_id
     JOIN companies c ON f.company_id = c.company_id
     ORDER BY c.company_name, v.img_id
 """
@@ -150,7 +150,7 @@ CONFIRMATIONS_SEC_QUERY = f"""
         {_IMAGE_URL_FRAGMENT}
     FROM v2_image_metric_confirmations imc
     JOIN v2_image_assets v ON v.img_id = imc.img_id
-    JOIN filings f ON v.doc_id = f.filing_id
+    JOIN filings f ON v.filing_id = f.filing_id
     JOIN companies c ON f.company_id = c.company_id
     GROUP BY v.img_id, v.filename, v.width, v.height, v.nearby_text,
              v.classification, v.section_type, v.relevance_score,

--- a/scripts/migrate_image_decisions_to_v2.py
+++ b/scripts/migrate_image_decisions_to_v2.py
@@ -10,7 +10,7 @@ equivalents introduced in Phase B of the V1 deprecation plan:
   3. `image_review_decisions`                      → `v2_image_review_decisions`
 
 Join key: `(image_review_candidates.filing_id, image_review_candidates.image_src)`
-      ==  `(v2_image_assets.doc_id,            v2_image_assets.filename)`.
+      ==  `(v2_image_assets.filing_id,         v2_image_assets.filename)`.
 A composite key is required because bare filenames (e.g. `mdaa2.jpg`) collide
 across filings.
 
@@ -47,7 +47,7 @@ def preview_counts(db: DatabaseAdapter) -> dict:
         SELECT COUNT(*) AS n
         FROM image_review_candidates c
         JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         WHERE c.review_status != 'pending' OR c.predicted_relevance IS NOT NULL
         """
     )[0]["n"]
@@ -59,7 +59,7 @@ def preview_counts(db: DatabaseAdapter) -> dict:
         JOIN image_review_candidates c
             ON c.image_candidate_id = d.image_candidate_id
         JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         LEFT JOIN v2_image_review_decisions vd
             ON vd.img_id = v.img_id
         WHERE vd.image_decision_id IS NULL
@@ -71,7 +71,7 @@ def preview_counts(db: DatabaseAdapter) -> dict:
         SELECT COUNT(*) AS n
         FROM image_review_candidates c
         LEFT JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         WHERE v.img_id IS NULL
         """
     )[0]["n"]
@@ -83,7 +83,7 @@ def preview_counts(db: DatabaseAdapter) -> dict:
         JOIN image_review_candidates c
             ON c.image_candidate_id = d.image_candidate_id
         LEFT JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         WHERE v.img_id IS NULL
         """
     )[0]["n"]
@@ -103,7 +103,7 @@ def log_unmatched_samples(db: DatabaseAdapter, limit: int = 10) -> None:
         SELECT c.filing_id, c.image_src, c.review_status
         FROM image_review_candidates c
         LEFT JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         WHERE v.img_id IS NULL
         ORDER BY c.filing_id, c.image_candidate_id
         LIMIT %(limit)s
@@ -113,8 +113,12 @@ def log_unmatched_samples(db: DatabaseAdapter, limit: int = 10) -> None:
     if sample_cands:
         logger.info("  Sample unmatched V1 candidates (first %d):", len(sample_cands))
         for row in sample_cands:
-            logger.info("    filing_id=%s image_src=%s status=%s",
-                        row["filing_id"], row["image_src"], row["review_status"])
+            logger.info(
+                "    filing_id=%s image_src=%s status=%s",
+                row["filing_id"],
+                row["image_src"],
+                row["review_status"],
+            )
 
     sample_decs = db.query(
         """
@@ -122,7 +126,7 @@ def log_unmatched_samples(db: DatabaseAdapter, limit: int = 10) -> None:
         FROM image_review_decisions d
         JOIN image_review_candidates c ON c.image_candidate_id = d.image_candidate_id
         LEFT JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         WHERE v.img_id IS NULL
         ORDER BY c.filing_id, d.image_decision_id
         LIMIT %(limit)s
@@ -132,9 +136,13 @@ def log_unmatched_samples(db: DatabaseAdapter, limit: int = 10) -> None:
     if sample_decs:
         logger.info("  Sample orphan V1 decisions (first %d):", len(sample_decs))
         for row in sample_decs:
-            logger.info("    decision_id=%s filing_id=%s image_src=%s decision=%s",
-                        row["image_decision_id"], row["filing_id"],
-                        row["image_src"], row["decision"])
+            logger.info(
+                "    decision_id=%s filing_id=%s image_src=%s decision=%s",
+                row["image_decision_id"],
+                row["filing_id"],
+                row["image_src"],
+                row["decision"],
+            )
 
 
 def copy_review_status_and_relevance(db: DatabaseAdapter) -> int:
@@ -145,7 +153,7 @@ def copy_review_status_and_relevance(db: DatabaseAdapter) -> int:
         SET review_status       = c.review_status,
             predicted_relevance = c.predicted_relevance
         FROM image_review_candidates c
-        WHERE v.doc_id   = c.filing_id
+        WHERE v.filing_id = c.filing_id
           AND v.filename = c.image_src
           AND (
                 v.review_status       IS DISTINCT FROM c.review_status
@@ -172,7 +180,7 @@ def copy_decisions(db: DatabaseAdapter) -> int:
         JOIN image_review_candidates c
             ON c.image_candidate_id = d.image_candidate_id
         JOIN v2_image_assets v
-            ON v.doc_id = c.filing_id AND v.filename = c.image_src
+            ON v.filing_id = c.filing_id AND v.filename = c.image_src
         ON CONFLICT (img_id) DO NOTHING
         RETURNING image_decision_id
         """
@@ -182,8 +190,9 @@ def copy_decisions(db: DatabaseAdapter) -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Report what would change without writing")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report what would change without writing"
+    )
     parser.add_argument("--database-url", type=str)
     args = parser.parse_args()
 
@@ -225,8 +234,9 @@ def main() -> None:
         return
 
     status_updated = copy_review_status_and_relevance(db)
-    logger.info("Updated review_status/predicted_relevance on %d v2_image_assets rows",
-                status_updated)
+    logger.info(
+        "Updated review_status/predicted_relevance on %d v2_image_assets rows", status_updated
+    )
 
     decisions_inserted = copy_decisions(db)
     logger.info("Inserted %d v2_image_review_decisions rows", decisions_inserted)

--- a/scripts/repair_filing_url_mismatch.py
+++ b/scripts/repair_filing_url_mismatch.py
@@ -124,7 +124,7 @@ def _recheck_guards(db: DatabaseAdapter, filing_id: int) -> dict:
         SELECT count(*) AS n
         FROM v2_image_review_decisions ird
         JOIN v2_image_assets ia ON ia.img_id = ird.img_id
-        WHERE ia.doc_id = %(id)s
+        WHERE ia.filing_id = %(id)s
         """,
         {"id": filing_id},
     )

--- a/scripts/validate_database_urls.py
+++ b/scripts/validate_database_urls.py
@@ -79,13 +79,11 @@ def validate_url_format(url: str | None, cik: str | None, accession_number: str 
     # FilingFetcher incidents) and aren't the class of bug this validator
     # gates against (NULL columns + malformed image URLs).
     if _normalise_cik(url_cik) != _normalise_cik(cik):
-        result["warnings"].append(
-            f"CIK mismatch: URL has {url_cik}, DB has {cik}"
-        )
+        result["warnings"].append(f"CIK mismatch: URL has {url_cik}, DB has {cik}")
 
     if accession_number:
         if accession_number.startswith("presentation:"):
-            parts = accession_number[len("presentation:"):].split("/")
+            parts = accession_number[len("presentation:") :].split("/")
             real_accession = parts[1] if len(parts) >= 2 else ""
         else:
             real_accession = accession_number
@@ -103,7 +101,7 @@ def _built_image_url(cik: str | None, accession_number: str | None, filename: st
     norm_cik = _normalise_cik(cik)
     acc = accession_number or ""
     if acc.startswith("presentation:"):
-        parts = acc[len("presentation:"):].split("/")
+        parts = acc[len("presentation:") :].split("/")
         acc = parts[1] if len(parts) >= 2 else ""
     acc_no_dashes = acc.replace("-", "")
     return f"/images/cache/{norm_cik}/{acc_no_dashes}/{filename}"
@@ -169,7 +167,7 @@ def _validate_image_urls(db: DatabaseAdapter, doc_types: list[str]) -> dict:
         SELECT v.img_id, v.filename, c.cik AS company_cik,
                f.accession_number, f.document_type
         FROM v2_image_assets v
-        JOIN filings f ON v.doc_id = f.filing_id
+        JOIN filings f ON v.filing_id = f.filing_id
         JOIN companies c ON f.company_id = c.company_id
         WHERE f.document_type = ANY(%(types)s)
         """,
@@ -275,7 +273,9 @@ def main() -> None:
     if args.fail_on_errors:
         logger.error("VALIDATION FAILED - %d invalid row(s)", total_invalid)
         sys.exit(1)
-    logger.warning("VALIDATION REPORTED %d invalid row(s) (run with --fail-on-errors to exit 1)", total_invalid)
+    logger.warning(
+        "VALIDATION REPORTED %d invalid row(s) (run with --fail-on-errors to exit 1)", total_invalid
+    )
     sys.exit(0)
 
 

--- a/sql/202604291308_rename_doc_id_to_filing_id_on_v2_segments_tables_image_assets_metric_definitions.sql
+++ b/sql/202604291308_rename_doc_id_to_filing_id_on_v2_segments_tables_image_assets_metric_definitions.sql
@@ -1,0 +1,63 @@
+-- Migration 202604291308: rename doc_id → filing_id on v2_segments, v2_tables,
+-- v2_image_assets, v2_metric_definitions
+--
+-- All four columns are BIGINT REFERENCES filings(filing_id) but were named
+-- doc_id, suggesting a UUID reference to v2_documents.doc_id. Same trap
+-- class as v2_metric_facts.doc_id (fixed in migration 202604282225 / legacy-038).
+-- Postgres views in sql/09 and sql/38 use attnums — no view recreation needed.
+--
+-- Idempotent: information_schema existence guard per table. See legacy-038.
+
+BEGIN;
+
+-- v2_segments
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v2_segments' AND column_name = 'doc_id'
+  ) THEN
+    ALTER TABLE v2_segments RENAME COLUMN doc_id TO filing_id;
+  END IF;
+END $$;
+
+-- v2_tables
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v2_tables' AND column_name = 'doc_id'
+  ) THEN
+    ALTER TABLE v2_tables RENAME COLUMN doc_id TO filing_id;
+  END IF;
+END $$;
+
+-- v2_image_assets
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v2_image_assets' AND column_name = 'doc_id'
+  ) THEN
+    ALTER TABLE v2_image_assets RENAME COLUMN doc_id TO filing_id;
+  END IF;
+END $$;
+
+-- v2_metric_definitions
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v2_metric_definitions' AND column_name = 'doc_id'
+  ) THEN
+    ALTER TABLE v2_metric_definitions RENAME COLUMN doc_id TO filing_id;
+  END IF;
+END $$;
+
+-- Rename indices that embed the old column name
+ALTER INDEX IF EXISTS idx_v2_segments_doc_id        RENAME TO idx_v2_segments_filing_id;
+ALTER INDEX IF EXISTS idx_v2_tables_doc_id           RENAME TO idx_v2_tables_filing_id;
+ALTER INDEX IF EXISTS idx_v2_image_assets_doc_id     RENAME TO idx_v2_image_assets_filing_id;
+ALTER INDEX IF EXISTS idx_v2_metric_definitions_doc  RENAME TO idx_v2_metric_definitions_filing;
+
+COMMIT;

--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -317,7 +317,7 @@ class MetricFact:
 
     # Identity
     fact_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    doc_id: str = ""  # Filing ID
+    document_uuid: str = ""  # Document UUID (v2_documents.doc_id; not persisted to DB)
     canonical_metric_id: str = ""  # e.g., "net_revenue_retention"
 
     # Value
@@ -449,7 +449,7 @@ class MetricDefinition:
 
     # Identity
     definition_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    doc_id: str = ""
+    filing_id: str = ""
     canonical_metric_id: str = ""
 
     # Definition text (what the metric means)
@@ -563,7 +563,7 @@ class Table:
 
     # Identity
     table_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    doc_id: str = ""
+    filing_id: str = ""
     segment_id: str = ""
 
     # DOM locator
@@ -631,7 +631,7 @@ class Segment:
 
     # Identity
     segment_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    doc_id: str = ""
+    filing_id: str = ""
 
     # Type and content
     segment_type: SegmentType = SegmentType.PARAGRAPH
@@ -768,7 +768,7 @@ class ImageAsset:
 
     # Identity
     img_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    doc_id: str = ""
+    filing_id: str = ""
     segment_id: str | None = None
 
     # File info

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -545,13 +545,13 @@ class V2PersistenceAdapter:
 
         sql = """
             INSERT INTO v2_segments (
-                segment_id, doc_id, segment_type, segment_text,
+                segment_id, filing_id, segment_type, segment_text,
                 dom_locator, section_path, section_type, sequence_idx,
                 prev_segment_id, next_segment_id,
                 source_type, source_img_id, created_at
             )
             VALUES (
-                %(segment_id)s, %(doc_id)s, %(segment_type)s, %(segment_text)s,
+                %(segment_id)s, %(filing_id)s, %(segment_type)s, %(segment_text)s,
                 %(dom_locator)s, %(section_path)s, %(section_type)s, %(sequence_idx)s,
                 %(prev_segment_id)s, %(next_segment_id)s,
                 %(source_type)s, %(source_img_id)s, NOW()
@@ -572,7 +572,7 @@ class V2PersistenceAdapter:
         params_list = [
             {
                 "segment_id": segment.segment_id,
-                "doc_id": filing_id,
+                "filing_id": filing_id,
                 "segment_type": segment.segment_type.value,
                 "segment_text": segment.text,
                 "dom_locator": segment.dom_locator,
@@ -601,13 +601,13 @@ class V2PersistenceAdapter:
 
         table_sql = """
             INSERT INTO v2_tables (
-                table_id, doc_id, segment_id, dom_locator,
+                table_id, filing_id, segment_id, dom_locator,
                 section_path, section_type,
                 row_count, col_count, header_rows, stub_cols,
                 raw_html, created_at
             )
             VALUES (
-                %(table_id)s, %(doc_id)s, %(segment_id)s, %(dom_locator)s,
+                %(table_id)s, %(filing_id)s, %(segment_id)s, %(dom_locator)s,
                 %(section_path)s, %(section_type)s,
                 %(row_count)s, %(col_count)s, %(header_rows)s, %(stub_cols)s,
                 %(raw_html)s, NOW()
@@ -649,7 +649,7 @@ class V2PersistenceAdapter:
         table_params_list = [
             {
                 "table_id": table.table_id,
-                "doc_id": filing_id,
+                "filing_id": filing_id,
                 "segment_id": None,  # v2_tables.segment_id FKs to V1 source_segments; not used in V2
                 "dom_locator": table.dom_locator,
                 "section_path": table.section_path or [],
@@ -851,7 +851,7 @@ class V2PersistenceAdapter:
                   FROM v2_image_assets v
                   LEFT JOIN v2_image_review_decisions rd ON rd.img_id = v.img_id
                   LEFT JOIN v2_image_metric_confirmations imc ON imc.img_id = v.img_id
-                 WHERE v.doc_id = %(filing_id)s
+                 WHERE v.filing_id = %(filing_id)s
                    AND v.filename = ANY(%(filenames)s)
                    AND (rd.img_id IS NOT NULL OR imc.img_id IS NOT NULL)
                 """,
@@ -888,7 +888,7 @@ class V2PersistenceAdapter:
                     hidden_transitions,
                 )
 
-        # Upsert on (doc_id, filename), NOT on img_id: ImageAsset.img_id is a
+        # Upsert on (filing_id, filename), NOT on img_id: ImageAsset.img_id is a
         # fresh random UUID per extraction run, so keying on img_id would
         # insert a new row every time and orphan decisions in
         # v2_image_review_decisions (which FK to img_id). The UNIQUE constraint
@@ -897,7 +897,7 @@ class V2PersistenceAdapter:
         # existing value on conflict.
         sql = """
             INSERT INTO v2_image_assets (
-                img_id, doc_id, filename, file_path,
+                img_id, filing_id, filename, file_path,
                 width, height, dom_locator, nearby_text,
                 section_path, section_type,
                 classification, relevance_score,
@@ -906,7 +906,7 @@ class V2PersistenceAdapter:
                 detected_keywords, detected_metrics, created_at
             )
             VALUES (
-                %(img_id)s, %(doc_id)s, %(filename)s, %(file_path)s,
+                %(img_id)s, %(filing_id)s, %(filename)s, %(file_path)s,
                 %(width)s, %(height)s, %(dom_locator)s, %(nearby_text)s,
                 %(section_path)s, %(section_type)s,
                 %(classification)s, %(relevance_score)s,
@@ -914,7 +914,7 @@ class V2PersistenceAdapter:
                 %(processed)s, %(confidence)s, %(requires_manual)s,
                 %(detected_keywords)s, %(detected_metrics)s, NOW()
             )
-            ON CONFLICT (doc_id, filename) DO UPDATE SET
+            ON CONFLICT (filing_id, filename) DO UPDATE SET
                 file_path = COALESCE(EXCLUDED.file_path, v2_image_assets.file_path),
                 width = EXCLUDED.width,
                 height = EXCLUDED.height,
@@ -939,7 +939,7 @@ class V2PersistenceAdapter:
         params_list = [
             {
                 "img_id": image.img_id,
-                "doc_id": filing_id,
+                "filing_id": filing_id,
                 "filename": image.filename,
                 "file_path": image.file_path,
                 "width": image.width,
@@ -1090,7 +1090,7 @@ class V2PersistenceAdapter:
                    COUNT(DISTINCT imc.reviewer_id) AS reviewer_count
               FROM v2_image_metric_confirmations imc
               JOIN v2_image_assets ia ON ia.img_id = imc.img_id
-             WHERE ia.doc_id = %(filing_id)s
+             WHERE ia.filing_id = %(filing_id)s
             """,
             {"filing_id": filing_id},
         )
@@ -1202,20 +1202,20 @@ class V2PersistenceAdapter:
 
         sql = """
             INSERT INTO v2_metric_definitions (
-                definition_id, doc_id, canonical_metric_id,
+                definition_id, filing_id, canonical_metric_id,
                 definition_text, definition_text_normalized,
                 methodology_text, methodology_text_normalized,
                 definition_segment_id, methodology_segment_id,
                 alignment_flag, created_at
             )
             VALUES (
-                %(definition_id)s, %(doc_id)s, %(canonical_metric_id)s,
+                %(definition_id)s, %(filing_id)s, %(canonical_metric_id)s,
                 %(definition_text)s, %(definition_text_normalized)s,
                 %(methodology_text)s, %(methodology_text_normalized)s,
                 %(definition_segment_id)s, %(methodology_segment_id)s,
                 %(alignment_flag)s, NOW()
             )
-            ON CONFLICT (doc_id, canonical_metric_id) DO UPDATE SET
+            ON CONFLICT (filing_id, canonical_metric_id) DO UPDATE SET
                 definition_text = EXCLUDED.definition_text,
                 definition_text_normalized = EXCLUDED.definition_text_normalized,
                 methodology_text = EXCLUDED.methodology_text,
@@ -1228,7 +1228,7 @@ class V2PersistenceAdapter:
         params_list = [
             {
                 "definition_id": defn.definition_id,
-                "doc_id": filing_id,
+                "filing_id": filing_id,
                 "canonical_metric_id": defn.canonical_metric_id,
                 "definition_text": defn.definition_text,
                 "definition_text_normalized": defn.definition_text_normalized,

--- a/src/extraction_v2/stages/definition_extraction.py
+++ b/src/extraction_v2/stages/definition_extraction.py
@@ -154,11 +154,8 @@ class DefinitionExtractionStage:
                     metric_id, def_normalized or meth_normalized
                 )
 
-                # Get the doc_id from context
-                doc_id = context.document.doc_id if context.document else ""
-
                 md = MetricDefinition(
-                    doc_id=doc_id,
+                    filing_id=str(context.filing_id) if context.filing_id else "",
                     canonical_metric_id=metric_id,
                     definition_text=def_text,
                     definition_text_normalized=def_normalized,

--- a/src/extraction_v2/stages/fact_construction.py
+++ b/src/extraction_v2/stages/fact_construction.py
@@ -226,7 +226,7 @@ class FactConstructionStage:
 
         # Build the fact
         fact = MetricFact(
-            doc_id=context.document.doc_id if context.document else "",
+            document_uuid=context.document.doc_id if context.document else "",
             canonical_metric_id=metric_id,
             value=bv.value,
             value_raw=bv.value_raw,

--- a/src/extraction_v2/stages/ingestion.py
+++ b/src/extraction_v2/stages/ingestion.py
@@ -885,7 +885,7 @@ class IngestionStage:
 
             # Create ImageAsset
             asset = ImageAsset(
-                doc_id=str(filing_id),
+                filing_id=str(filing_id),
                 filename=src,
                 width=width,
                 height=height,
@@ -982,7 +982,7 @@ class IngestionStage:
             # Assign unified sequence numbers
             for idx, (segment, _) in enumerate(all_segments_with_elements):
                 segment.sequence = idx
-                segment.doc_id = str(context.filing_id)  # Ensure doc_id is set
+                segment.filing_id = str(context.filing_id)
 
             # Extract just the segments
             all_segments = [seg for seg, _ in all_segments_with_elements]

--- a/src/extraction_v2/stages/ocr_extraction.py
+++ b/src/extraction_v2/stages/ocr_extraction.py
@@ -70,7 +70,7 @@ def _synthesize_ocr_segment(
     """
     next_sequence = max((s.sequence for s in context.segments), default=-1) + 1
     return Segment(
-        doc_id=str(context.filing_id) if context.filing_id else "",
+        filing_id=str(context.filing_id) if context.filing_id else "",
         segment_type=SegmentType.PARAGRAPH,
         text=ocr_text,
         dom_locator=f"image:{image.img_id}",

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -897,14 +897,14 @@ class DatabaseAdapter:
             ),
             image_progress AS (
                 SELECT
-                    v.doc_id                                                               AS filing_id,
+                    v.filing_id,
                     COUNT(v.img_id)                                                         AS image_count,
                     COUNT(CASE WHEN v.review_status = 'pending'    THEN 1 END)              AS images_pending,
                     COUNT(CASE WHEN v.review_status = 'reviewed'   THEN 1 END)              AS images_reviewed
                 FROM v2_image_assets v
                 WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
                   AND v.filename IS NOT NULL AND v.filename != ''
-                GROUP BY v.doc_id
+                GROUP BY v.filing_id
             ),
             reviewer_progress AS (
                 SELECT
@@ -917,7 +917,7 @@ class DatabaseAdapter:
                     JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
                     WHERE rd.reviewer_id IS NOT NULL
                     UNION ALL
-                    SELECT va.doc_id AS filing_id, ird.reviewer_id
+                    SELECT va.filing_id, ird.reviewer_id
                     FROM v2_image_review_decisions ird
                     JOIN v2_image_assets va ON va.img_id = ird.img_id
                     WHERE ird.reviewer_id IS NOT NULL
@@ -1001,12 +1001,12 @@ class DatabaseAdapter:
             ),
             image_progress AS (
                 SELECT
-                    v.doc_id AS filing_id,
+                    v.filing_id,
                     COUNT(CASE WHEN v.review_status = 'pending' THEN 1 END) AS images_pending
                 FROM v2_image_assets v
                 WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
                   AND v.filename IS NOT NULL AND v.filename != ''
-                GROUP BY v.doc_id
+                GROUP BY v.filing_id
             ),
             reviewer_progress AS (
                 SELECT
@@ -1019,7 +1019,7 @@ class DatabaseAdapter:
                     JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
                     WHERE rd.reviewer_id IS NOT NULL
                     UNION ALL
-                    SELECT va.doc_id AS filing_id, ird.reviewer_id
+                    SELECT va.filing_id, ird.reviewer_id
                     FROM v2_image_review_decisions ird
                     JOIN v2_image_assets va ON va.img_id = ird.img_id
                     WHERE ird.reviewer_id IS NOT NULL
@@ -1106,14 +1106,14 @@ class DatabaseAdapter:
             ),
             image_progress AS (
                 SELECT
-                    v.doc_id AS filing_id,
+                    v.filing_id,
                     COUNT(v.img_id) AS image_count,
                     COUNT(CASE WHEN v.review_status = 'pending' THEN 1 END) AS images_pending,
                     COUNT(CASE WHEN v.review_status = 'reviewed' THEN 1 END) AS images_reviewed
                 FROM v2_image_assets v
                 WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
                   AND v.filename IS NOT NULL AND v.filename != ''
-                GROUP BY v.doc_id
+                GROUP BY v.filing_id
             ),
             reviewer_progress AS (
                 SELECT
@@ -1126,7 +1126,7 @@ class DatabaseAdapter:
                     JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
                     WHERE rd.reviewer_id IS NOT NULL
                     UNION ALL
-                    SELECT va.doc_id AS filing_id, ird.reviewer_id
+                    SELECT va.filing_id, ird.reviewer_id
                     FROM v2_image_review_decisions ird
                     JOIN v2_image_assets va ON va.img_id = ird.img_id
                     WHERE ird.reviewer_id IS NOT NULL
@@ -1204,7 +1204,7 @@ class DatabaseAdapter:
             SELECT
                 COUNT(CASE WHEN v.review_status = 'pending' THEN 1 END) AS images_pending
             FROM v2_image_assets v
-            WHERE v.doc_id = %(filing_id)s
+            WHERE v.filing_id = %(filing_id)s
               AND v.classification NOT IN ('decorative', 'logo', 'signature')
               AND v.filename IS NOT NULL AND v.filename != ''
         """
@@ -1326,7 +1326,7 @@ class DatabaseAdapter:
         result = self.query(sql, params)
         return result[0]["cnt"] if result else 0
 
-    def get_segment_context(self, doc_id: int, segment_id: str, window: int = 2) -> list[dict]:
+    def get_segment_context(self, filing_id: int, segment_id: str, window: int = 2) -> list[dict]:
         """
         Return the target segment plus up to `window` neighbors on each side,
         ordered by sequence_idx. Used to show surrounding paragraph context
@@ -1337,17 +1337,17 @@ class DatabaseAdapter:
             WITH target AS (
                 SELECT sequence_idx
                 FROM v2_segments
-                WHERE segment_id = %(segment_id)s AND doc_id = %(doc_id)s
+                WHERE segment_id = %(segment_id)s AND filing_id = %(filing_id)s
             )
             SELECT s.segment_id::text, s.segment_type, s.segment_text,
                    s.section_path, s.section_type, s.sequence_idx
             FROM v2_segments s, target t
-            WHERE s.doc_id = %(doc_id)s
+            WHERE s.filing_id = %(filing_id)s
               AND s.sequence_idx BETWEEN t.sequence_idx - %(window)s
                                      AND t.sequence_idx + %(window)s
             ORDER BY s.sequence_idx
             """,
-            {"doc_id": doc_id, "segment_id": segment_id, "window": window},
+            {"filing_id": filing_id, "segment_id": segment_id, "window": window},
         )
 
     def get_v2_image_ocr_segments_for_filing(self, filing_id: int) -> list[dict]:
@@ -1372,14 +1372,14 @@ class DatabaseAdapter:
                    ia.ocr_text AS image_ocr_text
             FROM v2_segments s
             LEFT JOIN v2_image_assets ia ON ia.img_id = s.source_img_id
-            WHERE s.doc_id = %(filing_id)s
+            WHERE s.filing_id = %(filing_id)s
               AND s.source_type = 'image_ocr'
             ORDER BY s.sequence_idx
             """,
             {"filing_id": filing_id},
         )
 
-    def get_table_context(self, doc_id: int, table_id: str) -> dict | None:
+    def get_table_context(self, filing_id: int, table_id: str) -> dict | None:
         """
         Return table metadata and a reconstructed HTML table for a V2 table fact.
         Used to show the full table in the review UI when evidence_pack
@@ -1392,10 +1392,10 @@ class DatabaseAdapter:
             """
             SELECT table_id::text, section_path, section_type, row_count, col_count
             FROM v2_tables
-            WHERE table_id = %(table_id)s AND doc_id = %(doc_id)s
+            WHERE table_id = %(table_id)s AND filing_id = %(filing_id)s
             LIMIT 1
             """,
-            {"doc_id": doc_id, "table_id": table_id},
+            {"filing_id": filing_id, "table_id": table_id},
         )
         if not meta_rows:
             return None
@@ -1764,7 +1764,7 @@ class DatabaseAdapter:
 
     _V2_IMAGE_CANDIDATE_SELECT = """
         v.img_id,
-        v.doc_id AS filing_id,
+        v.filing_id,
         f.company_id,
         v.filename,
         v.filename AS image_src,
@@ -1926,18 +1926,18 @@ class DatabaseAdapter:
         else:  # position
             order_by = "v.img_id ASC"
 
-        # Dedup by (doc_id, filename): repeated extraction runs produce fresh
+        # Dedup by (filing_id, filename): repeated extraction runs produce fresh
         # img_id UUIDs for the same file, so v2_image_assets can hold multiple
         # rows per physical image. Keep the most recent row per filename —
         # prefer rows that already have a review decision so reviewer work
         # is not hidden behind a newer un-reviewed duplicate.
         sql = f"""
             WITH deduped_img AS (
-                SELECT DISTINCT ON (doc_id, filename) img_id
+                SELECT DISTINCT ON (filing_id, filename) img_id
                 FROM v2_image_assets
-                WHERE doc_id = %(filing_id)s
+                WHERE filing_id = %(filing_id)s
                 ORDER BY
-                    doc_id,
+                    filing_id,
                     filename,
                     EXISTS (
                         SELECT 1 FROM v2_image_review_decisions rd
@@ -1950,7 +1950,7 @@ class DatabaseAdapter:
                 ic.predicted_metrics,
                 ic.confidence        AS classification_confidence
             FROM v2_image_assets v
-            JOIN filings f ON v.doc_id = f.filing_id
+            JOIN filings f ON v.filing_id = f.filing_id
             JOIN companies c ON f.company_id = c.company_id
             LEFT JOIN v2_image_review_decisions d ON d.img_id = v.img_id
             LEFT JOIN LATERAL (
@@ -1961,7 +1961,7 @@ class DatabaseAdapter:
                 LIMIT 1
             ) ic ON true
             {self._V2_IMAGE_CONFIRMATION_ROLLUP_JOIN}
-            WHERE v.doc_id = %(filing_id)s
+            WHERE v.filing_id = %(filing_id)s
               AND v.img_id IN (SELECT img_id FROM deduped_img)
               AND v.classification NOT IN ('decorative', 'logo', 'signature')
               AND v.filename IS NOT NULL
@@ -1984,7 +1984,7 @@ class DatabaseAdapter:
                 ic.predicted_metrics,
                 ic.confidence        AS classification_confidence
             FROM v2_image_assets v
-            JOIN filings f ON v.doc_id = f.filing_id
+            JOIN filings f ON v.filing_id = f.filing_id
             JOIN companies c ON f.company_id = c.company_id
             LEFT JOIN v2_image_review_decisions d ON d.img_id = v.img_id
             LEFT JOIN LATERAL (
@@ -2037,14 +2037,14 @@ class DatabaseAdapter:
             """
             params["current_img_id"] = current_img_id
 
-        # Dedup by (doc_id, filename) — see get_image_review_candidates_for_filing_v2.
+        # Dedup by (filing_id, filename) — see get_image_review_candidates_for_filing_v2.
         sql = f"""
             WITH deduped_img AS (
-                SELECT DISTINCT ON (doc_id, filename) img_id
+                SELECT DISTINCT ON (filing_id, filename) img_id
                 FROM v2_image_assets
-                WHERE doc_id = %(filing_id)s
+                WHERE filing_id = %(filing_id)s
                 ORDER BY
-                    doc_id,
+                    filing_id,
                     filename,
                     EXISTS (
                         SELECT 1 FROM v2_image_review_decisions rd
@@ -2054,11 +2054,11 @@ class DatabaseAdapter:
             )
             SELECT {self._V2_IMAGE_CANDIDATE_SELECT}
             FROM v2_image_assets v
-            JOIN filings f ON v.doc_id = f.filing_id
+            JOIN filings f ON v.filing_id = f.filing_id
             JOIN companies c ON f.company_id = c.company_id
             LEFT JOIN v2_image_review_decisions d ON d.img_id = v.img_id
             {self._V2_IMAGE_CONFIRMATION_ROLLUP_JOIN}
-            WHERE v.doc_id = %(filing_id)s
+            WHERE v.filing_id = %(filing_id)s
               AND v.img_id IN (SELECT img_id FROM deduped_img)
               AND v.review_status = ANY(%(status_list)s)
               AND v.classification NOT IN ('decorative', 'logo', 'signature')
@@ -2214,7 +2214,7 @@ class DatabaseAdapter:
         otherwise they are across all filings. Only non-decorative images are counted
         (matches queue semantics used by the UI).
         """
-        filter_clause = "AND v.doc_id = %(filing_id)s" if filing_id is not None else ""
+        filter_clause = "AND v.filing_id = %(filing_id)s" if filing_id is not None else ""
         params: dict[str, Any] = {}
         if filing_id is not None:
             params["filing_id"] = filing_id
@@ -2266,7 +2266,7 @@ class DatabaseAdapter:
             SELECT COUNT(*) AS n
               FROM v2_image_metric_confirmations imc
               JOIN v2_image_assets ia ON ia.img_id = imc.img_id
-             WHERE ia.doc_id = %(filing_id)s
+             WHERE ia.filing_id = %(filing_id)s
                AND imc.decision = 'reject'
         """
         rows = self.query(sql, {"filing_id": filing_id})
@@ -2324,13 +2324,13 @@ class DatabaseAdapter:
         with self.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+                    "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
                     {"img_id": img_id},
                 )
                 doc_row = cur.fetchone()
                 if doc_row is None:
                     raise ValueError(f"Image not found: img_id={img_id}")
-                doc_id = doc_row["doc_id"]
+                filing_id = doc_row["filing_id"]
 
                 for entry in confirmations:
                     decision = entry["decision"]
@@ -2352,19 +2352,19 @@ class DatabaseAdapter:
 
                     if decision == "accept":
                         self._promote_chart_fact(
-                            cur, doc_id, img_id, detected_metric_id, reviewer_id
+                            cur, filing_id, img_id, detected_metric_id, reviewer_id
                         )
                     elif decision == "correct":
-                        self._demote_chart_fact(cur, doc_id, img_id, detected_metric_id)
+                        self._demote_chart_fact(cur, filing_id, img_id, detected_metric_id)
                         self._promote_chart_fact(
-                            cur, doc_id, img_id, confirmed_metric_id, reviewer_id
+                            cur, filing_id, img_id, confirmed_metric_id, reviewer_id
                         )
                     elif decision == "add":
                         self._promote_chart_fact(
-                            cur, doc_id, img_id, confirmed_metric_id, reviewer_id
+                            cur, filing_id, img_id, confirmed_metric_id, reviewer_id
                         )
                     elif decision in ("reject", "skip"):
-                        self._demote_chart_fact(cur, doc_id, img_id, detected_metric_id)
+                        self._demote_chart_fact(cur, filing_id, img_id, detected_metric_id)
 
         logger.debug(
             "Upserted %d image metric confirmations: img_id=%s reviewer_id=%s",
@@ -2377,7 +2377,7 @@ class DatabaseAdapter:
     def _promote_chart_fact(
         self,
         cur,
-        doc_id: int,
+        filing_id: int,
         img_id: str,
         metric_id: str | None,
         reviewer_id: str,
@@ -2396,12 +2396,12 @@ class DatabaseAdapter:
         cur.execute(
             """
             SELECT fact_id FROM v2_metric_facts
-            WHERE filing_id = %(doc_id)s
+            WHERE filing_id = %(filing_id)s
               AND canonical_metric_id = %(metric_id)s
               AND source_type = 'chart'
             LIMIT 1
             """,
-            {"doc_id": doc_id, "metric_id": metric_id},
+            {"filing_id": filing_id, "metric_id": metric_id},
         )
         if cur.fetchone() is not None:
             return
@@ -2413,14 +2413,14 @@ class DatabaseAdapter:
                 confidence, extraction_method, requires_review, review_status,
                 pipeline_version
             ) VALUES (
-                %(doc_id)s, %(metric_id)s, '', 'other',
+                %(filing_id)s, %(metric_id)s, '', 'other',
                 'chart', %(source_locator)s::jsonb,
                 1.0, 'manual', FALSE, 'accepted',
                 '2.0.0'
             )
             """,
             {
-                "doc_id": doc_id,
+                "filing_id": filing_id,
                 "metric_id": metric_id,
                 "source_locator": json.dumps({"img_id": img_id}),
             },
@@ -2429,7 +2429,7 @@ class DatabaseAdapter:
     def _demote_chart_fact(
         self,
         cur,
-        doc_id: int,
+        filing_id: int,
         img_id: str,
         metric_id: str | None,
     ) -> None:
@@ -2449,7 +2449,7 @@ class DatabaseAdapter:
             SELECT 1
               FROM v2_image_metric_confirmations imc
               JOIN v2_image_assets ia ON ia.img_id = imc.img_id
-             WHERE ia.doc_id = %(doc_id)s
+             WHERE ia.filing_id = %(filing_id)s
                AND (
                    (imc.decision = 'accept'  AND imc.detected_metric_id  = %(metric_id)s) OR
                    (imc.decision = 'correct' AND imc.confirmed_metric_id = %(metric_id)s) OR
@@ -2457,18 +2457,18 @@ class DatabaseAdapter:
                )
              LIMIT 1
             """,
-            {"doc_id": doc_id, "metric_id": metric_id},
+            {"filing_id": filing_id, "metric_id": metric_id},
         )
         if cur.fetchone() is not None:
             return
         cur.execute(
             """
             DELETE FROM v2_metric_facts
-            WHERE filing_id = %(doc_id)s
+            WHERE filing_id = %(filing_id)s
               AND canonical_metric_id = %(metric_id)s
               AND source_type = 'chart'
             """,
-            {"doc_id": doc_id, "metric_id": metric_id},
+            {"filing_id": filing_id, "metric_id": metric_id},
         )
 
     def delete_image_metric_confirmation(
@@ -2503,14 +2503,14 @@ class DatabaseAdapter:
                     return None
 
                 cur.execute(
-                    "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+                    "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
                     {"img_id": row["img_id"]},
                 )
                 doc_row = cur.fetchone()
                 if doc_row is not None:
-                    doc_id = doc_row["doc_id"]
+                    filing_id = doc_row["filing_id"]
                     metric_id = row["confirmed_metric_id"] or row["detected_metric_id"]
-                    self._demote_chart_fact(cur, doc_id, row["img_id"], metric_id)
+                    self._demote_chart_fact(cur, filing_id, row["img_id"], metric_id)
 
         logger.debug(
             "Deleted image metric confirmation %s (reviewer=%s, decision=%s)",

--- a/tests/integration/extraction_v2/test_definition_persistence.py
+++ b/tests/integration/extraction_v2/test_definition_persistence.py
@@ -84,26 +84,26 @@ def cleanup_v2_tables(test_db_adapter: DatabaseAdapter, test_filing_id: int):
             with conn.cursor() as cur:
                 # Delete in order respecting foreign keys
                 cur.execute(
-                    "DELETE FROM v2_metric_definitions WHERE doc_id = %s",
+                    "DELETE FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 cur.execute("DELETE FROM v2_metric_facts WHERE filing_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
                 cur.execute(
                     """
                     DELETE FROM v2_table_cells
                     WHERE table_id IN (
-                        SELECT table_id FROM v2_tables WHERE doc_id = %s
+                        SELECT table_id FROM v2_tables WHERE filing_id = %s
                     )
                 """,
                     (test_filing_id,),
                 )
-                cur.execute("DELETE FROM v2_tables WHERE doc_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_segments WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_tables WHERE filing_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_segments WHERE filing_id = %s", (test_filing_id,))
                 cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (test_filing_id,))
 
     _cleanup()
-    # Create v2_documents row required by FK on v2_metric_definitions.doc_id
+    # Create v2_documents row required by FK on v2_metric_definitions.filing_id
     with test_db_adapter.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -126,7 +126,7 @@ def make_definition(
     """Build a MetricDefinition with sensible defaults."""
     defaults: dict[str, object] = {
         "definition_id": str(uuid.uuid4()),
-        "doc_id": str(uuid.uuid4()),
+        "filing_id": str(uuid.uuid4()),
         "canonical_metric_id": metric_id,
         "definition_text": "Customers who placed at least one order in the period.",
         "definition_text_normalized": "Customers who placed at least one order in the period.",
@@ -155,7 +155,7 @@ class TestDefinitionPersistence:
         with test_db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT * FROM v2_metric_definitions WHERE doc_id = %s",
+                    "SELECT * FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 row = cur.fetchone()
@@ -185,7 +185,7 @@ class TestDefinitionPersistence:
         with test_db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE doc_id = %s",
+                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 result = cur.fetchone()
@@ -205,7 +205,7 @@ class TestDefinitionPersistence:
         with test_db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE doc_id = %s",
+                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 result = cur.fetchone()
@@ -227,7 +227,7 @@ class TestDefinitionPersistence:
         with test_db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE doc_id = %s",
+                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 assert cur.fetchone()["cnt"] == 1
@@ -244,7 +244,7 @@ class TestDefinitionPersistence:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT COUNT(*) AS cnt, MAX(definition_text_normalized) AS norm_text "
-                    "FROM v2_metric_definitions WHERE doc_id = %s",
+                    "FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 row = cur.fetchone()
@@ -275,7 +275,7 @@ class TestDefinitionPersistence:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT canonical_metric_id, alignment_flag "
-                    "FROM v2_metric_definitions WHERE doc_id = %s",
+                    "FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 rows = {r["canonical_metric_id"]: r["alignment_flag"] for r in cur.fetchall()}
@@ -354,7 +354,7 @@ class TestDefinitionPipelineResultIntegration:
         with test_db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE doc_id = %s",
+                    "SELECT COUNT(*) AS cnt FROM v2_metric_definitions WHERE filing_id = %s",
                     (test_filing_id,),
                 )
                 row = cur.fetchone()

--- a/tests/integration/extraction_v2/test_e2e_pipeline.py
+++ b/tests/integration/extraction_v2/test_e2e_pipeline.py
@@ -101,18 +101,18 @@ def cleanup_v2_tables(db_adapter: DatabaseAdapter, test_filing_id: int):
             with conn.cursor() as cur:
                 # Delete in order respecting foreign keys
                 cur.execute("DELETE FROM v2_metric_facts WHERE filing_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
                 cur.execute(
                     """
                     DELETE FROM v2_table_cells
                     WHERE table_id IN (
-                        SELECT table_id FROM v2_tables WHERE doc_id = %s
+                        SELECT table_id FROM v2_tables WHERE filing_id = %s
                     )
                 """,
                     (test_filing_id,),
                 )
-                cur.execute("DELETE FROM v2_tables WHERE doc_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_segments WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_tables WHERE filing_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_segments WHERE filing_id = %s", (test_filing_id,))
                 cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (test_filing_id,))
 
     _cleanup()
@@ -354,7 +354,8 @@ class TestE2EPersistence:
 
                 # Check segments
                 cur.execute(
-                    "SELECT COUNT(*) as cnt FROM v2_segments WHERE doc_id = %s", (test_filing_id,)
+                    "SELECT COUNT(*) as cnt FROM v2_segments WHERE filing_id = %s",
+                    (test_filing_id,),
                 )
                 segment_count = cur.fetchone()["cnt"]
                 assert segment_count == len(result.segments)

--- a/tests/integration/extraction_v2/test_full_page_ocr_pipeline.py
+++ b/tests/integration/extraction_v2/test_full_page_ocr_pipeline.py
@@ -137,8 +137,8 @@ def cleanup_v2_tables(db_adapter: DatabaseAdapter, test_filing_id: int):
     def _cleanup() -> None:
         with db_adapter.get_connection() as conn, conn.cursor() as cur:
             cur.execute("DELETE FROM v2_metric_facts WHERE filing_id = %s", (test_filing_id,))
-            cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
-            cur.execute("DELETE FROM v2_segments WHERE doc_id = %s", (test_filing_id,))
+            cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
+            cur.execute("DELETE FROM v2_segments WHERE filing_id = %s", (test_filing_id,))
             cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (test_filing_id,))
 
     _cleanup()

--- a/tests/integration/extraction_v2/test_persistence.py
+++ b/tests/integration/extraction_v2/test_persistence.py
@@ -109,18 +109,18 @@ def cleanup_v2_tables(db_adapter: DatabaseAdapter, test_filing_id: int):
             with conn.cursor() as cur:
                 # Delete in order respecting foreign keys
                 cur.execute("DELETE FROM v2_metric_facts WHERE filing_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
                 cur.execute(
                     """
                     DELETE FROM v2_table_cells
                     WHERE table_id IN (
-                        SELECT table_id FROM v2_tables WHERE doc_id = %s
+                        SELECT table_id FROM v2_tables WHERE filing_id = %s
                     )
                 """,
                     (test_filing_id,),
                 )
-                cur.execute("DELETE FROM v2_tables WHERE doc_id = %s", (test_filing_id,))
-                cur.execute("DELETE FROM v2_segments WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_tables WHERE filing_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_segments WHERE filing_id = %s", (test_filing_id,))
                 cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (test_filing_id,))
 
     _cleanup()
@@ -244,7 +244,7 @@ class TestSegmentPersistence:
         segments = [
             Segment(
                 segment_id=str(uuid.uuid4()),
-                doc_id=str(test_filing_id),
+                filing_id=str(test_filing_id),
                 segment_type=SegmentType.PARAGRAPH,
                 text=f"Segment {i} text content",
                 dom_locator=f"/html/body/p[{i}]",
@@ -261,7 +261,8 @@ class TestSegmentPersistence:
         with db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) as cnt FROM v2_segments WHERE doc_id = %s", (test_filing_id,)
+                    "SELECT COUNT(*) as cnt FROM v2_segments WHERE filing_id = %s",
+                    (test_filing_id,),
                 )
                 result = cur.fetchone()
                 assert result["cnt"] == 5
@@ -298,7 +299,7 @@ class TestSegmentPersistence:
             with conn.cursor() as cur:
                 cur.execute(
                     """SELECT segment_text, sequence_idx
-                       FROM v2_segments WHERE doc_id = %s
+                       FROM v2_segments WHERE filing_id = %s
                        ORDER BY sequence_idx""",
                     (test_filing_id,),
                 )
@@ -320,7 +321,7 @@ class TestTablePersistence:
         """Test inserting table with cells."""
         table = Table(
             table_id=str(uuid.uuid4()),
-            doc_id=str(test_filing_id),
+            filing_id=str(test_filing_id),
             dom_locator="/html/body/table[1]",
             row_count=3,
             col_count=2,
@@ -427,7 +428,7 @@ class TestFactPersistence:
         """Test inserting fact with full provenance."""
         fact = MetricFact(
             fact_id=str(uuid.uuid4()),
-            doc_id=str(test_filing_id),
+            document_uuid=str(test_filing_id),
             canonical_metric_id="cm_new_customers_acquired",  # Use valid metric ID
             value=1000000.0,
             value_raw="$1.0M",
@@ -640,7 +641,7 @@ class TestImagePersistence:
         """Test inserting basic image asset."""
         image = ImageAsset(
             img_id=str(uuid.uuid4()),
-            doc_id=str(test_filing_id),
+            filing_id=str(test_filing_id),
             filename="chart1.png",
             file_path="/data/images/chart1.png",
             width=800,
@@ -752,7 +753,7 @@ class TestImageFilePathPreservation:
                     """
                     SELECT file_path, classification, nearby_text
                       FROM v2_image_assets
-                     WHERE doc_id = %s AND filename = %s
+                     WHERE filing_id = %s AND filename = %s
                     """,
                     (test_filing_id, "legacy103.png"),
                 )
@@ -796,7 +797,7 @@ class TestImageFilePathPreservation:
         with db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT file_path FROM v2_image_assets WHERE doc_id = %s AND filename = %s",
+                    "SELECT file_path FROM v2_image_assets WHERE filing_id = %s AND filename = %s",
                     (test_filing_id, "legacy103_overwrite.png"),
                 )
                 result = cur.fetchone()
@@ -1079,7 +1080,7 @@ class TestConcurrentExtraction:
                     assert cur.fetchone()["cnt"] == 1
 
                     cur.execute(
-                        "SELECT COUNT(*) as cnt FROM v2_segments WHERE doc_id = %s",
+                        "SELECT COUNT(*) as cnt FROM v2_segments WHERE filing_id = %s",
                         (fid,),
                     )
                     assert cur.fetchone()["cnt"] == 3
@@ -1089,5 +1090,5 @@ class TestConcurrentExtraction:
             with db_adapter.get_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute("DELETE FROM v2_metric_facts WHERE filing_id = %s", (fid,))
-                    cur.execute("DELETE FROM v2_segments WHERE doc_id = %s", (fid,))
+                    cur.execute("DELETE FROM v2_segments WHERE filing_id = %s", (fid,))
                     cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (fid,))

--- a/tests/integration/extraction_v2/test_persistence_detected_metrics.py
+++ b/tests/integration/extraction_v2/test_persistence_detected_metrics.py
@@ -3,7 +3,7 @@ Integration test: round-trip ImageAsset.detected_metrics through Postgres.
 
 Verifies that `V2PersistenceAdapter._persist_images_in_tx` serializes and
 persists ``detected_metrics`` to the ``v2_image_assets.detected_metrics``
-JSONB column, and that re-extraction via ON CONFLICT (doc_id, filename)
+JSONB column, and that re-extraction via ON CONFLICT (filing_id, filename)
 overwrites the column with the latest values.
 
 Requires ``TEST_DATABASE_URL``; skips otherwise.
@@ -81,23 +81,23 @@ def cleanup_image_rows(db_adapter: DatabaseAdapter, test_filing_id: int):
     def _cleanup():
         with db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
 
     _cleanup()
     yield
     _cleanup()
 
 
-def _read_detected_metrics(db: DatabaseAdapter, doc_id: int, filename: str):
+def _read_detected_metrics(db: DatabaseAdapter, filing_id: int, filename: str):
     with db.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT detected_metrics
                   FROM v2_image_assets
-                 WHERE doc_id = %s AND filename = %s
+                 WHERE filing_id = %s AND filename = %s
                 """,
-                (doc_id, filename),
+                (filing_id, filename),
             )
             row = cur.fetchone()
             if row is None:

--- a/tests/integration/extraction_v2/test_persistence_guard.py
+++ b/tests/integration/extraction_v2/test_persistence_guard.py
@@ -110,12 +110,12 @@ def _cleanup(db_adapter: DatabaseAdapter, test_filing_id: int):
                     """
                     DELETE FROM v2_image_review_decisions
                      WHERE img_id IN (
-                        SELECT img_id FROM v2_image_assets WHERE doc_id = %s
+                        SELECT img_id FROM v2_image_assets WHERE filing_id = %s
                      )
                     """,
                     (test_filing_id,),
                 )
-                cur.execute("DELETE FROM v2_image_assets WHERE doc_id = %s", (test_filing_id,))
+                cur.execute("DELETE FROM v2_image_assets WHERE filing_id = %s", (test_filing_id,))
                 cur.execute("DELETE FROM v2_documents WHERE filing_id = %s", (test_filing_id,))
 
     _purge()
@@ -149,7 +149,7 @@ def _make_fact(
         snippet = f"<p>{value}</p>"
     return MetricFact(
         fact_id=str(uuid.uuid4()),
-        doc_id=str(filing_id),
+        document_uuid=str(filing_id),
         canonical_metric_id=metric_id,
         value=value,
         value_raw=str(value),
@@ -355,7 +355,7 @@ def _img_id_for(db_adapter: DatabaseAdapter, filing_id: int, filename: str) -> s
     with db_adapter.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT img_id FROM v2_image_assets WHERE doc_id = %s AND filename = %s",
+                "SELECT img_id FROM v2_image_assets WHERE filing_id = %s AND filename = %s",
                 (filing_id, filename),
             )
             row = cur.fetchone()
@@ -367,7 +367,7 @@ def _classification_for(db_adapter: DatabaseAdapter, filing_id: int, filename: s
     with db_adapter.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT classification FROM v2_image_assets WHERE doc_id = %s AND filename = %s",
+                "SELECT classification FROM v2_image_assets WHERE filing_id = %s AND filename = %s",
                 (filing_id, filename),
             )
             row = cur.fetchone()
@@ -966,13 +966,13 @@ def _seed_image_and_confirmation(
             cur.execute(
                 """
                 INSERT INTO v2_image_assets (
-                    img_id, doc_id, filename, dom_locator, classification, processed
+                    img_id, filing_id, filename, dom_locator, classification, processed
                 ) VALUES (
-                    %(img_id)s, %(doc_id)s, 'guard_confirmation_test.png',
+                    %(img_id)s, %(filing_id)s, 'guard_confirmation_test.png',
                     '/html/body/img[1]', 'chart', TRUE
                 )
                 """,
-                {"img_id": img_id, "doc_id": filing_id},
+                {"img_id": img_id, "filing_id": filing_id},
             )
             cur.execute(
                 """

--- a/tests/integration/extraction_v2/test_transcript_e2e.py
+++ b/tests/integration/extraction_v2/test_transcript_e2e.py
@@ -685,7 +685,7 @@ class TestTranscriptDBSchema:
                         (test_transcript_filing_id,),
                     )
                     cur.execute(
-                        "DELETE FROM v2_segments WHERE doc_id = %s",
+                        "DELETE FROM v2_segments WHERE filing_id = %s",
                         (test_transcript_filing_id,),
                     )
                     cur.execute(

--- a/tests/integration/test_db_filings_reviewers.py
+++ b/tests/integration/test_db_filings_reviewers.py
@@ -26,16 +26,16 @@ def _insert_v2_image(
     rows = db.query(
         """
         INSERT INTO v2_image_assets
-            (doc_id, filename, dom_locator, width, height, nearby_text,
+            (filing_id, filename, dom_locator, width, height, nearby_text,
              classification, relevance_score, review_status, section_type)
         VALUES
-            (%(doc_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
+            (%(filing_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
              %(nearby_text)s, %(classification)s, %(relevance_score)s,
              %(review_status)s, %(section_type)s)
         RETURNING img_id
         """,
         {
-            "doc_id": filing_id,
+            "filing_id": filing_id,
             "filename": filename,
             "dom_locator": f"body > img[src='{filename}']",
             "width": 600,

--- a/tests/integration/test_db_v2_image_methods.py
+++ b/tests/integration/test_db_v2_image_methods.py
@@ -37,17 +37,17 @@ def _insert_v2_image(
     rows = db.query(
         """
         INSERT INTO v2_image_assets
-            (doc_id, filename, dom_locator, width, height, nearby_text,
+            (filing_id, filename, dom_locator, width, height, nearby_text,
              classification, relevance_score, predicted_relevance,
              review_status, section_type)
         VALUES
-            (%(doc_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
+            (%(filing_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
              %(nearby_text)s, %(classification)s, %(relevance_score)s,
              %(predicted_relevance)s, %(review_status)s, %(section_type)s)
         RETURNING img_id
         """,
         {
-            "doc_id": filing_id,
+            "filing_id": filing_id,
             "filename": filename,
             "dom_locator": f"body > img[src='{filename}']",
             "width": width,
@@ -534,7 +534,7 @@ class TestPersistImagesStableImgId:
         original = self._make_asset("chart1.jpg")
         adapter.persist_images([original], filing_id)
         rows = clean_db.query(
-            "SELECT img_id FROM v2_image_assets WHERE doc_id=%(d)s AND filename=%(f)s",
+            "SELECT img_id FROM v2_image_assets WHERE filing_id=%(d)s AND filename=%(f)s",
             {"d": filing_id, "f": "chart1.jpg"},
         )
         assert len(rows) == 1
@@ -554,7 +554,7 @@ class TestPersistImagesStableImgId:
 
         # Row count unchanged; img_id is still the original; decision survives.
         rows_after = clean_db.query(
-            "SELECT img_id FROM v2_image_assets WHERE doc_id=%(d)s AND filename=%(f)s",
+            "SELECT img_id FROM v2_image_assets WHERE filing_id=%(d)s AND filename=%(f)s",
             {"d": filing_id, "f": "chart1.jpg"},
         )
         assert len(rows_after) == 1
@@ -601,7 +601,7 @@ class TestPersistImagesStableImgId:
         adapter.persist_images([seed], filing_id)
         stable_img_id = str(
             clean_db.query(
-                "SELECT img_id FROM v2_image_assets WHERE doc_id=%(d)s AND filename=%(f)s",
+                "SELECT img_id FROM v2_image_assets WHERE filing_id=%(d)s AND filename=%(f)s",
                 {"d": filing_id, "f": "chart2.jpg"},
             )[0]["img_id"]
         )

--- a/tests/integration/web/test_image_metric_confirmations.py
+++ b/tests/integration/web/test_image_metric_confirmations.py
@@ -75,16 +75,16 @@ def seeded_image(db_adapter: DatabaseAdapter) -> str:
             cur.execute(
                 """
                 INSERT INTO v2_image_assets (
-                    img_id, doc_id, filename, dom_locator, classification, processed,
+                    img_id, filing_id, filename, dom_locator, classification, processed,
                     detected_metrics
                 ) VALUES (
-                    %(img_id)s, %(doc_id)s, 'chart_test.png', '/html/body/img[1]',
+                    %(img_id)s, %(filing_id)s, 'chart_test.png', '/html/body/img[1]',
                     'chart', true, %(detected)s::jsonb
                 )
                 """,
                 {
                     "img_id": img_id,
-                    "doc_id": filing_id,
+                    "filing_id": filing_id,
                     "detected": '[{"metric_id":"cm_revenue_by_cohort","score":0.92}]',
                 },
             )
@@ -249,16 +249,16 @@ class TestImageMetricConfirmationsPost:
                 cur.execute(
                     """
                     INSERT INTO v2_image_assets (
-                        img_id, doc_id, filename, dom_locator, classification, processed,
+                        img_id, filing_id, filename, dom_locator, classification, processed,
                         detected_metrics
                     ) VALUES (
-                        %(img_id)s, %(doc_id)s, 'multi.png', '/html/body/img[1]',
+                        %(img_id)s, %(filing_id)s, 'multi.png', '/html/body/img[1]',
                         'chart', true, %(detected)s::jsonb
                     )
                     """,
                     {
                         "img_id": img_id,
-                        "doc_id": filing_id,
+                        "filing_id": filing_id,
                         "detected": (
                             '[{"metric_id":"cm_revenue_by_cohort","score":0.82},'
                             ' {"metric_id":"cm_net_revenue_retention","score":0.71},'
@@ -341,9 +341,9 @@ class TestFactPromotion:
 
     def test_accept_promotes_fact(self, client, db_adapter, seeded_image):
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
         resp = self._post(
             client,
             {
@@ -359,9 +359,9 @@ class TestFactPromotion:
 
     def test_reject_does_not_promote_fact(self, client, db_adapter, seeded_image):
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
         resp = self._post(
             client,
             {
@@ -381,9 +381,9 @@ class TestFactPromotion:
 
     def test_correct_rolls_back_and_promotes_new(self, client, db_adapter, seeded_image):
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
         # First accept the detected metric
         self._post(
             client,
@@ -421,9 +421,9 @@ class TestFactPromotion:
 
     def test_delete_confirmation_rolls_back_fact(self, client, db_adapter, seeded_image):
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
         # Accept
         post_resp = self._post(
             client,
@@ -492,9 +492,9 @@ class TestNoRelevantMetricsSentinel:
 
         # Sentinel rows do NOT promote a chart fact
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
         facts = db_adapter.query(
             """
             SELECT 1 FROM v2_metric_facts
@@ -527,9 +527,9 @@ class TestNoRelevantMetricsSentinel:
         """db.count_image_metric_rejections_for_filing counts both
         per-metric rejects and the no-relevant-metrics sentinel."""
         filing_id = db_adapter.query(
-            "SELECT doc_id FROM v2_image_assets WHERE img_id = %(img_id)s",
+            "SELECT filing_id FROM v2_image_assets WHERE img_id = %(img_id)s",
             {"img_id": seeded_image},
-        )[0]["doc_id"]
+        )[0]["filing_id"]
 
         assert db_adapter.count_image_metric_rejections_for_filing(filing_id) == 0
 

--- a/tests/integration/web/test_ingest_flow.py
+++ b/tests/integration/web/test_ingest_flow.py
@@ -428,8 +428,8 @@ def two_seeded_filings(db_adapter: DatabaseAdapter):
         {"fid": filing_id_a},
     )
     db_adapter.execute(
-        "DELETE FROM v2_documents WHERE doc_id = %(doc_id)s::uuid",
-        {"doc_id": doc_id},
+        "DELETE FROM v2_documents WHERE filing_id = %(filing_id)s::uuid",
+        {"filing_id": doc_id},
     )
     db_adapter.execute(
         "DELETE FROM filings WHERE filing_id IN (%(a)s, %(b)s)",

--- a/tests/integration/web/test_ingest_flow.py
+++ b/tests/integration/web/test_ingest_flow.py
@@ -428,8 +428,8 @@ def two_seeded_filings(db_adapter: DatabaseAdapter):
         {"fid": filing_id_a},
     )
     db_adapter.execute(
-        "DELETE FROM v2_documents WHERE filing_id = %(filing_id)s::uuid",
-        {"filing_id": doc_id},
+        "DELETE FROM v2_documents WHERE doc_id = %(doc_id)s::uuid",
+        {"doc_id": doc_id},
     )
     db_adapter.execute(
         "DELETE FROM filings WHERE filing_id IN (%(a)s, %(b)s)",

--- a/tests/unit/extraction_v2/test_candidate_generation.py
+++ b/tests/unit/extraction_v2/test_candidate_generation.py
@@ -70,7 +70,7 @@ def make_segment(
     """Create a test segment."""
     return Segment(
         segment_id=segment_id,
-        doc_id="doc-1",
+        filing_id=1,
         segment_type=segment_type,
         text=text,
         raw_html=f"<p>{text}</p>",
@@ -89,7 +89,7 @@ def make_table(
     """Create a test table with cells."""
     return Table(
         table_id=table_id,
-        doc_id="doc-1",
+        filing_id=1,
         segment_id=segment_id,
         section_type=section_type,
         row_count=len(set(c.row for c in cells)) if cells else 0,

--- a/tests/unit/extraction_v2/test_deduplication.py
+++ b/tests/unit/extraction_v2/test_deduplication.py
@@ -64,7 +64,7 @@ def make_fact(
     """Create a MetricFact for testing."""
     return MetricFact(
         fact_id=fact_id,
-        doc_id="doc-1",
+        document_uuid="doc-1",
         canonical_metric_id=metric_id,
         value=value,
         value_raw=str(value) if value else "",

--- a/tests/unit/extraction_v2/test_definition_extraction.py
+++ b/tests/unit/extraction_v2/test_definition_extraction.py
@@ -160,7 +160,12 @@ class TestDefinitionSegmentFound:
 
     def test_methodology_segment_captured(self, stage):
         para = _seg("s1", 1, SegmentType.PARAGRAPH, "ARR was $10M.")
-        meth = _seg("s2", 2, SegmentType.METHODOLOGY, "Calculated by summing monthly recurring revenue times 12.")
+        meth = _seg(
+            "s2",
+            2,
+            SegmentType.METHODOLOGY,
+            "Calculated by summing monthly recurring revenue times 12.",
+        )
         ctx = MockPipelineContext(
             facts=[_fact("cm_average_order_value")],
             segments=[para, meth],
@@ -221,19 +226,16 @@ class TestDefinitionSegmentFound:
         stage.process(ctx)
         assert len(ctx.definitions) == 1
 
-    def test_doc_id_comes_from_context_document(self, stage):
-        doc = Document()
-        doc.doc_id = "test-doc-uuid-123"
+    def test_filing_id_comes_from_context(self, stage):
         para = _seg("s1", 1, SegmentType.PARAGRAPH, "Metric mention.")
         defn = _seg("s2", 2, SegmentType.DEFINITION, "A definition.")
         ctx = MockPipelineContext(
-            document=doc,
             facts=[_fact("cm_customers_period_end")],
             segments=[para, defn],
             candidates=[_candidate("c1", "cm_customers_period_end", "s1")],
         )
         stage.process(ctx)
-        assert ctx.definitions[0].doc_id == "test-doc-uuid-123"
+        assert ctx.definitions[0].filing_id == str(ctx.filing_id)
 
 
 # ============================================================================

--- a/tests/unit/extraction_v2/test_fact_construction.py
+++ b/tests/unit/extraction_v2/test_fact_construction.py
@@ -57,6 +57,7 @@ def _route_image_cache_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     image_cache_dir.cache_clear()
     get_image_storage.cache_clear()
 
+
 # ============================================================================
 # Fixtures
 # ============================================================================
@@ -238,7 +239,7 @@ def test_single_bound_value_to_fact(
     assert len(mock_context.facts) == 1
 
     fact = mock_context.facts[0]
-    assert fact.doc_id == "TEST_DOC"
+    assert fact.document_uuid == "TEST_DOC"
     assert fact.canonical_metric_id == "cm_average_order_value"
     assert fact.value == 1000.0
     assert fact.value_raw == "1,000"

--- a/tests/unit/extraction_v2/test_metric_presence_stage.py
+++ b/tests/unit/extraction_v2/test_metric_presence_stage.py
@@ -67,7 +67,7 @@ def _fact(
 ) -> MetricFact:
     return MetricFact(
         fact_id=fact_id or str(uuid.uuid4()),
-        doc_id="42",
+        document_uuid="42",
         canonical_metric_id=metric_id,
         value=100.0,
         value_raw="100",
@@ -177,7 +177,7 @@ class TestMetricPresenceStage:
     def test_definition_alone_emits_presence_at_floor_score(self) -> None:
         defn = MetricDefinition(
             canonical_metric_id="cm_net_revenue_retention",
-            doc_id="42",
+            filing_id="42",
             definition_text="Net revenue retention measures...",
             definition_segment_id="seg-def",
         )
@@ -196,7 +196,7 @@ class TestMetricPresenceStage:
         fact = _fact("cm_a", confidence=0.95, segment_id="seg-f")
         defn = MetricDefinition(
             canonical_metric_id="cm_a",
-            doc_id="42",
+            filing_id="42",
             definition_text="cm_a is...",
             definition_segment_id="seg-d",
         )
@@ -242,7 +242,7 @@ class TestMetricPresenceStage:
         fact = _fact("cm_a", confidence=0.8, segment_id="seg")
         defn = MetricDefinition(
             canonical_metric_id="cm_b",
-            doc_id="42",
+            filing_id="42",
             definition_text="cm_b is...",
             definition_segment_id="seg-def",
         )

--- a/tests/unit/extraction_v2/test_models.py
+++ b/tests/unit/extraction_v2/test_models.py
@@ -148,7 +148,7 @@ class TestMetricFact:
     def test_creation(self) -> None:
         """Test basic creation with required fields."""
         fact = MetricFact(
-            doc_id="doc123",
+            document_uuid="doc123",
             canonical_metric_id="net_revenue_retention",
             value=112.0,
             value_raw="112%",
@@ -159,7 +159,7 @@ class TestMetricFact:
             source_type=SourceType.HTML_TABLE,
             confidence=0.95,
         )
-        assert fact.doc_id == "doc123"
+        assert fact.document_uuid == "doc123"
         assert fact.value == 112.0
         assert fact.unit == Unit.PERCENT
         assert fact.confidence == 0.95
@@ -492,7 +492,7 @@ class TestTable:
     def test_creation(self) -> None:
         """Test basic creation."""
         table = Table(
-            doc_id="doc123",
+            filing_id=1,
             segment_id="seg456",
             row_count=5,
             col_count=3,
@@ -541,7 +541,7 @@ class TestSegment:
     def test_creation(self) -> None:
         """Test basic creation."""
         segment = Segment(
-            doc_id="doc123",
+            filing_id=1,
             segment_type=SegmentType.PARAGRAPH,
             text="Our net revenue retention was 112% for fiscal 2023.",
             dom_locator="/html/body/div[3]/p[5]",
@@ -560,7 +560,7 @@ class TestImageAsset:
     def test_creation(self) -> None:
         """Test basic creation."""
         image = ImageAsset(
-            doc_id="doc123",
+            filing_id=1,
             filename="chart1.png",
             dom_locator="/html/body/img[3]",
             nearby_text="Figure 1: Cohort Revenue Analysis",

--- a/tests/unit/extraction_v2/test_period_inference.py
+++ b/tests/unit/extraction_v2/test_period_inference.py
@@ -955,7 +955,7 @@ class TestPeriodHintFromRespectively:
         """Strategy 0 fires before Strategy 2 (text context)."""
         segment = Segment(
             segment_id="s-resp",
-            doc_id="doc-1",
+            filing_id=1,
             text="Revenue for 2020 was high.",
         )
         mock_context.segments = [segment]
@@ -983,7 +983,7 @@ class TestPeriodHintFromRespectively:
         """An empty period_hint does not interfere with normal period inference."""
         segment = Segment(
             segment_id="s-normal",
-            doc_id="doc-1",
+            filing_id=1,
             text="In Q1 2024, we had strong results.",
         )
         mock_context.segments = [segment]

--- a/tests/unit/extraction_v2/test_section_classification.py
+++ b/tests/unit/extraction_v2/test_section_classification.py
@@ -121,7 +121,7 @@ class TestSectionHeadingDetection:
         """Test heading detection by uppercase text."""
         stage = SectionClassificationStage()
         segment = Segment(
-            doc_id="1",
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text="RISK FACTORS",
@@ -134,7 +134,7 @@ class TestSectionHeadingDetection:
         """Test heading detection by ITEM/PART prefix."""
         stage = SectionClassificationStage()
         segment = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text="ITEM 1A. Risk Factors",
@@ -147,7 +147,7 @@ class TestSectionHeadingDetection:
         """Test heading detection by h1 tag in XPath."""
         stage = SectionClassificationStage()
         segment = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text="Risk Factors",
@@ -161,7 +161,7 @@ class TestSectionHeadingDetection:
         stage = SectionClassificationStage()
         for tag in ["h2", "h3", "h4", "h5", "h6"]:
             segment = Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Section Heading",
@@ -175,7 +175,7 @@ class TestSectionHeadingDetection:
         stage = SectionClassificationStage()
         long_text = "ITEM 1A. " + "A" * 200
         segment = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text=long_text,
@@ -188,7 +188,7 @@ class TestSectionHeadingDetection:
         """Test that regular paragraphs are not headings."""
         stage = SectionClassificationStage()
         segment = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text="This is a regular paragraph with mixed case text.",
@@ -347,7 +347,7 @@ class TestProcessMethod:
         # Add segments without any section headings
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Company overview text at the beginning.",
@@ -355,7 +355,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="More introductory text in the cover section.",
@@ -384,7 +384,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Cover page text.",
@@ -392,7 +392,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="RISK FACTORS",
@@ -400,7 +400,7 @@ class TestProcessMethod:
                 sequence=1,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-3",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Risk factor content here.",
@@ -430,7 +430,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Cover text",
@@ -438,7 +438,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="RISK FACTORS",
@@ -446,7 +446,7 @@ class TestProcessMethod:
                 sequence=1,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-3",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Risk content",
@@ -454,7 +454,7 @@ class TestProcessMethod:
                 sequence=2,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-4",
                 segment_type=SegmentType.PARAGRAPH,
                 text="BUSINESS",
@@ -462,7 +462,7 @@ class TestProcessMethod:
                 sequence=3,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-5",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Business content",
@@ -491,7 +491,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="BUSINESS",
@@ -499,7 +499,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Business content",
@@ -525,7 +525,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="RISK FACTORS",
@@ -533,7 +533,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Risk content",
@@ -560,7 +560,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Cover text",
@@ -568,7 +568,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="SOME UNKNOWN SECTION",
@@ -576,7 +576,7 @@ class TestProcessMethod:
                 sequence=1,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-3",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Content after unknown heading",
@@ -604,7 +604,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="BUSINESS",
@@ -612,7 +612,7 @@ class TestProcessMethod:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.TABLE,
                 text="Metric [CELL] Value [ROW] Customers [CELL] 100",
@@ -639,7 +639,7 @@ class TestProcessMethod:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Test content",
@@ -668,7 +668,7 @@ class TestEdgeCases:
 
         context.segments = [
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="BUSINESS",
@@ -676,7 +676,7 @@ class TestEdgeCases:
                 sequence=0,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Content 1",
@@ -684,7 +684,7 @@ class TestEdgeCases:
                 sequence=1,
             ),
             Segment(
-                doc_id=1,
+                filing_id=1,
                 segment_id="seg-3",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Content 2",
@@ -705,7 +705,7 @@ class TestEdgeCases:
         """Test that whitespace-only text is not detected as heading."""
         stage = SectionClassificationStage()
         segment = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text="    ",
@@ -899,7 +899,7 @@ class TestPresentationSlideClassification:
 
         context.segments = [
             Segment(
-                doc_id="1",
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.HEADING,
                 text="Key Metrics",
@@ -908,7 +908,7 @@ class TestPresentationSlideClassification:
                 sequence=0,
             ),
             Segment(
-                doc_id="1",
+                filing_id=1,
                 segment_id="seg-2",
                 segment_type=SegmentType.TABLE,
                 text="ARR $100M",
@@ -937,7 +937,7 @@ class TestPresentationSlideClassification:
 
         context.segments = [
             Segment(
-                doc_id="1",
+                filing_id=1,
                 segment_id="seg-1",
                 segment_type=SegmentType.PARAGRAPH,
                 text="Key Metrics for our business.",
@@ -973,9 +973,7 @@ class TestEightKHeadingPatterns:
             ("Q2 2025 Guidance", SectionType.GUIDANCE),
         ],
     )
-    def test_eight_k_heading_classified(
-        self, heading: str, expected: SectionType
-    ) -> None:
+    def test_eight_k_heading_classified(self, heading: str, expected: SectionType) -> None:
         stage = SectionClassificationStage()
         assert stage._detect_section_type(heading) == expected
 
@@ -987,7 +985,7 @@ class TestEightKHeadingPatterns:
             "which include revenue growth and improved margins across all segments."
         )
         seg = Segment(
-            doc_id=1,
+            filing_id=1,
             segment_id="seg-1",
             segment_type=SegmentType.PARAGRAPH,
             text=long_body,
@@ -999,10 +997,5 @@ class TestEightKHeadingPatterns:
     def test_pattern_precedence_stable(self) -> None:
         """Precedence lock: 'Financial Highlights' vs 'Q3 2025 Highlights'."""
         stage = SectionClassificationStage()
-        assert (
-            stage._detect_section_type("Financial Highlights")
-            == SectionType.FINANCIAL_OVERVIEW
-        )
-        assert (
-            stage._detect_section_type("Q3 2025 Highlights") == SectionType.KEY_METRICS
-        )
+        assert stage._detect_section_type("Financial Highlights") == SectionType.FINANCIAL_OVERVIEW
+        assert stage._detect_section_type("Q3 2025 Highlights") == SectionType.KEY_METRICS

--- a/tests/unit/extraction_v2/test_value_binding.py
+++ b/tests/unit/extraction_v2/test_value_binding.py
@@ -111,12 +111,8 @@ def simple_table() -> Table:
             header_path=["Metric"],
             stub_path=[],
         ),
-        Cell(
-            row=2, col=1, text="50,000", header_path=["2023"], stub_path=["Customers"]
-        ),
-        Cell(
-            row=2, col=2, text="45,000", header_path=["2022"], stub_path=["Customers"]
-        ),
+        Cell(row=2, col=1, text="50,000", header_path=["2023"], stub_path=["Customers"]),
+        Cell(row=2, col=2, text="45,000", header_path=["2022"], stub_path=["Customers"]),
     ]
 
     table = Table(
@@ -142,9 +138,7 @@ def percentage_table() -> Table:
     cells = [
         # Header row
         Cell(row=0, col=0, text="KPI", is_header=True, header_path=[], stub_path=[]),
-        Cell(
-            row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]
-        ),
+        Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
         # Data row
         Cell(
             row=1,
@@ -184,7 +178,7 @@ def text_segment() -> Segment:
     """Create a text segment for proximity testing."""
     return Segment(
         segment_id="seg-1",
-        doc_id="doc-1",
+        filing_id=1,
         segment_type=SegmentType.PARAGRAPH,
         text="Our total revenue for the year was $1.5 billion, representing a 25% increase.",
         section_type=SectionType.MDA,
@@ -231,13 +225,9 @@ class TestTableBindingHeaderPath:
         cells = [
             # Header row 1
             Cell(row=0, col=0, text="", is_header=True, header_path=[], stub_path=[]),
-            Cell(
-                row=0, col=1, text="FY 2023", is_header=True, header_path=[], stub_path=[]
-            ),
+            Cell(row=0, col=1, text="FY 2023", is_header=True, header_path=[], stub_path=[]),
             # Header row 2
-            Cell(
-                row=1, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]
-            ),
+            Cell(row=1, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(
                 row=1,
                 col=1,
@@ -255,9 +245,7 @@ class TestTableBindingHeaderPath:
                 header_path=["Metric"],
                 stub_path=[],
             ),
-            Cell(
-                row=2, col=1, text="$100M", header_path=["FY 2023", "Q4"], stub_path=["ARR"]
-            ),
+            Cell(row=2, col=1, text="$100M", header_path=["FY 2023", "Q4"], stub_path=["ARR"]),
         ]
 
         table = Table(
@@ -416,7 +404,9 @@ class TestTableBindingStubPath:
             Cell(row=0, col=2, text="Value", is_header=True, header_path=[], stub_path=[]),
             # Data
             Cell(row=1, col=0, text="Growth", is_stub=True, header_path=["Category"], stub_path=[]),
-            Cell(row=1, col=1, text="ARR", is_stub=True, header_path=["Metric"], stub_path=["Growth"]),
+            Cell(
+                row=1, col=1, text="ARR", is_stub=True, header_path=["Metric"], stub_path=["Growth"]
+            ),
             Cell(row=1, col=2, text="$50M", header_path=["Value"], stub_path=["Growth", "ARR"]),
         ]
 
@@ -510,9 +500,7 @@ class TestTextBinding:
         # Should find $1.5 billion and 25%
         assert len(context.bound_values) >= 1
 
-    def test_value_in_same_sentence(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_value_in_same_sentence(self, stage: ValueBindingStage) -> None:
         """Values in the same sentence as keyword are preferred."""
         segment = Segment(
             segment_id="seg-sentence",
@@ -804,9 +792,7 @@ class TestNumberParsing:
         text = "January 31, 2019"
         results = stage._find_numbers_in_proximity(text, 0, 7, 100)
         raw_values = [raw for _, _, _, raw in results]
-        assert "201" not in raw_values, (
-            f"Year '2019' was split into fragments: {raw_values}"
-        )
+        assert "201" not in raw_values, f"Year '2019' was split into fragments: {raw_values}"
         # Should find "31" and "2019" as whole numbers
         values = [v for _, v, _, _ in results]
         assert 2019 in values
@@ -832,32 +818,22 @@ class TestConfidenceScoring:
 
     def test_exact_match_bonus(self, stage: ValueBindingStage) -> None:
         """Exact match in path adds confidence bonus."""
-        with_exact = stage._compute_table_confidence(
-            "revenue", ["Revenue", "2023"], [], Unit.COUNT
-        )
-        without_exact = stage._compute_table_confidence(
-            "rev", ["Revenue", "2023"], [], Unit.COUNT
-        )
+        with_exact = stage._compute_table_confidence("revenue", ["Revenue", "2023"], [], Unit.COUNT)
+        without_exact = stage._compute_table_confidence("rev", ["Revenue", "2023"], [], Unit.COUNT)
 
         assert with_exact > without_exact
 
     def test_unit_presence_bonus(self, stage: ValueBindingStage) -> None:
         """Having explicit unit adds confidence bonus."""
-        with_unit = stage._compute_table_confidence(
-            "metric", [], [], Unit.CURRENCY
-        )
-        without_unit = stage._compute_table_confidence(
-            "metric", [], [], Unit.COUNT
-        )
+        with_unit = stage._compute_table_confidence("metric", [], [], Unit.CURRENCY)
+        without_unit = stage._compute_table_confidence("metric", [], [], Unit.COUNT)
 
         assert with_unit > without_unit
 
     def test_confidence_capped_at_one(self, stage: ValueBindingStage) -> None:
         """Confidence never exceeds 1.0."""
         # Maximum bonuses
-        conf = stage._compute_table_confidence(
-            "revenue", ["Revenue"], ["Revenue"], Unit.CURRENCY
-        )
+        conf = stage._compute_table_confidence("revenue", ["Revenue"], ["Revenue"], Unit.CURRENCY)
         assert conf <= 1.0
 
     def test_confidence_capped_at_zero(self, stage: ValueBindingStage) -> None:
@@ -1013,9 +989,7 @@ class TestEdgeCases:
         assert result.success
         assert len(context.bound_values) == 0
 
-    def test_missing_segment_logs_warning(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_missing_segment_logs_warning(self, stage: ValueBindingStage) -> None:
         """Missing segment is handled gracefully."""
         candidate = MetricCandidate(
             candidate_id="cand-missing-seg",
@@ -1049,16 +1023,23 @@ class TestEdgeCases:
         assert result.success
         assert len(context.bound_values) == 0
 
-    def test_multiple_metrics_same_row(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_multiple_metrics_same_row(self, stage: ValueBindingStage) -> None:
         """Multiple metrics in same table row are handled correctly."""
         cells = [
             Cell(row=0, col=0, text="Metric A", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Metric B", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=2, text="Value", is_header=True, header_path=[], stub_path=[]),
-            Cell(row=1, col=0, text="Revenue", is_stub=True, header_path=["Metric A"], stub_path=[]),
-            Cell(row=1, col=1, text="Growth", is_stub=True, header_path=["Metric B"], stub_path=["Revenue"]),
+            Cell(
+                row=1, col=0, text="Revenue", is_stub=True, header_path=["Metric A"], stub_path=[]
+            ),
+            Cell(
+                row=1,
+                col=1,
+                text="Growth",
+                is_stub=True,
+                header_path=["Metric B"],
+                stub_path=["Revenue"],
+            ),
             Cell(row=1, col=2, text="25%", header_path=["Value"], stub_path=["Revenue", "Growth"]),
         ]
 
@@ -1214,7 +1195,9 @@ class TestEdgeCases:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
             Cell(row=1, col=0, text="Test", is_stub=True, header_path=["Metric"], stub_path=[]),
-            Cell(row=1, col=1, text="N/A", header_path=["Value"], stub_path=["Test"]),  # Not a number
+            Cell(
+                row=1, col=1, text="N/A", header_path=["Value"], stub_path=["Test"]
+            ),  # Not a number
         ]
 
         table = Table(
@@ -1247,9 +1230,7 @@ class TestEdgeCases:
         assert result.success
         assert len(context.bound_values) == 0  # No parseable value
 
-    def test_parse_number_returns_none_for_invalid(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_parse_number_returns_none_for_invalid(self, stage: ValueBindingStage) -> None:
         """_parse_number returns None for non-numeric text."""
         assert stage._parse_number("not a number") is None
         assert stage._parse_number("") is None
@@ -1319,17 +1300,28 @@ class TestUnitFiltering:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="Paid Customers",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="Paid Customers",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="$14.8M",
-                header_path=["Value"], stub_path=["Paid Customers"],
+                row=1,
+                col=1,
+                text="$14.8M",
+                header_path=["Value"],
+                stub_path=["Paid Customers"],
             ),
         ]
         table = Table(
             table_id="unit-filter-table",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1341,7 +1333,9 @@ class TestUnitFiltering:
             match_text="Paid Customers",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-table", cell_row=1, cell_col=0,
+                table_id="unit-filter-table",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1357,17 +1351,28 @@ class TestUnitFiltering:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Growth", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="Customers",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="Customers",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="152%",
-                header_path=["Growth"], stub_path=["Customers"],
+                row=1,
+                col=1,
+                text="152%",
+                header_path=["Growth"],
+                stub_path=["Customers"],
             ),
         ]
         table = Table(
             table_id="unit-filter-pct",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1379,7 +1384,9 @@ class TestUnitFiltering:
             match_text="Customers",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-pct", cell_row=1, cell_col=0,
+                table_id="unit-filter-pct",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1395,17 +1402,28 @@ class TestUnitFiltering:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Total", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="Customers",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="Customers",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="50,000",
-                header_path=["Total"], stub_path=["Customers"],
+                row=1,
+                col=1,
+                text="50,000",
+                header_path=["Total"],
+                stub_path=["Customers"],
             ),
         ]
         table = Table(
             table_id="unit-filter-count",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1417,7 +1435,9 @@ class TestUnitFiltering:
             match_text="Customers",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-count", cell_row=1, cell_col=0,
+                table_id="unit-filter-count",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1467,17 +1487,28 @@ class TestUnitFiltering:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="ARR",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="ARR",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="500",
-                header_path=["Value"], stub_path=["ARR"],
+                row=1,
+                col=1,
+                text="500",
+                header_path=["Value"],
+                stub_path=["ARR"],
             ),
         ]
         table = Table(
             table_id="unit-filter-curr",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1489,7 +1520,9 @@ class TestUnitFiltering:
             match_text="ARR",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-curr", cell_row=1, cell_col=0,
+                table_id="unit-filter-curr",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1505,17 +1538,28 @@ class TestUnitFiltering:
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="ARR",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="ARR",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="$500M",
-                header_path=["Value"], stub_path=["ARR"],
+                row=1,
+                col=1,
+                text="$500M",
+                header_path=["Value"],
+                stub_path=["ARR"],
             ),
         ]
         table = Table(
             table_id="unit-filter-curr-ok",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1527,7 +1571,9 @@ class TestUnitFiltering:
             match_text="ARR",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-curr-ok", cell_row=1, cell_col=0,
+                table_id="unit-filter-curr-ok",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1539,25 +1585,34 @@ class TestUnitFiltering:
         assert context.bound_values[0].value == 500_000_000
         assert context.bound_values[0].unit == Unit.CURRENCY
 
-    def test_unconstrained_metric_accepts_all_units(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_unconstrained_metric_accepts_all_units(self, stage: ValueBindingStage) -> None:
         """Unconstrained metric (cm_revenue_by_cohort) accepts any unit."""
         cells = [
             Cell(row=0, col=0, text="Metric", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=1, text="Value", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="Revenue by Cohort",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="Revenue by Cohort",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="$500M",
-                header_path=["Value"], stub_path=["Revenue by Cohort"],
+                row=1,
+                col=1,
+                text="$500M",
+                header_path=["Value"],
+                stub_path=["Revenue by Cohort"],
             ),
         ]
         table = Table(
             table_id="unit-filter-uncons",
-            row_count=2, col_count=2, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=2,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 2 for _ in range(2)]
         for cell in cells:
@@ -1569,7 +1624,9 @@ class TestUnitFiltering:
             match_text="Revenue by Cohort",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-uncons", cell_row=1, cell_col=0,
+                table_id="unit-filter-uncons",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1586,21 +1643,35 @@ class TestUnitFiltering:
             Cell(row=0, col=1, text="2023", is_header=True, header_path=[], stub_path=[]),
             Cell(row=0, col=2, text="2022", is_header=True, header_path=[], stub_path=[]),
             Cell(
-                row=1, col=0, text="Customers",
-                is_stub=True, header_path=["Metric"], stub_path=[],
+                row=1,
+                col=0,
+                text="Customers",
+                is_stub=True,
+                header_path=["Metric"],
+                stub_path=[],
             ),
             Cell(
-                row=1, col=1, text="$14.8M",
-                header_path=["2023"], stub_path=["Customers"],
+                row=1,
+                col=1,
+                text="$14.8M",
+                header_path=["2023"],
+                stub_path=["Customers"],
             ),
             Cell(
-                row=1, col=2, text="152%",
-                header_path=["2022"], stub_path=["Customers"],
+                row=1,
+                col=2,
+                text="152%",
+                header_path=["2022"],
+                stub_path=["Customers"],
             ),
         ]
         table = Table(
             table_id="unit-filter-meta",
-            row_count=2, col_count=3, header_rows=1, stub_cols=1, cells=cells,
+            row_count=2,
+            col_count=3,
+            header_rows=1,
+            stub_cols=1,
+            cells=cells,
         )
         table._grid = [[None] * 3 for _ in range(2)]
         for cell in cells:
@@ -1612,7 +1683,9 @@ class TestUnitFiltering:
             match_text="Customers",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-meta", cell_row=1, cell_col=0,
+                table_id="unit-filter-meta",
+                cell_row=1,
+                cell_col=0,
             ),
         )
 
@@ -1627,14 +1700,20 @@ class TestUnitFiltering:
         """Strategy 5 (value in candidate cell) also applies unit filtering."""
         cells = [
             Cell(
-                row=0, col=0,
+                row=0,
+                col=0,
                 text="Customers: $14.8M",
-                header_path=[], stub_path=[],
+                header_path=[],
+                stub_path=[],
             ),
         ]
         table = Table(
             table_id="unit-filter-s5",
-            row_count=1, col_count=1, header_rows=0, stub_cols=0, cells=cells,
+            row_count=1,
+            col_count=1,
+            header_rows=0,
+            stub_cols=0,
+            cells=cells,
         )
         table._grid = [[cells[0]]]
 
@@ -1644,7 +1723,9 @@ class TestUnitFiltering:
             match_text="Customers",
             source_type=SourceType.HTML_TABLE,
             source_locator=SourceLocator(
-                table_id="unit-filter-s5", cell_row=0, cell_col=0,
+                table_id="unit-filter-s5",
+                cell_row=0,
+                cell_col=0,
             ),
         )
 
@@ -1817,13 +1898,15 @@ class TestWiderProximityMetrics:
 
     def test_wider_proximity_metrics_frozenset_contents(self) -> None:
         """_WIDER_PROXIMITY_METRICS contains exactly the expected metric IDs."""
-        expected = frozenset({
-            "cm_balance_by_cohort",
-            "cm_gross_margin_by_cohort",
-            "cm_ltv_to_cac_ratio",
-            "cm_ltv_to_cac_ratio_by_cohort",
-            "cm_cac_payback_period",
-        })
+        expected = frozenset(
+            {
+                "cm_balance_by_cohort",
+                "cm_gross_margin_by_cohort",
+                "cm_ltv_to_cac_ratio",
+                "cm_ltv_to_cac_ratio_by_cohort",
+                "cm_cac_payback_period",
+            }
+        )
         assert _WIDER_PROXIMITY_METRICS == expected
 
 
@@ -1887,9 +1970,7 @@ class TestTranscriptBindingFeatures:
         assert len(context_sec.bound_values) == 0
 
         # Transcript context (250 char proximity) — should find value
-        context_tx = TranscriptPipelineContext(
-            segments=[segment], candidates=[candidate]
-        )
+        context_tx = TranscriptPipelineContext(segments=[segment], candidates=[candidate])
         stage.process(context_tx)  # type: ignore
         assert len(context_tx.bound_values) >= 1
 
@@ -1913,9 +1994,7 @@ class TestTranscriptBindingFeatures:
             ),
         )
 
-        context = TranscriptPipelineContext(
-            segments=[segment], candidates=[candidate]
-        )
+        context = TranscriptPipelineContext(segments=[segment], candidates=[candidate])
         result = stage.process(context)  # type: ignore
         assert result.success
         assert len(context.bound_values) >= 1
@@ -1946,9 +2025,7 @@ class TestTranscriptBindingFeatures:
             ),
         )
 
-        context = TranscriptPipelineContext(
-            segments=[segment], candidates=[candidate]
-        )
+        context = TranscriptPipelineContext(segments=[segment], candidates=[candidate])
         stage.process(context)  # type: ignore
         assert len(context.bound_values) >= 1
 
@@ -1993,9 +2070,7 @@ class TestTranscriptBindingFeatures:
             ),
         )
 
-        context = TranscriptPipelineContext(
-            segments=[segment], candidates=[candidate]
-        )
+        context = TranscriptPipelineContext(segments=[segment], candidates=[candidate])
         stage.process(context)  # type: ignore
         assert len(context.bound_values) >= 1
         # "150 million" should parse to 150,000,000
@@ -2027,7 +2102,9 @@ class TestTranscriptBindingFeatures:
         if context.bound_values:
             bv = context.bound_values[0]
             # Should NOT have adjacent sentence bonus in SEC mode
-            assert bv.binding_confidence <= stage.TEXT_BINDING_BASE + stage.UNIT_PRESENCE_BONUS + 0.01
+            assert (
+                bv.binding_confidence <= stage.TEXT_BINDING_BASE + stage.UNIT_PRESENCE_BONUS + 0.01
+            )
 
 
 # ============================================================================
@@ -2072,7 +2149,9 @@ class TestAmbiguityPenaltyPostFilter:
         assert bv.value == pytest.approx(4_100_000_000, rel=0.01)
         assert bv.unit == Unit.CURRENCY
         # No ambiguity penalty — only one compatible value survived
-        expected_conf = stage.TEXT_BINDING_BASE + stage.UNIT_PRESENCE_BONUS + stage.SAME_SENTENCE_BONUS
+        expected_conf = (
+            stage.TEXT_BINDING_BASE + stage.UNIT_PRESENCE_BONUS + stage.SAME_SENTENCE_BONUS
+        )
         assert bv.binding_confidence == pytest.approx(expected_conf, abs=0.01)
 
     def test_ambiguity_penalty_when_multiple_compatible_survive(self) -> None:
@@ -2249,7 +2328,9 @@ class TestWordNumberTimeUnitParsing:
             text, kw_start, kw_end, stage.proximity_window, metric_id="cm_customers_period_end"
         )
         values = [r[1] for r in results]
-        assert 6.0 not in values, f"word-number '6' should not bind to non-time metric; values={values}"
+        assert 6.0 not in values, (
+            f"word-number '6' should not bind to non-time metric; values={values}"
+        )
 
     def test_time_unit_pattern_without_metric_id(self) -> None:
         """No metric_id passed → no time-unit parsing (preserves existing behavior)."""
@@ -3241,9 +3322,7 @@ class TestProseCellBinding:
 
     def test_ltv_cac_prose_cell_rejects_currency(self, stage: ValueBindingStage) -> None:
         """Currency values are rejected for LTV/CAC ratio metric."""
-        cell_text = (
-            "LTV/CAC ratio for 2015, 2016 cohorts was $100, $200, respectively"
-        )
+        cell_text = "LTV/CAC ratio for 2015, 2016 cohorts was $100, $200, respectively"
         cell = self._make_prose_cell(cell_text)
         table = self._make_prose_table("ff-ltv-2", cell)
         candidate = MetricCandidate(
@@ -3371,15 +3450,11 @@ class TestRespectivelyPatternBinding:
         for bv in results:
             assert bv.binding_type == "respectively_pattern"
 
-    def test_bind_prose_cell_fallback_to_respectively(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_bind_prose_cell_fallback_to_respectively(self, stage: ValueBindingStage) -> None:
         """When normal proximity binding fails, respectively fallback fires."""
         # Normal proximity window is 100 chars. The values are 150+ chars from the keyword.
         long_preamble = "X " * 60  # ~120 chars
-        text = (
-            f"LTV/CAC ratio {long_preamble}for 2020, 2021 and 2022 was 1.1, 1.2 and 1.3, respectively"
-        )
+        text = f"LTV/CAC ratio {long_preamble}for 2020, 2021 and 2022 was 1.1, 1.2 and 1.3, respectively"
         table = _make_prose_table("ff-prose-2", text)
         candidate = MetricCandidate(
             candidate_id="cand-ff-2",
@@ -3403,9 +3478,7 @@ class TestRespectivelyPatternBinding:
             assert bv.binding_type == "respectively_pattern"
             assert bv.period_hint in {"2020", "2021", "2022"}
 
-    def test_bind_prose_cell_no_respectively_unchanged(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_bind_prose_cell_no_respectively_unchanged(self, stage: ValueBindingStage) -> None:
         """Prose cell without 'respectively' is unaffected by the new fallback."""
         text = "LTV/CAC ratio for 2022 was 1.55"
         table = _make_prose_table("ff-prose-3", text)
@@ -3487,9 +3560,7 @@ class TestProseRespectivelyPriority:
         values = sorted(bv.value for bv in results)
         assert values == pytest.approx([1.42, 1.53, 1.77], rel=1e-3)
 
-    def test_cohort_sentence_populates_cohort_hint(
-        self, stage: ValueBindingStage
-    ) -> None:
+    def test_cohort_sentence_populates_cohort_hint(self, stage: ValueBindingStage) -> None:
         """Cohort-intent sentence sets cohort_hint and leaves period_hint empty."""
         cell = Cell(row=0, col=0, text=self.FARFETCH_TEXT, header_path=[], stub_path=[])
         candidate = MetricCandidate(
@@ -3976,9 +4047,7 @@ class TestStubFinancialLineItemGuard:
         context = MockPipelineContext(tables=[table], candidates=[candidate])
         stage.process(context)  # type: ignore
 
-        assert len(context.bound_values) == 0, (
-            "Adjusted EBITDA Margin stub row must be suppressed"
-        )
+        assert len(context.bound_values) == 0, "Adjusted EBITDA Margin stub row must be suppressed"
 
     def test_accounts_payable_suppressed(self) -> None:
         """Row with stub 'Accounts payable, provisions and other liabilities' is not bound."""
@@ -3993,9 +4062,7 @@ class TestStubFinancialLineItemGuard:
         context = MockPipelineContext(tables=[table], candidates=[candidate])
         stage.process(context)  # type: ignore
 
-        assert len(context.bound_values) == 0, (
-            "Accounts payable stub row must be suppressed"
-        )
+        assert len(context.bound_values) == 0, "Accounts payable stub row must be suppressed"
 
     def test_allow_list_not_suppressed(self) -> None:
         """cm_gross_margin_by_cohort with stub containing 'margin' is NOT suppressed."""

--- a/tests/unit/gold_standard/test_unified_comparison.py
+++ b/tests/unit/gold_standard/test_unified_comparison.py
@@ -88,7 +88,7 @@ def make_metric_fact(
     """Create a minimal MetricFact for testing."""
     return MetricFact(
         fact_id=fact_id,
-        doc_id="doc-1",
+        document_uuid="doc-1",
         canonical_metric_id=canonical_metric_id,
         value=value,
         value_raw=str(value),


### PR DESCRIPTION
## Summary

- Adds migration `202604291308` to rename `doc_id → filing_id` on `v2_segments`, `v2_tables`, `v2_image_assets`, and `v2_metric_definitions` — four tables that share the same BIGINT-named-doc_id smell fixed for `v2_metric_facts` in legacy-038
- Renames `MetricFact.doc_id → document_uuid` (gh-323) to clarify it holds a Document UUID, not a filing_id — the field was never persisted to DB
- Full callsite sweep: `persistence.py`, `db.py`, all extraction stages, 13 scripts, 26 test files
- Semantic fix: `MetricDefinition` was being constructed with `context.document.doc_id` (UUID) where the DB expects a bigint — now correctly passes `context.filing_id`

## Test plan

- [x] Unit tests: 3987 passed
- [x] Integration tests: 169 passed, 56 skipped
- [x] Migration applies cleanly (1 applied to test DB via `apply_all_migrations.py`)
- [x] Lint: ruff clean

Closes #324, closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)