### PR TITLE
feat: chart-read default → Haiku-4.5 with Sonnet escalation fallback (PR 3/5)

### DIFF
--- a/.claude/rules/v2-pipeline.md
+++ b/.claude/rules/v2-pipeline.md
@@ -83,12 +83,12 @@ verification SQL.
 ## Vision Model Selection
 
 Per-site model knobs are documented in `docs/operations/vision-model-selection.md`.
-Triage sites (`process_full_page_scan`, `_prescan_ambiguous_images`) default to
-Gemini (`gemini-2.0-flash`) regardless of `VISION_PROVIDER` so legacy-mode
-operators don't accidentally pay gpt-4o for recall calls. Override per-site via
-`VISION_MODEL_FULL_PAGE_OCR` / `VISION_MODEL_PRESCAN` (and the matching
-`VISION_PROVIDER_*` knobs). Cost is observed via
-`PipelineResult.vision_spend_usd_by_site`.
+Triage sites (`process_full_page_scan`, `_prescan_ambiguous_images`) default
+to Gemini (`gemini-2.0-flash`) regardless of `VISION_PROVIDER`. The
+two-stage chart-read site defaults to Haiku-4.5 with a Sonnet fallback
+that rescues low-confidence chart responses (PR 3). Cost is observed via
+`PipelineResult.vision_spend_usd_by_site`; fallback rate via
+`StageResult.metadata['chart_fallback_escalations']`.
 
 ## Image Asset Identity
 

--- a/.env.template
+++ b/.env.template
@@ -48,6 +48,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # VISION_PROVIDER_PRESCAN=gemini
 # VISION_MODEL_PRESCAN=gemini-2.0-flash
 #
+# ---- PR 3: Chart-read fallback escalation (default: Sonnet rescues low-conf Haiku) ----
+# VISION_CHART_FALLBACK_MODEL=claude-sonnet-4-6
+# VISION_CHART_FALLBACK_PROVIDER=anthropic
+# VISION_CHART_CONFIDENCE_THRESHOLD=0.7
+#
 # Spend cap for the full bake-off sweep (scripts/benchmark_vision.py --bakeoff).
 # Default is 15.0 USD. Harness aborts mid-sweep if cumulative spend crosses this.
 # MAX_BAKEOFF_USD=15.0

--- a/docs/known-issues/gh-366-vision-routing-mode-test-contamination.md
+++ b/docs/known-issues/gh-366-vision-routing-mode-test-contamination.md
@@ -1,0 +1,25 @@
+---
+id: 366
+source: gh
+slug: vision-routing-mode-test-contamination
+title: Fix VISION_ROUTING_MODE test contamination causing 16 ordering-dependent failures
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-04-30
+updated: 2026-04-30
+gh_issue: 366
+note: 16 chart-related tests fail in full suite due to VISION_ROUTING_MODE=two_stage leaking from an earlier test; all pass in isolation; root cause not yet traced
+---
+
+### Problem
+
+When `tests/unit/extraction_v2/` runs as a full suite, 16 chart-extraction tests fail because `VISION_ROUTING_MODE=two_stage` leaks from an earlier test into subsequent tests that expect legacy mode. All 16 pass when run in isolation. The failure set is identical between the current `main` and the PR 3 worktree — pre-existing, not introduced by recent changes. Root cause: a test somewhere before `test_image_pipeline_integration.py`, `test_ocr_extraction.py`, and `test_vision_cost_telemetry.py` sets the env var without monkeypatch cleanup.
+
+### Next Steps
+
+- Bisect to find which test file introduces the contamination (binary search via `pytest --collect-only` ordering)
+- Fix the leaking test to use `monkeypatch.setenv` instead of direct `os.environ` mutation
+- Consider adding a session-scoped fixture that asserts `VISION_ROUTING_MODE` is unset at the start of each test file

--- a/docs/known-issues/gh-366-vision-routing-mode-test-contamination.md
+++ b/docs/known-issues/gh-366-vision-routing-mode-test-contamination.md
@@ -3,7 +3,7 @@ id: 366
 source: gh
 slug: vision-routing-mode-test-contamination
 title: Fix VISION_ROUTING_MODE test contamination causing 16 ordering-dependent failures
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: —
@@ -11,15 +11,16 @@ touches: []
 discovered: 2026-04-30
 updated: 2026-04-30
 gh_issue: 366
-note: 16 chart-related tests fail in full suite due to VISION_ROUTING_MODE=two_stage leaking from an earlier test; all pass in isolation; root cause not yet traced
+note: Root cause identified and fixed — test_batch_runner.py's module-level exec_module runs load_dotenv() which sets VISION_ROUTING_MODE=two_stage from local .env; fixed via autouse conftest fixture + save/restore guard in test_batch_runner.py
 ---
 
 ### Problem
 
