### PR TITLE
fix(image-review): disambiguate "Skipped" vs "No relevant metrics"

### DIFF
--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -834,7 +834,14 @@
               {% if current_image.review_status == 'reviewed' %}
               <span class="badge bg-success">Reviewed</span>
               {% elif current_image.review_status == 'skipped' %}
+              {# Disambiguate: 'skipped' + per-metric confirmations means the reviewer
+                 hit "Reject all (no relevant metrics)" — surface that intent rather
+                 than collapsing it into a plain "Skipped" badge. See .claude/rules/web.md. #}
+              {% if current_image_confirmations|length > 0 %}
+              <span class="badge bg-secondary">No relevant metrics</span>
+              {% else %}
               <span class="badge bg-secondary">Skipped</span>
+              {% endif %}
               {% else %}
               <span class="badge bg-warning text-dark">Pending</span>
               {% endif %}
@@ -866,7 +873,13 @@
           {% if current_image.review_status == 'skipped' %}
           <div class="alert alert-secondary mb-3">
             <div class="d-flex justify-content-between align-items-center">
+              {% if current_image_confirmations|length > 0 %}
+              <div><strong>Status:</strong> No relevant metrics — verified by reviewer
+                <small class="text-muted ms-1">({{ current_image_confirmations|length }} per-metric decision{{ '' if current_image_confirmations|length == 1 else 's' }} recorded)</small>
+              </div>
+              {% else %}
               <div><strong>Status:</strong> Image skipped</div>
+              {% endif %}
               <button type="button" id="btn-undo" class="btn btn-outline-secondary btn-sm">
                 <span class="badge bg-secondary me-1">U</span> Undo
               </button>


### PR DESCRIPTION
Previously, an image with `review_status='skipped'` rendered as "Status:
Image skipped" / "Skipped" regardless of how it got there — both a
plain "Skip whole image" click and a "Reject all (no relevant metrics)"
click landed on the same flat label, hiding the reviewer's intent.

The .claude/rules/web.md contract calls for disambiguating by
`total_confirmation_count`: > 0 reads "No relevant metrics" (reject-all
flow recorded per-metric reject rows in v2_image_metric_confirmations,
or a sentinel row when the image had zero detected metrics), == 0
reads "Skipped" (image-level park, no per-metric judgement).

Implementation: branch the badge and status alert in unified_review.html
on `current_image_confirmations|length`. The route already passes that
list to the template so no route or DB change is required.

Net: when a reviewer hits "Reject all (no relevant metrics)" the UI now
surfaces "No relevant metrics — verified by reviewer (N per-metric
decisions recorded)" instead of "Image skipped", making the
human-verified ML training signal visible at the point of action.
