### PR TITLE
feat(ingest): extend facet cascade to form-types (3-axis)

### DIFF
--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -350,32 +350,33 @@ it_services_consulting, homebuilding) plus aliases (`bio`, `pharma`,
 SEC's published list. To add a new industry, append to the YAML and run
 `pytest tests/unit/universe/test_onboarding.py::test_load_industry_map_includes_new_industries`.
 
-### Year ↔ industry facet cascade (Phase 2b, 2026-04-30)
+### Year ↔ industry ↔ form-type facet cascade (Phase 2b–2c, 2026-04-30)
 
 The discovery form (the lower section under the Build-universe panel) is
-now **facet-driven**: both Industries and Year are multi-select listboxes
-populated from the actual contents of `filings`, with row counts shown
-next to each option. Selecting one axis narrows the other:
+**facet-driven across three axes**: Industries (multi-select listbox),
+Year (multi-select listbox), and Form Types (checkbox row). All three
+are populated from the actual contents of `filings`, with row counts
+shown next to each option. Each axis count equals the number of filings
+matching the OTHER two axes' selections (standard facet UX — each axis
+ignores its own selection so the user always sees the full set of
+choices for that axis):
 
-- Selecting year(s) → industries listbox re-renders with counts narrowed
-  to filings in those years; industries with zero rows in the selection
-  are hidden.
-- Selecting industries → year listbox re-renders with counts narrowed to
-  filings whose company SIC is in any selected industry's SIC list.
-- Each axis ignores its own selections (standard facet UX), so picking
-  "2016" doesn't shrink the year list to just "2016".
-- Selected options that drop to zero count stay visible-and-selected
-  (greyed `(0)`) so the user can deselect them.
+- Selecting year(s) narrows industries + form-types.
+- Selecting industries narrows years + form-types.
+- Selecting form-type(s) narrows years + industries.
+- Form-type checkboxes: multiple selections are OR-ed, so `IPO` + `10-K`
+  shows year/industry counts for filings in either bundle.
+- Selected options that drop to zero count stay visible (greyed `(0)`)
+  so the user can deselect them. For Year and Industry listboxes,
+  unselected zero-count options are hidden; for Form-type checkboxes,
+  unselected zero-count options stay visible-but-disabled (the row only
+  has 3 entries, hiding would be jarring).
 
-Backed by `GET /api/v2/ingest/filter-options?year=...&industry=...` →
-`{years: [{year, count}], industries: [{key, label, count}]}`. Both
-queries live in `src/universe/onboarding.py`
-(`query_universe_year_counts`, `query_universe_industry_counts`).
+Backed by `GET /api/v2/ingest/filter-options?year=...&industry=...&form_type=...`
+→ `{years: [...], industries: [...], form_types: [...]}`. Helpers in
+`src/universe/onboarding.py`: `query_universe_year_counts`,
+`query_universe_industry_counts`, `query_universe_form_type_counts`.
 Cascade JS: `src/web/static/js/ingest_form_facets.js`.
-
-**Form-types row** is intentionally NOT part of the cascade — it stays
-as the full 4-checkbox set. Add to the cascade if it becomes confusing
-in practice.
 
 **Year multi-select edge case:** non-contiguous selections (e.g. 2016 +
 2018 with 2017 omitted) silently expand to the inclusive (min, max) range

--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -848,6 +848,8 @@ WHERE 1=1
 
 _YEAR_COUNTS_INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
 
+_YEAR_COUNTS_FORM_TYPE_GATE = "  AND f.form_type = ANY(%(form_types)s)\n"
+
 _YEAR_COUNTS_TAIL = """GROUP BY yr
 ORDER BY yr DESC
 """
@@ -857,12 +859,15 @@ def query_universe_year_counts(
     db: DatabaseAdapter,
     *,
     sic_codes: list[str] | None = None,
+    form_types: list[str] | None = None,
 ) -> list[YearCount]:
     """Return distinct years in `filings` with their row count, DESC.
 
     Optional ``sic_codes`` restricts to filings whose
-    ``companies.industry_code`` IS IN the list. None or empty list means
-    all-time, all-industry.
+    ``companies.industry_code`` IS IN the list. ``form_types`` is a list of
+    canonical form-type strings (e.g. ["S-1", "F-1/A", "10-K"]); the caller
+    is responsible for resolving bundle keys via ``FORM_TYPE_BUNDLES``.
+    None or empty for either means no filter on that axis.
 
     Years with count==0 are not returned (they wouldn't have a row in
     ``filings`` anyway).
@@ -872,6 +877,9 @@ def query_universe_year_counts(
     if sic_codes:
         sql += _YEAR_COUNTS_INDUSTRY_GATE
         params["sic_codes"] = list(sic_codes)
+    if form_types:
+        sql += _YEAR_COUNTS_FORM_TYPE_GATE
+        params["form_types"] = list(form_types)
     sql += _YEAR_COUNTS_TAIL
     rows = db.query(sql, params)
     return [YearCount(year=int(r["yr"]), count=int(r["cnt"])) for r in rows]
@@ -888,7 +896,7 @@ FROM unnest(
 ) AS industry_sic(industry_key, industry_label, sic)
 LEFT JOIN companies c ON c.industry_code = industry_sic.sic
 LEFT JOIN filings  f ON f.company_id = c.company_id
-{year_filter}
+    {filing_join_extra}
 GROUP BY industry_sic.industry_key, industry_sic.industry_label
 ORDER BY industry_sic.industry_label
 """