-When `tests/unit/extraction_v2/` runs as a full suite, 16 chart-extraction tests fail because `VISION_ROUTING_MODE=two_stage` leaks from an earlier test into subsequent tests that expect legacy mode. All 16 pass when run in isolation. The failure set is identical between the current `main` and the PR 3 worktree — pre-existing, not introduced by recent changes. Root cause: a test somewhere before `test_image_pipeline_integration.py`, `test_ocr_extraction.py`, and `test_vision_cost_telemetry.py` sets the env var without monkeypatch cleanup.
+When `tests/unit/` runs as a full suite, `test_image_pipeline_integration.py::TestChartAnnotationExtraction::test_annotations_parsed_from_response` fails because `VISION_ROUTING_MODE=two_stage` leaks from `test_batch_runner.py` into subsequent tests that expect legacy mode. The test passes in isolation. The failure was pre-existing on `main`.
 
-### Next Steps
+**Root cause:** `test_batch_runner.py` loads `batch_v2_extraction.py` via `importlib.exec_module` at module collection time. That script calls `load_dotenv()` at module level, which reads `VISION_ROUTING_MODE=two_stage` from the local `.env` file and sets it in `os.environ` for the rest of the test session.
 
-- Bisect to find which test file introduces the contamination (binary search via `pytest --collect-only` ordering)
-- Fix the leaking test to use `monkeypatch.setenv` instead of direct `os.environ` mutation
-- Consider adding a session-scoped fixture that asserts `VISION_ROUTING_MODE` is unset at the start of each test file
+### Fix Applied
+
+1. Added `tests/unit/extraction_v2/conftest.py` with an `autouse=True` fixture that calls `monkeypatch.delenv("VISION_ROUTING_MODE", raising=False)` before each test — runtime guarantee.
+2. Added save/restore guard around `exec_module` in `test_batch_runner.py` — documents the root cause and provides module-load-time protection.

--- a/docs/operations/vision-model-selection.md
+++ b/docs/operations/vision-model-selection.md
@@ -8,7 +8,7 @@ One-page reference for which model each vision call site uses, what env var cont
 |---|------|-------|--------|------------|---------|--------|
 | 1 | Table OCR | OCRExtraction | `process_table_image` | `VISION_MODEL_OCR` (two_stage) / `VISION_PROVIDER`+`VISION_MODEL_OCR` (legacy) | `gemini-2.5-flash-lite` (two_stage) / `gpt-4o` (legacy) | ≤5 calls/filing |
 | 2 | Chart OCR fast | OCRExtraction | `process_chart` (first pass) | `VISION_MODEL_OCR` (two_stage only) | `gemini-2.5-flash-lite` | 5–15 calls/filing |
-| 3 | Chart read premium | OCRExtraction | `process_chart` (second pass) | `VISION_MODEL_CHART` (two_stage) / inherits VISION_PROVIDER (legacy) | `claude-sonnet-4-6` (two_stage) / `gpt-4o` (legacy) | 5–15 calls/filing, $0.25 budget cap |
+| 3 | Chart read premium | OCRExtraction | `process_chart` (second pass) | `VISION_MODEL_CHART` (two_stage) / inherits VISION_PROVIDER (legacy) | `claude-haiku-4-5-20251001` (two_stage), Sonnet fallback on conf<0.7 / `gpt-4o` (legacy) | 5–15 calls/filing, $0.25 budget cap |
 | 4 | Full-page OCR | OCRExtraction | `process_full_page_scan` | `VISION_PROVIDER_FULL_PAGE_OCR`, `VISION_MODEL_FULL_PAGE_OCR` | `gemini` / `gemini-2.0-flash` | ≤30 calls/filing on full-page-scan filings |
 | 5 | Prescan | OCRExtraction | `_prescan_ambiguous_images` | `VISION_PROVIDER_PRESCAN`, `VISION_MODEL_PRESCAN` | `gemini` / `gemini-2.0-flash` | ≤10 calls/filing |
 | 6 | Metric classify | ImageClassify | `analyze_image_for_metric_classification` | `VISION_CLASSIFY_PROVIDER`, `VISION_CLASSIFY_MODEL` | `gemini` / `gemini-2.5-flash-lite` | 10–40 calls/filing when ENABLE_METRIC_CLASSIFY=true |
@@ -18,6 +18,24 @@ One-page reference for which model each vision call site uses, what env var cont
 - `VISION_ROUTING_MODE=legacy` (default): single provider for table-OCR + chart-OCR + chart-read, set by `VISION_PROVIDER`.
 - `VISION_ROUTING_MODE=two_stage`: cheap OCR provider for sites 1+2, premium provider for site 3.
 - Sites 4, 5, 6 are independent of `VISION_ROUTING_MODE` and `VISION_PROVIDER` — their per-site env knobs always win.
