### PR TITLE
feat(db): reject non-SELECT writes in db.query with helpful error

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -29,6 +29,36 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _reject_non_select(sql: str) -> None:
+    """Raise ValueError if `sql` is a write that lacks RETURNING.
+
+    `DatabaseAdapter.query` calls `cur.fetchall()` unconditionally; passing a
+    bare INSERT/UPDATE/DELETE produces an opaque
+    `psycopg.ProgrammingError: the last operation didn't produce records`.
+    Catch the misuse here with a message that points at `db.execute`.
+    """
+    # Strip leading whitespace, line comments, and block comments to find the
+    # first SQL token.
+    stripped = sql.lstrip()
+    while True:
+        if stripped.startswith("--"):
+            nl = stripped.find("\n")
+            stripped = stripped[nl + 1 :].lstrip() if nl != -1 else ""
+            continue
+        if stripped.startswith("/*"):
+            end = stripped.find("*/")
+            stripped = stripped[end + 2 :].lstrip() if end != -1 else ""
+            continue
+        break
+    first = stripped.split(None, 1)[0].upper() if stripped else ""
+    if first in ("INSERT", "UPDATE", "DELETE") and "RETURNING" not in sql.upper():
+        raise ValueError(
+            f"db.query is SELECT-only (got {first} without RETURNING). "
+            "Use db.execute(sql, params) for non-fetching writes, or add "
+            "RETURNING to fetch result rows."
+        )
+
+
 # Analytical tab → SQL fragment. Tabs are the UI grouping (IPO vs Earnings vs
 # Investor Day) and combine `v2_documents.document_type` with `filings.form_type`.
 # Keys are validated server-side before use — fragments are string-constant SQL,
@@ -454,7 +484,14 @@ class DatabaseAdapter:
 
         Returns:
             List of result rows as dictionaries
+
+        Raises:
+            ValueError: if `sql` is a non-fetching write (INSERT/UPDATE/DELETE
+                without RETURNING). Use `db.execute()` for those — `query`
+                calls `cur.fetchall()` unconditionally and would otherwise
+                surface as an opaque `psycopg.ProgrammingError`.
         """
+        _reject_non_select(sql)
         result = self.execute(sql, params, fetch=True)
         return result or []
 

--- a/tests/unit/infra/test_db_query_select_only.py
+++ b/tests/unit/infra/test_db_query_select_only.py
@@ -1,0 +1,52 @@
+"""Unit tests for the SELECT-only guard on DatabaseAdapter.query.
+
+Catches the easy misuse where a developer reaches for `db.query` for an
+INSERT/UPDATE/DELETE and gets an opaque psycopg error instead of a useful
+"use db.execute" message. See `_reject_non_select` in src/infra/db.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.infra.db import _reject_non_select
+
+
+class TestRejectNonSelect:
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT * FROM filings",
+            "  SELECT 1",
+            "SELECT id FROM v2_documents WHERE doc_id = %(id)s",
+            "WITH x AS (SELECT 1) SELECT * FROM x",
+            "INSERT INTO t (a) VALUES (1) RETURNING id",
+            "UPDATE t SET a = 1 WHERE id = 2 RETURNING *",
+            "DELETE FROM t WHERE id = 3 RETURNING id",
+            "-- a leading comment\nSELECT 1",
+            "/* block */ SELECT 1",
+            "",
+        ],
+    )
+    def test_allowed_statements(self, sql: str) -> None:
+        # Should not raise
+        _reject_non_select(sql)
+
+    @pytest.mark.parametrize(
+        ("sql", "verb"),
+        [
+            ("INSERT INTO t (a) VALUES (1)", "INSERT"),
+            ("  insert into t values (1)", "INSERT"),
+            ("UPDATE t SET a = 1 WHERE id = 2", "UPDATE"),
+            ("DELETE FROM t WHERE id = 3", "DELETE"),
+            ("-- comment\nINSERT INTO t (a) VALUES (1)", "INSERT"),
+            ("/* leading block */\nUPDATE t SET a = 1", "UPDATE"),
+        ],
+    )
+    def test_blocked_statements(self, sql: str, verb: str) -> None:
+        with pytest.raises(ValueError, match=f"SELECT-only.*{verb}"):
+            _reject_non_select(sql)
+
+    def test_error_message_points_to_execute(self) -> None:
+        with pytest.raises(ValueError, match=r"db\.execute"):
+            _reject_non_select("DELETE FROM t WHERE id = 1")


### PR DESCRIPTION
DatabaseAdapter.query() calls cur.fetchall() unconditionally, so passing a
plain INSERT/UPDATE/DELETE (without RETURNING) surfaces as the opaque
psycopg.ProgrammingError "the last operation didn't produce records",
which costs at least one debug cycle to diagnose. The mistake is easy
because db.query is the most-used method when writing test fixtures.

Add a small _reject_non_select() helper that inspects the leading SQL
token (after stripping whitespace, line comments, and block comments)
and raises ValueError with a pointer to db.execute() when the verb is
INSERT/UPDATE/DELETE and RETURNING is absent. SELECTs, CTEs, and
RETURNING-bearing writes are unaffected.

17 unit tests cover allowed forms (SELECT, CTE, RETURNING-bearing
writes, leading comments, empty string) and blocked forms (bare
INSERT/UPDATE/DELETE, leading-comment variants).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
