### PR TITLE
fix: restore unreachable Statistics page in unified review UI

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -25,6 +25,8 @@ paths:
 HTML templates in `src/web/templates/`. Base: `base.html`. Unified V2 templates: `unified_filing_list.html`, `unified_review.html`, `unified_stats.html`.
 Static: `src/web/static/js/review_images_v2.js`, `static/css/review.css`.
 
+The Statistics page (`unified_stats.html`, `review_unified.stats` → `/v2/review/stats`) renders text-fact totals / confidence bands / per-company progress (`get_v2_review_stats`) and image per-tier precision + rejection-reason × tier (`get_image_decision_overall_v2` / `get_image_decisions_by_tier_v2` / `get_image_rejection_reasons_by_tier_v2`). The legacy `v2_image_review_decisions`-based panels (avg review time, daily activity, chart-type distribution) were removed when the per-metric pivot landed. The route is intentionally fail-loud: a DB-method regression must surface as a 500, not a flash + redirect (the prior swallow-and-redirect masked five missing methods for months).
+
 ## Reviewer identity invariant
 
 **Every decision-persisting API endpoint MUST (a) forward `reviewer_id` to the DB write and (b) reject missing / blocklisted values via `_require_reviewer_id(data)` in `src/web/routes/api_unified.py`.** The gate returns HTTP 403 with `{"error": "reviewer_name_required"}`. Blocklist: `""`, `"anonymous"`, `"web_reviewer"`, `"test"`, `"test_user"`, anything prefixed `bulk:`. Mirror the same blocklist client-side via `window.requireReviewerName()` (defined in `base.html`) — it returns the valid name or opens the reviewer modal and returns `null`, so callers bail before the fetch. Do NOT fall back to `"anonymous"` / `"web_reviewer"` in payloads; those sentinels only exist in historical data (rewritten to `RGM` on 2026-04-23 per the v2_review_decisions / v2_image_review_decisions cleanup).

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2290,6 +2290,130 @@ class DatabaseAdapter:
             "review_pct": round(reviewed / total * 100, 1) if total > 0 else 0.0,
         }
 