+
+## Chart-read fallback escalation (PR 3)
+
+The two-stage chart-read pass uses Haiku-4.5 by default for cost. If the
+parsed chart response's confidence falls below `VISION_CHART_CONFIDENCE_THRESHOLD`
+(default 0.7), the stage re-calls a fallback model (default `claude-sonnet-4-6`)
+and uses whichever response has higher confidence. Both calls' costs are
+attributed to `chart_read_premium`. The escalation count is exposed in
+`StageResult.metadata['chart_fallback_escalations']`.
+
+**Production monitoring:** if escalation rate exceeds ~15-20% on a filing
+or in aggregate, consider lowering the threshold (Haiku is rescuing too
+often → its accuracy is bad enough to warrant just defaulting to Sonnet
+again) or raising the threshold (Haiku is rescuing rarely → drop the
+fallback entirely to save the cost of monitoring).
+
+**Disabling the fallback:** set `VISION_CHART_FALLBACK_MODEL=` (empty string).
+This pins chart-read to Haiku regardless of confidence.
 
 ## Measuring spend
 

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -214,6 +214,16 @@ class PipelineConfig:
     vision_prescan_provider: str = "gemini"
     vision_prescan_model: str = "gemini-2.0-flash"
 
+    # Chart-read fallback (PR 3). Default chart-read uses Haiku-4.5 for cost;
+    # low-confidence chart responses re-call the fallback model (Sonnet) so
+    # hard charts still get premium quality.
+    vision_chart_fallback_model: str = "claude-sonnet-4-6"
+    vision_chart_fallback_provider: str = "anthropic"
+    vision_chart_confidence_threshold: float = 0.7
+    """Below this confidence on the primary chart-read response, re-call the
+    fallback model on the same image. Default 0.7 — tune via gold-standard
+    validation."""
+
     @classmethod
     def for_transcript(cls, **overrides) -> PipelineConfig:
         """Create a config tuned for earnings call transcripts."""
@@ -498,6 +508,23 @@ class V2Pipeline:
             self.config.vision_prescan_provider = os.environ["VISION_PROVIDER_PRESCAN"]
         if os.environ.get("VISION_MODEL_PRESCAN"):
             self.config.vision_prescan_model = os.environ["VISION_MODEL_PRESCAN"]
+        if os.environ.get("VISION_CHART_FALLBACK_MODEL") is not None:
+            self.config.vision_chart_fallback_model = os.environ["VISION_CHART_FALLBACK_MODEL"]
+        if os.environ.get("VISION_CHART_FALLBACK_PROVIDER"):
+            self.config.vision_chart_fallback_provider = os.environ[
+                "VISION_CHART_FALLBACK_PROVIDER"
+            ]
+        if os.environ.get("VISION_CHART_CONFIDENCE_THRESHOLD"):
+            try:
+                self.config.vision_chart_confidence_threshold = float(
+                    os.environ["VISION_CHART_CONFIDENCE_THRESHOLD"]
+                )
+            except ValueError:
+                logger.warning(
+                    "Invalid VISION_CHART_CONFIDENCE_THRESHOLD=%r; keeping default %s",
+                    os.environ["VISION_CHART_CONFIDENCE_THRESHOLD"],
+                    self.config.vision_chart_confidence_threshold,
+                )
 
     def _check_vision_api_availability(self) -> None:
         """Check if OPENAI_API_KEY is set; disable image/chart extraction if not."""

--- a/src/extraction_v2/stages/ocr_extraction.py
+++ b/src/extraction_v2/stages/ocr_extraction.py
@@ -109,6 +109,32 @@ def _build_cheap_ocr_client(provider: str, model: str) -> Any:
             os.environ["VISION_MODEL_OCR"] = prior_model
 
 
