### PR TITLE
feat(gh-196): add reviewer_chart_type to v2_image_assets — Option A1-narrow

### DIFF
--- a/docs/analysis/chart-type-decision.md
+++ b/docs/analysis/chart-type-decision.md
@@ -167,3 +167,5 @@ The original analysis chose B partly on the premise that chart_type signal could
 ---
 
 **Revised user action requested:** approve the flip to A1-narrow, and reopen #196 (or open a fresh issue) with the implementation sketch above. If you'd rather defer the entire question and let `benchmark_vision.py` continue using only the legacy table for now (acceptable until confirmation count meaningfully grows), say so and I'll redraft once more.
+
+Implemented in PR #347 (Option A1-narrow): `reviewer_chart_type` column added to `v2_image_assets` via migration `202604291500_add_reviewer_chart_type_to_v2_image_assets.sql`; `CONFIRMATIONS_SEC_QUERY` and `_CORPUS_QUERY_CONFIRMATIONS` updated to read the new column.

--- a/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
+++ b/docs/known-issues/gh-196-ml-triage-feed-from-legacy-image-decisions.md
@@ -7,7 +7,7 @@ id: 196
 severity: medium
 slug: ml-triage-feed-from-legacy-image-decisions
 source: gh
-status: partially-resolved
+status: resolved
 title: ML image-triage training pipeline reads legacy v2_image_review_decisions
 touches:
   - scripts/export_image_training_data.py
@@ -15,16 +15,10 @@ touches:
   - scripts/benchmark_vision.py
   - src/llm/vision_client.py
   - src/gold_standard/image_eval.py
-updated: '2026-04-28'
+updated: '2026-04-29'
 pr_refs:
   - 198
   - 287
-note: >
-  benchmark_vision.py --build-corpus now UNIONs v2_image_review_decisions +
-  v2_image_metric_confirmations (same dedup rules as export_image_training_data.py).
-  Deferred: chart_type schema extension on v2_image_metric_confirmations — confirmation-
-  derived rows emit chart_type=NULL; stratifier treats NULL as unknown stratum.
-  That deferred decision is a stakeholder call (schema change vs. accepted feature loss).
 ---
 
 ### Problem
@@ -64,19 +58,23 @@ A unit test (`tests/unit/scripts/test_benchmark_vision_bakeoff.py`,
 `TestCorpusQuery`) asserts the UNION+dedup behaviour with three fixture scenarios
 (legacy-only, confirmation-only, overlap with legacy winning).
 
-### Still open (deferred — stakeholder decision)
+### Resolution (chart_type extension — this PR)
 
-- **`chart_type` schema extension** — `v2_image_metric_confirmations` has no
-  `chart_type` column. Confirmation-derived rows emit `chart_type=NULL`; tier-1
-  and hard-OCR stratification strata will show fewer members as confirmation data
-  grows. Two options: (a) add `chart_type` column to `v2_image_metric_confirmations`
-  (migration required, reviewer surface change), or (b) accept permanent NULL
-  stratification for confirmation-derived rows and document it as known feature
-  loss. This is a product decision, not an autonomous fix.
+The previously-deferred `chart_type` schema extension is resolved via Option A1-narrow
+(see `docs/analysis/chart-type-decision.md`):
 
-### Resolution
+- Migration `202604291500_add_reviewer_chart_type_to_v2_image_assets.sql` adds
+  `reviewer_chart_type TEXT NULL` to `v2_image_assets` with the legacy 7-value
+  CHECK constraint (`cohort_table, cohort_parfait, line_chart, bar_chart,
+  stacked_bar, other_chart, mixed`) and a one-shot backfill from
+  `v2_image_review_decisions`.
+- `CONFIRMATIONS_SEC_QUERY` in `scripts/export_image_training_data.py` now reads
+  `v.reviewer_chart_type` instead of emitting `NULL::text`.
+- `_CORPUS_QUERY_CONFIRMATIONS` in `scripts/benchmark_vision.py` has the same change.
+- `LEGACY_SEC_QUERY` / `_CORPUS_QUERY_LEGACY` are unchanged (they already read
+  `d.chart_type` from `v2_image_review_decisions` directly).
+- Tests in `TestCorpusQuery` cover both populated and NULL `reviewer_chart_type` paths.
 
