### PR TITLE
feat(image-review): keyboard shortcuts for per-metric actions and undo

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -61,7 +61,7 @@ The unified review UI persists filter/sort/tab state client-side via localStorag
 
 The unified review page (`unified_review.html`) binds shortcuts on both tabs. Cross-tab semantics (next/prev navigation, next-filing) should match — when adding a new button, give it a shortcut from day one and follow the rule below.
 
-**Rule**: image-tab buttons that affect a single detected metric get a single-letter shortcut; bulk/destructive buttons that touch every detected metric on the image at once get a chord (`Shift+key`).
+**Rule**: every keyboard-actionable image-tab button must carry an on-button `<span class="kbd">` badge so the binding is discoverable without opening the help overlay. Per-row single-metric actions use the unmodified single letter (`A`/`R`/`C`/`S`/`U`/`N`/`P`). Bulk image-level actions use either a single dedicated letter (`X` = reject-all, picked for discoverability) or a `Shift+key` chord (`Shift+U` = re-open). Single-letter image-level bindings must not collide with per-row letters; that's why `X` (and not `R`) is the bulk-reject key.
 
 **Text tab** (`unified_review.html:1355–1392`, only active when `active_tab == 'text'`):
 
@@ -84,16 +84,20 @@ The unified review page (`unified_review.html`) binds shortcuts on both tabs. Cr
 | `N` / `P`  | Next / previous image (alias)               |
 | `?` / `H`  | Toggle help overlay                         |
 | `F`        | Next filing                                 |
-| `Shift+R`  | Reject all (no relevant metrics) — chord, fires regardless of row focus |
+| `X`        | Reject all (no relevant metrics) — fires regardless of row focus, triggers `#btn-reject-all-metrics` click |
+| `Shift+R`  | Reject all (deprecated alias for `X`, kept for muscle memory) |
+| `Shift+U`  | Re-open a fully-reviewed image (only effective when `#btn-reopen-image` is rendered) |
 
 **Image tab — per-metric row** (when `state.focusedRow` is set):
 
-| Key       | Action                       |
-|-----------|------------------------------|
-| `A`       | Accept row                   |
-| `R`       | Open reject form             |
-| `C`       | Open correct form            |
-| `S`       | Skip row                     |
-| `N`       | Focus next unreviewed row    |
+| Key       | Action                                                   |
+|-----------|----------------------------------------------------------|
+| `A`       | Accept row                                               |
+| `R`       | Open reject form                                         |
+| `C`       | Open correct form                                        |
+| `S`       | Skip row                                                 |
+| `U`       | Undo this row's decision (no-op + warning toast if none) |
+| `N`       | Focus next unreviewed row                                |
+| `P`       | Focus previous unreviewed row                            |
 
-`Shift+R` is intercepted at image-level before the per-row handler runs, so a focused-row `Shift+R` does not also fire `openReject` on that row.
+`X` and `Shift+R` are intercepted at image-level before the per-row handler's `R` runs (per-row handler returns early on `event.shiftKey`, and has no `X` case). `Shift+U` is intercepted at image-level for re-open; per-row `U` is the unmodified key only. The per-row handler is registered with `useCapture=true` so it sees keys before image-level handlers; it `stopPropagation`s only for keys it handles, letting unhandled keys (including `X`, `Shift+U`, `F`) reach the image-level handler.

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -67,12 +67,29 @@
         if (event.metaKey || event.ctrlKey || event.altKey) return;
         if (state.submitting) return;
 