+def _build_chart_fallback_client(provider: str, model: str) -> Any:
+    """Build an isolated VisionClient for the chart-read fallback (Sonnet by default).
+
+    Mirrors _build_cheap_ocr_client. Forces VISION_PROVIDER + VISION_MODEL_CHART
+    via env override, then restores prior values so the primary chart-read client
+    is unaffected.
+    """
+    from src.llm.vision_client import VisionClient
+
+    prior_provider = os.environ.get("VISION_PROVIDER")
+    prior_chart_model = os.environ.get("VISION_MODEL_CHART")
+    os.environ["VISION_PROVIDER"] = provider
+    os.environ["VISION_MODEL_CHART"] = model
+    try:
+        return VisionClient()
+    finally:
+        if prior_provider is None:
+            os.environ.pop("VISION_PROVIDER", None)
+        else:
+            os.environ["VISION_PROVIDER"] = prior_provider
+        if prior_chart_model is None:
+            os.environ.pop("VISION_MODEL_CHART", None)
+        else:
+            os.environ["VISION_MODEL_CHART"] = prior_chart_model
+
+
 class OCRExtractionStage:
     """
     Stage 5: OCR & Chart Extraction - process high-relevance images.
@@ -187,6 +213,9 @@ class OCRExtractionStage:
         # None at the top of each process() call for per-filing isolation.
         self._full_page_ocr_client: Any = None
         self._prescan_client: Any = None
+        # PR 3: chart-read fallback (Sonnet rescue for low-confidence Haiku responses).
+        self._chart_fallback_client: Any = None
+        self._chart_fallback_escalations: int = 0
 
     @staticmethod
     def _zero_spend_by_site() -> dict[str, float]:
@@ -213,6 +242,14 @@ class OCRExtractionStage:
                 context.config.vision_prescan_model,
             )
         return self._prescan_client
+
+    def _get_chart_fallback_client(self, context: pipeline.PipelineContext) -> Any:
+        if self._chart_fallback_client is None:
+            self._chart_fallback_client = _build_chart_fallback_client(
+                context.config.vision_chart_fallback_provider,
+                context.config.vision_chart_fallback_model,
+            )
+        return self._chart_fallback_client
 
     @property
     def vision_client(self) -> Any:
@@ -796,7 +833,9 @@ numbers also appear as explicit data labels on the chart itself.
             _grid=grid,
         )
 
-    def process_chart(self, asset: ImageAsset) -> float:
+    def process_chart(
+        self, asset: ImageAsset, context: pipeline.PipelineContext | None = None
+    ) -> float:
         """
         Extract labeled values from chart.
 
@@ -895,6 +934,44 @@ numbers also appear as explicit data labels on the chart itself.
                 asset.confidence = 0.0
                 asset.requires_manual_capture = True
                 return call_cost
+
+            # Fallback escalation (PR 3): if primary (Haiku) confidence is below threshold,
+            # re-call the fallback model (Sonnet) on the same image. Both calls' costs
+            # are recorded; escalation count is surfaced in stage metadata.
+            # context may be None when process_chart is called directly in tests.
+            primary_confidence = float(chart_response.get("confidence", 0.8))
+            fallback_model = (
+                context.config.vision_chart_fallback_model if context is not None else ""
+            )
+            if (
+                context is not None
+                and primary_confidence < context.config.vision_chart_confidence_threshold
+                and fallback_model
+            ):
+                fallback_client = self._get_chart_fallback_client(context)
+                try:
+                    fallback_response = fallback_client.analyze_image_targeted(
+                        image_bytes=image_bytes,
+                        prompt=self._get_chart_extraction_prompt(
+                            nearby_text=asset.nearby_text,
+                            ocr_text=ocr_text_blob,
+                        ),
+                        task_type="chart_read",
+                        detail="high",
+                        max_tokens=2000,
+                        response_format={"type": "json_object"},
+                    )
+                    fallback_cost = float(getattr(fallback_response, "cost_usd", 0.0))
+                    call_cost += fallback_cost
+                    self._vision_spend_by_site["chart_read_premium"] += fallback_cost
+                    fallback_parsed = self._parse_chart_json(fallback_response.content)
+                    if fallback_parsed is not None:
+                        fallback_confidence = float(fallback_parsed.get("confidence", 0.8))
+                        if fallback_confidence > primary_confidence:
+                            chart_response = fallback_parsed
+                            self._chart_fallback_escalations += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"Chart fallback escalation failed for {asset.img_id}: {exc}")
 
             # Extract chart metadata
             chart_type_str = chart_response.get("chart_type", "unknown")
@@ -1254,6 +1331,8 @@ numbers also appear as explicit data labels on the chart itself.
         self._vision_spend_by_site = self._zero_spend_by_site()
         self._full_page_ocr_client = None
         self._prescan_client = None
+        self._chart_fallback_client = None
+        self._chart_fallback_escalations = 0
 
         # A3: per-filing chart-spend ceiling. Read env each call so tests
         # and operators can tune at runtime without reconstructing the stage.
@@ -1375,7 +1454,7 @@ numbers also appear as explicit data labels on the chart itself.
                         if asset.ocr_table is not None:
                             context.tables.append(asset.ocr_table)
                     elif asset.classification == ImageClassification.CHART:
-                        chart_cost = self.process_chart(asset)
+                        chart_cost = self.process_chart(asset, context)
                         self._chart_call_count += 1
                         self._chart_vision_spend += chart_cost
                         # Track charts that were processed but yielded no data.
@@ -1391,7 +1470,7 @@ numbers also appear as explicit data labels on the chart itself.
                         if contains_chart:
                             has_tier1 = bool(self.TIER1_KEYWORDS_RE.search(asset.nearby_text or ""))
                             if has_tier1 or round(self._chart_vision_spend, 4) < chart_budget_usd:
