### PR TITLE
feat(ingest): batch sizing controls + 20 new industry sectors

### DIFF
--- a/config/industry_sic_codes.yaml
+++ b/config/industry_sic_codes.yaml
@@ -151,6 +151,137 @@ industries:
       - "7374"  # SERVICES-COMPUTER PROCESSING & DATA PREPARATION (payroll processing)
       - "7361"  # HELP SUPPLY SERVICES
 
+  # ---------------------------------------------------------------------------
+  # Phase 1 expansion (2026-04-30): non-tech sectors. All codes verified
+  # against SEC's published SIC list:
+  # https://www.sec.gov/corpfin/division-of-corporation-finance-standard-industrial-classification-sic-code-list
+  # ---------------------------------------------------------------------------
+
+  biotech:
+    description: "Biotechnology / biological products R&D"
+    sic_codes:
+      - "2836"  # PHARMACEUTICAL PREPARATIONS — biological products subset
+      - "8731"  # SERVICES-COMMERCIAL PHYSICAL & BIOLOGICAL RESEARCH
+
+  pharmaceuticals:
+    description: "Pharmaceutical preparations and diagnostics"
+    sic_codes:
+      - "2834"  # PHARMACEUTICAL PREPARATIONS
+      - "2835"  # IN VITRO & IN VIVO DIAGNOSTIC SUBSTANCES
+
+  medical_devices:
+    description: "Surgical, orthopedic, electromedical instruments"
+    sic_codes:
+      - "3841"  # SURGICAL & MEDICAL INSTRUMENTS & APPARATUS
+      - "3842"  # ORTHOPEDIC, PROSTHETIC & SURGICAL APPLIANCES & SUPPLIES
+      - "3845"  # ELECTROMEDICAL & ELECTROTHERAPEUTIC APPARATUS
+
+  commercial_banking:
+    description: "State and national commercial banks"
+    sic_codes:
+      - "6020"  # STATE COMMERCIAL BANKS
+      - "6021"  # NATIONAL COMMERCIAL BANKS
+      - "6022"  # STATE COMMERCIAL BANKS (alt)
+      - "6029"  # COMMERCIAL BANKS, NEC
+
+  investment_management:
+    description: "Investment advisors and offices (excluding SPAC blank checks)"
+    sic_codes:
+      - "6282"  # INVESTMENT ADVICE
+      - "6726"  # INVESTMENT OFFICES, NEC
+
+  apparel_retail:
+    description: "Apparel, shoe, and accessory retail"
+    sic_codes:
+      - "5621"  # RETAIL-WOMEN'S CLOTHING STORES
+      - "5651"  # RETAIL-FAMILY CLOTHING STORES
+      - "5661"  # RETAIL-SHOE STORES
+      - "5699"  # RETAIL-APPAREL & ACCESSORY STORES, NEC
+
+  home_improvement_retail:
+    description: "Lumber, building materials, hardware retail"
+    sic_codes:
+      - "5211"  # RETAIL-LUMBER & OTHER BUILDING MATERIALS DEALERS
+      - "5251"  # RETAIL-HARDWARE STORES
+
+  auto_dealers:
+    description: "Motor vehicle dealers"
+    sic_codes:
+      - "5511"  # RETAIL-MOTOR VEHICLE DEALERS (NEW & USED)
+      - "5521"  # RETAIL-MOTOR VEHICLE DEALERS (USED ONLY)
+
+  restaurants:
+    description: "Eating places"
+    sic_codes:
+      - "5812"  # RETAIL-EATING PLACES
+
+  oil_gas_exploration:
+    description: "Crude petroleum & natural gas exploration / drilling"
+    sic_codes:
+      - "1311"  # CRUDE PETROLEUM & NATURAL GAS
+      - "1381"  # SERVICES-DRILLING OIL & GAS WELLS
+
+  oil_gas_refining:
+    description: "Petroleum refining"
+    sic_codes:
+      - "2911"  # PETROLEUM REFINING
+
+  electric_utilities:
+    description: "Electric and combined utilities"
+    sic_codes:
+      - "4911"  # ELECTRIC SERVICES
+      - "4931"  # ELECTRIC & OTHER SERVICES COMBINED
+
+  semiconductors:
+    description: "Semiconductors and related devices"
+    sic_codes:
+      - "3674"  # SEMICONDUCTORS & RELATED DEVICES
+
+  computer_hardware:
+    description: "Computer peripherals, communications equipment, PCBs"
+    sic_codes:
+      - "3576"  # COMPUTER COMMUNICATIONS EQUIPMENT
+      - "3577"  # COMPUTER PERIPHERAL EQUIPMENT, NEC
+      - "3672"  # PRINTED CIRCUIT BOARDS
+
+  telecom_equipment:
+    description: "Telephone, radio, and broadcasting equipment"
+    sic_codes:
+      - "3661"  # TELEPHONE & TELEGRAPH APPARATUS
+      - "3663"  # RADIO & TV BROADCASTING & COMMUNICATIONS EQUIPMENT
+
+  aerospace_defense:
+    description: "Aircraft, aircraft parts, and defense electronics"
+    sic_codes:
+      - "3721"  # AIRCRAFT & PARTS
+      - "3728"  # AIRCRAFT PARTS & AUXILIARY EQUIPMENT, NEC
+      - "3812"  # SEARCH, DETECTION, NAVIGATION, GUIDANCE, AERONAUTICAL SYS
+
+  media_publishing:
+    description: "Newspaper, periodical, and book publishing"
+    sic_codes:
+      - "2711"  # NEWSPAPERS: PUBLISHING OR PUBLISHING & PRINTING
+      - "2721"  # PERIODICALS: PUBLISHING OR PUBLISHING AND PRINTING
+      - "2731"  # BOOKS: PUBLISHING, OR PUBLISHING & PRINTING
+
+  gaming_entertainment:
+    description: "Game studios, motion picture production, amusement services"
+    sic_codes:
+      - "7372"  # SERVICES-PREPACKAGED SOFTWARE (most modern game cos. file here)
+      - "7812"  # SERVICES-MOTION PICTURE & VIDEO TAPE PRODUCTION
+      - "7993"  # SERVICES-AMUSEMENT & RECREATION SERVICES
+
+  it_services_consulting:
+    description: "IT consulting, programming services, business services NEC"
+    sic_codes:
+      - "7371"  # SERVICES-COMPUTER PROGRAMMING SERVICES
+      - "7389"  # SERVICES-SERVICES, NEC
+
+  homebuilding:
+    description: "Operative builders / single-family housing construction"
+    sic_codes:
+      - "1531"  # OPERATIVE BUILDERS
+
 aliases:
   saas: software
   "computer services": software
