### PR TITLE
chore: improve commit-proj and cleanup commands

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -49,6 +49,8 @@
      - If dead: `git worktree remove -f -f <path>` then `git branch -D <branch>` for the matching `worktree-agent-*` branch. Double `-f` is required — a single `--force` won't override the worktree's lock and fails with `cannot remove a locked working tree`.
      - Worktrees without a `locked` line (unexpected): report and skip — do not auto-remove.
 
+   - **Non-agent internal trees** (path is under `.claude/worktrees/` but does NOT match `agent-*`): legacy worktrees created by older session workflows (e.g. direct `git worktree add .claude/worktrees/<name>`). Apply the same dirty + in-use + disposition logic as ccw trees below. Use `--force` on removal since these trees may have been created outside of `ccw` and lack a clean lock state. Report removed trees in the summary as `removed stale internal worktrees`.
+
    - **`ccw` trees** (path under `$HOME/.claude-worktrees/<repo>/`, created by the `ccw` zsh wrapper — see `docs/development/claude-sessions-and-worktrees.md`):
      - **Dirty check**: `git -C <path> status --porcelain`. If non-empty, skip and report as `dirty: <branch>`.
      - **In-use check**: `lsof +D <path> 2>/dev/null | awk 'NR>1'`. If any process has files open under the path (typically a live `claude` session), skip and report as `in-use: <branch>`.
@@ -57,7 +59,7 @@
        - Branch starts with `scratch/` AND `git -C <path> log origin/main..HEAD --oneline` is empty (no unique commits) → remove. Run `git worktree remove <path>`, then `git branch -d <branch>`.
        - Anything else (open PR, closed-not-merged PR, scratch with commits, unknown branch state) → skip and report as `keep: <branch> (<reason>)`.
 
-   - **Any other worktree path** (primary working tree, user-managed worktrees elsewhere): skip silently. Never touched.
+   - **Any other worktree path** (primary working tree, user-managed worktrees outside `.claude/worktrees/` and `$HOME/.claude-worktrees/`): skip silently. Never touched.
 
 6. **Report.** Output a concise summary:
    ```
@@ -65,9 +67,10 @@
      pruned remote-tracking refs: N
      deleted local branches: <list or "none">
      removed stale agent worktrees: <list or "none">
+     removed stale internal worktrees: <list or "none">
      removed merged ccw worktrees: <list or "none">
      removed empty scratch worktrees: <list or "none">
-     kept ccw worktrees: <list with one-word reason, or "none">
+     kept internal/ccw worktrees: <list with one-word reason, or "none">
      skipped active agent worktrees: N (live pids)
    ```
 
@@ -76,9 +79,9 @@
 - Never touch `main` or the currently checked-out branch.
 - Never delete a local branch unless GitHub confirms its PR is merged (step 3 is the source of truth; do not infer from `git branch --merged`).
 - Never force-remove a worktree whose lock pid is live. A live lock means an active session owns it.
-- Never remove a ccw worktree whose tree is dirty (`git status --porcelain` non-empty) or whose files are open in any process (`lsof +D` non-empty). Both checks must pass.
-- For ccw worktrees, auto-remove only on two dispositions: (a) branch has a merged PR per step 3, or (b) branch name starts with `scratch/` AND the worktree has zero unique commits beyond `origin/main`. Every other case skips with a reported reason.
-- Worktrees whose path is neither `.claude/worktrees/agent-*` nor `$HOME/.claude-worktrees/<repo>/` are never touched — they're user-managed.
+- Never remove a ccw or non-agent internal worktree whose tree is dirty (`git status --porcelain` non-empty) or whose files are open in any process (`lsof +D` non-empty). Both checks must pass.
+- For ccw and non-agent internal worktrees, auto-remove only on two dispositions: (a) branch has a merged PR per step 3, or (b) branch name starts with `scratch/` AND the worktree has zero unique commits beyond `origin/main`. Every other case skips with a reported reason.
+- Worktrees whose path is neither under `.claude/worktrees/` nor under `$HOME/.claude-worktrees/<repo>/` are never touched — they're user-managed.
 - Do not prune branches via step 4 that are still checked out in any linked worktree — step 5 removes the worktree and branch together.
 
 ## Out of scope

--- a/.claude/commands/commit-proj.md
+++ b/.claude/commands/commit-proj.md
@@ -145,31 +145,44 @@
     - Otherwise: `gh pr create --fill` (auto-title from commit subject, auto-body from commit body + PR template). Capture the URL.
     - On `gh` failure (auth, rate-limit, etc.): report the exact error and stop. Do NOT fall back to any other form of merge.
 
