### PR TITLE
feat(ingest): facet-driven Industries + Year picker on /ingest/ form

### DIFF
--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -350,6 +350,38 @@ it_services_consulting, homebuilding) plus aliases (`bio`, `pharma`,
 SEC's published list. To add a new industry, append to the YAML and run
 `pytest tests/unit/universe/test_onboarding.py::test_load_industry_map_includes_new_industries`.
 
+### Year ↔ industry facet cascade (Phase 2b, 2026-04-30)
+
+The discovery form (the lower section under the Build-universe panel) is
+now **facet-driven**: both Industries and Year are multi-select listboxes
+populated from the actual contents of `filings`, with row counts shown
+next to each option. Selecting one axis narrows the other:
+
+- Selecting year(s) → industries listbox re-renders with counts narrowed
+  to filings in those years; industries with zero rows in the selection
+  are hidden.
+- Selecting industries → year listbox re-renders with counts narrowed to
+  filings whose company SIC is in any selected industry's SIC list.
+- Each axis ignores its own selections (standard facet UX), so picking
+  "2016" doesn't shrink the year list to just "2016".
+- Selected options that drop to zero count stay visible-and-selected
+  (greyed `(0)`) so the user can deselect them.
+
+Backed by `GET /api/v2/ingest/filter-options?year=...&industry=...` →
+`{years: [{year, count}], industries: [{key, label, count}]}`. Both
+queries live in `src/universe/onboarding.py`
+(`query_universe_year_counts`, `query_universe_industry_counts`).
+Cascade JS: `src/web/static/js/ingest_form_facets.js`.
+
+**Form-types row** is intentionally NOT part of the cascade — it stays
+as the full 4-checkbox set. Add to the cascade if it becomes confusing
+in practice.
+
+**Year multi-select edge case:** non-contiguous selections (e.g. 2016 +
+2018 with 2017 omitted) silently expand to the inclusive (min, max) range
+because the underlying discovery SQL uses `BETWEEN year_min AND year_max`.
+For a true gap, submit two batches.
+
 ### Universe gap banner
 
 If the criteria reference (year × form_type) combinations with zero rows in

--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -806,3 +806,150 @@ def onboard(
             break
 
     return summary
+
+
+# ---------------------------------------------------------------------------
+# Universe-state aggregations — power the /ingest/ form facet cascade.
+# Year ↔ industry counts so the operator only sees slices that actually have
+# rows in the universe. See docs/operations/TICKER_ONBOARDING.md.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class YearCount:
+    """A year present in `filings` and the count of rows that fall in it."""
+
+    year: int
+    count: int
+
+
+@dataclass(frozen=True)
+class IndustryCount:
+    """A YAML industry entry and the count of filings whose company SIC code
+    is in that industry's sic_codes list."""
+
+    key: str  # canonical industry name from YAML (e.g. "biotech")
+    label: str  # humanised (e.g. "Biotech") — same shape as `_industry_options()`
+    count: int
+
+
+def _industry_label(key: str) -> str:
+    """Match the legacy `_industry_options()` label format."""
+    return key.replace("_", " ").title()
+
+
+_YEAR_COUNTS_SQL = """
+SELECT EXTRACT(YEAR FROM f.filing_date)::int AS yr,
+       COUNT(*)::int AS cnt
+FROM filings f
+JOIN companies c ON c.company_id = f.company_id
+WHERE 1=1
+"""
+
+_YEAR_COUNTS_INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
+
+_YEAR_COUNTS_TAIL = """GROUP BY yr
+ORDER BY yr DESC
+"""
+
+
+def query_universe_year_counts(
+    db: DatabaseAdapter,
+    *,
+    sic_codes: list[str] | None = None,
+) -> list[YearCount]:
+    """Return distinct years in `filings` with their row count, DESC.
+
+    Optional ``sic_codes`` restricts to filings whose
+    ``companies.industry_code`` IS IN the list. None or empty list means
+    all-time, all-industry.
+
+    Years with count==0 are not returned (they wouldn't have a row in
+    ``filings`` anyway).
+    """
+    sql = _YEAR_COUNTS_SQL
+    params: dict[str, Any] = {}
+    if sic_codes:
+        sql += _YEAR_COUNTS_INDUSTRY_GATE
+        params["sic_codes"] = list(sic_codes)
+    sql += _YEAR_COUNTS_TAIL
+    rows = db.query(sql, params)
+    return [YearCount(year=int(r["yr"]), count=int(r["cnt"])) for r in rows]
+
+
+_INDUSTRY_COUNTS_SQL_TEMPLATE = """
+SELECT industry_sic.industry_key,
+       industry_sic.industry_label,
+       COUNT(f.filing_id)::int AS cnt
+FROM unnest(
+    %(keys)s::text[],
+    %(labels)s::text[],
+    %(sics)s::text[]
+) AS industry_sic(industry_key, industry_label, sic)
+LEFT JOIN companies c ON c.industry_code = industry_sic.sic
+LEFT JOIN filings  f ON f.company_id = c.company_id
+{year_filter}
+GROUP BY industry_sic.industry_key, industry_sic.industry_label
+ORDER BY industry_sic.industry_label
+"""
+
+
+def query_universe_industry_counts(
+    db: DatabaseAdapter,
+    industry_map: dict[str, Any],
+    *,
+    years: list[int] | None = None,
+) -> list[IndustryCount]:
+    """For every industry in *industry_map*, return its filing count.
+
+    Implementation: a single SQL query joins filings → companies → an inline
+    relation built from ``unnest()`` of three parallel arrays
+    ``(industry_key, industry_label, sic)`` derived from the YAML.
+
+    SIC-code overlap across industries is handled cleanly: a filing whose
+    ``companies.industry_code`` matches multiple industries contributes one
+    row toward each (the unnest gives one tuple per (industry, sic) pair).
+
+    Optional ``years`` restricts to filings whose filing_date year is in the
+    list. The filter is applied ON the JOIN, not in WHERE, so industries
+    with zero filings are still returned (count=0). The endpoint / template
+    decides whether to display zero-count entries.
+
+    Sorted alphabetically by ``label``.
+    """
+    industries: dict[str, Any] = industry_map.get("industries") or {}
+    if not industries:
+        return []
+
+    keys: list[str] = []
+    labels: list[str] = []
+    sics: list[str] = []
+    for industry_key, entry in industries.items():
+        label = _industry_label(industry_key)
+        for sic in entry.get("sic_codes") or []:
+            keys.append(industry_key)
+            labels.append(label)
+            sics.append(sic)
+
+    if not keys:
+        return []
+
+    if years:
+        year_filter = "AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)"
+    else:
+        year_filter = ""
+
+    sql = _INDUSTRY_COUNTS_SQL_TEMPLATE.format(year_filter=year_filter)
+    params: dict[str, Any] = {"keys": keys, "labels": labels, "sics": sics}
+    if years:
+        params["years"] = [int(y) for y in years]
+
+    rows = db.query(sql, params)
+    return [
+        IndustryCount(
+            key=str(r["industry_key"]),
+            label=str(r["industry_label"]),
+            count=int(r["cnt"]),
+        )
+        for r in rows
+    ]

--- a/src/web/routes/api_ingest.py
+++ b/src/web/routes/api_ingest.py
@@ -4,6 +4,7 @@ JSON API endpoints for batch ingestion.
 Routes:
   GET  /api/v2/ingest/batches/<uuid>/status  — JSON status + filings list
   POST /api/v2/ingest/batches/<uuid>/cancel  — Soft-cancel a batch
+  GET  /api/v2/ingest/filter-options         — Year ↔ industry facet counts
 """
 
 from __future__ import annotations
@@ -13,8 +14,14 @@ import logging
 import uuid as _uuid
 
 import psycopg
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
+from src.universe.onboarding import (
+    load_industry_map,
+    query_universe_industry_counts,
+    query_universe_year_counts,
+    resolve_industry,
+)
 from src.web.app import get_db
 from src.web.middleware import register_api_auth
 
@@ -194,3 +201,60 @@ def batch_cancel(batch_id: str):
         return jsonify({"status": "ok", "message": "no-op"}), 200
 
     return jsonify({"status": "ok"}), 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v2/ingest/filter-options
+#
+# Year ↔ industry facet counts for the /ingest/ form. Each axis ignores its
+# own selections (standard facet behaviour) so the user always sees the full
+# set of options for that axis given the OTHER axis's filter.
+# ---------------------------------------------------------------------------
+
+
+@api_ingest_bp.route("/filter-options", methods=["GET"])
+def filter_options():
+    raw_years = request.args.getlist("year")
+    raw_industries = request.args.getlist("industry")
+
+    selected_years: list[int] = []
+    for raw in raw_years:
+        try:
+            selected_years.append(int(raw))
+        except (TypeError, ValueError):
+            continue  # ignore malformed input rather than 400 — facet is best-effort
+
+    industry_map = load_industry_map()
+    selected_sic_codes: list[str] = []
+    for ind_name in raw_industries:
+        try:
+            _, codes = resolve_industry(ind_name, industry_map)
+        except ValueError:
+            continue  # unknown industry → ignored
+        selected_sic_codes.extend(codes)
+    # Dedupe SIC codes while preserving order
+    seen: set[str] = set()
+    selected_sic_codes = [s for s in selected_sic_codes if not (s in seen or seen.add(s))]
+
+    db = get_db()
+
+    try:
+        # Year counts: filter only by selected industries (axis ignores its own selections)
+        year_rows = query_universe_year_counts(
+            db, sic_codes=selected_sic_codes if selected_sic_codes else None
+        )
+        # Industry counts: filter only by selected years (same reason)
+        industry_rows = query_universe_industry_counts(
+            db, industry_map, years=selected_years if selected_years else None
+        )
+    except psycopg.DatabaseError as exc:
+        logger.error("DB error in filter-options: %s", exc)
+        return jsonify({"status": "error", "message": "Database error"}), 500
+
+    payload = {
+        "years": [{"year": yc.year, "count": yc.count} for yc in year_rows],
+        "industries": [
+            {"key": ic.key, "label": ic.label, "count": ic.count} for ic in industry_rows
+        ],
+    }
+    return jsonify(payload), 200

--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -39,6 +39,8 @@ from src.universe.onboarding import (
     count_reviewer_work,
     discover,
     load_industry_map,
+    query_universe_industry_counts,
+    query_universe_year_counts,
     resolve_criteria,
 )
 from src.web.app import get_db
@@ -55,16 +57,41 @@ _PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 # ---------------------------------------------------------------------------
 
 
-def _industry_options() -> list[dict[str, str]]:
-    """Return sorted list of industry options from industry_sic_codes.yaml."""
+def _industry_options() -> list[dict[str, Any]]:
+    """Return industry options annotated with universe filing counts.
+
+    Industries with no filings in the universe (count == 0) are still
+    returned so the JS facet cascade can show them as disabled rather than
+    making them disappear when years narrow the result. The template
+    decides whether to hide zero-count rows on initial render.
+    """
     try:
         ind_map = load_industry_map()
-        return sorted(
-            [{"key": k, "label": k.replace("_", " ").title()} for k in ind_map["industries"]],
-            key=lambda x: x["label"],
-        )
+        rows = query_universe_industry_counts(get_db(), ind_map)
+        return [{"key": r.key, "label": r.label, "count": r.count} for r in rows]
     except Exception:  # noqa: BLE001
-        logger.warning("Failed to load industry map", exc_info=True)
+        logger.warning("Failed to load industry options with counts", exc_info=True)
+        # Fall back to YAML-only list with count=0 so the form still renders.
+        try:
+            ind_map = load_industry_map()
+            return sorted(
+                [
+                    {"key": k, "label": k.replace("_", " ").title(), "count": 0}
+                    for k in ind_map["industries"]
+                ],
+                key=lambda x: x["label"],
+            )
+        except Exception:  # noqa: BLE001
+            return []
+
+
+def _year_options() -> list[dict[str, int]]:
+    """Return [{year, count}] for every year present in `filings`, DESC."""
+    try:
+        rows = query_universe_year_counts(get_db())
+        return [{"year": r.year, "count": r.count} for r in rows]
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to load year options with counts", exc_info=True)
         return []
 
 
@@ -73,7 +100,27 @@ def _parse_form_criteria() -> dict[str, Any]:
     industries = request.form.getlist("industries")
     sic_codes_raw = request.form.get("sic_codes", "").strip()
     form_types = request.form.getlist("form_types")
-    year = request.form.get("year", "").strip()
+    # Year is now a multi-select listbox: getlist returns the list of
+    # selected year strings. Collapse to (min, max) range for ResolvedQuery,
+    # which keeps the existing year_min/year_max SQL contract intact.
+    # NOTE: a non-contiguous selection (e.g. 2016 + 2018 with 2017 omitted)
+    # silently expands to the full 2016-2018 range. The form's UI is
+    # facet-driven and most selections will be either single-year or
+    # contiguous spans, so this is an acceptable trade-off; a future
+    # refactor can pass an explicit list to a years=ANY(...) SQL clause.
+    # Defensive fallback to the legacy single-string input handles old
+    # callers still posting year="2023" (tests, populate flow, etc.).
+    year_list = [y.strip() for y in request.form.getlist("year") if y and y.strip()]
+    if len(year_list) > 1:
+        try:
+            ints = sorted(int(y) for y in year_list)
+            year_value = f"{ints[0]}-{ints[-1]}"
+        except ValueError:
+            year_value = ""  # let resolve_criteria raise with its own message
+    elif len(year_list) == 1:
+        year_value = year_list[0]
+    else:
+        year_value = request.form.get("year", "").strip()
     reviewer_name = request.form.get("reviewer_name", "").strip()
     company_name_ilike = request.form.get("company_name_ilike", "").strip() or None
     limit_raw = request.form.get("limit", "").strip() or None
@@ -82,7 +129,7 @@ def _parse_form_criteria() -> dict[str, Any]:
         "industries": industries,
         "sic_codes": sic_codes_raw,
         "form_types": form_types if form_types else ["s1f1"],
-        "year": year,
+        "year": year_value,
         "company_name_ilike": company_name_ilike,
         "limit": limit_raw,
         "_reviewer_name": reviewer_name,
@@ -135,6 +182,7 @@ def _render_ingest_form(form_state: dict[str, Any] | None = None, status: int = 
             "ingest_form.html",
             reviewer_name=reviewer_name,
             industries=_industry_options(),
+            years_available=_year_options(),
             form_types_available=_FORM_TYPES_AVAILABLE,
             form_state=state,
         ),

--- a/src/web/static/js/ingest_form_facets.js
+++ b/src/web/static/js/ingest_form_facets.js
@@ -1,0 +1,114 @@
+/**
+ * /ingest/ form facet cascade.
+ *
+ * Listens for change events on the Industries and Year multi-selects and
+ * fetches GET /api/v2/ingest/filter-options to refresh the OTHER axis's
+ * counts and visibility. Each axis ignores its own selection (standard
+ * facet pattern), so picking 2016 narrows industries; picking biotech
+ * narrows years.
+ *
+ * Vanilla ES5 IIFE — no framework dependency. Loaded as a static asset
+ * from src/web/templates/ingest_form.html.
+ */
+(function () {
+  "use strict";
+
+  var industriesEl = document.getElementById("industries");
+  var yearEl = document.getElementById("year");
+  if (!industriesEl || !yearEl) {
+    return; // not on the ingest form page
+  }
+
+  function selectedValues(selectEl) {
+    var out = [];
+    var options = selectEl.options;
+    for (var i = 0; i < options.length; i++) {
+      if (options[i].selected) {
+        out.push(options[i].value);
+      }
+    }
+    return out;
+  }
+
+  function buildQuery(years, industries) {
+    var parts = [];
+    var i;
+    for (i = 0; i < years.length; i++) {
+      parts.push("year=" + encodeURIComponent(years[i]));
+    }
+    for (i = 0; i < industries.length; i++) {
+      parts.push("industry=" + encodeURIComponent(industries[i]));
+    }
+    return parts.join("&");
+  }
+
+  /**
+   * Update a select's options in place from a `[{value, label, count}]` list.
+   * Selected options are kept enabled even when count == 0 so the user can
+   * deselect them. Zero-count, unselected options are hidden.
+   */
+  function applyCounts(selectEl, items, valueKey, labelTemplate) {
+    var byValue = {};
+    var i;
+    for (i = 0; i < items.length; i++) {
+      byValue[String(items[i][valueKey])] = items[i];
+    }
+    var options = selectEl.options;
+    for (i = 0; i < options.length; i++) {
+      var opt = options[i];
+      var item = byValue[opt.value];
+      if (!item) {
+        // Option no longer present in the response (shouldn't happen for our
+        // server which always returns the same axis). Treat as count 0.
+        opt.setAttribute("data-count", "0");
+        opt.text = labelTemplate(opt.value, 0);
+        opt.hidden = !opt.selected;
+        opt.disabled = !opt.selected;
+        continue;
+      }
+      var count = parseInt(item.count, 10) || 0;
+      opt.setAttribute("data-count", String(count));
+      opt.text = labelTemplate(item, count);
+      // Hide zero-count options unless they're currently selected.
+      opt.hidden = count === 0 && !opt.selected;
+      opt.disabled = false; // never disable — keep selected toggleable
+    }
+  }
+
+  function refresh() {
+    var years = selectedValues(yearEl);
+    var industries = selectedValues(industriesEl);
+    var qs = buildQuery(years, industries);
+    fetch("/api/v2/ingest/filter-options" + (qs ? "?" + qs : ""), {
+      credentials: "same-origin",
+    })
+      .then(function (r) {
+        if (!r.ok) {
+          throw new Error("HTTP " + r.status);
+        }
+        return r.json();
+      })
+      .then(function (data) {
+        applyCounts(yearEl, data.years || [], "year", function (item, count) {
+          var year = typeof item === "object" ? item.year : item;
+          return year + " (" + count + ")";
+        });
+        applyCounts(industriesEl, data.industries || [], "key", function (item, count) {
+          if (typeof item !== "object") {
+            // Stale option not in response — keep its current label minus count
+            return String(item);
+          }
+          return item.label + " (" + count + ")";
+        });
+      })
+      .catch(function (err) {
+        // Non-fatal — leave the form in its current state.
+        if (window.console && window.console.warn) {
+          window.console.warn("filter-options fetch failed:", err);
+        }
+      });
+  }
+
+  industriesEl.addEventListener("change", refresh);
+  yearEl.addEventListener("change", refresh);
+})();

--- a/src/web/templates/ingest_form.html
+++ b/src/web/templates/ingest_form.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Batch Ingest — {{ app_name }}{% endblock %}
+{% block title %}Ingest and process documents — {{ app_name }}{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-lg-8">
-    <h2 class="mb-4">Batch Ingest</h2>
+    <h2 class="mb-4">Ingest and process documents</h2>
 
     <!-- Build universe (populate from SEC) -->
     <div class="card mb-4 border-info">
@@ -56,19 +56,44 @@
     {% set state = form_state or {} %}
     {% set selected_industries = state.get('industries') or [] %}
     {% set selected_form_types = state.get('form_types') or ['s1f1'] %}
+    {% set selected_year_raw = state.get('year') or '' %}
+    {% set selected_years = [] %}
+    {% if selected_year_raw %}
+      {% if '-' in selected_year_raw %}
+        {% set _lo, _hi = selected_year_raw.split('-', 1) %}
+        {% if _lo.isdigit() and _hi.isdigit() %}
+          {% set selected_years = range(_lo|int, _hi|int + 1) | list %}
+        {% endif %}
+      {% elif selected_year_raw.isdigit() %}
+        {% set selected_years = [selected_year_raw|int] %}
+      {% endif %}
+    {% endif %}
     <form method="POST" action="{{ url_for('ingest.ingest_preview') }}">
 
-      <!-- Industry multi-select -->
-      <div class="mb-3">
-        <label for="industries" class="form-label fw-semibold">Industries</label>
-        <input type="text" id="industry_search" class="form-control form-control-sm mb-1"
-               placeholder="Search industries..." autocomplete="off">
-        <select id="industries" name="industries" class="form-select" multiple size="8">
-          {% for ind in industries %}
-          <option value="{{ ind.key }}" {% if ind.key in selected_industries %}selected{% endif %}>{{ ind.label }}</option>
-          {% endfor %}
-        </select>
-        <div class="form-text">Hold Ctrl / Cmd to select multiple industries. Provide an industry, SIC code, or company name filter.</div>
+      <!-- Row 1: Industries (left) + Direct SIC Codes (right) -->
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <label for="industries" class="form-label fw-semibold">Industries</label>
+          <input type="text" id="industry_search" class="form-control form-control-sm mb-1"
+                 placeholder="Search industries..." autocomplete="off">
+          <select id="industries" name="industries" class="form-select" multiple size="8">
+            {% for ind in industries %}
+            <option value="{{ ind.key }}"
+                    data-count="{{ ind.count }}"
+                    {% if ind.key in selected_industries %}selected{% endif %}
+                    {% if ind.count == 0 and ind.key not in selected_industries %}hidden{% endif %}>{{ ind.label }} ({{ ind.count }})</option>
+            {% endfor %}
+          </select>
+          <div class="form-text">Hold Ctrl / Cmd to select multiple. List narrows to industries with rows in the selected year(s).</div>
+        </div>
+
+        <div class="col-md-6">
+          <label for="sic_codes" class="form-label fw-semibold">Direct SIC Codes</label>
+          <input type="text" id="sic_codes" name="sic_codes"
+                 class="form-control" placeholder="e.g. 7372, 5411"
+                 value="{{ state.get('sic_codes') or '' }}">
+          <div class="form-text">Comma-separated 4-digit SIC codes. Unioned with the Industries selection on the left. Use this to reach industries that don't appear in the named list.</div>
+        </div>
       </div>
 
       <script>
@@ -81,20 +106,35 @@
             for (var i = 0; i < options.length; i++) {
               var opt = options[i];
               var match = opt.textContent.toLowerCase().indexOf(term) !== -1;
-              opt.hidden = !match;
-              // Never deselect already-selected options even when hidden
+              // Preserve the facet-cascade `hidden` when count==0; only hide when search excludes
+              if (term === '') {
+                opt.hidden = (parseInt(opt.getAttribute('data-count') || '0', 10) === 0 && !opt.selected);
+              } else {
+                opt.hidden = !match;
+              }
             }
           });
         })();
       </script>
 
-      <!-- Direct SIC codes -->
+      <!-- Year picker — multi-select listbox over years present in the universe -->
       <div class="mb-3">
-        <label for="sic_codes" class="form-label fw-semibold">Direct SIC Codes</label>
-        <input type="text" id="sic_codes" name="sic_codes"
-               class="form-control" placeholder="e.g. 7372, 5411"
-               value="{{ state.get('sic_codes') or '' }}">
-        <div class="form-text">Comma-separated 4-digit SIC codes. Combined (union) with industry selection above.</div>
+        <label for="year" class="form-label fw-semibold">Year</label>
+        {% set _year_keys = years_available | map(attribute='year') | list %}
+        <select id="year" name="year" class="form-select" multiple size="6">
+          {% for yr in years_available %}
+          <option value="{{ yr.year }}"
+                  data-count="{{ yr.count }}"
+                  {% if yr.year in selected_years %}selected{% endif %}>{{ yr.year }} ({{ yr.count }})</option>
+          {% endfor %}
+          {# Render any selected years that aren't in years_available (defensive — covers stale form_state and DB-unavailable test conditions) #}
+          {% for sy in selected_years %}
+            {% if sy not in _year_keys %}
+            <option value="{{ sy }}" data-count="0" selected>{{ sy }} (0)</option>
+            {% endif %}
+          {% endfor %}
+        </select>
+        <div class="form-text">Hold Ctrl / Cmd to multi-select. Showing only years with filings in the universe. Non-contiguous selections (e.g. 2016 + 2018) are treated as the inclusive range; submit twice for true gaps.</div>
       </div>
 
       <!-- Form types -->
@@ -110,15 +150,6 @@
           </div>
           {% endfor %}
         </div>
-      </div>
-
-      <!-- Year / year range -->
-      <div class="mb-3">
-        <label for="year" class="form-label fw-semibold">Year or Year Range</label>
-        <input type="text" id="year" name="year"
-               class="form-control" placeholder="e.g. 2023 or 2020-2024"
-               value="{{ state.get('year') or '' }}" required>
-        <div class="form-text">Single year (2023) or inclusive range (2020-2024).</div>
       </div>
 
       <!-- Company name filter -->
@@ -157,4 +188,5 @@
     </form>
   </div>
 </div>
+<script src="{{ url_for('static', filename='js/ingest_form_facets.js') }}"></script>
 {% endblock %}

--- a/tests/unit/universe/test_onboarding.py
+++ b/tests/unit/universe/test_onboarding.py
@@ -11,13 +11,17 @@ import pytest
 
 from src.universe.onboarding import (
     Gap,
+    IndustryCount,
     ResolvedQuery,
     VolumeBand,
+    YearCount,
     classify_volume,
     count_reviewer_work,
     detect_universe_gaps,
     discover_candidates,
     load_industry_map,
+    query_universe_industry_counts,
+    query_universe_year_counts,
     resolve_criteria,
     resolve_industry,
 )
@@ -581,3 +585,108 @@ def test_load_industry_map_resolves_new_aliases(alias: str, target: str) -> None
     m = load_industry_map()
     canon, _codes = resolve_industry(alias, m)
     assert canon == target
+
+
+# ---------------------------------------------------------------------------
+# query_universe_year_counts — facet support for /ingest/ form
+# ---------------------------------------------------------------------------
+
+
+def test_query_universe_year_counts_returns_dataclass_list() -> None:
+    db = _FakeDB(
+        rows=[
+            {"yr": 2018, "cnt": 412},
+            {"yr": 2017, "cnt": 380},
+            {"yr": 2016, "cnt": 215},
+        ]
+    )
+    out = query_universe_year_counts(db)
+    assert out == [
+        YearCount(year=2018, count=412),
+        YearCount(year=2017, count=380),
+        YearCount(year=2016, count=215),
+    ]
+
+
+def test_query_universe_year_counts_empty_universe_returns_empty_list() -> None:
+    db = _FakeDB(rows=[])
+    assert query_universe_year_counts(db) == []
+
+
+def test_query_universe_year_counts_no_industry_filter_omits_clause() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db, sic_codes=None)
+    assert "industry_code" not in db.last_sql
+    assert "sic_codes" not in (db.last_params or {})
+
+
+def test_query_universe_year_counts_with_industry_filter_includes_clause() -> None:
+    db = _FakeDB(rows=[{"yr": 2018, "cnt": 1}])
+    query_universe_year_counts(db, sic_codes=["6020", "6021"])
+    assert "industry_code" in db.last_sql
+    assert db.last_params["sic_codes"] == ["6020", "6021"]
+
+
+# ---------------------------------------------------------------------------
+# query_universe_industry_counts — facet support for /ingest/ form
+# ---------------------------------------------------------------------------
+
+
+def test_query_universe_industry_counts_builds_unnest_arrays() -> None:
+    """The query should unnest three parallel arrays of (key, label, sic)."""
+    industry_map = {
+        "industries": {
+            "biotech": {"sic_codes": ["2836", "8731"]},
+            "commercial_banking": {"sic_codes": ["6020"]},
+        },
+        "aliases": {},
+    }
+    db = _FakeDB(
+        rows=[
+            {"industry_key": "biotech", "industry_label": "Biotech", "cnt": 28},
+            {
+                "industry_key": "commercial_banking",
+                "industry_label": "Commercial Banking",
+                "cnt": 12,
+            },
+        ]
+    )
+    out = query_universe_industry_counts(db, industry_map)
+    assert out == [
+        IndustryCount(key="biotech", label="Biotech", count=28),
+        IndustryCount(key="commercial_banking", label="Commercial Banking", count=12),
+    ]
+    # The arrays passed to unnest carry one row per (industry, sic) tuple
+    assert db.last_params["keys"] == ["biotech", "biotech", "commercial_banking"]
+    assert db.last_params["labels"] == ["Biotech", "Biotech", "Commercial Banking"]
+    assert db.last_params["sics"] == ["2836", "8731", "6020"]
+
+
+def test_query_universe_industry_counts_with_year_filter_includes_clause() -> None:
+    industry_map = {
+        "industries": {"biotech": {"sic_codes": ["2836"]}},
+        "aliases": {},
+    }
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, years=[2016, 2017])
+    assert "EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)" in db.last_sql
+    assert db.last_params["years"] == [2016, 2017]
+
+
+def test_query_universe_industry_counts_no_year_filter_omits_clause() -> None:
+    industry_map = {
+        "industries": {"biotech": {"sic_codes": ["2836"]}},
+        "aliases": {},
+    }
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, years=None)
+    assert "EXTRACT(YEAR" not in db.last_sql
+    assert "years" not in (db.last_params or {})
+
+
+def test_query_universe_industry_counts_empty_yaml_returns_empty_list() -> None:
+    db = _FakeDB(rows=[])
+    out = query_universe_industry_counts(db, {"industries": {}, "aliases": {}})
+    assert out == []
+    # No SQL should fire if there's nothing to unnest
+    assert db.last_sql is None

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -110,6 +110,51 @@ def test_ingest_form_renders_new_industry_options(client):
     assert 'value="homebuilding"' in body
 
 
+def test_ingest_form_renders_new_page_title(client):
+    """GET /ingest/ uses the new combined page title."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Ingest and process documents" in body
+    # The old "Batch Ingest" h2 should not be present any more
+    assert '<h2 class="mb-4">Batch Ingest</h2>' not in body
+
+
+def test_ingest_form_year_picker_is_multi_select(client):
+    """GET /ingest/ renders Year as <select multiple> not a free-text input."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The year widget is now a select, not an input. The element appears with
+    # id="year" and the multiple attribute. The <input type="text" id="year">
+    # form has been replaced.
+    assert '<select id="year"' in body
+    assert "multiple" in body  # the year listbox carries multiple
+    assert '<input type="text" id="year"' not in body
+
+
+def test_ingest_form_industries_two_column_layout(client):
+    """Industries on the left half, Direct SIC Codes on the right (col-md-6)."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Bootstrap row + col-md-6 markers; the industries label is inside
+    # the same row as the SIC label (verifies column scoping).
+    assert '<div class="row g-3 mb-3">' in body
+    assert '<div class="col-md-6">' in body
+    # Both labels still rendered:
+    assert "Industries" in body
+    assert "Direct SIC Codes" in body
+
+
+def test_ingest_form_loads_facet_cascade_js(client):
+    """The new ingest_form_facets.js is loaded on the form page."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "ingest_form_facets.js" in body
+
+
 def test_ingest_form_renders_universe_build_panel(client):
     """GET /ingest/ exposes the Build-universe panel pointing at /ingest/populate."""
     resp = client.get("/ingest/")
@@ -150,6 +195,167 @@ def test_parse_form_criteria_defaults(app):
     assert result["form_types"] == ["s1f1"]
     assert result["year"] == "2023"
     assert result["_reviewer_name"] == "Rob"
+
+
+def test_parse_form_criteria_multi_year_collapses_to_range(app):
+    """Multiple `year` values posted (multi-select) collapse to YYYY-YYYY."""
+    from src.web.routes.ingest import _parse_form_criteria
+
+    with app.test_request_context(
+        "/ingest/preview",
+        method="POST",
+        data={
+            "industries": ["software"],
+            "year": ["2016", "2017", "2018"],
+            "reviewer_name": "Rob",
+        },
+    ):
+        result = _parse_form_criteria()
+    assert result["year"] == "2016-2018"
+
+
+def test_parse_form_criteria_single_year_multi_select(app):
+    """A single `year` value from the multi-select stays as a bare string."""
+    from src.web.routes.ingest import _parse_form_criteria
+
+    with app.test_request_context(
+        "/ingest/preview",
+        method="POST",
+        data={
+            "industries": ["software"],
+            "year": ["2017"],
+            "reviewer_name": "Rob",
+        },
+    ):
+        result = _parse_form_criteria()
+    assert result["year"] == "2017"
+
+
+def test_filter_options_endpoint_no_filters_returns_both_axes(client):
+    """GET /api/v2/ingest/filter-options without query params returns all-time
+    counts on both axes, derived from the mocked DB rows."""
+    from src.universe.onboarding import IndustryCount, YearCount
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            return_value=[YearCount(year=2018, count=412), YearCount(year=2017, count=380)],
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            return_value=[
+                IndustryCount(key="biotech", label="Biotech", count=28),
+                IndustryCount(key="commercial_banking", label="Commercial Banking", count=12),
+            ],
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["years"] == [
+        {"year": 2018, "count": 412},
+        {"year": 2017, "count": 380},
+    ]
+    assert data["industries"] == [
+        {"key": "biotech", "label": "Biotech", "count": 28},
+        {"key": "commercial_banking", "label": "Commercial Banking", "count": 12},
+    ]
+
+
+def test_filter_options_endpoint_year_param_passes_through(client):
+    """A `year=2016` query param reaches query_universe_industry_counts(years=...)."""
+    from src.universe.onboarding import IndustryCount, YearCount
+
+    captured: dict = {}
+
+    def fake_industry_counts(db, industry_map, *, years=None):
+        captured["years"] = years
+        return [IndustryCount(key="biotech", label="Biotech", count=5)]
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            return_value=[YearCount(year=2016, count=10)],
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            side_effect=fake_industry_counts,
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options?year=2016&year=2017")
+    assert resp.status_code == 200
+    assert captured["years"] == [2016, 2017]
+
+
+def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
+    """A `industry=biotech` query param resolves to biotech's SIC list and
+    flows into query_universe_year_counts(sic_codes=...)."""
+    from src.universe.onboarding import IndustryCount, YearCount
+
+    captured: dict = {}
+
+    def fake_year_counts(db, *, sic_codes=None):
+        captured["sic_codes"] = sic_codes
+        return [YearCount(year=2018, count=3)]
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            side_effect=fake_year_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            return_value=[IndustryCount(key="biotech", label="Biotech", count=3)],
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options?industry=biotech")
+    assert resp.status_code == 200
+    # biotech's YAML SIC codes are 2836 and 8731
+    assert set(captured["sic_codes"]) == {"2836", "8731"}
+
+
+def test_filter_options_endpoint_unknown_industry_silently_ignored(client):
+    """An `industry=not_a_thing` is ignored rather than 400'd — facet is
+    best-effort."""
+    captured: dict = {}
+
+    def fake_year_counts(db, *, sic_codes=None):
+        captured["sic_codes"] = sic_codes
+        return []
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            side_effect=fake_year_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            return_value=[],
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options?industry=not_a_thing&industry=biotech")
+    assert resp.status_code == 200
+    # not_a_thing is dropped; biotech's SICs reach the year-count call
+    assert set(captured["sic_codes"]) == {"2836", "8731"}
+
+
+def test_parse_form_criteria_non_contiguous_years_become_min_max(app):
+    """Non-contiguous selection (e.g. 2016 + 2018) collapses to inclusive range."""
+    from src.web.routes.ingest import _parse_form_criteria
+
+    with app.test_request_context(
+        "/ingest/preview",
+        method="POST",
+        data={
+            "industries": ["software"],
+            "year": ["2018", "2016"],  # unsorted, gap at 2017
+            "reviewer_name": "Rob",
+        },
+    ):
+        result = _parse_form_criteria()
+    # Documented trade-off: non-contiguous selections silently expand to
+    # the (min, max) inclusive range.
+    assert result["year"] == "2016-2018"
 
 
 def test_parse_form_criteria_multi_industry(app):

--- a/tests/unit/web/test_url_for_resolves.py
+++ b/tests/unit/web/test_url_for_resolves.py
@@ -35,6 +35,9 @@ _ENDPOINTS: list[tuple[str, dict]] = [
     # Ingest API routes
     ("api_ingest.batch_status", {"batch_id": "00000000-0000-0000-0000-000000000000"}),
     ("api_ingest.batch_cancel", {"batch_id": "00000000-0000-0000-0000-000000000000"}),
+    ("api_ingest.filter_options", {}),
+    # Static assets new with the facet cascade
+    ("static", {"filename": "js/ingest_form_facets.js"}),
 ]
 
 


### PR DESCRIPTION
Page header renames to "Ingest and process documents". The discovery form
moves to a 2-column layout (Industries left half, Direct SIC Codes right
half) and Year becomes a multi-select listbox. Both Industries and Year
are populated from what's actually in `filings`, with row counts shown
beside each option, and they bidirectionally facet — picking year(s)
narrows industries, picking industry(ies) narrows years. Each axis ignores
its own selection so the user always sees the full set of choices for
that axis given the OTHER axis's filter.

New backend:
- `query_universe_year_counts` and `query_universe_industry_counts` in
  `src/universe/onboarding.py`. The industry query unnests three parallel
  arrays (key, label, sic) so SIC overlaps between industries count
  cleanly without first-match bias.
- `GET /api/v2/ingest/filter-options?year=...&industry=...` returning
  `{years: [...], industries: [...]}` for the cascade.

New frontend:
- `static/js/ingest_form_facets.js` — vanilla IIFE that listens for
  change events on both selects, fetches the API, and updates option
  labels + visibility. Selected-but-now-zero options stay enabled with
  `(0)` so the user can deselect them.

Multi-year selections collapse to (min, max) inclusive range to keep the
existing year_min/year_max SQL contract intact; documented in
docs/operations/TICKER_ONBOARDING.md as a UX edge case.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