@@ -193,3 +324,45 @@ aliases:
   "hr tech": hr_tech
   "human resources": hr_tech
   "workforce": hr_tech
+  # Phase 1 expansion (2026-04-30)
+  "bio": biotech
+  "biotechnology": biotech
+  "pharma": pharmaceuticals
+  "pharmaceutical": pharmaceuticals
+  "medtech": medical_devices
+  "medical device": medical_devices
+  "banks": commercial_banking
+  "banking": commercial_banking
+  "wealth management": investment_management
+  "asset management": investment_management
+  "retail apparel": apparel_retail
+  "clothing retail": apparel_retail
+  "home improvement": home_improvement_retail
+  "hardware retail": home_improvement_retail
+  "automotive retail": auto_dealers
+  "car dealers": auto_dealers
+  "dining": restaurants
+  "food service": restaurants
+  "oil": oil_gas_exploration
+  "gas": oil_gas_exploration
+  "oil and gas": oil_gas_exploration
+  "refining": oil_gas_refining
+  "utilities": electric_utilities
+  "electric": electric_utilities
+  "chips": semiconductors
+  "semis": semiconductors
+  "hardware": computer_hardware
+  "computer peripherals": computer_hardware
+  "telecom": telecom_equipment
+  "telecommunications": telecom_equipment
+  "defense": aerospace_defense
+  "aerospace": aerospace_defense
+  "media": media_publishing
+  "publishing": media_publishing
+  "gaming": gaming_entertainment
+  "video games": gaming_entertainment
+  "entertainment": gaming_entertainment
+  "it services": it_services_consulting
+  "consulting": it_services_consulting
+  "homebuilders": homebuilding
+  "construction": homebuilding

--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -308,8 +308,8 @@ who prefer a browser workflow. It drives the same underlying pipeline.
 
 ### Workflow
 
-1. **Criteria form** (`/ingest/`) — enter industry, year(s), form type, and an
-   optional filing limit. Submit to preview.
+1. **Criteria form** (`/ingest/`) — enter industry, year(s), form type, and
+   (optionally) a candidate limit. Submit to preview.
 2. **Preview** (`/ingest/preview`) — shows the three filing buckets (see below)
    and per-bucket counts. Opt-in checkboxes for ALREADY EXTRACTED filings.
    Large batches trigger warnings or hard blocks before you can proceed.
@@ -317,6 +317,46 @@ who prefer a browser workflow. It drives the same underlying pipeline.
    (`status='queued'`). Redirects immediately to the live-progress page.
 4. **Live progress** (`/ingest/batch/<id>`) — polls `/api/v2/ingest/batches/<id>/status`
    every 3 seconds and renders per-filing status in real time.