-                                chart_cost = self.process_chart(asset)
+                                chart_cost = self.process_chart(asset, context)
                                 self._chart_call_count += 1
                                 self._chart_vision_spend += chart_cost
                                 self._api_call_count += 1
@@ -1462,6 +1541,7 @@ numbers also appear as explicit data labels on the chart itself.
                     "skipped_by_budget_cap": skipped_by_budget_cap,
                     "parse_failed": self._parse_failed_count,
                     "chart_data_none_after_processing": chart_data_none_after_processing,
+                    "chart_fallback_escalations": self._chart_fallback_escalations,
                     "vision_spend_usd_by_site": {
                         site: round(spend, 6) for site, spend in self._vision_spend_by_site.items()
                     },

--- a/src/llm/vision_client.py
+++ b/src/llm/vision_client.py
@@ -20,7 +20,7 @@ Wave B4 two-stage routing:
   - CHART calls make *two* sequential calls:
     1. Fast OCR pass (same fast provider) to extract axis labels / legends /
        annotation strings as a text blob.
-    2. Premium reader (``VISION_MODEL_CHART``, default ``claude-sonnet-4-6``)
+    2. Premium reader (``VISION_MODEL_CHART``, default ``claude-haiku-4-5-20251001``)
        with the standard chart-extraction prompt augmented by the OCR blob as
        grounding context.  The premium prompt still enforces "labeled values
        only — no interpolation".
@@ -253,7 +253,7 @@ def _build_provider(provider_name: str, model: str) -> object:
 # Default models for two-stage routing (Wave B4).
 # These are read at stage init; operators can override via env vars.
 _TWO_STAGE_DEFAULT_OCR_MODEL = "gemini-2.5-flash-lite"
-_TWO_STAGE_DEFAULT_CHART_MODEL = "claude-sonnet-4-6"
+_TWO_STAGE_DEFAULT_CHART_MODEL = "claude-haiku-4-5-20251001"
 _TWO_STAGE_DEFAULT_OCR_PROVIDER = "gemini"
 _TWO_STAGE_DEFAULT_CHART_PROVIDER = "anthropic"
 
@@ -266,7 +266,7 @@ def _resolve_two_stage_providers() -> tuple[tuple[str, str], tuple[str, str]]:
 
     OCR model is controlled by ``VISION_MODEL_OCR`` env var (default:
     ``gemini-2.5-flash-lite`` via Gemini).  Chart model is controlled by
-    ``VISION_MODEL_CHART`` env var (default: ``claude-sonnet-4-6`` via
+    ``VISION_MODEL_CHART`` env var (default: ``claude-haiku-4-5-20251001`` via
     Anthropic).  When an env-var override specifies a model that belongs to a
     different provider, we make a best-effort guess based on model name
     prefixes; callers can also set ``VISION_PROVIDER_OCR`` /
@@ -535,7 +535,7 @@ class VisionClient:
         - ``task_type='table_ocr'`` or ``'chart_ocr'`` → fast provider
           (``VISION_MODEL_OCR``, default ``gemini-2.5-flash-lite``).
         - ``task_type='chart_read'`` → premium reader (``VISION_MODEL_CHART``,
-          default ``claude-sonnet-4-6``).
+          default ``claude-haiku-4-5-20251001``).
 
         When ``VISION_ROUTING_MODE=legacy`` (default), all task types route
         through the single provider configured at init — behavior is