-        // Shift+R — reject all (no relevant metrics). Fires regardless of
-        // whether a per-metric row is focused, so this check must come before
-        // the focusedRow early-return below.
-        if (event.shiftKey && (event.key === 'R' || event.key === 'r')) {
+        // X (or Shift+R deprecated alias) — reject all (no relevant metrics).
+        // Fires regardless of whether a per-metric row is focused, so this
+        // check must come before the focusedRow early-return below. We trigger
+        // the button click rather than calling rejectAllUnreviewed() directly
+        // because that function lives in the per-metric IIFE (module 2) and
+        // isn't visible from this closure. Plain X is the primary,
+        // on-button-labelled binding.
+        const isRejectAllChord =
+            (event.shiftKey && (event.key === 'R' || event.key === 'r')) ||
+            (!event.shiftKey && (event.key === 'x' || event.key === 'X'));
+        if (isRejectAllChord) {
             event.preventDefault();
-            rejectAllUnreviewed();
+            const btn = document.getElementById('btn-reject-all-metrics');
+            if (btn) btn.click();
+            return;
+        }
+
+        // Shift+U — re-open a fully-reviewed image. The button is only
+        // rendered when review_status == 'reviewed' (template branch); when
+        // it's absent, this is a no-op.
+        if (event.shiftKey && (event.key === 'U' || event.key === 'u')) {
+            event.preventDefault();
+            reopenImage();
             return;
         }
 
@@ -531,6 +548,35 @@
             event.preventDefault();
             event.stopPropagation();
             focusNextUnreviewed(row);
+        } else if (key === 'p') {
+            // Shift+P is unbound; let it propagate.
+            if (event.shiftKey) return;
+            event.preventDefault();
+            event.stopPropagation();
+            focusPrevUnreviewed(row);
+        } else if (key === 'u') {
+            // Shift+U is image-level "re-open" — let it propagate to the
+            // image-level handler.
+            if (event.shiftKey) return;
+            // Per-row undo only makes sense if the row already has a decision
+            // (in-progress in state.decisions, or persisted via confirmationIds).
+            const detected = row.dataset.metricId;
+            const addedKey = row.dataset.addedMetric ? addKey(row.dataset.addedMetric) : null;
+            const lookupKey = addedKey || detected;
+            const hasDecision = lookupKey && (state.decisions[lookupKey] || state.confirmationIds[lookupKey]);
+            if (!hasDecision) {
+                showMetricsToast('No decision to undo on this row', 'warning');
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            if (addedKey) {
+                undoRowByKey(addedKey).then(() => row.remove());
+            } else {
+                undoRow(row);
+            }
         }
     }
 
@@ -674,6 +720,23 @@
         input.value = '';
         const panel = document.getElementById('add-missed-detected-expansion');
         if (panel) panel.style.display = 'none';
