### PR TITLE
fix(filings-list): count "Reject all" images as reviewed in progress

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -934,11 +934,28 @@ class DatabaseAdapter:
                 GROUP BY mf.filing_id
             ),
             image_progress AS (
+                -- "images_reviewed" widens beyond raw review_status='reviewed' to also
+                -- include images the reviewer flipped to 'skipped' via "Reject all (no
+                -- relevant metrics)" — those carry per-metric reject rows in
+                -- v2_image_metric_confirmations. Without this widening the filings-list
+                -- progress counter under-reports completion (skipped images with
+                -- confirmations are neither pending nor counted as reviewed).
+                -- Mirrors the per-image badge disambiguation in unified_review.html
+                -- (PR #371). True "Skip whole image" parks (skipped, zero confirmations)
+                -- still don't count as reviewed.
                 SELECT
                     v.filing_id,
                     COUNT(v.img_id)                                                         AS image_count,
                     COUNT(CASE WHEN v.review_status = 'pending'    THEN 1 END)              AS images_pending,
-                    COUNT(CASE WHEN v.review_status = 'reviewed'   THEN 1 END)              AS images_reviewed
+                    COUNT(
+                        CASE
+                            WHEN v.review_status = 'reviewed' THEN 1
+                            WHEN v.review_status = 'skipped' AND EXISTS (
+                                SELECT 1 FROM v2_image_metric_confirmations c
+                                WHERE c.img_id = v.img_id
+                            ) THEN 1
+                        END
+                    )                                                                       AS images_reviewed
                 FROM v2_image_assets v
                 WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
                   AND v.filename IS NOT NULL AND v.filename != ''
@@ -1143,11 +1160,20 @@ class DatabaseAdapter:
                 GROUP BY mf.filing_id
             ),
             image_progress AS (
+                -- See parallel CTE in get_unified_filings_for_review for rationale.
                 SELECT
                     v.filing_id,
                     COUNT(v.img_id) AS image_count,
                     COUNT(CASE WHEN v.review_status = 'pending' THEN 1 END) AS images_pending,
-                    COUNT(CASE WHEN v.review_status = 'reviewed' THEN 1 END) AS images_reviewed
+                    COUNT(
+                        CASE
+                            WHEN v.review_status = 'reviewed' THEN 1
+                            WHEN v.review_status = 'skipped' AND EXISTS (
+                                SELECT 1 FROM v2_image_metric_confirmations c
+                                WHERE c.img_id = v.img_id
+                            ) THEN 1
+                        END
+                    ) AS images_reviewed
                 FROM v2_image_assets v
                 WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
                   AND v.filename IS NOT NULL AND v.filename != ''

--- a/tests/integration/test_db_filings_reviewers.py
+++ b/tests/integration/test_db_filings_reviewers.py
@@ -129,3 +129,40 @@ class TestReviewerAggregation:
 
         assert row is not None
         assert row["reviewers"] == []
+
+
+class TestImagesReviewedCount:
+    """Guards the filings-list `images_reviewed` counter against under-reporting
+    images that the reviewer flipped to 'skipped' via "Reject all (no relevant
+    metrics)" — those carry per-metric reject rows in
+    v2_image_metric_confirmations and should count as reviewed."""
+
+    def test_skipped_with_confirmations_counts_as_reviewed(self, clean_db: DatabaseAdapter) -> None:
+        _, filing_id = create_test_company_and_filing(clean_db)
+        create_test_v2_document(clean_db, filing_id)
+
+        # Image #1 — finalized via Mark Complete: counts.
+        _insert_v2_image(clean_db, filing_id, "img1.jpg", review_status="reviewed")
+        # Image #2 — Reject-all: skipped + per-metric reject row. Should count.
+        img2 = _insert_v2_image(clean_db, filing_id, "img2.jpg", review_status="skipped")
+        clean_db.execute(
+            """
+            INSERT INTO v2_image_metric_confirmations
+                (img_id, detected_metric_id, confirmed_metric_id,
+                 decision, rejection_reason, reviewer_id)
+            VALUES
+                (%(img_id)s, NULL, NULL, 'reject', 'no_relevant_metrics', 'rgm')
+            """,
+            {"img_id": img2},
+        )
+        # Image #3 — pure "Skip whole image" with zero confirmations. Should NOT count.
+        _insert_v2_image(clean_db, filing_id, "img3.jpg", review_status="skipped")
+        # Image #4 — pending. Should NOT count toward reviewed.
+        _insert_v2_image(clean_db, filing_id, "img4.jpg", review_status="pending")
+
+        rows = clean_db.get_unified_filings_for_review()
+        row = _find_filing_row(rows, filing_id)
+
+        assert row is not None
+        assert row["images_pending"] == 1
+        assert row["images_reviewed"] == 2  # img1 (reviewed) + img2 (skipped+confirmation)


### PR DESCRIPTION
The filings-list progress counter at get_unified_filings_for_review (and
its sibling find_first_filing_after_cursor) computed images_reviewed
strictly as v2_image_assets.review_status='reviewed'. But "Reject all
(no relevant metrics)" sets review_status='skipped' and writes per-metric
reject rows in v2_image_metric_confirmations — so reject-alled images
were neither pending nor counted as reviewed, leaving the per-filing
progress bar misleading (e.g. 1 reviewed reported on a filing where the
reviewer had verified ~15 images as having no relevant metrics).

Widen images_reviewed to also include images where review_status='skipped'
AND any v2_image_metric_confirmations row exists for that img_id. This
mirrors the per-image badge disambiguation already in unified_review.html
(PR #371). Pure "Skip whole image" parks (skipped, zero confirmations)
remain excluded from images_reviewed, matching reviewer intent.

Adds an integration test covering all four states: reviewed, skipped+
confirmation (NEW path), skipped+no-confirmation, pending.
