### PR TITLE
feat: log per-filing vision spend and chart-fallback rate

### DIFF
--- a/docs/operations/vision-model-selection.md
+++ b/docs/operations/vision-model-selection.md
@@ -39,7 +39,29 @@ This pins chart-read to Haiku regardless of confidence.
 
 ## Measuring spend
 
-After a cold-cache run (`LLM_CACHE_DISABLED=1`), inspect `PipelineResult.vision_spend_usd_by_site` (added in PR #357) for per-filing breakdown, or sum across filings via `vision_spend_usd_total`.
+After a cold-cache run (`LLM_CACHE_ENABLED=false`), inspect `PipelineResult.vision_spend_usd_by_site` (added in PR #357) for per-filing breakdown, or sum across filings via `vision_spend_usd_total`.
+
+### Production observability
+
+Every successful pipeline run emits a single structured log line at INFO level via `V2Pipeline.process()`:
+
+```
+vision_spend filing_id=<id> total_usd=<f> by_site=<json> chart_fallback_escalations=<n> duration_ms=<n>
+```
+
+The `by_site` field is JSON-encoded with all six call-site keys present (zero-spend keys included). To recover the production distribution from Render logs:
+
+```bash
+# Stream recent vision_spend lines
+gh run view ...                              # or use Render's log search UI
+grep "vision_spend filing_id=" <log>         # all rows
+grep "chart_fallback_escalations=" <log> | awk -F'chart_fallback_escalations=' '{print $2}' | awk '{print $1}' | sort | uniq -c
+                                              # escalation-rate distribution
+```
+
+Healthy ranges (post-PR #367):
+- `chart_read_premium` averaging ~$0.07–0.10 on chart-heavy filings (was ~$0.23 with Sonnet primary).
+- `chart_fallback_escalations` per chart-heavy filing in the 0–3 range; aggregate escalation rate 5–20% across filings. >25% suggests Haiku is rescuing too often (consider rolling back); <5% suggests the fallback is dead weight (drop it).
 
 ## Changing a model
 

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -39,6 +39,7 @@ Design principles:
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -344,6 +345,21 @@ class PipelineResult:
     def vision_spend_usd_total(self) -> float:
         """Sum of ``vision_spend_usd_by_site`` across every site."""
         return round(sum(self.vision_spend_usd_by_site.values()), 6)
+
+    @property
+    def chart_fallback_escalations(self) -> int:
+        """Total chart-read fallback escalations across all stages.
+
+        Sums ``stage_results[*].metadata['chart_fallback_escalations']``,
+        which `OCRExtractionStage` increments each time the Sonnet
+        fallback's response replaces a low-confidence Haiku response.
+        """
+        total = 0
+        for result in self.stage_results:
+            value = result.metadata.get("chart_fallback_escalations")
+            if isinstance(value, int):
+                total += value
+        return total
 
     @property
     def stub_stage_warnings(self) -> list[str]:
@@ -725,7 +741,7 @@ class V2Pipeline:
             f"extracted in {total_ms}ms"
         )
 
-        return PipelineResult(
+        result = PipelineResult(
             document=context.document or Document(),
             facts=output_facts,
             tables=context.tables,
@@ -739,6 +755,21 @@ class V2Pipeline:
             presences=context.presences,
             context=context if self.config.retain_context else None,
         )
+
+        # Structured single-line telemetry for production cost monitoring.
+        # Grep `vision_spend filing_id=` in Render logs to recover per-filing
+        # spend distributions and chart-fallback escalation rate.
+        logger.info(
+            "vision_spend filing_id=%s total_usd=%.6f by_site=%s "
+            "chart_fallback_escalations=%d duration_ms=%d",
+            filing_id,
+            result.vision_spend_usd_total,
+            json.dumps(result.vision_spend_usd_by_site, sort_keys=True),
+            result.chart_fallback_escalations,
+            total_ms,
+        )
+
+        return result
 
     def _build_failure_result(
         self,

--- a/tests/unit/extraction_v2/test_vision_cost_telemetry.py
+++ b/tests/unit/extraction_v2/test_vision_cost_telemetry.py
@@ -544,3 +544,118 @@ class TestPipelineResultRollup:
         ):
             assert spend[site] == 0.0
         assert result.vision_spend_usd_total == 0.0
+
+
+class TestChartFallbackEscalationsRollup:
+    def _make_result(self, stage_results: list[StageResult]) -> PipelineResult:
+        return PipelineResult(
+            document=Document(),
+            facts=[],
+            tables=[],
+            images=[],
+            segments=[],
+            stage_results=stage_results,
+            total_duration_ms=1,
+            success=True,
+        )
+
+    def test_rollup_sums_escalations_across_stages(self) -> None:
+        result = self._make_result(
+            [
+                StageResult(
+                    stage=PipelineStage.OCR_CHART_EXTRACTION,
+                    success=True,
+                    duration_ms=1,
+                    items_processed=0,
+                    items_output=0,
+                    metadata={"chart_fallback_escalations": 3},
+                ),
+                StageResult(
+                    stage=PipelineStage.IMAGE_CLASSIFY,
+                    success=True,
+                    duration_ms=1,
+                    items_processed=0,
+                    items_output=0,
+                    metadata={},
+                ),
+            ]
+        )
+
+        assert result.chart_fallback_escalations == 3
+
+    def test_rollup_returns_zero_when_no_stage_emits_metadata(self) -> None:
+        result = self._make_result(
+            [
+                StageResult(
+                    stage=PipelineStage.SECTION_CLASSIFICATION,
+                    success=True,
+                    duration_ms=1,
+                    items_processed=0,
+                    items_output=0,
+                )
+            ]
+        )
+
+        assert result.chart_fallback_escalations == 0
+
+    def test_rollup_ignores_non_int_metadata_values(self) -> None:
+        result = self._make_result(
+            [
+                StageResult(
+                    stage=PipelineStage.OCR_CHART_EXTRACTION,
+                    success=True,
+                    duration_ms=1,
+                    items_processed=0,
+                    items_output=0,
+                    metadata={"chart_fallback_escalations": "oops"},  # type: ignore[dict-item]
+                ),
+            ]
+        )
+
+        assert result.chart_fallback_escalations == 0
+
+
+class TestVisionSpendLogLine:
+    """End-to-end coverage of the structured `vision_spend` log line emitted
+    by V2Pipeline.process(). This is the production observability hook —
+    Render log search keys on `vision_spend filing_id=` to recover per-filing
+    spend distributions.
+    """
+
+    def test_log_line_emitted_on_successful_pipeline(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from src.extraction_v2.pipeline import V2Pipeline
+
+        html_file = tmp_path / "test_filing.html"
+        html_file.write_text("<html><body><p>Test content</p></body></html>")
+
+        with caplog.at_level("INFO", logger="src.extraction_v2.pipeline"):
+            pipeline = V2Pipeline()
+            result = pipeline.process(html_file, filing_id=42)
+
+        assert result.success is True
+
+        spend_lines = [r for r in caplog.records if r.getMessage().startswith("vision_spend ")]
+        assert len(spend_lines) == 1, (
+            f"Expected exactly one vision_spend log line, got {len(spend_lines)}"
+        )
+
+        msg = spend_lines[0].getMessage()
+        assert "filing_id=42" in msg
+        assert "total_usd=" in msg
+        assert "by_site=" in msg
+        assert "chart_fallback_escalations=" in msg
+        assert "duration_ms=" in msg
+
+        # by_site must be valid JSON with all six expected keys
+        by_site_str = msg.split("by_site=", 1)[1].split(" chart_fallback_escalations=", 1)[0]
+        parsed = json.loads(by_site_str)
+        assert set(parsed.keys()) == {
+            "table_ocr",
+            "chart_ocr_fast",
+            "chart_read_premium",
+            "full_page_ocr",
+            "prescan",
+            "metric_classify",
+        }


### PR DESCRIPTION
Adds a structured single-line INFO log at the end of V2Pipeline.process()
so production cost telemetry (PR #357) and chart-fallback escalation
counts (PR #367) are recoverable from Render logs via grep
`vision_spend filing_id=`. Adds a chart_fallback_escalations rollup
property on PipelineResult and updates docs/operations/vision-model-selection.md
with the production grep workflow and healthy-range guidance.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