@@ -899,6 +907,7 @@ def query_universe_industry_counts(
     industry_map: dict[str, Any],
     *,
     years: list[int] | None = None,
+    form_types: list[str] | None = None,
 ) -> list[IndustryCount]:
     """For every industry in *industry_map*, return its filing count.
 
@@ -910,10 +919,12 @@ def query_universe_industry_counts(
     ``companies.industry_code`` matches multiple industries contributes one
     row toward each (the unnest gives one tuple per (industry, sic) pair).
 
-    Optional ``years`` restricts to filings whose filing_date year is in the
-    list. The filter is applied ON the JOIN, not in WHERE, so industries
-    with zero filings are still returned (count=0). The endpoint / template
-    decides whether to display zero-count entries.
+    Optional ``years`` and ``form_types`` restrict to filings matching those
+    criteria. ``form_types`` is a list of canonical form-type strings (the
+    caller resolves bundle keys via ``FORM_TYPE_BUNDLES``). Both filters
+    apply on the LEFT JOIN to filings, not in WHERE, so industries with
+    zero matching filings are still returned (count=0). The endpoint /
+    template decides whether to display zero-count entries.
 
     Sorted alphabetically by ``label``.
     """
@@ -934,15 +945,19 @@ def query_universe_industry_counts(
     if not keys:
         return []
 
+    extra_clauses = []
     if years:
-        year_filter = "AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)"
-    else:
-        year_filter = ""
+        extra_clauses.append("AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)")
+    if form_types:
+        extra_clauses.append("AND f.form_type = ANY(%(form_types)s)")
+    filing_join_extra = "\n    ".join(extra_clauses)
 
-    sql = _INDUSTRY_COUNTS_SQL_TEMPLATE.format(year_filter=year_filter)
+    sql = _INDUSTRY_COUNTS_SQL_TEMPLATE.format(filing_join_extra=filing_join_extra)
     params: dict[str, Any] = {"keys": keys, "labels": labels, "sics": sics}
     if years:
         params["years"] = [int(y) for y in years]
+    if form_types:
+        params["form_types"] = list(form_types)
 
     rows = db.query(sql, params)
     return [
@@ -952,4 +967,109 @@ def query_universe_industry_counts(
             count=int(r["cnt"]),
         )
         for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Form-type counts — third axis of the /ingest/ form facet cascade.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FormTypeCount:
+    """A FORM_TYPE_BUNDLES entry and the count of filings whose form_type
+    is in the bundle's list of canonical form types."""
+
+    key: str  # bundle key from FORM_TYPE_BUNDLES (e.g. "s1f1", "10k", "8k")
+    label: str  # human label (e.g. "S-1 / F-1 (IPO filings)")
+    count: int
+
+
+_FORM_TYPE_COUNTS_SQL_TEMPLATE = """
+SELECT bundle.bundle_key,
+       bundle.bundle_label,
+       COUNT(f.filing_id) FILTER (
+           WHERE f.filing_id IS NOT NULL {company_filter_clause}
+       )::int AS cnt
+FROM unnest(
+    %(keys)s::text[],
+    %(labels)s::text[],
+    %(form_types)s::text[]
+) AS bundle(bundle_key, bundle_label, form_type)
+LEFT JOIN filings f ON f.form_type = bundle.form_type
+    {year_clause}
+LEFT JOIN companies c ON c.company_id = f.company_id
+GROUP BY bundle.bundle_key, bundle.bundle_label
+"""
+
+
+def query_universe_form_type_counts(
+    db: DatabaseAdapter,
+    bundles: dict[str, tuple[str, list[str]]] | None = None,
+    *,
+    years: list[int] | None = None,
+    sic_codes: list[str] | None = None,
+) -> list[FormTypeCount]:
+    """Return [{key, label, count}] for every form-type bundle.
+
+    *bundles* maps bundle_key → (label, [canonical_form_types]). When None,
+    defaults to the visible-form-row bundles (s1f1, 10k, 8k) — the same
+    set rendered in the discovery form's checkbox row. Each filing whose
+    ``form_type`` matches any of the bundle's canonical types contributes
+    +1 to that bundle's count. A filing's ``form_type`` matches at most
+    one bundle in our YAML (S-1 → s1f1, 10-K → 10k, etc.), so no DISTINCT
+    is needed.
+
+    Optional ``years`` restricts by filing year; optional ``sic_codes``
+    restricts by company SIC. Filters apply on the LEFT JOIN so bundles
+    with zero matches still appear (count=0).
+
+    Sorted by bundle key for stable output (s1f1 → 10k → 8k).
+    """
+    if bundles is None:
+        bundles = {
+            "s1f1": ("S-1 / F-1 (IPO filings)", FORM_TYPE_BUNDLES["s1f1"]),
+            "10k": ("10-K (Annual reports)", FORM_TYPE_BUNDLES["10k"]),
+            "8k": ("8-K (Current reports)", FORM_TYPE_BUNDLES["8k"]),
+        }
+    if not bundles:
+        return []
+
+    keys: list[str] = []
+    labels: list[str] = []
+    form_types_flat: list[str] = []
+    label_by_key: dict[str, str] = {}
+    bundle_order: list[str] = []
+    for bundle_key, (label, form_types_list) in bundles.items():
+        label_by_key[bundle_key] = label
+        bundle_order.append(bundle_key)
+        for ft in form_types_list:
+            keys.append(bundle_key)
+            labels.append(label)
+            form_types_flat.append(ft)
+
+    if not keys:
+        return []
+
+    year_clause = "AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)" if years else ""
+    company_filter_clause = "AND c.industry_code = ANY(%(sic_codes)s)" if sic_codes else ""
+
+    sql = _FORM_TYPE_COUNTS_SQL_TEMPLATE.format(
+        year_clause=year_clause,
+        company_filter_clause=company_filter_clause,
+    )
+    params: dict[str, Any] = {
+        "keys": keys,
+        "labels": labels,
+        "form_types": form_types_flat,
+    }
+    if years:
+        params["years"] = [int(y) for y in years]
+    if sic_codes:
+        params["sic_codes"] = list(sic_codes)
+
+    rows = db.query(sql, params)
+    by_key = {str(r["bundle_key"]): int(r["cnt"]) for r in rows}
+    return [
+        FormTypeCount(key=k, label=label_by_key[k], count=by_key.get(k, 0)) for k in bundle_order
     ]

--- a/src/web/routes/api_ingest.py
+++ b/src/web/routes/api_ingest.py
@@ -17,7 +17,9 @@ import psycopg
 from flask import Blueprint, jsonify, request
 
 from src.universe.onboarding import (
+    FORM_TYPE_BUNDLES,
     load_industry_map,
+    query_universe_form_type_counts,
     query_universe_industry_counts,
     query_universe_year_counts,
     resolve_industry,
@@ -206,9 +208,10 @@ def batch_cancel(batch_id: str):
 # ---------------------------------------------------------------------------
 # GET /api/v2/ingest/filter-options
 #
-# Year ↔ industry facet counts for the /ingest/ form. Each axis ignores its
-# own selections (standard facet behaviour) so the user always sees the full
-# set of options for that axis given the OTHER axis's filter.
+# Year ↔ industry ↔ form-type facet counts for the /ingest/ form. Each axis
+# ignores its own selections (standard facet behaviour) so the user always
+# sees the full set of options for that axis given the OTHER two axes'
+# filters.
 # ---------------------------------------------------------------------------
 
 
@@ -216,6 +219,7 @@ def batch_cancel(batch_id: str):
 def filter_options():
     raw_years = request.args.getlist("year")
     raw_industries = request.args.getlist("industry")
+    raw_form_types = request.args.getlist("form_type")
 
     selected_years: list[int] = []
     for raw in raw_years:
@@ -236,16 +240,36 @@ def filter_options():
     seen: set[str] = set()
     selected_sic_codes = [s for s in selected_sic_codes if not (s in seen or seen.add(s))]
 
+    # Resolve form-type bundle keys (s1f1, 10k, 8k) to canonical form-type
+    # strings (S-1, S-1/A, 10-K, ...). Unknown bundle keys are ignored.
+    selected_form_types: list[str] = []
+    seen_ft: set[str] = set()
+    for ft_key in raw_form_types:
+        if ft_key in FORM_TYPE_BUNDLES:
+            for ft in FORM_TYPE_BUNDLES[ft_key]:
+                if ft not in seen_ft:
+                    selected_form_types.append(ft)
+                    seen_ft.add(ft)
+
     db = get_db()
 
     try:
-        # Year counts: filter only by selected industries (axis ignores its own selections)
+        # Each axis is filtered by the OTHER two axes' selections, ignoring its own.
         year_rows = query_universe_year_counts(
-            db, sic_codes=selected_sic_codes if selected_sic_codes else None
+            db,
+            sic_codes=selected_sic_codes or None,
+            form_types=selected_form_types or None,
         )
-        # Industry counts: filter only by selected years (same reason)
         industry_rows = query_universe_industry_counts(
-            db, industry_map, years=selected_years if selected_years else None
+            db,
+            industry_map,
+            years=selected_years or None,
+            form_types=selected_form_types or None,
+        )
+        form_type_rows = query_universe_form_type_counts(
+            db,
+            years=selected_years or None,
+            sic_codes=selected_sic_codes or None,
         )
     except psycopg.DatabaseError as exc:
         logger.error("DB error in filter-options: %s", exc)
@@ -255,6 +279,9 @@ def filter_options():
         "years": [{"year": yc.year, "count": yc.count} for yc in year_rows],
         "industries": [
             {"key": ic.key, "label": ic.label, "count": ic.count} for ic in industry_rows
+        ],
+        "form_types": [
+            {"key": ftc.key, "label": ftc.label, "count": ftc.count} for ftc in form_type_rows
         ],
     }
     return jsonify(payload), 200

--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -39,6 +39,7 @@ from src.universe.onboarding import (
     count_reviewer_work,
     discover,
     load_industry_map,
+    query_universe_form_type_counts,
     query_universe_industry_counts,
     query_universe_year_counts,
     resolve_criteria,
@@ -93,6 +94,32 @@ def _year_options() -> list[dict[str, int]]:
     except Exception:  # noqa: BLE001
         logger.warning("Failed to load year options with counts", exc_info=True)
         return []
+
+
+# Static labels for the form-type checkbox row. Counts are added dynamically
+# by `_form_type_options()`; the static fallback (DB unavailable in tests)
+# preserves the legacy labels with count=0.
+_FORM_TYPE_STATIC_LABELS: dict[str, str] = {
+    "s1f1": "S-1 / F-1 (IPO filings)",
+    "10k": "10-K (Annual reports)",
+    "8k": "8-K (Current reports)",
+}
+
+
+def _form_type_options() -> list[dict[str, Any]]:
+    """Return [{key, label, count}] for the form-type checkbox row.
+
+    Counts come from ``query_universe_form_type_counts`` (no axis filter
+    on initial render — JS facet cascade refreshes them as the user
+    selects years/industries). Falls back to count=0 when the DB is
+    unavailable so the form still renders during tests.
+    """
+    try:
+        rows = query_universe_form_type_counts(get_db())
+        return [{"key": r.key, "label": r.label, "count": r.count} for r in rows]
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to load form-type options with counts", exc_info=True)
+        return [{"key": k, "label": v, "count": 0} for k, v in _FORM_TYPE_STATIC_LABELS.items()]
 
 
 def _parse_form_criteria() -> dict[str, Any]:
@@ -164,13 +191,6 @@ def _volume_band_message(band: VolumeBand, total: int) -> str:
     return messages.get(band, f"{total} filings.")
 
 
-_FORM_TYPES_AVAILABLE = [
-    {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)"},
-    {"key": "10k", "label": "10-K (Annual reports)"},
-    {"key": "8k", "label": "8-K (Current reports)"},
-]
-
-
 def _render_ingest_form(form_state: dict[str, Any] | None = None, status: int = 200):
     """Render the criteria form. When *form_state* is given, the template
     repopulates fields so a validation error doesn't wipe user input.
@@ -183,7 +203,7 @@ def _render_ingest_form(form_state: dict[str, Any] | None = None, status: int = 
             reviewer_name=reviewer_name,
             industries=_industry_options(),
             years_available=_year_options(),
-            form_types_available=_FORM_TYPES_AVAILABLE,
+            form_types_available=_form_type_options(),
             form_state=state,
         ),
         status,

--- a/src/web/static/js/ingest_form_facets.js
+++ b/src/web/static/js/ingest_form_facets.js
@@ -1,11 +1,14 @@
 /**
- * /ingest/ form facet cascade.
+ * /ingest/ form 3-axis facet cascade.
  *
- * Listens for change events on the Industries and Year multi-selects and
- * fetches GET /api/v2/ingest/filter-options to refresh the OTHER axis's
- * counts and visibility. Each axis ignores its own selection (standard
- * facet pattern), so picking 2016 narrows industries; picking biotech
- * narrows years.
+ * Listens for change events on the Industries multi-select, Year
+ * multi-select, and Form-type checkboxes. On each change, fetches
+ * GET /api/v2/ingest/filter-options with the current selections, and
+ * rewrites the OTHER two axes' option counts + visibility.
+ *
+ * Each axis ignores its own selection (standard facet pattern), so
+ * picking 2016 narrows industries + form-types; picking biotech narrows
+ * years + form-types; picking a form-type narrows years + industries.
  *
  * Vanilla ES5 IIFE — no framework dependency. Loaded as a static asset
  * from src/web/templates/ingest_form.html.
@@ -15,7 +18,8 @@
 
   var industriesEl = document.getElementById("industries");
   var yearEl = document.getElementById("year");
-  if (!industriesEl || !yearEl) {
+  var formTypeEls = document.querySelectorAll('input[name="form_types"]');
+  if (!industriesEl || !yearEl || formTypeEls.length === 0) {
     return; // not on the ingest form page
   }
 
@@ -30,7 +34,17 @@
     return out;
   }
 
-  function buildQuery(years, industries) {
+  function selectedFormTypes() {
+    var out = [];
+    for (var i = 0; i < formTypeEls.length; i++) {
+      if (formTypeEls[i].checked) {
+        out.push(formTypeEls[i].value);
+      }
+    }
+    return out;
+  }
+
+  function buildQuery(years, industries, formTypes) {
     var parts = [];
     var i;
     for (i = 0; i < years.length; i++) {
@@ -39,12 +53,15 @@
     for (i = 0; i < industries.length; i++) {
       parts.push("industry=" + encodeURIComponent(industries[i]));
     }
+    for (i = 0; i < formTypes.length; i++) {
+      parts.push("form_type=" + encodeURIComponent(formTypes[i]));
+    }
     return parts.join("&");
   }
 
   /**
-   * Update a select's options in place from a `[{value, label, count}]` list.
-   * Selected options are kept enabled even when count == 0 so the user can
+   * Update a <select>'s options in place from a `[{value, label, count}]` list.
+   * Selected options stay enabled even when count == 0 so the user can
    * deselect them. Zero-count, unselected options are hidden.
    */
   function applyCounts(selectEl, items, valueKey, labelTemplate) {
@@ -58,8 +75,6 @@
       var opt = options[i];
       var item = byValue[opt.value];
       if (!item) {
-        // Option no longer present in the response (shouldn't happen for our
-        // server which always returns the same axis). Treat as count 0.
         opt.setAttribute("data-count", "0");
         opt.text = labelTemplate(opt.value, 0);
         opt.hidden = !opt.selected;
@@ -69,16 +84,51 @@
       var count = parseInt(item.count, 10) || 0;
       opt.setAttribute("data-count", String(count));
       opt.text = labelTemplate(item, count);
-      // Hide zero-count options unless they're currently selected.
       opt.hidden = count === 0 && !opt.selected;
-      opt.disabled = false; // never disable — keep selected toggleable
+      opt.disabled = false;
+    }
+  }
+
+  /**
+   * Update form-type checkbox row counts + disabled state.
+   *
+   * Per UX choice: zero-count unchecked checkboxes are disabled+greyed
+   * (not hidden) so the small fixed set of form-types stays visually
+   * stable. Checked checkboxes always stay enabled so the user can
+   * uncheck them.
+   */
+  function applyFormTypeCounts(items) {
+    var byKey = {};
+    for (var i = 0; i < items.length; i++) {
+      byKey[String(items[i].key)] = items[i];
+    }
+    for (var j = 0; j < formTypeEls.length; j++) {
+      var input = formTypeEls[j];
+      var item = byKey[input.value];
+      var count = item ? parseInt(item.count, 10) || 0 : 0;
+      var label = input.parentNode.querySelector("label.form-check-label");
+      var baseLabel = item ? item.label : (label ? label.textContent.replace(/\s*\(\d+\)\s*$/, "") : input.value);
+      input.setAttribute("data-count", String(count));
+      if (label) {
+        label.textContent = baseLabel + " (" + count + ")";
+      }
+      var shouldDisable = count === 0 && !input.checked;
+      input.disabled = shouldDisable;
+      if (label) {
+        if (shouldDisable) {
+          label.classList.add("text-muted");
+        } else {
+          label.classList.remove("text-muted");
+        }
+      }
     }
   }
 
   function refresh() {
     var years = selectedValues(yearEl);
     var industries = selectedValues(industriesEl);
-    var qs = buildQuery(years, industries);
+    var formTypes = selectedFormTypes();
+    var qs = buildQuery(years, industries, formTypes);
     fetch("/api/v2/ingest/filter-options" + (qs ? "?" + qs : ""), {
       credentials: "same-origin",
     })
@@ -95,14 +145,13 @@
         });
         applyCounts(industriesEl, data.industries || [], "key", function (item, count) {
           if (typeof item !== "object") {
-            // Stale option not in response — keep its current label minus count
             return String(item);
           }
           return item.label + " (" + count + ")";
         });
+        applyFormTypeCounts(data.form_types || []);
       })
       .catch(function (err) {
-        // Non-fatal — leave the form in its current state.
         if (window.console && window.console.warn) {
           window.console.warn("filter-options fetch failed:", err);
         }
@@ -111,4 +160,7 @@
 
   industriesEl.addEventListener("change", refresh);
   yearEl.addEventListener("change", refresh);
+  for (var k = 0; k < formTypeEls.length; k++) {
+    formTypeEls[k].addEventListener("change", refresh);
+  }
 })();

--- a/src/web/templates/ingest_form.html
+++ b/src/web/templates/ingest_form.html
@@ -142,11 +142,16 @@
         <label class="form-label fw-semibold">Form Types</label>
         <div>
           {% for ft in form_types_available %}
+          {% set ft_count = ft.get('count', 0) %}
+          {% set ft_checked = ft.key in selected_form_types %}
+          {% set ft_disabled = ft_count == 0 and not ft_checked %}
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="checkbox"
                    id="ft_{{ ft.key }}" name="form_types" value="{{ ft.key }}"
-                   {% if ft.key in selected_form_types %}checked{% endif %}>
-            <label class="form-check-label" for="ft_{{ ft.key }}">{{ ft.label }}</label>
+                   data-count="{{ ft_count }}"
+                   {% if ft_checked %}checked{% endif %}
+                   {% if ft_disabled %}disabled{% endif %}>
+            <label class="form-check-label{% if ft_disabled %} text-muted{% endif %}" for="ft_{{ ft.key }}">{{ ft.label }} ({{ ft_count }})</label>
           </div>
           {% endfor %}
         </div>

--- a/tests/unit/universe/test_onboarding.py
+++ b/tests/unit/universe/test_onboarding.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from src.universe.onboarding import (
+    FormTypeCount,
     Gap,
     IndustryCount,
     ResolvedQuery,
@@ -20,6 +21,7 @@ from src.universe.onboarding import (
     detect_universe_gaps,
     discover_candidates,
     load_industry_map,
+    query_universe_form_type_counts,
     query_universe_industry_counts,
     query_universe_year_counts,
     resolve_criteria,
@@ -690,3 +692,114 @@ def test_query_universe_industry_counts_empty_yaml_returns_empty_list() -> None:
     assert out == []
     # No SQL should fire if there's nothing to unnest
     assert db.last_sql is None
+
+
+# ---------------------------------------------------------------------------
+# query_universe_year_counts — form_types filter (Phase 2c)
+# ---------------------------------------------------------------------------
+
+
+def test_query_universe_year_counts_with_form_types_filter() -> None:
+    db = _FakeDB(rows=[{"yr": 2018, "cnt": 1}])
+    query_universe_year_counts(db, form_types=["S-1", "S-1/A"])
+    assert "f.form_type = ANY(%(form_types)s)" in db.last_sql
+    assert db.last_params["form_types"] == ["S-1", "S-1/A"]
+
+
+def test_query_universe_year_counts_no_form_types_filter_omits_clause() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db)
+    assert "form_type" not in db.last_sql
+    assert "form_types" not in (db.last_params or {})
+
+
+# ---------------------------------------------------------------------------
+# query_universe_industry_counts — form_types filter (Phase 2c)
+# ---------------------------------------------------------------------------
+
+
+def test_query_universe_industry_counts_with_form_types_filter() -> None:
+    industry_map = {
+        "industries": {"biotech": {"sic_codes": ["2836"]}},
+        "aliases": {},
+    }
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, form_types=["10-K"])
+    assert "AND f.form_type = ANY(%(form_types)s)" in db.last_sql
+    assert db.last_params["form_types"] == ["10-K"]
+
+
+def test_query_universe_industry_counts_year_and_form_types_combined() -> None:
+    industry_map = {
+        "industries": {"biotech": {"sic_codes": ["2836"]}},
+        "aliases": {},
+    }
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, years=[2016], form_types=["S-1"])
+    assert "EXTRACT(YEAR" in db.last_sql
+    assert "f.form_type = ANY(%(form_types)s)" in db.last_sql
+    assert db.last_params["years"] == [2016]
+    assert db.last_params["form_types"] == ["S-1"]
+
+
+# ---------------------------------------------------------------------------
+# query_universe_form_type_counts — third axis of the facet cascade
+# ---------------------------------------------------------------------------
+
+
+def test_query_universe_form_type_counts_default_bundles() -> None:
+    """Without explicit bundles, returns counts for s1f1 / 10k / 8k in that order."""
+    db = _FakeDB(
+        rows=[
+            {"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 467},
+            {"bundle_key": "10k", "bundle_label": "10-K (Annual reports)", "cnt": 0},
+            {"bundle_key": "8k", "bundle_label": "8-K (Current reports)", "cnt": 0},
+        ]
+    )
+    out = query_universe_form_type_counts(db)
+    keys = [c.key for c in out]
+    assert keys == ["s1f1", "10k", "8k"]
+    by_key = {c.key: c for c in out}
+    assert by_key["s1f1"].count == 467
+    assert by_key["10k"].count == 0
+    assert by_key["8k"].count == 0
+
+
+def test_query_universe_form_type_counts_zero_count_bundles_preserved() -> None:
+    """A bundle with no matching filings still appears in the result with count=0."""
+    db = _FakeDB(rows=[{"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 5}])
+    out = query_universe_form_type_counts(db)
+    by_key = {c.key: c.count for c in out}
+    assert by_key["s1f1"] == 5
+    assert by_key["10k"] == 0
+    assert by_key["8k"] == 0
+
+
+def test_query_universe_form_type_counts_with_year_filter() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_form_type_counts(db, years=[2016, 2017])
+    assert "EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)" in db.last_sql
+    assert db.last_params["years"] == [2016, 2017]
+
+
+def test_query_universe_form_type_counts_with_sic_codes_filter() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_form_type_counts(db, sic_codes=["6020", "6021"])
+    assert "c.industry_code = ANY(%(sic_codes)s)" in db.last_sql
+    assert db.last_params["sic_codes"] == ["6020", "6021"]
+
+
+def test_query_universe_form_type_counts_no_filters_omits_clauses() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_form_type_counts(db)
+    assert "EXTRACT(YEAR" not in db.last_sql
+    assert "industry_code" not in db.last_sql
+
+
+def test_query_universe_form_type_counts_returns_dataclass_instances() -> None:
+    db = _FakeDB(rows=[{"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 3}])
+    out = query_universe_form_type_counts(db)
+    assert all(isinstance(c, FormTypeCount) for c in out)
+    assert out[0].key == "s1f1"
+    assert out[0].label == "S-1 / F-1 (IPO filings)"
+    assert out[0].count == 3

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -155,6 +155,28 @@ def test_ingest_form_loads_facet_cascade_js(client):
     assert "ingest_form_facets.js" in body
 
 
+def test_ingest_form_form_types_show_counts_and_disable_zero(client):
+    """Form-type checkboxes carry data-count, show "(N)" in the label, and the
+    disabled+text-muted style applies when count==0 and the option isn't
+    pre-checked. With the DB unavailable in tests _form_type_options() falls
+    back to count=0 for every bundle, so all three should be disabled."""
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Every form-type checkbox carries data-count="0" in the test environment
+    assert 'data-count="0"' in body
+    # The "(0)" suffix appears in at least one form-type label
+    assert "(0)" in body
+    # In the test environment all three bundles default to count=0 with no
+    # pre-selection (the form_state defaults to selected=['s1f1']), so 10k
+    # and 8k must be marked disabled.
+    assert 'id="ft_10k"' in body
+    assert 'id="ft_8k"' in body
+    # Find the input for ft_10k and confirm it's disabled
+    chunk_10k = next(c for c in body.split("<input") if 'id="ft_10k"' in c)
+    assert "disabled" in chunk_10k.split(">", 1)[0]
+
+
 def test_ingest_form_renders_universe_build_panel(client):
     """GET /ingest/ exposes the Build-universe panel pointing at /ingest/populate."""
     resp = client.get("/ingest/")
@@ -231,10 +253,10 @@ def test_parse_form_criteria_single_year_multi_select(app):
     assert result["year"] == "2017"
 
 
-def test_filter_options_endpoint_no_filters_returns_both_axes(client):
+def test_filter_options_endpoint_no_filters_returns_three_axes(client):
     """GET /api/v2/ingest/filter-options without query params returns all-time
-    counts on both axes, derived from the mocked DB rows."""
-    from src.universe.onboarding import IndustryCount, YearCount
+    counts on all three axes, derived from the mocked DB rows."""
+    from src.universe.onboarding import FormTypeCount, IndustryCount, YearCount
 
     with (
         patch(
@@ -246,6 +268,14 @@ def test_filter_options_endpoint_no_filters_returns_both_axes(client):
             return_value=[
                 IndustryCount(key="biotech", label="Biotech", count=28),
                 IndustryCount(key="commercial_banking", label="Commercial Banking", count=12),
+            ],
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[
+                FormTypeCount(key="s1f1", label="S-1 / F-1 (IPO filings)", count=467),
+                FormTypeCount(key="10k", label="10-K (Annual reports)", count=0),
+                FormTypeCount(key="8k", label="8-K (Current reports)", count=0),
             ],
         ),
     ):
@@ -260,6 +290,11 @@ def test_filter_options_endpoint_no_filters_returns_both_axes(client):
         {"key": "biotech", "label": "Biotech", "count": 28},
         {"key": "commercial_banking", "label": "Commercial Banking", "count": 12},
     ]
+    assert data["form_types"] == [
+        {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)", "count": 467},
+        {"key": "10k", "label": "10-K (Annual reports)", "count": 0},
+        {"key": "8k", "label": "8-K (Current reports)", "count": 0},
+    ]
 
 
 def test_filter_options_endpoint_year_param_passes_through(client):
@@ -268,7 +303,7 @@ def test_filter_options_endpoint_year_param_passes_through(client):
 
     captured: dict = {}
 
-    def fake_industry_counts(db, industry_map, *, years=None):
+    def fake_industry_counts(db, industry_map, *, years=None, form_types=None):
         captured["years"] = years
         return [IndustryCount(key="biotech", label="Biotech", count=5)]
 
@@ -280,6 +315,10 @@ def test_filter_options_endpoint_year_param_passes_through(client):
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
             side_effect=fake_industry_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[],
         ),
     ):
         resp = client.get("/api/v2/ingest/filter-options?year=2016&year=2017")