-16. **Enable auto-merge.** `gh pr merge --auto --squash` (idempotent — no-op if already enabled). `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
-
-    **Verify it actually got set.** Auto-merge enablement has been observed to silently no-op even when the command exits 0. After step 16, run:
+16. **Enable auto-merge.** The `gh pr merge --auto --squash` CLI and the GraphQL `enablePullRequestAutoMerge` mutation both fail with auth errors in this environment (keyring token scope). Use the REST API directly instead:
 
     ```
-    gh pr view --json autoMergeRequest,state,mergeStateStatus
+    gh api --method PUT repos/RGMjr/filings_reviewer/pulls/<num>/merge --field merge_method=squash
     ```
 
-    - `autoMergeRequest` non-null → set; proceed.
-    - `autoMergeRequest` null AND `mergeStateStatus == UNSTABLE` → step 17's UNSTABLE branch handles it; don't retry here.
-    - `autoMergeRequest` null otherwise → retry `gh pr merge --auto --squash <num>` once. If still null, warn: "Auto-merge did not engage on PR #<n> — verify manually after CI completes."
+    This is idempotent-safe when CI is green and squash-merges immediately. `--squash` keeps main's history linear, matching the repo's existing pattern. Never use `--admin`.
 
-17. **Conflict guard.** After enabling auto-merge, wait 5 seconds for GitHub to compute merge status, then check:
+    **If CI is still running**, do not merge yet — wait for required checks (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)) to complete first, then issue the PUT.
+
+17. **Conflict guard.** Before issuing the merge PUT, check:
     ```
-    gh pr view --json mergeable,mergeStateStatus,statusCheckRollup
+    gh api repos/RGMjr/filings_reviewer/pulls/<num> --jq '{mergeable_state,mergeable}'
     ```
-    - `DIRTY`: run `gh pr update-branch` (merges `main` into the PR branch). If it exits non-zero (real content conflict), warn: "Branch is DIRTY and update-branch failed — manual conflict resolution required."
-    - `UNSTABLE`: a non-required check is failing or in-progress and `--auto --squash` will not engage. Inspect `statusCheckRollup` — if every check on the project's required list (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)) has `conclusion: SUCCESS`, fall back to `gh pr merge --squash <num>` (without `--auto`). A direct merge is permitted when required checks are green; the UNSTABLE from non-required checks does not block it. If any required check is still pending or failed, do nothing — wait for them.
-    - `BLOCKED` / `CLEAN` / `UNKNOWN`: no action.
+    - `mergeable_state: dirty`: run `gh pr update-branch --rebase <num>` to bring the branch up to date. If it fails (real content conflict), warn: "Branch is DIRTY and update-branch failed — manual conflict resolution required." Do not merge.
+    - `mergeable_state: unknown`: GitHub is still computing — the REST PUT will still succeed if CI is green; proceed.
+    - `mergeable_state: clean` or `unstable`: proceed with the PUT. `unstable` means a non-required check is failing; as long as all 5 required checks are `SUCCESS`, a direct merge is permitted.
+    - `mergeable: false`: do not merge; report the exact state.
 
 18. **Report.** Final one-line summary to the user, naming the actual PR head branch (which may differ from the local branch if a follow-up rename happened):
     ```
-    PR #<n> opened/updated on <headRefName>: <url>. Auto-merge enabled (squash). Waits on: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright). Run /ci-fix if checks go red.
+    PR #<n> opened/updated on <headRefName>: <url>. Will merge via REST PUT once CI passes. Waits on: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright). Run /ci-fix if checks go red.
     ```
     Get `<headRefName>` from `gh pr view --json headRefName -q .headRefName`.
+
+19. **Concurrent-PR check.** After reporting, run:
+    ```
+    gh api repos/RGMjr/filings_reviewer/pulls --jq '[.[] | select(.state=="open")] | length'
+    ```
+    If the count is **2 or more**, fetch the open PR numbers:
+    ```
+    gh api repos/RGMjr/filings_reviewer/pulls --jq '[.[] | select(.state=="open") | .number] | join(" ")'
+    ```
+    Then append to the report:
+    ```
+    N PRs currently open (#X #Y ...). Consider running: /loop 5m /supervise-prs X Y
+    ```
+    If only 1 PR is open (the one just created), skip silently.
 
 ---
 


### PR DESCRIPTION
## Summary
- **commit-proj**: rewrites step 16 to use REST PUT for merge (GraphQL/CLI auth issues in this env), tightens step 17 conflict guard to use `mergeable_state` API field, adds step 19 concurrent-PR check that suggests `/loop /supervise-prs` when 2+ PRs are open after a commit
- **cleanup**: adds explicit handling for non-agent internal worktrees under `.claude/worktrees/` that don't match `agent-*` naming; updates catch-all description to exclude managed paths

## Test plan
- [ ] Run `/commit-proj` with multiple PRs open — verify step 19 appends the loop suggestion
- [ ] Run `/cleanup` with a stale non-agent worktree under `.claude/worktrees/` — verify it is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)