+    }
+
+    function focusPrevUnreviewed(current) {
+        const rows = Array.from(document.querySelectorAll(`#${CARD_ID} ${ROW_SELECTOR}:not(.added-metric-row)`));
+        if (!rows.length) return;
+        const idx = rows.indexOf(current);
+        // Walk backwards from current, wrapping around to the end.
+        const before = idx >= 0 ? rows.slice(0, idx).reverse() : [];
+        const after = idx >= 0 ? rows.slice(idx + 1).reverse() : rows.slice().reverse();
+        const order = before.concat(after);
+        for (const row of order) {
+            const mid = row.dataset.metricId;
+            if (!state.decisions[mid]) {
+                row.focus();
+                return;
+            }
+        }
     }
 
     function focusNextUnreviewed(current) {

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -867,7 +867,7 @@
               <button type="button" id="btn-reopen-image" class="btn btn-outline-secondary"
                       data-img-id="{{ current_image.img_id }}"
                       title="Return this image to the pending queue. Prior decisions are preserved.">
-                Re-open for review
+                Re-open for review <span class="kbd ms-1">Shift+U</span>
               </button>
             </div>
           </div>
@@ -879,7 +879,7 @@
               </button>
               <button type="button" id="btn-reject-all-metrics" class="btn btn-outline-danger"
                       title="Mark every unreviewed detected metric as 'not present' on this chart and move to the next image.">
-                Reject all (no relevant metrics)
+                Reject all (no relevant metrics) <span class="kbd ms-1">X</span>
               </button>
             </div>
             <a href="{{ url_for('review_unified.review_filing', filing_id=filing.filing_id, tab='images', image_status=image_filters.status) }}"
@@ -951,7 +951,7 @@
                     </div>
                     <button type="button" class="btn btn-link btn-sm btn-undo-metric ms-2"
                             data-action="undo" style="display: none;">
-                      Undo
+                      Undo <span class="kbd ms-1">U</span>
                     </button>
                   </div>
                   <div class="reject-expansion mt-2" style="display: none;">
@@ -1094,19 +1094,38 @@
   {# Keyboard Hints Bar #}
   <div id="keyboard-hints" class="keyboard-hints-bar d-none">
     <div class="container-fluid">
-      <div class="d-flex justify-content-between align-items-center">
+      <div class="d-flex justify-content-between align-items-start">
         <div class="hints-content">
-          <kbd>S</kbd> Skip
-          <span class="mx-1">|</span>
-          <kbd>U</kbd> Undo
-          <span class="mx-1">|</span>
-          <kbd>&larr;&rarr;</kbd> / <kbd>N</kbd>/<kbd>P</kbd> Navigate
-          <span class="mx-1">|</span>
-          <kbd>Shift+R</kbd> Reject all
-          <span class="mx-1">|</span>
-          <kbd>F</kbd> Next filing
-          <span class="mx-1">|</span>
-          <kbd>?</kbd> Help
+          <div>
+            <strong class="me-2">Image:</strong>
+            <kbd>S</kbd> Skip
+            <span class="mx-1">|</span>
+            <kbd>U</kbd> Undo skip
+            <span class="mx-1">|</span>
+            <kbd>X</kbd> Reject all
+            <span class="mx-1">|</span>
+            <kbd>Shift+U</kbd> Re-open
+            <span class="mx-1">|</span>
+            <kbd>&larr;&rarr;</kbd> / <kbd>N</kbd>/<kbd>P</kbd> Navigate
+            <span class="mx-1">|</span>
+            <kbd>F</kbd> Next filing
+            <span class="mx-1">|</span>
+            <kbd>?</kbd> Help
+          </div>
+          <div class="mt-1">
+            <strong class="me-2">On focused metric row:</strong>
+            <kbd>A</kbd> Accept
+            <span class="mx-1">|</span>
+            <kbd>R</kbd> Reject
+            <span class="mx-1">|</span>
+            <kbd>C</kbd> Correct
+            <span class="mx-1">|</span>
+            <kbd>S</kbd> Skip
+            <span class="mx-1">|</span>
+            <kbd>U</kbd> Undo decision
+            <span class="mx-1">|</span>
+            <kbd>N</kbd>/<kbd>P</kbd> Next/prev metric
+          </div>
         </div>
         <button type="button" class="btn-close btn-close-white btn-sm" id="close-hints" aria-label="Close"></button>
       </div>


### PR DESCRIPTION
Image-tab keyboard shortcuts now mirror the text-tab ergonomics:

- X (and deprecated Shift+R alias) — reject all on the focused image,
  routed through #btn-reject-all-metrics click to side-step the latent
  cross-IIFE scope bug at handleKeydown:73 (rejectAllUnreviewed lives
  in module 2 and was unreachable from module 1's keyboard handler).
- Shift+U — re-open a fully-reviewed image (calls existing reopenImage).
- Per-row P — focus previous unreviewed metric (new focusPrevUnreviewed,
  mirrors focusNextUnreviewed).
- Per-row U — undo this row's decision; warning toast if nothing to undo.

Discoverability: added on-button kbd badges to #btn-reject-all-metrics
(X), #btn-reopen-image (Shift+U), and the per-row Undo button (U).
Restructured the keyboard-hints overlay into Image: vs On focused
metric row: groupings.

Updated .claude/rules/web.md keyboard-shortcut matrix and softened the
bulk-action rule to allow uppercase single letters when discoverability
matters.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