@@ -294,7 +333,7 @@ def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
 
     captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None):
+    def fake_year_counts(db, *, sic_codes=None, form_types=None):
         captured["sic_codes"] = sic_codes
         return [YearCount(year=2018, count=3)]
 
@@ -306,6 +345,10 @@ def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
             return_value=[IndustryCount(key="biotech", label="Biotech", count=3)],
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[],
         ),
     ):
         resp = client.get("/api/v2/ingest/filter-options?industry=biotech")
@@ -319,7 +362,7 @@ def test_filter_options_endpoint_unknown_industry_silently_ignored(client):
     best-effort."""
     captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None):
+    def fake_year_counts(db, *, sic_codes=None, form_types=None):
         captured["sic_codes"] = sic_codes
         return []
 
@@ -332,11 +375,89 @@ def test_filter_options_endpoint_unknown_industry_silently_ignored(client):
             "src.web.routes.api_ingest.query_universe_industry_counts",
             return_value=[],
         ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[],
+        ),
     ):
         resp = client.get("/api/v2/ingest/filter-options?industry=not_a_thing&industry=biotech")
     assert resp.status_code == 200
     # not_a_thing is dropped; biotech's SICs reach the year-count call
     assert set(captured["sic_codes"]) == {"2836", "8731"}
+
+
+def test_filter_options_endpoint_form_type_param_resolves_bundle(client):
+    """A `form_type=s1f1` resolves to the S-1/F-1 canonical form types and
+    flows into query_universe_year_counts(form_types=...) and
+    query_universe_industry_counts(form_types=...)."""
+    from src.universe.onboarding import IndustryCount, YearCount
+
+    year_captured: dict = {}
+    industry_captured: dict = {}
+
+    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+        year_captured["form_types"] = form_types
+        return [YearCount(year=2015, count=467)]
+
+    def fake_industry_counts(db, industry_map, *, years=None, form_types=None):
+        industry_captured["form_types"] = form_types
+        return [IndustryCount(key="biotech", label="Biotech", count=5)]
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            side_effect=fake_year_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            side_effect=fake_industry_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[],
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options?form_type=s1f1")
+    assert resp.status_code == 200
+    expected = {"S-1", "S-1/A", "F-1", "F-1/A"}
+    assert set(year_captured["form_types"] or []) == expected
+    assert set(industry_captured["form_types"] or []) == expected
+
+
+def test_filter_options_endpoint_multiple_form_types_union(client):
+    """Multiple `form_type=` values union the bundles."""
+    from src.universe.onboarding import IndustryCount, YearCount
+
+    year_captured: dict = {}
+
+    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+        year_captured["form_types"] = form_types
+        return [YearCount(year=2015, count=10)]
+
+    with (
+        patch(
+            "src.web.routes.api_ingest.query_universe_year_counts",
+            side_effect=fake_year_counts,
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_industry_counts",
+            return_value=[IndustryCount(key="biotech", label="Biotech", count=1)],
+        ),
+        patch(
+            "src.web.routes.api_ingest.query_universe_form_type_counts",
+            return_value=[],
+        ),
+    ):
+        resp = client.get("/api/v2/ingest/filter-options?form_type=s1f1&form_type=10k")
+    assert resp.status_code == 200
+    assert set(year_captured["form_types"] or []) == {
+        "S-1",
+        "S-1/A",
+        "F-1",
+        "F-1/A",
+        "10-K",
+        "10-K/A",
+    }
 
 
 def test_parse_form_criteria_non_contiguous_years_become_min_max(app):


### PR DESCRIPTION
Form-types row now participates symmetrically in the discovery-form
facet cascade. Each axis count = filings matching the OTHER two axes'
selections. Concretely:

- Selecting year(s)        → industries + form-types narrow.
- Selecting industries     → years + form-types narrow.
- Selecting form-type(s)   → years + industries narrow (multiple
                             form-type selections OR — IPO + 10-K
                             shows the union).

Backend:
- query_universe_year_counts / query_universe_industry_counts gain a
  form_types kwarg (canonical form-type strings).
- New query_universe_form_type_counts(years, sic_codes) returns counts
  per FORM_TYPE_BUNDLES key with zero-count bundles preserved.
- /api/v2/ingest/filter-options accepts a form_type= query param
  (resolved server-side via FORM_TYPE_BUNDLES) and returns a third
  axis: {form_types: [{key, label, count}]}.

Frontend:
- Form-type checkbox labels show "(N)"; unchecked + zero-count rows
  render disabled+greyed (label.text-muted, input disabled). Checked
  rows always stay enabled so the user can uncheck them.
- ingest_form_facets.js listens on form-type checkbox changes too and
  re-applies counts to all three axes on every change.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