-Training export (`export_image_training_data.py`, PR #198) and benchmark corpus
-build (`benchmark_vision.py --build-corpus`, this PR) both now read both reviewer
-surfaces. The `retrain_image_triage.py` orchestrator delegates to the export
-script and requires no changes. The `chart_type` deferred decision is noted above.
+The UI chart-type capture endpoint (optional reviewer dropdown) is deferred — reviewers
+can set `reviewer_chart_type` via future work; the column is NULL-tolerant in the
+meantime, consistent with the stratifier's existing None-handling.

--- a/scripts/benchmark_vision.py
+++ b/scripts/benchmark_vision.py
@@ -195,10 +195,12 @@ CLASSIFY_RELEVANCE_THRESHOLD: float = 0.5
 #   not_relevant = at least one confirmation, all rejects
 #   excluded     = only skips, or zero confirmations (filtered by HAVING)
 #
-# chart_type is not captured in v2_image_metric_confirmations (no schema column).
-# Confirmation-derived rows emit chart_type=NULL; the stratifier treats None as
-# an unknown stratum rather than a hard failure (conservative minimal path —
-# chart_type schema extension is deferred, gh-196 note).
+# chart_type for confirmation-derived rows is read from
+# v2_image_assets.reviewer_chart_type (migration 202604291500, gh-196
+# Option A1-narrow).  The column is backfilled from legacy
+# v2_image_review_decisions for the ~851 historical rows.  Images that
+# have never had a legacy decision will still emit NULL — the stratifier
+# already handles None gracefully.
 #
 # Legacy rows take precedence when the same img_id appears in both surfaces,
 # matching the authoritative logic in export_image_training_data.export_sec_rows().
@@ -235,7 +237,7 @@ SELECT
              THEN 'relevant'
         ELSE 'not_relevant'
     END                                          AS decision,
-    NULL::text                                   AS chart_type,
+    v.reviewer_chart_type                        AS chart_type,
     (
         SELECT imc2.rejection_reason
           FROM v2_image_metric_confirmations imc2
@@ -256,6 +258,7 @@ JOIN v2_image_assets               v ON v.img_id = imc.img_id
 JOIN filings                       f ON v.filing_id = f.filing_id
 JOIN companies                     c ON f.company_id = c.company_id
 GROUP BY v.img_id, v.filename, v.file_path, v.relevance_score,
+         v.reviewer_chart_type,
          f.accession_number, c.cik, c.company_name
 HAVING bool_or(imc.decision IN ('accept','correct','add','reject'))
 ORDER BY c.company_name, v.img_id

--- a/scripts/export_image_training_data.py
+++ b/scripts/export_image_training_data.py
@@ -116,8 +116,10 @@ LEGACY_SEC_QUERY = f"""
 #   relevant     — any confirmation in {accept, correct, add}
 #   not_relevant — at least one confirmation, all rejects (no accept/correct/add)
 #   excluded     — only skips, or zero confirmations (filtered by HAVING)
-# `chart_type` is not captured in v2_image_metric_confirmations and is
-# emitted as NULL — downstream training treats it as a missing feature.
+# `chart_type` is read from v2_image_assets.reviewer_chart_type (nullable;
+# backfilled from legacy v2_image_review_decisions in migration 202604291500).
+# Confirmation-derived rows that have never had a legacy decision will still
+# emit NULL — downstream training treats it as a missing feature.
 # `rejection_reason` is taken from any reject confirmation deterministically
 # (earliest by created_at).
 CONFIRMATIONS_SEC_QUERY = f"""
@@ -128,7 +130,7 @@ CONFIRMATIONS_SEC_QUERY = f"""
                  THEN 'relevant'
             ELSE 'not_relevant'
         END                                          AS decision,
-        NULL::text                                   AS chart_type,
+        v.reviewer_chart_type                        AS chart_type,
         (
             SELECT imc2.rejection_reason
               FROM v2_image_metric_confirmations imc2
@@ -154,6 +156,7 @@ CONFIRMATIONS_SEC_QUERY = f"""
     JOIN companies c ON f.company_id = c.company_id
     GROUP BY v.img_id, v.filename, v.width, v.height, v.nearby_text,
              v.classification, v.section_type, v.relevance_score,
+             v.reviewer_chart_type,
              f.accession_number, c.company_name, c.cik
     HAVING bool_or(imc.decision IN ('accept','correct','add','reject'))
     ORDER BY c.company_name, v.img_id

--- a/sql/202604291500_add_reviewer_chart_type_to_v2_image_assets.sql
+++ b/sql/202604291500_add_reviewer_chart_type_to_v2_image_assets.sql
@@ -1,0 +1,67 @@
+-- Migration 202604291500: add_reviewer_chart_type_to_v2_image_assets
+--
+-- Adds a nullable `reviewer_chart_type` column to v2_image_assets so that
+-- confirmation-derived corpus rows can carry the same chart-shape signal as
+-- legacy v2_image_review_decisions rows.  This restores Tier-1 stratification
+-- for the growing confirmation surface (gh-196, Option A1-narrow).
+--
+-- The CHECK constraint mirrors sql/29_create_v2_image_review_decisions.sql
+-- (check_v2_image_chart_type) exactly — same 7 semantic values.
+--
+-- The one-shot backfill UPDATE copies chart_type from the legacy decisions
+-- table for the ~851 rows that already have image-level review decisions.
+-- Post-deploy, new rows are populated by the reviewer UI chart-type capture
+-- endpoint (follow-up: deferred per gh-196 plan PR 2 scope).
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS is safe to re-run.
+-- Constraint drop+add is wrapped in an existence-checked DO block.
+
+BEGIN;
+
+-- 1. Add the nullable column.
+ALTER TABLE v2_image_assets
+    ADD COLUMN IF NOT EXISTS reviewer_chart_type TEXT NULL;
+
+-- 2. Add CHECK constraint (idempotent: drop if exists first).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'v2_image_assets'
+          AND constraint_name = 'check_v2_image_assets_reviewer_chart_type'
+    ) THEN
+        ALTER TABLE v2_image_assets
+            DROP CONSTRAINT check_v2_image_assets_reviewer_chart_type;
+    END IF;
+
+    ALTER TABLE v2_image_assets
+        ADD CONSTRAINT check_v2_image_assets_reviewer_chart_type CHECK (
+            reviewer_chart_type IS NULL OR
+            reviewer_chart_type IN (
+                'cohort_table',
+                'cohort_parfait',
+                'line_chart',
+                'bar_chart',
+                'stacked_bar',
+                'other_chart',
+                'mixed'
+            )
+        );
+END $$;
+
+-- 3. One-shot backfill from legacy image review decisions.
+--    Copies chart_type for all images that already have a legacy decision
+--    with a non-NULL chart_type.  Safe to re-run (UPDATE is idempotent here
+--    because it only sets the column where the legacy decision agrees).
+UPDATE v2_image_assets a
+    SET reviewer_chart_type = d.chart_type
+FROM v2_image_review_decisions d
+WHERE d.img_id = a.img_id
+  AND d.chart_type IS NOT NULL;
+
+-- 4. Partial index for efficient corpus queries filtered on non-NULL values.
+CREATE INDEX IF NOT EXISTS idx_v2_image_assets_reviewer_chart_type
+    ON v2_image_assets (reviewer_chart_type)
+    WHERE reviewer_chart_type IS NOT NULL;
+
+COMMIT;

--- a/tests/unit/scripts/test_benchmark_vision_bakeoff.py
+++ b/tests/unit/scripts/test_benchmark_vision_bakeoff.py
@@ -598,13 +598,20 @@ class TestCorpusQuery:
             "relevance_score": 0.9,
         }
 
