### PR TITLE
feat(hooks): block repo-wide ruff format + verify docs/README links

### DIFF
--- a/.claude/hooks/ruff-format-scope-guard.sh
+++ b/.claude/hooks/ruff-format-scope-guard.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: block repo-wide `ruff format <dir>` invocations.
+#
+# Why: the repo's existing tree is not uniformly formatted to current ruff
+# defaults. A repo-wide `ruff format src/ tests/` reformats ~90+ files
+# unrelated to the change, ballooning the diff (PR #290 went from 12 → 103
+# files before manual revert). The pre-commit framework's ruff-format hook
+# already targets staged files only — trust that path.
+#
+# Allowed: file-list invocations (`ruff format path/to/file.py`),
+#          piped from staged-files (`xargs ruff format`),
+#          ruff check / ruff check --fix (anything not "ruff format").
+# Blocked: `ruff format src/`, `ruff format tests/`, `ruff format scripts/`,
+#          `ruff format .`, and any combination thereof.
+
+cmd="${CLAUDE_TOOL_INPUT_command:-$1}"
+
+# Match `ruff format` followed by any of: src/, tests/, scripts/, src, tests, scripts, .
+# Whitespace-aware; only triggers when one of these appears as a positional arg.
+if echo "$cmd" | grep -Eq '(^|[^a-zA-Z_-])ruff format([[:space:]]+--[a-z-]+)*[[:space:]]+(src|tests|scripts|\.)/?([[:space:]]|$)'; then
+    cat >&2 <<'EOF'
+BLOCKED: repo-wide `ruff format <dir>` reformats ~90+ unrelated files (the
+repo's tree predates current ruff defaults).
+
+Scope to staged files instead:
+    git diff --cached --name-only --diff-filter=ACMR | grep -E '\.py$' | xargs ruff format
+
+Or rely on the pre-commit framework, which already runs ruff-format on staged
+files only. See feedback_ruff_format_repo_wide_blast_radius (PR #290 incident).
+EOF
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,10 @@
           {
             "type": "command",
             "command": "bash -c 'cmd=\"${CLAUDE_TOOL_INPUT_command:-$1}\"; case \"$cmd\" in *\"git commit\"*) br=$(git -C \"$CLAUDE_PROJECT_DIR\" branch --show-current 2>/dev/null); if [ \"$br\" = \"main\" ] || [ \"$br\" = \"master\" ]; then echo \"BLOCKED: refusing to commit on $br. Use /commit-proj (auto-branches) or git checkout -b <branch> first.\" >&2; exit 2; fi ;; esac' _ \"$CLAUDE_TOOL_INPUT_command\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ruff-format-scope-guard.sh\" \"$CLAUDE_TOOL_INPUT_command\""
           }
         ]
       },

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,15 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
         files: ^(sql/.*\.sql$|scripts/apply_all_migrations\.py$)
+
+      # Pre-commit: verify [text](path.md) links in docs/README.md still
+      # resolve. The README is a navigation table; file moves silently break
+      # links. See feedback_docs_link_check_after_moves (2026-04-27 cleanup
+      # incident: 3 broken links landed on main).
+      - id: docs-readme-links
+        name: docs/README.md broken-link check
+        entry: bash scripts/pre-commit-docs-readme-links.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: ^docs/.*\.md$

--- a/scripts/pre-commit-docs-readme-links.sh
+++ b/scripts/pre-commit-docs-readme-links.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-commit hook: verify every [text](path.md) link in docs/README.md
+# resolves to an existing file under docs/.
+#
+# Why: docs/README.md is a navigation table indexing docs/. File moves don't
+# update the table — links silently 404. Discovered when archiving 40+ files
+# in the 2026-04-27 cleanup left three broken links in main.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)/docs"
+
+if [ ! -f README.md ]; then
+    exit 0  # repo without docs/README.md (shouldn't happen here, but be tolerant)
+fi
+
+broken=0
+# Extract paths from markdown links: [text](path.md), [text](path.md#anchor).
+# Skip http(s):// links and pure anchor links (#section).
+while IFS= read -r raw; do
+    # Strip anchor fragment (#...) for filesystem check
+    path="${raw%%#*}"
+    # Skip empty (pure-anchor link) and external URLs
+    [ -z "$path" ] && continue
+    case "$path" in
+        http://*|https://*) continue ;;
+    esac
+    if [ ! -f "$path" ]; then
+        echo "BROKEN: docs/$path referenced from docs/README.md" >&2
+        broken=1
+    fi
+done < <(grep -oE '\]\([^)]+\.md[^)]*\)' README.md | sed -E 's/^\]\(//; s/\)$//' | sort -u)
+
+exit $broken


### PR DESCRIPTION
Two small structural moves that convert recurring memory-to-recall items
into mechanical guards:

- PreToolUse(Bash) hook: deny `ruff format <dir>` invocations (src/,
  tests/, scripts/, .). The repo's tree predates current ruff defaults,
  so a repo-wide format reformats ~90+ unrelated files (PR #290 went
  from 12 → 103 files before manual revert). File-list invocations and
  the pre-commit framework's staged-files path are unaffected.

- pre-commit hook: verify every [text](path.md) link in docs/README.md
  resolves to an existing file under docs/. Catches the silent-404 case
  when files are moved or archived (2026-04-27 cleanup left 3 broken
  links in main).

Tested both: ruff guard correctly blocks 5 directory-arg variants and
allows 5 file-list / non-format variants; README check correctly fires
on a synthetic broken link and passes on the current tree.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