+    def get_image_decision_overall_v2(self) -> dict:
+        """Aggregate totals over all v2_image_metric_confirmations rows.
+
+        Returns total_decisions, relevant_count (accept|correct|add),
+        not_relevant_count (reject, including sentinel), and percentage breakdowns.
+        """
+        sql = """
+            SELECT
+                COUNT(*) AS total_decisions,
+                COUNT(*) FILTER (WHERE decision IN ('accept', 'correct', 'add')) AS relevant_count,
+                COUNT(*) FILTER (WHERE decision = 'reject') AS not_relevant_count
+            FROM v2_image_metric_confirmations
+        """
+        rows = self.query(sql)
+        if not rows:
+            return {
+                "total_decisions": 0,
+                "relevant_count": 0,
+                "not_relevant_count": 0,
+                "relevant_pct": 0.0,
+                "not_relevant_pct": 0.0,
+            }
+        row = rows[0]
+        total = row["total_decisions"] or 0
+        relevant = row["relevant_count"] or 0
+        not_relevant = row["not_relevant_count"] or 0
+        return {
+            "total_decisions": total,
+            "relevant_count": relevant,
+            "not_relevant_count": not_relevant,
+            "relevant_pct": round(relevant / total * 100, 1) if total > 0 else 0.0,
+            "not_relevant_pct": round(not_relevant / total * 100, 1) if total > 0 else 0.0,
+        }
+
+    def get_image_decisions_by_tier_v2(self) -> list[dict]:
+        """Per-detection-tier precision counts over v2_image_metric_confirmations.
+
+        Excludes sentinel rows (detected_metric_id IS NULL) and 'add' rows.
+        Returns relevant_count, not_relevant_count, total_decisions, precision_pct per tier.
+        """
+        sql = """
+            SELECT
+                CASE
+                    WHEN v.classification = 'presentation' THEN 'presence_seed'
+                    WHEN v.classification = 'chart' AND v.relevance_score >= 0.6
+                        THEN 'tier_1_cohort'
+                    WHEN v.classification IN ('chart', 'table_image')
+                         AND COALESCE(v.width, 0) >= 300
+                         AND COALESCE(v.height, 0) >= 300
+                        THEN 'tier_2_large'
+                    ELSE 'tier_3_all'
+                END AS detection_tier,
+                COUNT(*) FILTER (WHERE imc.decision IN ('accept', 'correct')) AS relevant_count,
+                COUNT(*) FILTER (WHERE imc.decision = 'reject') AS not_relevant_count,
+                COUNT(*) AS total_decisions,
+                CASE
+                    WHEN COUNT(*) FILTER (WHERE imc.decision IN ('accept', 'correct'))
+                       + COUNT(*) FILTER (WHERE imc.decision = 'reject') = 0 THEN 0.0
+                    ELSE ROUND(
+                        100.0
+                        * COUNT(*) FILTER (WHERE imc.decision IN ('accept', 'correct'))
+                        / (
+                            COUNT(*) FILTER (WHERE imc.decision IN ('accept', 'correct'))
+                          + COUNT(*) FILTER (WHERE imc.decision = 'reject')
+                        ),
+                        1
+                    )
+                END AS precision_pct
+            FROM v2_image_metric_confirmations imc
+            JOIN v2_image_assets v ON v.img_id = imc.img_id
+            WHERE imc.detected_metric_id IS NOT NULL
+              AND imc.decision IN ('accept', 'reject', 'correct')
+            GROUP BY detection_tier
+            ORDER BY detection_tier
+        """
+        rows = self.query(sql)
+        return [dict(r) for r in rows]
+
+    def get_image_rejection_reasons_by_tier_v2(self) -> list[dict]:
+        """Per-(detection_tier, rejection_reason) rejection counts.
+
+        Includes the sentinel row (rejection_reason='no_relevant_metrics').
+        Returns rejection_count and pct_of_tier_rejections per row.
+        """
+        sql = """
+            SELECT
+                CASE
+                    WHEN v.classification = 'presentation' THEN 'presence_seed'
+                    WHEN v.classification = 'chart' AND v.relevance_score >= 0.6
+                        THEN 'tier_1_cohort'
+                    WHEN v.classification IN ('chart', 'table_image')
+                         AND COALESCE(v.width, 0) >= 300
+                         AND COALESCE(v.height, 0) >= 300
+                        THEN 'tier_2_large'
+                    ELSE 'tier_3_all'
+                END AS detection_tier,
+                imc.rejection_reason,
+                COUNT(*) AS rejection_count,
+                ROUND(
+                    100.0 * COUNT(*) / SUM(COUNT(*)) OVER (
+                        PARTITION BY
+                            CASE
+                                WHEN v.classification = 'presentation' THEN 'presence_seed'
+                                WHEN v.classification = 'chart' AND v.relevance_score >= 0.6
+                                    THEN 'tier_1_cohort'
+                                WHEN v.classification IN ('chart', 'table_image')
+                                     AND COALESCE(v.width, 0) >= 300
+                                     AND COALESCE(v.height, 0) >= 300
+                                    THEN 'tier_2_large'
+                                ELSE 'tier_3_all'
+                            END
+                    ),
+                    1
+                ) AS pct_of_tier_rejections
+            FROM v2_image_metric_confirmations imc
+            JOIN v2_image_assets v ON v.img_id = imc.img_id
+            WHERE imc.decision = 'reject'
+              AND imc.rejection_reason IS NOT NULL
+            GROUP BY detection_tier, imc.rejection_reason
+            ORDER BY detection_tier, rejection_count DESC
+        """
+        rows = self.query(sql)
+        return [dict(r) for r in rows]
+
     def count_image_metric_rejections_for_filing(self, filing_id: int) -> int:
         """
         Count v2_image_metric_confirmations rows with decision='reject' that

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -193,17 +193,11 @@ def filing_list():
 def stats():
     """Display aggregate review statistics for both text and image review."""
     db = get_db()
-    try:
-        text_data = db.get_v2_review_stats()
-        image_overall = db.get_image_overall_decision_statistics()
-        image_tier = db.get_image_decision_statistics()
-        image_progress = db.get_image_review_progress()
-        image_chart_types = db.get_image_chart_type_distribution()
-        image_rejections = db.get_image_rejection_reason_stats()
-    except Exception as e:
-        logger.error(f"Error loading unified stats: {e}")
-        flash("Error loading statistics.", "danger")
-        return redirect(url_for("review_unified.filing_list"))
+    text_data = db.get_v2_review_stats()
+    image_overall = db.get_image_decision_overall_v2()
+    image_progress = db.get_image_review_progress_v2()
+    image_tier = db.get_image_decisions_by_tier_v2()
+    image_rejections = db.get_image_rejection_reasons_by_tier_v2()
 
     return render_template(
         "unified_stats.html",
@@ -211,11 +205,9 @@ def stats():
         totals=text_data["totals"],
         confidence_bands=text_data["confidence_bands"],
         image_overall=image_overall,
-        image_tier=image_tier,
         image_progress=image_progress,
-        image_chart_types=image_chart_types,
+        image_tier=image_tier,
         image_rejections=image_rejections,
-        chart_type_labels=IMAGE_CHART_TYPE_LABELS,
         rejection_reason_labels=IMAGE_REJECTION_REASON_LABELS,
     )
 

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -2,12 +2,6 @@
 
 {% block title %}Review Statistics - {{ super() }}{% endblock %}
 
-{% block head %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
-        integrity="sha384-zNy6FEbO50N+Cg5wap8IKA4M/ZnLJgzc6w2NqACZaK0u0FXfOWRRJOnQtpZun8ha"
-        crossorigin="anonymous"></script>
-{% endblock %}
-
 {% block content %}
 <div class="row mb-4">
   <div class="col-12 d-flex justify-content-between align-items-center">
@@ -292,7 +286,6 @@
     {% set overall_stats = image_overall %}
     {% set progress = image_progress %}
     {% set tier_stats = image_tier %}
-    {% set chart_type_stats = image_chart_types %}
     {% set rejection_stats = image_rejections %}
 
     {% if overall_stats is none or overall_stats.total_decisions == 0 %}
@@ -346,9 +339,9 @@
       </div>
     </div>
 
-    {# Progress and Average Review Time Row #}
+    {# Overall Progress Row #}
     <div class="row mb-4">
-      <div class="col-md-8">
+      <div class="col-md-12">
         <div class="card">
           <div class="card-body">
             <h5 class="card-title">Overall Progress</h5>
@@ -390,31 +383,6 @@
                 </div>
               {% endif %}
             </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-md-4">
-        <div class="card">
-          <div class="card-body">
-            <h6 class="card-subtitle mb-2 text-muted">Avg Review Time</h6>
-            {% if overall_stats.avg_review_time_seconds %}
-            <h2 class="mb-0">{{ overall_stats.avg_review_time_seconds|round(0)|int }}s</h2>
-            {% else %}
-            <h2 class="mb-0 text-muted">N/A</h2>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </div>
-
-    {# Daily Decisions Chart #}
-    <div class="row mb-4">
-      <div class="col-12">
-        <div class="card">
-          <div class="card-body">
-            <h5 class="card-title">Daily Review Activity (Last 7 Days)</h5>
-            <canvas id="dailyDecisionsChart" style="max-height: 300px;"></canvas>
           </div>
         </div>
       </div>
@@ -465,41 +433,6 @@
             </div>
             {% else %}
             <p class="text-muted">No decision statistics available.</p>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </div>
-
-    {# Chart Type Distribution Table #}
-    <div class="row mb-4">
-      <div class="col-12">
-        <div class="card">
-          <div class="card-body">
-            <h5 class="card-title">Chart Type Distribution</h5>
-            {% if chart_type_stats %}
-            <div class="table-responsive">
-              <table class="table table-sm table-hover">
-                <thead>
-                  <tr>
-                    <th>Chart Type</th>
-                    <th>Count</th>
-                    <th>% of Relevant</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for row in chart_type_stats %}
-                  <tr>
-                    <td>{{ chart_type_labels.get(row.chart_type, row.chart_type) }}</td>
-                    <td>{{ row.chart_count }}</td>
-                    <td>{{ row.pct_of_relevant|round(1) }}%</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
-            {% else %}
-            <p class="text-muted">No chart type data yet.</p>
             {% endif %}
           </div>
         </div>
@@ -560,59 +493,4 @@
   </div> {# end images-stats tab pane #}
 
 </div> {# end tab-content #}
-{% endblock %}
-
-{% block scripts %}
-{% if image_overall and image_overall.total_decisions > 0 %}
-<script>
-(function() {
-    'use strict';
-
-    const dailyData = {{ image_daily_counts | tojson }};
-
-    const labels = dailyData.map(d => {
-        const date = new Date(d.date);
-        return (date.getMonth() + 1) + '/' + date.getDate();
-    });
-    const counts = dailyData.map(d => d.count);
-
-    const ctx = document.getElementById('dailyDecisionsChart');
-    if (ctx) {
-        new Chart(ctx, {
-            type: 'bar',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: 'Decisions',
-                    data: counts,
-                    backgroundColor: 'rgba(13, 110, 253, 0.5)',
-                    borderColor: 'rgba(13, 110, 253, 1)',
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: true,
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        ticks: { stepSize: 1, precision: 0 }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        callbacks: {
-                            label: function(context) {
-                                return 'Decisions: ' + context.parsed.y;
-                            }
-                        }
-                    }
-                }
-            }
-        });
-    }
-})();
-</script>
-{% endif %}
 {% endblock %}

--- a/tests/integration/test_db_image_confirmation_stats.py
+++ b/tests/integration/test_db_image_confirmation_stats.py
@@ -1,0 +1,305 @@
+"""Integration tests for the per-metric image confirmation stats methods.
+
+Covers:
+- DatabaseAdapter.get_image_decision_overall_v2
+- DatabaseAdapter.get_image_decisions_by_tier_v2
+- DatabaseAdapter.get_image_rejection_reasons_by_tier_v2
+
+These methods power the unified review Statistics page (image tab).
+Rows are inserted directly into v2_image_metric_confirmations to keep
+the seed isolated from insert_image_metric_confirmations' side-effects
+(fact promotion, validation).
+"""
+
+from __future__ import annotations
+
+from src.infra.db import DatabaseAdapter
+from tests.integration.conftest import create_test_company_and_filing
+
+
+def _insert_image(
+    db: DatabaseAdapter,
+    filing_id: int,
+    filename: str,
+    *,
+    classification: str = "chart",
+    relevance_score: float = 0.8,
+    width: int | None = 600,
+    height: int | None = 400,
+) -> str:
+    rows = db.query(
+        """
+        INSERT INTO v2_image_assets
+            (filing_id, filename, dom_locator, width, height,
+             classification, relevance_score, review_status)
+        VALUES
+            (%(filing_id)s, %(filename)s, %(dom_locator)s, %(width)s, %(height)s,
+             %(classification)s, %(relevance_score)s, 'pending')
+        RETURNING img_id
+        """,
+        {
+            "filing_id": filing_id,
+            "filename": filename,
+            "dom_locator": f"body > img[src='{filename}']",
+            "width": width,
+            "height": height,
+            "classification": classification,
+            "relevance_score": relevance_score,
+        },
+    )
+    return str(rows[0]["img_id"])
+
+
+def _insert_confirmation(
+    db: DatabaseAdapter,
+    img_id: str,
+    *,
+    decision: str,
+    detected_metric_id: str | None = None,
+    confirmed_metric_id: str | None = None,
+    rejection_reason: str | None = None,
+    reviewer_id: str = "test_reviewer",
+) -> None:
+    db.execute(
+        """
+        INSERT INTO v2_image_metric_confirmations
+            (img_id, detected_metric_id, confirmed_metric_id,
+             decision, rejection_reason, reviewer_id)
+        VALUES
+            (%(img_id)s, %(detected_metric_id)s, %(confirmed_metric_id)s,
+             %(decision)s, %(rejection_reason)s, %(reviewer_id)s)
+        """,
+        {
+            "img_id": img_id,
+            "detected_metric_id": detected_metric_id,
+            "confirmed_metric_id": confirmed_metric_id,
+            "decision": decision,
+            "rejection_reason": rejection_reason,
+            "reviewer_id": reviewer_id,
+        },
+    )
+
+
+# tier_1_cohort: classification='chart' AND relevance_score >= 0.6
+# tier_2_large: chart|table_image AND width>=300 AND height>=300 AND score<0.6
+# tier_3_all: anything else (e.g. small)
+def _seed_three_tiers(db: DatabaseAdapter) -> dict[str, str]:
+    _, filing_id = create_test_company_and_filing(db)
+    return {
+        "tier_1": _insert_image(
+            db, filing_id, "t1.jpg", classification="chart", relevance_score=0.9
+        ),
+        "tier_2": _insert_image(
+            db,
+            filing_id,
+            "t2.jpg",
+            classification="chart",
+            relevance_score=0.3,
+            width=600,
+            height=400,
+        ),
+        "tier_3": _insert_image(
+            db,
+            filing_id,
+            "t3.jpg",
+            classification="chart",
+            relevance_score=0.3,
+            width=100,
+            height=100,
+        ),
+    }
+
+
+class TestGetImageDecisionOverallV2:
+    def test_empty_table_returns_zeros(self, clean_db):
+        result = clean_db.get_image_decision_overall_v2()
+        assert result == {
+            "total_decisions": 0,
+            "relevant_count": 0,
+            "not_relevant_count": 0,
+            "relevant_pct": 0.0,
+            "not_relevant_pct": 0.0,
+        }
+
+    def test_counts_relevant_vs_not_relevant(self, clean_db):
+        imgs = _seed_three_tiers(clean_db)
+        # 3 relevant: accept, correct, add
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_1"],
+            decision="accept",
+            detected_metric_id="cm_a",
+            confirmed_metric_id="cm_a",
+        )
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_1"],
+            decision="correct",
+            detected_metric_id="cm_b",
+            confirmed_metric_id="cm_c",
+        )
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_2"],
+            decision="add",
+            detected_metric_id=None,
+            confirmed_metric_id="cm_d",
+        )
+        # 2 not_relevant: reject + sentinel reject
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_2"],
+            decision="reject",
+            detected_metric_id="cm_e",
+            rejection_reason="not_a_chart",
+        )
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_3"],
+            decision="reject",
+            detected_metric_id=None,
+            confirmed_metric_id=None,
+            rejection_reason="no_relevant_metrics",
+        )
+
+        result = clean_db.get_image_decision_overall_v2()
+        assert result["total_decisions"] == 5
+        assert result["relevant_count"] == 3
+        assert result["not_relevant_count"] == 2
+        assert result["relevant_pct"] == 60.0
+        assert result["not_relevant_pct"] == 40.0
+
+
+class TestGetImageDecisionsByTierV2:
+    def test_empty_returns_empty_list(self, clean_db):
+        assert clean_db.get_image_decisions_by_tier_v2() == []
+
+    def test_excludes_add_and_sentinel_rows(self, clean_db):
+        imgs = _seed_three_tiers(clean_db)
+        # tier_1: accept (counted) + add (excluded)
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_1"],
+            decision="accept",
+            detected_metric_id="cm_a",
+            confirmed_metric_id="cm_a",
+        )
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_1"],
+            decision="add",
+            detected_metric_id=None,
+            confirmed_metric_id="cm_x",
+        )
+        # tier_2: sentinel reject (excluded — detected_metric_id IS NULL)
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_2"],
+            decision="reject",
+            detected_metric_id=None,
+            confirmed_metric_id=None,
+            rejection_reason="no_relevant_metrics",
+        )
+
+        rows = {r["detection_tier"]: r for r in clean_db.get_image_decisions_by_tier_v2()}
+        # Only tier_1 should appear (one accept). tier_2's row was a sentinel; excluded.
+        assert "tier_1_cohort" in rows
+        assert rows["tier_1_cohort"]["relevant_count"] == 1
+        assert rows["tier_1_cohort"]["not_relevant_count"] == 0
+        assert rows["tier_1_cohort"]["total_decisions"] == 1
+        assert rows["tier_1_cohort"]["precision_pct"] == 100.0
+        assert "tier_2_large" not in rows
+
+    def test_precision_pct_with_mixed_tiers(self, clean_db):
+        imgs = _seed_three_tiers(clean_db)
+        # tier_1: 2 accepts, 0 rejects → 100%
+        for m in ("cm_a", "cm_b"):
+            _insert_confirmation(
+                clean_db,
+                imgs["tier_1"],
+                decision="accept",
+                detected_metric_id=m,
+                confirmed_metric_id=m,
+            )
+        # tier_2: 1 correct, 3 rejects → 25%
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_2"],
+            decision="correct",
+            detected_metric_id="cm_c",
+            confirmed_metric_id="cm_c2",
+        )
+        for m in ("cm_d", "cm_e", "cm_f"):
+            _insert_confirmation(
+                clean_db,
+                imgs["tier_2"],
+                decision="reject",
+                detected_metric_id=m,
+                rejection_reason="wrong_subject",
+            )
+        # tier_3: 0 accepts, 1 reject → 0%
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_3"],
+            decision="reject",
+            detected_metric_id="cm_g",
+            rejection_reason="not_a_chart",
+        )
+
+        rows = {r["detection_tier"]: r for r in clean_db.get_image_decisions_by_tier_v2()}
+        assert rows["tier_1_cohort"]["precision_pct"] == 100.0
+        assert rows["tier_2_large"]["relevant_count"] == 1
+        assert rows["tier_2_large"]["not_relevant_count"] == 3
+        assert rows["tier_2_large"]["precision_pct"] == 25.0
+        assert rows["tier_3_all"]["precision_pct"] == 0.0
+
+
+class TestGetImageRejectionReasonsByTierV2:
+    def test_empty_returns_empty_list(self, clean_db):
+        assert clean_db.get_image_rejection_reasons_by_tier_v2() == []
+
+    def test_pct_sums_to_100_per_tier_and_includes_sentinel(self, clean_db):
+        imgs = _seed_three_tiers(clean_db)
+        # tier_2: 3 wrong_subject + 1 unreadable = 4 rejects
+        for m in ("cm_a", "cm_b", "cm_c"):
+            _insert_confirmation(
+                clean_db,
+                imgs["tier_2"],
+                decision="reject",
+                detected_metric_id=m,
+                rejection_reason="wrong_subject",
+            )
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_2"],
+            decision="reject",
+            detected_metric_id="cm_d",
+            rejection_reason="unreadable",
+        )
+        # tier_3: 1 sentinel reject (rejection_reason='no_relevant_metrics')
+        _insert_confirmation(
+            clean_db,
+            imgs["tier_3"],
+            decision="reject",
+            detected_metric_id=None,
+            confirmed_metric_id=None,
+            rejection_reason="no_relevant_metrics",
+        )
+
+        rows = clean_db.get_image_rejection_reasons_by_tier_v2()
+
+        by_tier: dict[str, list[dict]] = {}
+        for r in rows:
+            by_tier.setdefault(r["detection_tier"], []).append(r)
+
+        # tier_2 has two reasons; counts and pct sum check
+        t2 = {r["rejection_reason"]: r for r in by_tier["tier_2_large"]}
+        assert t2["wrong_subject"]["rejection_count"] == 3
+        assert t2["unreadable"]["rejection_count"] == 1
+        assert t2["wrong_subject"]["pct_of_tier_rejections"] == 75.0
+        assert t2["unreadable"]["pct_of_tier_rejections"] == 25.0
+
+        # Sentinel surfaces under tier_3 with 100% of that tier's rejects
+        t3 = {r["rejection_reason"]: r for r in by_tier["tier_3_all"]}
+        assert t3["no_relevant_metrics"]["rejection_count"] == 1
+        assert t3["no_relevant_metrics"]["pct_of_tier_rejections"] == 100.0

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -1,0 +1,152 @@
+"""Smoke tests for the unified review Statistics page (/v2/review/stats).
+
+The route was historically unreachable because it called DB methods that
+no longer existed on DatabaseAdapter. These tests pin the route to its
+current contract: it must render with both the empty-state and the
+populated-state shapes returned by the per-metric DB methods.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.web.app import create_app
+
+
+@pytest.fixture
+def app():
+    app = create_app("testing")
+    app.config["TESTING"] = True
+    app.config["DATABASE_URL"] = "postgresql://test"
+    app.config["_db_pool"] = None
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def mock_db():
+    with patch("src.web.routes.review_unified.get_db") as mock_get_db:
+        mock = MagicMock()
+        mock_get_db.return_value = mock
+        yield mock
+
+
+def _empty_text_data() -> dict:
+    return {
+        "per_company": [],
+        "totals": {
+            "filing_count": 0,
+            "fact_count": 0,
+            "reviewed_count": 0,
+            "pending_count": 0,
+            "accepted_count": 0,
+            "rejected_count": 0,
+            "corrected_count": 0,
+            "auto_accepted_count": 0,
+        },
+        "confidence_bands": {
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "total_count": 0,
+        },
+    }
+
+
+def test_stats_renders_empty(client, mock_db):
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Review Statistics" in body
+    # Empty-state alert in the images tab pane
+    assert "No image review decisions yet" in body
+
+
+def test_stats_renders_with_data(client, mock_db):
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 10,
+        "relevant_count": 7,
+        "not_relevant_count": 3,
+        "relevant_pct": 70.0,
+        "not_relevant_pct": 30.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 12,
+        "pending_count": 2,
+        "reviewed_count": 10,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 83.3,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = [
+        {
+            "detection_tier": "tier_1_cohort",
+            "relevant_count": 5,
+            "not_relevant_count": 1,
+            "total_decisions": 6,
+            "precision_pct": 83.3,
+        },
+        {
+            "detection_tier": "tier_3_all",
+            "relevant_count": 2,
+            "not_relevant_count": 2,
+            "total_decisions": 4,
+            "precision_pct": 50.0,
+        },
+    ]
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = [
+        {
+            "detection_tier": "tier_3_all",
+            "rejection_reason": "wrong_subject",
+            "rejection_count": 2,
+            "pct_of_tier_rejections": 100.0,
+        },
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Decisions by Detection Tier" in body
+    assert "Rejection Reasons by Detection Tier" in body
+    # tier badge text rendered via |replace('_', ' ')|title
+    assert "Tier 1 Cohort" in body
+    assert "Tier 3 All" in body
+
+
+def test_stats_does_not_swallow_db_errors(app, mock_db):
+    """A DB regression should propagate, not be swallowed by a flash + redirect.
+
+    The legacy try/except masked five missing DB methods for months by
+    302-ing back to the filing list. This test pins the new contract:
+    DB errors surface as real exceptions (which Flask converts to 500
+    in production, but the testing client re-raises so the regression
+    is loud in CI).
+    """
+    mock_db.get_v2_review_stats.side_effect = RuntimeError("schema regression")
+    client = app.test_client()
+    with pytest.raises(RuntimeError, match="schema regression"):
+        client.get("/v2/review/stats")


### PR DESCRIPTION
The /v2/review/stats route called five DB methods that no longer existed
(legacy of the per-image → per-metric image review pivot), and the
try/except silently 302'd back to the filing list — masking the breakage
for months. Rebuild the image-tab data path against
v2_image_metric_confirmations and remove low-utility legacy panels.

- src/infra/db.py: add get_image_decision_overall_v2,
  get_image_decisions_by_tier_v2 (per-tier precision = calibration signal),
  and get_image_rejection_reasons_by_tier_v2 (FP-pattern signal).
  Sentinel 'no_relevant_metrics' rows excluded from precision but
  included in rejection-reason rollup.
- src/web/routes/review_unified.py: rewire stats() to the new methods +
  the existing get_image_review_progress_v2; drop the swallow-and-redirect
  so future regressions surface as real 500s.
- src/web/templates/unified_stats.html: drop avg-review-time card,
  daily-decisions chart, chart-type-distribution table, and the Chart.js
  CDN — all backed by legacy data not captured under the per-metric schema.
- .claude/rules/web.md: document the route, panels, and fail-loud contract.
- Tests: 7 integration tests (per-tier precision, sentinel handling,
  rejection-reason percentages) + 3 unit smoke tests (empty/populated/
  fail-loud).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