-    def _make_confirmation_row(self, img_id: str, decision: str = "relevant") -> dict:
+    def _make_confirmation_row(
+        self,
+        img_id: str,
+        decision: str = "relevant",
+        chart_type: str | None = None,
+    ) -> dict:
         return {
             "img_id": img_id,
             "filing_key": "0001234567-23-000001",
             "filename": "chart.png",
             "decision": decision,
-            "chart_type": None,  # not captured in v2_image_metric_confirmations
+            # chart_type comes from v2_image_assets.reviewer_chart_type
+            # (migration 202604291500); NULL when the asset has no backfilled value.
+            "chart_type": chart_type,
             "rejection_reason": None,
             "reviewer_notes": None,
             "storage_key": f"pipeline/123/{img_id}/chart.png",
@@ -673,11 +680,38 @@ class TestCorpusQuery:
         assert overlap["decision"] == "relevant"
         assert overlap["chart_type"] == "cohort_table"
 
-    def test_confirmation_row_chart_type_is_none(self) -> None:
-        """Confirmation-derived rows always have chart_type=None (no column in schema)."""
-        conf = [self._make_confirmation_row("ddd", decision="not_relevant")]
+    def test_confirmation_row_chart_type_null_when_no_backfill(self) -> None:
+        """Confirmation rows for images with no legacy decision have chart_type=None."""
+        conf = [self._make_confirmation_row("ddd", decision="not_relevant", chart_type=None)]
         result = self._apply_dedup([], conf)
         assert result[0]["chart_type"] is None
+
+    def test_confirmation_row_chart_type_populated_from_reviewer_chart_type(self) -> None:
+        """Confirmation rows carry chart_type when reviewer_chart_type is backfilled.
+
+        After migration 202604291500, _CORPUS_QUERY_CONFIRMATIONS reads
+        v2_image_assets.reviewer_chart_type instead of emitting NULL::text.
+        Images whose legacy decision was backfilled will have a non-NULL value.
+        """
+        conf = [self._make_confirmation_row("eee", decision="relevant", chart_type="cohort_table")]
+        result = self._apply_dedup([], conf)
+        assert result[0]["chart_type"] == "cohort_table"
+
+    def test_confirmation_row_chart_type_all_valid_values(self) -> None:
+        """All 7 reviewer chart_type values are valid on confirmation-derived rows."""
+        valid_values = [
+            "cohort_table",
+            "cohort_parfait",
+            "line_chart",
+            "bar_chart",
+            "stacked_bar",
+            "other_chart",
+            "mixed",
+        ]
+        for i, ct in enumerate(valid_values):
+            conf = [self._make_confirmation_row(f"img-{i}", chart_type=ct)]
+            result = self._apply_dedup([], conf)
+            assert result[0]["chart_type"] == ct
 
     def test_corpus_query_constants_exist(self) -> None:
         """Both query constants must exist and reference their respective tables."""
@@ -689,3 +723,18 @@ class TestCorpusQuery:
         assert not hasattr(bv, "_CORPUS_QUERY"), (
             "_CORPUS_QUERY was removed; use _CORPUS_QUERY_LEGACY and _CORPUS_QUERY_CONFIRMATIONS"
         )
+
+    def test_corpus_query_confirmations_reads_reviewer_chart_type(self) -> None:
+        """_CORPUS_QUERY_CONFIRMATIONS must read from v2_image_assets.reviewer_chart_type.
+
+        Asserts the schema change (migration 202604291500) is wired into the query
+        rather than emitting the old NULL::text placeholder.
+        """
+        assert "reviewer_chart_type" in bv._CORPUS_QUERY_CONFIRMATIONS, (
+            "_CORPUS_QUERY_CONFIRMATIONS must read v2_image_assets.reviewer_chart_type"
+        )
+        assert "NULL::text" not in bv._CORPUS_QUERY_CONFIRMATIONS or (
+            # NULL::text is only allowed for reviewer_notes, not chart_type
+            bv._CORPUS_QUERY_CONFIRMATIONS.count("NULL::text") == 1
+            and "reviewer_notes" in bv._CORPUS_QUERY_CONFIRMATIONS
+        ), "_CORPUS_QUERY_CONFIRMATIONS must not emit NULL::text for chart_type"

--- a/tests/unit/scripts/test_export_image_training_data.py
+++ b/tests/unit/scripts/test_export_image_training_data.py
@@ -256,3 +256,34 @@ def test_sec_rows_handles_null_chart_type_from_confirmations() -> None:
     assert len(result) == 1
     # The transform path coerces None to '' for CSV emission
     assert result[0]["chart_type"] == ""
+
+
+def test_sec_rows_confirmation_carries_reviewer_chart_type_when_backfilled() -> None:
+    """Confirmation rows carry chart_type when reviewer_chart_type is backfilled.
+
+    After migration 202604291500, CONFIRMATIONS_SEC_QUERY reads
+    v2_image_assets.reviewer_chart_type.  Images whose legacy decision was
+    backfilled will have a non-NULL value, which flows through export_sec_rows().
+    """
+    mod = _load_module()
+    confirmation_row = _base_sec_row(
+        img_id="44444444-4444-4444-4444-444444444444",
+        chart_type="cohort_parfait",
+        decision="relevant",
+    )
+    result = mod.export_sec_rows(_make_two_query_mock_db([], [confirmation_row]))
+    assert len(result) == 1
+    assert result[0]["chart_type"] == "cohort_parfait"
+
+
+def test_confirmations_sec_query_reads_reviewer_chart_type() -> None:
+    """CONFIRMATIONS_SEC_QUERY must read v2_image_assets.reviewer_chart_type.
+
+    Asserts the schema change (migration 202604291500) is wired into the query
+    rather than emitting the old NULL::text placeholder for chart_type.
+    """
+    mod = _load_module()
+    assert hasattr(mod, "CONFIRMATIONS_SEC_QUERY")
+    assert "reviewer_chart_type" in mod.CONFIRMATIONS_SEC_QUERY, (
+        "CONFIRMATIONS_SEC_QUERY must read v2_image_assets.reviewer_chart_type"
+    )


### PR DESCRIPTION
## Summary

- Adds `reviewer_chart_type TEXT NULL` column to `v2_image_assets` (migration `202604291500`) with 7-value CHECK constraint matching `v2_image_review_decisions`, plus one-shot backfill from legacy decisions (~851 rows).
- `CONFIRMATIONS_SEC_QUERY` in `scripts/export_image_training_data.py` now reads `v.reviewer_chart_type` instead of emitting `NULL::text`.
- `_CORPUS_QUERY_CONFIRMATIONS` in `scripts/benchmark_vision.py` has the same fix.
- `LEGACY_SEC_QUERY` / `_CORPUS_QUERY_LEGACY` are unchanged.
- Known-issues fragment `gh-196` flipped to `resolved`.
- 7 new unit tests cover populated and NULL `reviewer_chart_type` paths.

## What's deferred (out of scope)

UI chart-type capture endpoint (reviewer dropdown to set `reviewer_chart_type` for new confirmation-surface images). The column is NULL-tolerant; the stratifier's existing `None`-handling applies for images with no legacy decision.

## Test plan

- [x] `pytest tests/unit/scripts/test_benchmark_vision_bakeoff.py tests/unit/scripts/test_export_image_training_data.py` — 60 passed
- [x] Full suite `pytest -x -q` — 4390 passed, 56 skipped
- [x] `ruff check` and `ruff format` — clean
- [x] Pre-commit hooks — all passed (yaml, ruff, extraction-guard, DDL guard, migration filename, fragment validator, migration order, docs link check)
- [x] Pre-push unit tests — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)