--- a/tests/unit/extraction_v2/conftest.py
+++ b/tests/unit/extraction_v2/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for extraction_v2 unit tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_vision_routing_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure VISION_ROUTING_MODE is unset at the start of each test.
+
+    test_batch_runner.py imports batch_v2_extraction via exec_module, which
+    calls load_dotenv() and can set VISION_ROUTING_MODE from a local .env file.
+    This fixture prevents that from contaminating tests that expect legacy mode.
+    """
+    monkeypatch.delenv("VISION_ROUTING_MODE", raising=False)

--- a/tests/unit/extraction_v2/test_batch_runner.py
+++ b/tests/unit/extraction_v2/test_batch_runner.py
@@ -9,6 +9,7 @@ circuit-breaker logic, timeout handling, and transient retry using mocks
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 import time
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -28,7 +29,15 @@ assert spec is not None and spec.loader is not None, f"Could not locate {_BATCH_
 batch_v2_extraction = importlib.util.module_from_spec(spec)
 # Register module so patch() can find it by dotted name
 sys.modules["batch_v2_extraction"] = batch_v2_extraction
+# exec_module runs load_dotenv() inside the script which may set env vars (e.g.
+# VISION_ROUTING_MODE) from a local .env file.  Save and restore so we don't
+# contaminate later tests that assume a clean environment.
+_prior_routing_mode = os.environ.get("VISION_ROUTING_MODE")
 spec.loader.exec_module(batch_v2_extraction)  # type: ignore[union-attr]
+if _prior_routing_mode is None:
+    os.environ.pop("VISION_ROUTING_MODE", None)
+else:
+    os.environ["VISION_ROUTING_MODE"] = _prior_routing_mode
 
 BatchConfig = batch_v2_extraction.BatchConfig
 BatchStats = batch_v2_extraction.BatchStats

--- a/tests/unit/extraction_v2/test_chart_fallback_escalation.py
+++ b/tests/unit/extraction_v2/test_chart_fallback_escalation.py
@@ -1,0 +1,370 @@
+"""
+Chart-read fallback escalation (PR 3 of vision cost experiments).
+
+Validates that:
+- PipelineConfig defaults to Sonnet fallback at threshold 0.7.
+- Env overrides flow into config via _apply_env_feature_flags.
+- No fallback fires when primary confidence >= threshold.
+- Fallback fires and replaces primary when primary confidence < threshold and
+  fallback confidence > primary confidence.
+- Fallback does NOT replace primary when its confidence <= primary confidence.
+- Fallback exceptions are non-fatal (primary response is preserved).
+- Empty VISION_CHART_FALLBACK_MODEL disables the fallback entirely.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.extraction_v2.models import ImageAsset, ImageClassification
+from src.extraction_v2.pipeline import PipelineConfig, PipelineContext, V2Pipeline
+from src.extraction_v2.stages.ocr_extraction import OCRExtractionStage
+from src.llm.vision_client import VisionResponse
+
+# ---------------------------------------------------------------------------
+# Fixtures — route image storage to tmp so get_bytes() resolves
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _route_image_cache_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.infra.image_storage import get_image_storage
+    from src.infra.paths import image_cache_dir
+
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("R2_BUCKET", raising=False)
+    image_cache_dir.cache_clear()
+    get_image_storage.cache_clear()
+    yield  # type: ignore[misc]
+    image_cache_dir.cache_clear()
+    get_image_storage.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_dummy_png(path: Path) -> None:
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+        b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+
+def _chart_payload(confidence: float = 0.9) -> dict[str, Any]:
+    return {
+        "chart_type": "bar",
+        "title": "Revenue",
+        "x_axis_label": "Year",
+        "y_axis_label": "USD",
+        "confidence": confidence,
+        "series": [{"name": "Revenue", "points": [{"x": "2021", "y": 100.0, "label": "100"}]}],
+        "annotations": [],
+    }
+
+
+def _vision_response(payload: dict[str, Any], *, cost: float) -> VisionResponse:
+    return VisionResponse(
+        content=json.dumps(payload),
+        model="mock",
+        prompt_tokens=10,
+        completion_tokens=10,
+        cost_usd=cost,
+        latency_ms=1,
+    )
+
+
+def _chart_ocr_response(cost: float = 0.005) -> VisionResponse:
+    return VisionResponse(
+        content=json.dumps({"text": "Revenue\n2021\n100", "labels": ["Revenue"]}),
+        model="mock",
+        prompt_tokens=5,
+        completion_tokens=5,
+        cost_usd=cost,
+        latency_ms=1,
+    )
+
+
+class _SequencedVisionClient:
+    """Returns pre-built VisionResponses in order."""
+
+    def __init__(self, responses: list[VisionResponse]) -> None:
+        self.responses = list(responses)
+        self.call_count = 0
+
+    def analyze_image(self, image_bytes: bytes, prompt: str, **_: Any) -> VisionResponse:
+        if self.call_count >= len(self.responses):
+            raise IndexError(f"no more responses (call_count={self.call_count})")
+        resp = self.responses[self.call_count]
+        self.call_count += 1
+        return resp
+
+    def analyze_image_targeted(self, **_: Any) -> VisionResponse:
+        return self.analyze_image(image_bytes=b"", prompt="")
+
+
+def _make_context(
+    tmp_path: Path, images: list[ImageAsset], config: PipelineConfig
+) -> PipelineContext:
+    return PipelineContext(
+        html_path=tmp_path / "test.html",
+        filing_id=1,
+        config=config,
+        images=images,
+    )
+
+
+def _chart_asset(tmp_path: Path) -> ImageAsset:
+    png = tmp_path / "chart.png"
+    _write_dummy_png(png)
+    return ImageAsset(
+        img_id="c1",
+        filename="chart.png",
+        nearby_text="Revenue",
+        width=800,
+        height=600,
+        classification=ImageClassification.CHART,
+        relevance_score=0.9,
+        file_path=png.name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Default config
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    def test_fallback_model_default(self) -> None:
+        cfg = PipelineConfig()
+        assert cfg.vision_chart_fallback_model == "claude-sonnet-4-6"
+
+    def test_fallback_provider_default(self) -> None:
+        cfg = PipelineConfig()
+        assert cfg.vision_chart_fallback_provider == "anthropic"
+
+    def test_confidence_threshold_default(self) -> None:
+        cfg = PipelineConfig()
+        assert cfg.vision_chart_confidence_threshold == 0.7
+
+
+# ---------------------------------------------------------------------------
+# 2. Env override flow
+# ---------------------------------------------------------------------------
+
+
+class TestEnvOverrides:
+    def test_fallback_model_env_flows_into_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VISION_CHART_FALLBACK_MODEL", "claude-opus-4-7")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        pipeline = V2Pipeline()
+        assert pipeline.config.vision_chart_fallback_model == "claude-opus-4-7"
+
+    def test_confidence_threshold_env_flows_into_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_CHART_CONFIDENCE_THRESHOLD", "0.8")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        pipeline = V2Pipeline()
+        assert pipeline.config.vision_chart_confidence_threshold == 0.8
+
+    def test_invalid_threshold_logs_warning_and_keeps_default(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("VISION_CHART_CONFIDENCE_THRESHOLD", "not-a-float")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            pipeline = V2Pipeline()
+        assert pipeline.config.vision_chart_confidence_threshold == 0.7
+        assert "VISION_CHART_CONFIDENCE_THRESHOLD" in caplog.text
+
+    def test_empty_fallback_model_env_disables_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_CHART_FALLBACK_MODEL", "")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        pipeline = V2Pipeline()
+        assert pipeline.config.vision_chart_fallback_model == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. No escalation when primary confidence >= threshold
+# ---------------------------------------------------------------------------
+
+
+class TestNoEscalationAboveThreshold:
+    def test_fallback_client_never_called_when_confidence_high(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+        primary_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.9), cost=0.02)]
+        )
+        config = PipelineConfig(vision_chart_confidence_threshold=0.7)
+        stage = OCRExtractionStage(vision_client=primary_client)
+        fallback_client = MagicMock()
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: fallback_client)
+
+        stage.process(_make_context(tmp_path, [asset], config))
+
+        fallback_client.analyze_image_targeted.assert_not_called()
+        assert stage._chart_fallback_escalations == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Escalation replaces primary when fallback has higher confidence
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationReplacesLowConfidence:
+    def test_fallback_used_when_primary_confidence_below_threshold(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+
+        primary_resp = _vision_response(_chart_payload(confidence=0.5), cost=0.01)
+        fallback_resp = _vision_response(_chart_payload(confidence=0.85), cost=0.03)
+
+        primary_client = _SequencedVisionClient([primary_resp])
+        fallback_client = _SequencedVisionClient([fallback_resp])
+
+        config = PipelineConfig(vision_chart_confidence_threshold=0.7)
+        stage = OCRExtractionStage(vision_client=primary_client)
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: fallback_client)
+
+        result = stage.process(_make_context(tmp_path, [asset], config))
+
+        assert stage._chart_fallback_escalations == 1
+        # Both calls' costs land in chart_read_premium
+        spend = result.metadata["vision_spend_usd_by_site"]
+        assert spend["chart_read_premium"] == pytest.approx(0.01 + 0.03)
+        assert result.metadata["chart_fallback_escalations"] == 1
+
+    def test_asset_confidence_reflects_fallback_response(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+
+        primary_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.5), cost=0.01)]
+        )
+        fallback_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.85), cost=0.03)]
+        )
+        config = PipelineConfig(vision_chart_confidence_threshold=0.7)
+        stage = OCRExtractionStage(vision_client=primary_client)
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: fallback_client)
+
+        stage.process(_make_context(tmp_path, [asset], config))
+
+        assert asset.confidence == pytest.approx(0.85)
+
+
+# ---------------------------------------------------------------------------
+# 5. Fallback rejected when its confidence is lower than primary's
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackRejectedWhenLowerConfidence:
+    def test_primary_kept_when_fallback_confidence_lower(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+
+        primary_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.5), cost=0.01)]
+        )
+        fallback_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.4), cost=0.03)]
+        )
+        config = PipelineConfig(vision_chart_confidence_threshold=0.7)
+        stage = OCRExtractionStage(vision_client=primary_client)
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: fallback_client)
+
+        result = stage.process(_make_context(tmp_path, [asset], config))
+
+        # Escalation count stays 0 — we didn't actually replace the primary
+        assert stage._chart_fallback_escalations == 0
+        assert result.metadata["chart_fallback_escalations"] == 0
+        # Both calls' costs still accumulate
+        spend = result.metadata["vision_spend_usd_by_site"]
+        assert spend["chart_read_premium"] == pytest.approx(0.01 + 0.03)
+        # Asset confidence reflects primary (not replaced by lower fallback)
+        assert asset.confidence == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# 6. Fallback exception is non-fatal
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackExceptionNonFatal:
+    def test_primary_preserved_on_fallback_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+
+        primary_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.5), cost=0.01)]
+        )
+        broken_fallback = MagicMock()
+        broken_fallback.analyze_image_targeted.side_effect = RuntimeError("API down")
+
+        config = PipelineConfig(vision_chart_confidence_threshold=0.7)
+        stage = OCRExtractionStage(vision_client=primary_client)
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: broken_fallback)
+
+        with caplog.at_level(logging.WARNING):
+            result = stage.process(_make_context(tmp_path, [asset], config))
+
+        # No exception bubbled up; asset was still processed
+        assert asset.processed is True
+        assert result.metadata["chart_fallback_escalations"] == 0
+        # Warning logged about the failure
+        assert "fallback" in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Disable fallback via empty VISION_CHART_FALLBACK_MODEL
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackDisabled:
+    def test_empty_fallback_model_skips_escalation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VISION_ROUTING_MODE", "legacy")
+        asset = _chart_asset(tmp_path)
+
+        primary_client = _SequencedVisionClient(
+            [_vision_response(_chart_payload(confidence=0.3), cost=0.01)]
+        )
+        # Even though confidence is well below 0.7, fallback is disabled
+        config = PipelineConfig(
+            vision_chart_confidence_threshold=0.7,
+            vision_chart_fallback_model="",
+        )
+        stage = OCRExtractionStage(vision_client=primary_client)
+        fallback_client = MagicMock()
+        monkeypatch.setattr(stage, "_get_chart_fallback_client", lambda ctx: fallback_client)
+
+        stage.process(_make_context(tmp_path, [asset], config))
+
+        fallback_client.analyze_image_targeted.assert_not_called()
+        assert stage._chart_fallback_escalations == 0


