### PR TITLE
refactor: rename doc_id → filing_id on v2_text_metric_presence (closes #338)

### DIFF
--- a/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
+++ b/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
@@ -3,9 +3,9 @@ id: 338
 source: gh
 slug: v2-text-metric-presence-doc-id-rename
 title: v2_text_metric_presence.doc_id should be renamed to filing_id
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: S
 touches:
 - sql/*.sql
@@ -14,6 +14,7 @@ touches:
 discovered: '2026-04-29'
 updated: '2026-04-29'
 gh_issue: 338
+pr_refs: []
 note: doc_id is BIGINT FK to filings(filing_id) — same naming smell fixed in gh-324 for four other v2 tables.
 ---
 
@@ -33,3 +34,14 @@ uuid = bigint" bug class for any future cross-join with `v2_documents.doc_id`.
 - Sweep callsites in `src/extraction_v2/persistence.py`
   (`_persist_text_metric_presence_in_tx`), tests
   (`test_presence_persistence.py`), and any scripts querying the table directly.
+
+### Resolution
+
+Resolved by migration `sql/202604291517_rename_doc_id_to_filing_id_on_v2_text_metric_presence.sql`
+(idempotency-guarded via `information_schema`; renames index
+`idx_v2_text_metric_presence_doc` → `idx_v2_text_metric_presence_filing`).
+
+Callsites updated:
+- `src/extraction_v2/persistence.py` — INSERT column, value placeholder, ON CONFLICT key, dict key in `_persist_text_metric_presence_in_tx`
+- `tests/integration/extraction_v2/test_presence_persistence.py` — DELETE/SELECT SQL and `_read_presences` function parameter
+- `tests/integration/extraction_v2/test_persistence_guard.py` — `_presence_count` SELECT, `_purge_presence` DELETE, and upsert-key comment

--- a/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
+++ b/docs/known-issues/gh-338-v2-text-metric-presence-doc-id-rename.md
@@ -14,7 +14,8 @@ touches:
 discovered: '2026-04-29'
 updated: '2026-04-29'
 gh_issue: 338
-pr_refs: []
+pr_refs:
+- 348
 note: doc_id is BIGINT FK to filings(filing_id) — same naming smell fixed in gh-324 for four other v2 tables.
 ---
 

--- a/sql/202604291517_rename_doc_id_to_filing_id_on_v2_text_metric_presence.sql
+++ b/sql/202604291517_rename_doc_id_to_filing_id_on_v2_text_metric_presence.sql
@@ -1,0 +1,21 @@
+-- Migration 202604291517: rename doc_id → filing_id on v2_text_metric_presence
+--
+-- BIGINT FK to filings(filing_id) was named doc_id — same naming smell fixed
+-- for v2_segments, v2_tables, v2_image_assets, v2_metric_definitions in
+-- migration 202604291308 (gh-324). Idempotent: information_schema guard.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v2_text_metric_presence' AND column_name = 'doc_id'
+  ) THEN
+    ALTER TABLE v2_text_metric_presence RENAME COLUMN doc_id TO filing_id;
+  END IF;
+END $$;
+
+ALTER INDEX IF EXISTS idx_v2_text_metric_presence_doc RENAME TO idx_v2_text_metric_presence_filing;
+
+COMMIT;

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -760,7 +760,7 @@ class V2PersistenceAdapter:
         cur.executemany(
             """
             INSERT INTO v2_text_metric_presence (
-                doc_id,
+                filing_id,
                 canonical_metric_id,
                 score,
                 detected_at_stage,
@@ -771,7 +771,7 @@ class V2PersistenceAdapter:
                 created_at,
                 updated_at
             ) VALUES (
-                %(doc_id)s,
+                %(filing_id)s,
                 %(canonical_metric_id)s,
                 %(score)s,
                 %(detected_at_stage)s,
@@ -782,7 +782,7 @@ class V2PersistenceAdapter:
                 NOW(),
                 NOW()
             )
-            ON CONFLICT (doc_id, canonical_metric_id) DO UPDATE SET
+            ON CONFLICT (filing_id, canonical_metric_id) DO UPDATE SET
                 score = EXCLUDED.score,
                 detected_at_stage = EXCLUDED.detected_at_stage,
                 evidence_segment_ids = EXCLUDED.evidence_segment_ids,
@@ -793,7 +793,7 @@ class V2PersistenceAdapter:
             """,
             [
                 {
-                    "doc_id": filing_id,
+                    "filing_id": filing_id,
                     "canonical_metric_id": p.canonical_metric_id,
                     "score": p.score,
                     "detected_at_stage": p.detected_at_stage,

--- a/tests/integration/extraction_v2/test_persistence_guard.py
+++ b/tests/integration/extraction_v2/test_persistence_guard.py
@@ -841,7 +841,7 @@ def _presence_count(db: DatabaseAdapter, filing_id: int) -> int:
     with db.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT COUNT(*) AS n FROM v2_text_metric_presence WHERE doc_id = %s",
+                "SELECT COUNT(*) AS n FROM v2_text_metric_presence WHERE filing_id = %s",
                 (filing_id,),
             )
             return int(cur.fetchone()["n"])
@@ -866,13 +866,13 @@ class TestPresenceOnlyMode:
     def _purge_presence(self, db_adapter: DatabaseAdapter, test_filing_id: int):
         with db_adapter.get_connection() as conn, conn.cursor() as cur:
             cur.execute(
-                "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                "DELETE FROM v2_text_metric_presence WHERE filing_id = %s",
                 (test_filing_id,),
             )
         yield
         with db_adapter.get_connection() as conn, conn.cursor() as cur:
             cur.execute(
-                "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                "DELETE FROM v2_text_metric_presence WHERE filing_id = %s",
                 (test_filing_id,),
             )
 
@@ -926,7 +926,7 @@ class TestPresenceOnlyMode:
         r1 = persistence_adapter.persist_pipeline_result(result, test_filing_id, presence_only=True)
         assert r1.success and r1.presences_upserted == 1
 
-        # Re-run with updated score — upsert on (doc_id, metric_id).
+        # Re-run with updated score — upsert on (filing_id, canonical_metric_id).
         p2 = MetricPresence(
             canonical_metric_id="cm_a", score=0.8, detected_at_stage="fact_construction"
         )
@@ -937,7 +937,7 @@ class TestPresenceOnlyMode:
 
         with db_adapter.get_connection() as conn, conn.cursor() as cur:
             cur.execute(
-                "SELECT score FROM v2_text_metric_presence WHERE doc_id = %s",
+                "SELECT score FROM v2_text_metric_presence WHERE filing_id = %s",
                 (test_filing_id,),
             )
             assert cur.fetchone()["score"] == 0.8

--- a/tests/integration/extraction_v2/test_presence_persistence.py
+++ b/tests/integration/extraction_v2/test_presence_persistence.py
@@ -2,7 +2,7 @@
 Integration test: round-trip MetricPresence through v2_text_metric_presence.
 
 Verifies _persist_presence_in_tx writes rows via the pipeline-result path,
-re-runs are idempotent (UPSERT on (doc_id, canonical_metric_id)), and the
+re-runs are idempotent (UPSERT on (filing_id, canonical_metric_id)), and the
 upsert never touches v2_metric_facts or v2_review_decisions. The
 presence_only=True mode is exercised in test_persistence_guard.py alongside
 the existing fact/image guard suite.
@@ -79,7 +79,7 @@ def _cleanup(db_adapter: DatabaseAdapter, test_filing_id: int):
         with db_adapter.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "DELETE FROM v2_text_metric_presence WHERE doc_id = %s",
+                    "DELETE FROM v2_text_metric_presence WHERE filing_id = %s",
                     (test_filing_id,),
                 )
 
@@ -118,7 +118,7 @@ def _make_pipeline_result(presences: list[MetricPresence]) -> PipelineResult:
     )
 
 
-def _read_presences(db: DatabaseAdapter, doc_id: int) -> list[dict]:
+def _read_presences(db: DatabaseAdapter, filing_id: int) -> list[dict]:
     with db.get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -127,10 +127,10 @@ def _read_presences(db: DatabaseAdapter, doc_id: int) -> list[dict]:
                        evidence_segment_ids, advisory_value_count, advisory_fact_ids,
                        pipeline_version
                   FROM v2_text_metric_presence
-                 WHERE doc_id = %s
+                 WHERE filing_id = %s
                  ORDER BY canonical_metric_id
                 """,
-                (doc_id,),
+                (filing_id,),
             )
             return [dict(row) for row in cur.fetchall()]
 


### PR DESCRIPTION
Same naming smell fixed for v2_segments, v2_tables, v2_image_assets, and
v2_metric_definitions in gh-324. Idempotent migration 202604291517 renames
the column and its index. Callsites updated in persistence.py and both
integration test files.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