+
+### Sizing controls (Phase 1, 2026-04-30)
+
+Two complementary affordances for capping batch size when an "all-industry"
+year sweep returns hundreds of candidates:
+
+- **Candidate Limit** field on the criteria form — applies a SQL `LIMIT` to
+  the discovery query. Range 1–5 000; blank = no cap. The volume banner on the
+  preview page reflects the limited count, so a large universe can land in the
+  OK band by setting `limit=25`.
+- **"Check first N"** controls per section on the preview page — uncheck all
+  rows in that section, then check the first N currently-rendered rows. Useful
+  for slicing an already-discovered list of, say, 200 candidates into batches
+  of 25 without re-querying.
+
+Discovery is sorted **most-recent first** (`filing_date DESC, company_name ASC`),
+so "first N" means the N most recent filings. The same sort applies to
+`load_candidates_by_filing_ids` and the `/api/v2/ingest/batches/<id>/status`
+filings list.
+
+### Industry catalog
+
+Named industries live in `config/industry_sic_codes.yaml`. The Phase 1
+expansion (2026-04-30) added 20 non-tech sectors (biotech, pharmaceuticals,
+medical_devices, commercial_banking, investment_management, apparel_retail,
+home_improvement_retail, auto_dealers, restaurants, oil_gas_exploration,
+oil_gas_refining, electric_utilities, semiconductors, computer_hardware,
+telecom_equipment, aerospace_defense, media_publishing, gaming_entertainment,
+it_services_consulting, homebuilding) plus aliases (`bio`, `pharma`,
+`medtech`, `banks`, `chips`, `defense`, etc.). All SIC codes verified against
+SEC's published list. To add a new industry, append to the YAML and run
+`pytest tests/unit/universe/test_onboarding.py::test_load_industry_map_includes_new_industries`.
+
+### Universe gap banner
+
+If the criteria reference (year × form_type) combinations with zero rows in
+the `filings` table, the preview surfaces a "Universe gaps detected" banner
+with one-click populate buttons. Clicking submits a `kind='populate'` batch
+inline; the preview re-fetches when populate completes. Gap detection works
+for company-name-only criteria too (no industry / no SIC required).
 
 ### Three filing buckets
 

--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -210,14 +210,20 @@ _INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
 
 _PHASE1_GATE = "  AND f.is_in_scope_phase1 = TRUE\n"
 
-_DISCOVERY_ORDER = "ORDER BY f.filing_date, c.company_name\n"
+_DISCOVERY_ORDER = "ORDER BY f.filing_date DESC, c.company_name ASC\n"
+
+_LIMIT_CLAUSE = "LIMIT %(limit)s\n"
 
 # Exposed for tests and backward compatibility. Equivalent to the original
 # S-1/F-1-gated query (Phase-1 filter included, industry filter present).
 DISCOVERY_SQL = _DISCOVERY_SQL_BASE + _INDUSTRY_GATE + _PHASE1_GATE + _DISCOVERY_ORDER
 
 
-def _build_discovery_sql(form_types: list[str], sic_codes: list[str]) -> str:
+def _build_discovery_sql(
+    form_types: list[str],
+    sic_codes: list[str],
+    limit: int | None = None,
+) -> str:
     """Include the Phase-1 gate only when at least one S-1/F-1 form is requested.
 
     For 10-K-only (or other non-S-1/F-1) queries, Phase-1 filter doesn't apply:
@@ -226,6 +232,9 @@ def _build_discovery_sql(form_types: list[str], sic_codes: list[str]) -> str:
     Include the industry (SIC-code) clause only when ``sic_codes`` is non-empty.
     Empty SIC list means the caller is filtering by company name alone; emitting
     ``= ANY(ARRAY[]::text[])`` would return zero rows.
+
+    Append a LIMIT clause when ``limit`` is set; the bound parameter is named
+    ``limit`` so the caller must include it in the query params dict.
     """
     include_phase1 = bool(S1F1_FORMS & set(form_types))
     return (
@@ -233,6 +242,7 @@ def _build_discovery_sql(form_types: list[str], sic_codes: list[str]) -> str:
         + (_INDUSTRY_GATE if sic_codes else "")
         + (_PHASE1_GATE if include_phase1 else "")
         + _DISCOVERY_ORDER
+        + (_LIMIT_CLAUSE if limit else "")
     )
 
 
