### PR TITLE
docs(CLAUDE.md): document how to patch an existing PR branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Source lives in `src/` (infra, universe, filing_fetcher, extraction_v2, review, 
 
 **Planning rule.** For any plan touching 3+ files or new deps / config, make worktree setup (`EnterWorktree` or `ccw <branch>`) the first step. The `/commit-proj` skill assumes you're in one.
 
+**Patching an existing PR branch:** do not use `EnterWorktree` — it always creates a new branch at the current HEAD. Instead, from within any worktree: `git fetch origin <branch>`, then `git checkout -b <local> origin/<branch>`, fix, and `git push origin <local>:<remote-branch> --force-with-lease`.
+
 Required status checks: **Lint**, **Unit Tests**, **Vulnerability Scan**, **Integration Tests**, **UI E2E (Playwright)**. Use `/ci-fix` when checks fail; `/merge-check` for a manual pre-merge sweep.
 
 Local guards (`.claude/settings.json`): `git push origin main`, `git push --force*`, and `gh pr merge --admin*` are denied. A PreToolUse hook refuses `git commit` on `main`. Pre-commit framework (`make hooks-install`) runs ruff + the Tier-1 regression / docs-folder guard on every commit.


### PR DESCRIPTION
## Summary

- Adds a **Patching an existing PR branch** note to the Workflow section of CLAUDE.md
- `EnterWorktree` always creates a new branch at HEAD — wrong tool when the goal is to fix a CI failure on an existing PR's remote branch
- Documents the correct pattern: `git fetch origin <branch>`, checkout a local tracking branch, fix, `git push ... --force-with-lease`

## Motivation

PR #339 fix session: used `EnterWorktree` to patch a blocked PR, ended up on the wrong branch, wasted several turns diagnosing the mismatch. A one-line doc note in the right place prevents this.

## Test plan

- [x] Docs-only change — no code, tests, or migrations affected
- [x] Pre-commit hooks passed (ruff skipped for docs-only, extraction guard passed)
- [x] Pre-push unit tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)