### PR DESCRIPTION
## Summary

PR 3 of 5 in the vision cost/quality experiment sequence.

- **Cost savings**: Changes the default two-stage chart-read model from `claude-sonnet-4-6` to `claude-haiku-4-5-20251001` (~3× cheaper at $0.075 per 1K tokens vs $0.232 for Sonnet chart-read premium)
- **Quality safety net**: Adds confidence-based Sonnet fallback — if Haiku's chart-read `confidence < 0.7`, re-calls Sonnet on the same image and replaces the result only if Sonnet's confidence is higher
- **Observability**: Adds `chart_fallback_escalations` counter to `StageResult.metadata`
- **Bug fix**: Resolves pre-existing `VISION_ROUTING_MODE` test contamination (issue #366) that was blocking the push — root cause traced to `test_batch_runner.py` loading `batch_v2_extraction.py` via `exec_module` at collection time, which ran `load_dotenv()` and leaked `VISION_ROUTING_MODE=two_stage` from the local `.env` file

## Changes

- `src/llm/vision_client.py`: `_TWO_STAGE_DEFAULT_CHART_MODEL = "claude-haiku-4-5-20251001"`
- `src/extraction_v2/pipeline.py`: 3 new `PipelineConfig` fields (`vision_chart_fallback_model`, `vision_chart_fallback_provider`, `vision_chart_confidence_threshold`) + env wiring in `_apply_env_feature_flags`
- `src/extraction_v2/stages/ocr_extraction.py`: `_build_chart_fallback_client()` + lazy `_get_chart_fallback_client()` + fallback escalation logic in `process_chart`; context param made optional for backward compat
- `.env.template`: PR 3 env var block (all commented out)
- `tests/unit/extraction_v2/test_chart_fallback_escalation.py`: 13 new tests (7 classes)
- `tests/unit/extraction_v2/conftest.py`: autouse fixture clearing `VISION_ROUTING_MODE` per test (fix for #366)
- `tests/unit/extraction_v2/test_batch_runner.py`: save/restore guard around `exec_module` (documents contamination source)
- `docs/operations/vision-model-selection.md`, `.claude/rules/v2-pipeline.md`: updated docs

## Test plan

- [x] 13 new unit tests for fallback escalation logic (all pass)
- [x] Full unit test suite: 4088 passed (pre-push hook confirmed green)
- [ ] Gold-standard chart presence-F1 informational check (advisory — not a blocker)

## Env knobs

```
VISION_CHART_FALLBACK_MODEL=claude-sonnet-4-6     # default; empty string disables fallback
VISION_CHART_FALLBACK_PROVIDER=anthropic           # default
VISION_CHART_CONFIDENCE_THRESHOLD=0.7             # default
```

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)