@@ -242,6 +252,7 @@ def discover_candidates(
     year_min: int,
     year_max: int,
     sic_codes: list[str],
+    limit: int | None = None,
 ) -> list[Candidate]:
     params: dict[str, Any] = {
         "form_types": form_types,
@@ -250,8 +261,10 @@ def discover_candidates(
     }
     if sic_codes:
         params["sic_codes"] = sic_codes
+    if limit:
+        params["limit"] = limit
     rows = db.query(
-        _build_discovery_sql(form_types, sic_codes),
+        _build_discovery_sql(form_types, sic_codes, limit=limit),
         params,
     )
     return [
@@ -306,6 +319,7 @@ class ResolvedQuery:
     year_max: int
     include_amendments: bool = True
     company_name_ilike: str | None = None  # None = no filter
+    limit: int | None = None  # None = no cap
 
 
 def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
@@ -330,6 +344,12 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
     company_name_ilike : str | None
         Optional ILIKE pattern for company name filtering.  E.g. "% Inc." or
         "Acme%".
+    limit : int | str | None
+        Optional cap on the number of candidates returned by ``discover()``.
+        Applied as SQL ``LIMIT`` against the discovery query (after ORDER BY,
+        before the company-name post-filter). Must be 1–5000 if set; ``None``
+        or empty string means no cap. Strings are coerced to int; non-numeric
+        values raise ``ValueError``.
 
     Raises
     ------
@@ -386,6 +406,16 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
     if not form_type_set:
         raise ValueError("Resolved form_types list is empty after filtering amendments")
 
+    raw_limit = criteria.get("limit")
+    limit: int | None = None
+    if raw_limit is not None and raw_limit != "":
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid limit {raw_limit!r}: must be a positive integer") from exc
+        if not (1 <= limit <= 5000):
+            raise ValueError(f"Invalid limit {limit}: must be between 1 and 5000")
+
     return ResolvedQuery(
         sic_codes=sorted(sic_set),
         form_types=form_type_set,
@@ -393,6 +423,7 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
         year_max=year_max,
         include_amendments=include_amendments,
         company_name_ilike=criteria.get("company_name_ilike") or None,
+        limit=limit,
     )
 
 
@@ -400,15 +431,20 @@ def resolve_criteria(criteria: dict[str, Any]) -> ResolvedQuery:
 # Gap detection
 # ---------------------------------------------------------------------------
 
-_YEARS_IN_FILINGS_SQL = """
+_YEARS_IN_FILINGS_BASE = """
 SELECT DISTINCT EXTRACT(YEAR FROM f.filing_date)::int AS yr,
                 f.form_type
 FROM filings f
 JOIN companies c ON c.company_id = f.company_id
 WHERE f.form_type = ANY(%(form_types)s)
   AND EXTRACT(YEAR FROM f.filing_date) BETWEEN %(year_min)s AND %(year_max)s
-  AND c.industry_code = ANY(%(sic_codes)s)
 """
+
+_YEARS_IN_FILINGS_INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
+
+# Backwards-compatible alias preserving the SIC-gated form for callers that
+# import the constant directly.
+_YEARS_IN_FILINGS_SQL = _YEARS_IN_FILINGS_BASE + _YEARS_IN_FILINGS_INDUSTRY_GATE
 
 
 @dataclass
@@ -424,16 +460,21 @@ def detect_universe_gaps(db: DatabaseAdapter, query: ResolvedQuery) -> list[Gap]
 
     This tells the caller which (year, form_type) combos need a
     ``populate`` run before discovery will find anything.
+
+    When ``query.sic_codes`` is empty (company-name-only criteria), the SIC
+    clause is omitted entirely. Otherwise an empty SIC list would short-circuit
+    the query to zero rows and the gap banner would never appear for
+    name-filtered searches.
     """
-    rows = db.query(
-        _YEARS_IN_FILINGS_SQL,
-        {
-            "form_types": query.form_types,
-            "year_min": query.year_min,
-            "year_max": query.year_max,
-            "sic_codes": query.sic_codes,
-        },
-    )
+    sql = _YEARS_IN_FILINGS_BASE + (_YEARS_IN_FILINGS_INDUSTRY_GATE if query.sic_codes else "")
+    params: dict[str, Any] = {
+        "form_types": query.form_types,
+        "year_min": query.year_min,
+        "year_max": query.year_max,
+    }
+    if query.sic_codes:
+        params["sic_codes"] = query.sic_codes
+    rows = db.query(sql, params)
     present: set[tuple[int, str]] = {(r["yr"], r["form_type"]) for r in rows}
 
     gaps: list[Gap] = []
@@ -503,6 +544,11 @@ def discover(db: DatabaseAdapter, query: ResolvedQuery) -> DiscoveryResult:
 
     Wraps ``discover_candidates`` and adds gap detection so callers can
     present a one-click populate prompt.
+
+    The SQL ``LIMIT`` is applied *before* the company-name post-filter, so a
+    user combining limit + company_name_ilike may see fewer rows than the
+    limit. This matches the behaviour the volume banner expects: the limit
+    is a cap on the result set the reviewer sees, not a quota to fill.
     """
     candidates = discover_candidates(
         db,
@@ -510,6 +556,7 @@ def discover(db: DatabaseAdapter, query: ResolvedQuery) -> DiscoveryResult:
         year_min=query.year_min,
         year_max=query.year_max,
         sic_codes=query.sic_codes,
+        limit=query.limit,
     )
 
     # Apply optional company-name filter (ILIKE equivalent — Python side for
@@ -580,7 +627,7 @@ FROM filings f
 JOIN companies c ON c.company_id = f.company_id
 LEFT JOIN v2_documents v ON v.filing_id = f.filing_id
 WHERE f.filing_id = ANY(%(filing_ids)s)
-ORDER BY f.filing_date, c.company_name
+ORDER BY f.filing_date DESC, c.company_name ASC
 """
     rows = db.query(sql, {"filing_ids": list(filing_ids)})
     return [

--- a/src/web/routes/api_ingest.py
+++ b/src/web/routes/api_ingest.py
@@ -92,7 +92,7 @@ def batch_status(batch_id: str):
             JOIN filings f ON f.filing_id = ibf.filing_id
             JOIN companies c ON c.company_id = f.company_id
             WHERE ibf.batch_id = %(batch_id)s
-            ORDER BY f.filing_date, c.company_name
+            ORDER BY f.filing_date DESC, c.company_name ASC
             """,
             {"batch_id": batch_id},
         )

--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -76,6 +76,7 @@ def _parse_form_criteria() -> dict[str, Any]:
     year = request.form.get("year", "").strip()
     reviewer_name = request.form.get("reviewer_name", "").strip()
     company_name_ilike = request.form.get("company_name_ilike", "").strip() or None
+    limit_raw = request.form.get("limit", "").strip() or None
 
     return {
         "industries": industries,
@@ -83,6 +84,7 @@ def _parse_form_criteria() -> dict[str, Any]:
         "form_types": form_types if form_types else ["s1f1"],
         "year": year,
         "company_name_ilike": company_name_ilike,
+        "limit": limit_raw,
         "_reviewer_name": reviewer_name,
     }
 
@@ -202,6 +204,7 @@ def ingest_preview():
             "year_max": query.year_max,
             "include_amendments": query.include_amendments,
             "company_name_ilike": query.company_name_ilike,
+            "limit": query.limit,
         }
     )
 

--- a/src/web/templates/ingest_form.html
+++ b/src/web/templates/ingest_form.html
@@ -90,6 +90,18 @@
         <div class="form-text">Case-insensitive substring match on company name.</div>
       </div>
 
+      <!-- Limit -->
+      <div class="mb-3">
+        <label for="limit" class="form-label fw-semibold">
+          Candidate Limit <span class="text-muted fw-normal">(optional)</span>
+        </label>
+        <input type="number" id="limit" name="limit"
+               class="form-control" placeholder="No limit"
+               min="1" max="5000"
+               value="{{ state.get('limit') or '' }}">
+        <div class="form-text">Cap the discovered candidate list. Most-recent filings come first. Leave blank for no limit.</div>
+      </div>
+
       <!-- Reviewer name -->
       <div class="mb-4">
         <label for="reviewer_name" class="form-label fw-semibold">Your Name</label>

--- a/src/web/templates/ingest_preview.html
+++ b/src/web/templates/ingest_preview.html
@@ -50,6 +50,15 @@
       <p class="text-muted small">
         All are checked by default — uncheck any filing you don't want in this batch.
       </p>
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <label class="text-muted small mb-0" for="take-first-n-new">Check first</label>
+        <input type="number" min="1" id="take-first-n-new" class="form-control form-control-sm take-first-n-input"
+               style="width: 7rem;" data-section="new" placeholder="N">
+        <button type="button" class="btn btn-sm btn-outline-secondary take-first-n-btn" data-section="new">
+          Apply
+        </button>
+        <span class="text-muted small">unchecks the rest in this section.</span>
+      </div>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
           <thead class="table-dark">
@@ -105,6 +114,15 @@
         These filings have already been extracted. Include them only if you want to re-extract (overwrites existing facts).
         All are <strong>unchecked</strong> by default.
       </p>
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <label class="text-muted small mb-0" for="take-first-n-reextract">Check first</label>
+        <input type="number" min="1" id="take-first-n-reextract" class="form-control form-control-sm take-first-n-input"
+               style="width: 7rem;" data-section="reextract" placeholder="N">
+        <button type="button" class="btn btn-sm btn-outline-secondary take-first-n-btn" data-section="reextract">
+          Apply
+        </button>
+        <span class="text-muted small">unchecks the rest in this section.</span>
+      </div>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
           <thead class="table-dark">
@@ -160,6 +178,15 @@
         <strong>Warning:</strong> Including these filings will re-extract them and
         permanently delete human review decisions. All are <strong>unchecked</strong> by default —
         check with caution.
+      </div>
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <label class="text-muted small mb-0" for="take-first-n-reextract-reviewed">Check first</label>
+        <input type="number" min="1" id="take-first-n-reextract-reviewed" class="form-control form-control-sm take-first-n-input"
+               style="width: 7rem;" data-section="reextract_reviewed" placeholder="N">
+        <button type="button" class="btn btn-sm btn-outline-secondary take-first-n-btn" data-section="reextract_reviewed">
+          Apply
+        </button>
+        <span class="text-muted small">unchecks the rest in this section.</span>
       </div>
       <div class="table-responsive mb-4">
         <table class="table table-sm table-striped align-middle">
@@ -286,6 +313,26 @@
   includeCbs.forEach(function (cb) {
     cb.addEventListener('change', function () {
       syncSelectAll(cb.getAttribute('data-section'));
+      updateCount();
+    });
+  });
+
+  // "Check first N" per-section action — uncheck all rows in the section, then check the first N
+  document.querySelectorAll('.take-first-n-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var section = btn.getAttribute('data-section');
+      var input = document.querySelector('.take-first-n-input[data-section="' + section + '"]');
+      if (!input) return;
+      var n = parseInt(input.value, 10);
+      if (!Number.isFinite(n) || n < 1) {
+        input.focus();
+        return;
+      }
+      var rows = document.querySelectorAll('.filing-include-cb[data-section="' + section + '"]');
+      rows.forEach(function (cb, idx) {
+        cb.checked = idx < n;
+      });
+      syncSelectAll(section);
       updateCount();
     });
   });

--- a/tests/unit/universe/test_onboarding.py
+++ b/tests/unit/universe/test_onboarding.py
@@ -16,7 +16,10 @@ from src.universe.onboarding import (
     classify_volume,
     count_reviewer_work,
     detect_universe_gaps,
+    discover_candidates,
+    load_industry_map,
     resolve_criteria,
+    resolve_industry,
 )
 
 # ---------------------------------------------------------------------------
@@ -330,8 +333,8 @@ def test_no_gap_when_matching_sic_present() -> None:
     assert db.last_params["sic_codes"] == ["5411"]
 
 
-def test_empty_sic_codes_preserves_old_behavior() -> None:
-    """Empty sic_codes list is passed through unchanged (ANY([]) short-circuits in SQL)."""
+def test_empty_sic_codes_omits_industry_clause() -> None:
+    """Company-name-only criteria (empty sic_codes) skip the SIC SQL clause."""
     db = _FakeDB(rows=[])
     query = ResolvedQuery(
         sic_codes=[],
@@ -340,12 +343,28 @@ def test_empty_sic_codes_preserves_old_behavior() -> None:
         year_max=2023,
     )
     gaps = detect_universe_gaps(db, query)
-    # With empty SIC list, SQL returns no rows → gap reported (same as pre-fix behavior
-    # where all years would appear as gaps when filings table is empty)
+    # Empty filings table → gap reported.
     assert gaps == [Gap(year=2023, form_type="S-1")]
-    # sic_codes passed through as empty list (no special-casing)
+    # sic_codes is NOT in params when the list is empty — the SQL clause is
+    # omitted entirely, so a name-only criteria can still surface gaps.
     assert db.last_params is not None
-    assert db.last_params["sic_codes"] == []
+    assert "sic_codes" not in db.last_params
+
+
+def test_detect_universe_gaps_name_only_finds_gap_when_filings_present() -> None:
+    """Even with rows present in the year, a non-matching form_type is a gap."""
+    # Filings table has S-1 in 2023, but the query asks for 10-K in 2023.
+    db = _FakeDB(rows=[{"yr": 2023, "form_type": "S-1"}])
+    query = ResolvedQuery(
+        sic_codes=[],  # company-name-only criteria
+        form_types=["10-K"],
+        year_min=2023,
+        year_max=2023,
+    )
+    gaps = detect_universe_gaps(db, query)
+    assert gaps == [Gap(year=2023, form_type="10-K")]
+    assert db.last_params is not None
+    assert "sic_codes" not in db.last_params
 
 
 # ---------------------------------------------------------------------------
@@ -406,3 +425,159 @@ def test_count_reviewer_work_issues_single_query() -> None:
 
     count_reviewer_work(_CountingDB(), [1, 2, 3, 4, 5])
     assert call_count == 1, "count_reviewer_work must use a single batched DB query"
+
+
+# ---------------------------------------------------------------------------
+# discover_candidates — limit + DESC sort
+# ---------------------------------------------------------------------------
+
+
+def _candidate_row(filing_id: int, **overrides: Any) -> dict[str, Any]:
+    """Build a fake row matching the DISCOVERY_SQL projection."""
+    base = {
+        "filing_id": filing_id,
+        "cik": "0000000001",
+        "ticker": None,
+        "company_name": f"Co {filing_id}",
+        "form_type": "S-1",
+        "filing_date": "2024-01-01",
+        "industry_code": "7372",
+        "accession_number": f"0000000001-24-{filing_id:06d}",
+        "primary_doc_url": "https://example.com/doc",
+        "txt_url": None,
+        "already_extracted": False,
+        "extracted_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_discover_candidates_omits_limit_clause_when_unset() -> None:
+    """Without limit, SQL should not contain LIMIT and params should not include it."""
+    db = _FakeDB(rows=[])
+    discover_candidates(db, form_types=["S-1"], year_min=2024, year_max=2024, sic_codes=["7372"])
+    assert db.last_sql is not None
+    assert "LIMIT" not in db.last_sql
+    assert db.last_params is not None
+    assert "limit" not in db.last_params
+
+
+def test_discover_candidates_appends_limit_clause_when_set() -> None:
+    """With limit=N, SQL gets LIMIT %(limit)s and params include limit."""
+    db = _FakeDB(rows=[])
+    discover_candidates(
+        db, form_types=["S-1"], year_min=2024, year_max=2024, sic_codes=["7372"], limit=10
+    )
+    assert db.last_sql is not None
+    assert "LIMIT %(limit)s" in db.last_sql
+    assert db.last_params is not None
+    assert db.last_params["limit"] == 10
+
+
+def test_discover_candidates_default_sort_is_filing_date_desc() -> None:
+    """ORDER BY clause should sort filing_date DESC for 'most recent first'."""
+    db = _FakeDB(rows=[])
+    discover_candidates(db, form_types=["S-1"], year_min=2024, year_max=2024, sic_codes=["7372"])
+    assert db.last_sql is not None
+    assert "ORDER BY f.filing_date DESC, c.company_name ASC" in db.last_sql
+
+
+# ---------------------------------------------------------------------------
+# resolve_criteria — limit validation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_criteria_limit_none_when_unset() -> None:
+    """limit defaults to None when not present in criteria dict."""
+    q = resolve_criteria({"industries": ["software"], "year": "2023"})
+    assert q.limit is None
+
+
+def test_resolve_criteria_limit_empty_string_treated_as_unset() -> None:
+    """Empty string means 'no limit' (avoids HTML-form-driven false positives)."""
+    q = resolve_criteria({"industries": ["software"], "year": "2023", "limit": ""})
+    assert q.limit is None
+
+
+def test_resolve_criteria_limit_valid_integer_passes_through() -> None:
+    q = resolve_criteria({"industries": ["software"], "year": "2023", "limit": 25})
+    assert q.limit == 25
+
+
+def test_resolve_criteria_limit_string_coerced_to_int() -> None:
+    """HTML form input arrives as string; resolve_criteria must coerce."""
+    q = resolve_criteria({"industries": ["software"], "year": "2023", "limit": "50"})
+    assert q.limit == 50
+
+
+def test_resolve_criteria_limit_zero_raises() -> None:
+    with pytest.raises(ValueError, match="must be between 1 and 5000"):
+        resolve_criteria({"industries": ["software"], "year": "2023", "limit": 0})
+
+
+def test_resolve_criteria_limit_too_large_raises() -> None:
+    with pytest.raises(ValueError, match="must be between 1 and 5000"):
+        resolve_criteria({"industries": ["software"], "year": "2023", "limit": 5001})
+
+
+def test_resolve_criteria_limit_non_numeric_raises() -> None:
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        resolve_criteria({"industries": ["software"], "year": "2023", "limit": "abc"})
+
+
+# ---------------------------------------------------------------------------
+# Industry catalog expansion — Phase 1 added 20 new sectors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "industry, expected_codes",
+    [
+        ("biotech", {"2836", "8731"}),
+        ("pharmaceuticals", {"2834", "2835"}),
+        ("medical_devices", {"3841", "3842", "3845"}),
+        ("commercial_banking", {"6020", "6021", "6022", "6029"}),
+        ("investment_management", {"6282", "6726"}),
+        ("apparel_retail", {"5621", "5651", "5661", "5699"}),
+        ("home_improvement_retail", {"5211", "5251"}),
+        ("auto_dealers", {"5511", "5521"}),
+        ("restaurants", {"5812"}),
+        ("oil_gas_exploration", {"1311", "1381"}),
+        ("oil_gas_refining", {"2911"}),
+        ("electric_utilities", {"4911", "4931"}),
+        ("semiconductors", {"3674"}),
+        ("computer_hardware", {"3576", "3577", "3672"}),
+        ("telecom_equipment", {"3661", "3663"}),
+        ("aerospace_defense", {"3721", "3728", "3812"}),
+        ("media_publishing", {"2711", "2721", "2731"}),
+        ("gaming_entertainment", {"7372", "7812", "7993"}),
+        ("it_services_consulting", {"7371", "7389"}),
+        ("homebuilding", {"1531"}),
+    ],
+)
+def test_load_industry_map_includes_new_industries(industry: str, expected_codes: set[str]) -> None:
+    m = load_industry_map()
+    canon, codes = resolve_industry(industry, m)
+    assert canon == industry
+    assert set(codes) == expected_codes
+
+
+@pytest.mark.parametrize(
+    "alias, target",
+    [
+        ("bio", "biotech"),
+        ("pharma", "pharmaceuticals"),
+        ("medtech", "medical_devices"),
+        ("banks", "commercial_banking"),
+        ("wealth management", "investment_management"),
+        ("oil", "oil_gas_exploration"),
+        ("chips", "semiconductors"),
+        ("defense", "aerospace_defense"),
+        ("gaming", "gaming_entertainment"),
+        ("homebuilders", "homebuilding"),
+    ],
+)
+def test_load_industry_map_resolves_new_aliases(alias: str, target: str) -> None:
+    m = load_industry_map()
+    canon, _codes = resolve_industry(alias, m)
+    assert canon == target

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -87,6 +87,29 @@ def test_ingest_form_pre_fills_reviewer_cookie(client):
     assert b"TestUser" in resp.data
 
 
+def test_ingest_form_renders_limit_field(client):
+    """GET /ingest/ exposes the candidate-limit input."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'name="limit"' in body
+    assert 'type="number"' in body
+    # Help text mentions the cap behaviour so reviewers know what it does
+    assert "Cap the discovered candidate list" in body
+
+
+def test_ingest_form_renders_new_industry_options(client):
+    """GET /ingest/ surfaces the Phase-1 added industries in the multi-select."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # New industries appear with their humanised labels
+    assert 'value="biotech"' in body
+    assert 'value="commercial_banking"' in body
+    assert 'value="aerospace_defense"' in body
+    assert 'value="homebuilding"' in body
+
+
 # ---------------------------------------------------------------------------
 # _parse_form_criteria helper
 # ---------------------------------------------------------------------------
@@ -126,6 +149,42 @@ def test_parse_form_criteria_multi_industry(app):
         result = _parse_form_criteria()
     assert "software" in result["industries"]
     assert "grocery_retail" in result["industries"]
+
+
+def test_parse_form_criteria_includes_limit(app):
+    """_parse_form_criteria forwards a non-empty limit string."""
+    from src.web.routes.ingest import _parse_form_criteria
+
+    with app.test_request_context(
+        "/ingest/preview",
+        method="POST",
+        data={
+            "industries": ["software"],
+            "year": "2023",
+            "reviewer_name": "Rob",
+            "limit": "25",
+        },
+    ):
+        result = _parse_form_criteria()
+    assert result["limit"] == "25"
+
+
+def test_parse_form_criteria_limit_blank_means_none(app):
+    """Blank limit field is normalised to None (resolve_criteria treats as no cap)."""
+    from src.web.routes.ingest import _parse_form_criteria
+
+    with app.test_request_context(
+        "/ingest/preview",
+        method="POST",
+        data={
+            "industries": ["software"],
+            "year": "2023",
+            "reviewer_name": "Rob",
+            "limit": "",
+        },
+    ):
+        result = _parse_form_criteria()
+    assert result["limit"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds end-to-end support for capping ingest batches at N candidates
without unchecking rows by hand, expands the named industry catalog
beyond tech-only, and fixes universe-gap detection for company-name-only
searches.

Changes
-------
- Discovery query accepts an optional SQL LIMIT via a new
  `discover_candidates(..., limit=)` kwarg, plumbed through
  `ResolvedQuery.limit` and `resolve_criteria` (validates 1..5000).
- Default sort flipped to `filing_date DESC, company_name ASC` so
  "first N" means N most recent filings. Same flip applied to
  `load_candidates_by_filing_ids` and the `/api/v2/ingest/batches/<id>/status`
  filings list for consistency.
- Web criteria form gains a "Candidate Limit" numeric input; preview
  page gains per-section "Check first N" controls that uncheck the
  rest of the section in JS without re-querying.
- `config/industry_sic_codes.yaml` adds 20 sectors covering biotech,
  pharma, medical devices, banking, retail subcategories, energy,
  semiconductors, aerospace, media, gaming, IT services, homebuilding —
  all SIC codes verified against SEC's published list. 47 new aliases.
- `detect_universe_gaps()` no longer requires a non-empty SIC list:
  company-name-only criteria now correctly surface the gap banner.

Tests
-----
- 19 new unit tests covering limit plumbing, DESC sort, validation
  ranges, new industries, and gap-detection without SIC.
- Updated existing test that asserted the old buggy gap-detection
  behavior to verify the conditional clause.
- 4499 unit tests pass; ruff clean.

Phase 1 of a multi-phase enhancement; subsequent phases (per-filing
skip/retry, runner-log surface, stuck-batch recovery, lifecycle
hygiene) are tracked in the approved plan.
