### PR TITLE
feat(review): one-click reject-all on image review

### DIFF
--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -901,7 +901,6 @@
         });
 
         let decisions;
-        let confirmMessage;
         if (targets.length === 0 && state.detectedMetrics.length === 0) {
             decisions = [{
                 detected_metric_id: null,
@@ -909,7 +908,6 @@
                 decision: 'reject',
                 rejection_reason: 'no_relevant_metrics',
             }];
-            confirmMessage = 'Mark this image as having no relevant metrics, and skip it?';
         } else if (targets.length === 0) {
             showMetricsToast('Already fully decided — every detected metric is accepted or corrected', 'warning');
             return;
@@ -919,13 +917,7 @@
                 decision: 'reject',
                 rejection_reason: 'not_present',
             }));
-            confirmMessage =
-                `Reject all ${targets.length} unreviewed metric${targets.length === 1 ? '' : 's'} on this image as 'not present', ` +
-                `and skip the image? Existing Accept/Correct decisions will be kept.`;
         }
-
-        const ok = window.confirm(confirmMessage);
-        if (!ok) return;
 
         const reviewerName = (typeof window.requireReviewerName === 'function')
             ? window.requireReviewerName()


### PR DESCRIPTION
Removes the window.confirm() prompt from rejectAllUnreviewed() in
review_images_v2.js. The reject-all action (button + Shift+R chord)
now submits immediately. Undo paths are unaffected: per-metric reject
rows are undone via the existing per-row undo (DELETE
/api/v2/image-metric-confirmations/<id>), and the chained image /skip
is undone via the existing U shortcut / Undo Skip button. The
zero-detected-metrics sentinel row is also deleted cleanly by the same
DELETE handler.
