### PR TITLE
feat(ingest): show extraction state per facet (pending/total) + Phase-1 gate

### DIFF
--- a/docs/operations/TICKER_ONBOARDING.md
+++ b/docs/operations/TICKER_ONBOARDING.md
@@ -350,31 +350,49 @@ it_services_consulting, homebuilding) plus aliases (`bio`, `pharma`,
 SEC's published list. To add a new industry, append to the YAML and run
 `pytest tests/unit/universe/test_onboarding.py::test_load_industry_map_includes_new_industries`.
 
-### Year ↔ industry ↔ form-type facet cascade (Phase 2b–2c, 2026-04-30)
+### Year ↔ industry ↔ form-type facet cascade (Phase 2b–2d, 2026-04-30)
 
 The discovery form (the lower section under the Build-universe panel) is
 **facet-driven across three axes**: Industries (multi-select listbox),
 Year (multi-select listbox), and Form Types (checkbox row). All three
-are populated from the actual contents of `filings`, with row counts
-shown next to each option. Each axis count equals the number of filings
-matching the OTHER two axes' selections (standard facet UX — each axis
-ignores its own selection so the user always sees the full set of
-choices for that axis):
+are populated from the actual contents of `filings`. Each option label
+reads **`(pending/total)`** — `pending` is the count of filings in the
+slice that haven't yet been extracted (no `v2_documents` row); `total`
+is the universe count for that slice. Each axis's counts reflect the
+OTHER two axes' selections (standard facet UX — each axis ignores its
+own selection so the user always sees the full set of choices for that
+axis):
 
 - Selecting year(s) narrows industries + form-types.
 - Selecting industries narrows years + form-types.
 - Selecting form-type(s) narrows years + industries.
 - Form-type checkboxes: multiple selections are OR-ed, so `IPO` + `10-K`
   shows year/industry counts for filings in either bundle.
-- Selected options that drop to zero count stay visible (greyed `(0)`)
+- Selected options that drop to total=0 stay visible (greyed `(0/0)`)
   so the user can deselect them. For Year and Industry listboxes,
-  unselected zero-count options are hidden; for Form-type checkboxes,
-  unselected zero-count options stay visible-but-disabled (the row only
-  has 3 entries, hiding would be jarring).
+  unselected zero-total options are hidden; for Form-type checkboxes,
+  unselected zero-total options stay visible-but-disabled (the row only
+  has 3 entries, hiding would be jarring). A slice with `pending=0` and
+  `total>0` (fully extracted) stays enabled.
+
+**Phase-1 in-scope gate alignment** (Phase 2d): the facet counts apply
+the same Phase-1 gate that `_build_discovery_sql` does — when the
+selection includes any S-1/F-1 form type, only `is_in_scope_phase1=TRUE`
+filings are counted. This means the facet number always matches what
+Preview will show. SPACs, post-combination de-SPACs, secondary-only
+offerings, investment vehicles, and resource-extraction companies are
+excluded from the count when the user is looking at IPO filings. 10-K
+and 8-K bundles bypass the gate (those filings are out-of-scope-phase1
+by design). For form-type counts the gate is applied per-bundle: the
+s1f1 row applies the gate, 10k/8k rows don't.
+
+Reviewed-status detail (extracted-with-reviews vs. extracted-without)
+still lives on the Preview page; the form folds both into the
+"extracted" portion of the total (i.e. `total - pending`).
 
 Backed by `GET /api/v2/ingest/filter-options?year=...&industry=...&form_type=...`
-→ `{years: [...], industries: [...], form_types: [...]}`. Helpers in
-`src/universe/onboarding.py`: `query_universe_year_counts`,
+→ `{years: [{year, total, pending}], industries: [{key, label, total, pending}], form_types: [...]}`.
+Helpers in `src/universe/onboarding.py`: `query_universe_year_counts`,
 `query_universe_industry_counts`, `query_universe_form_type_counts`.
 Cascade JS: `src/web/static/js/ingest_form_facets.js`.
 

--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -817,20 +817,25 @@ def onboard(
 
 @dataclass(frozen=True)
 class YearCount:
-    """A year present in `filings` and the count of rows that fall in it."""
+    """A year present in `filings`, with the universe total and the count of
+    those rows still pending extraction (no row in v2_documents).
+    """
 
     year: int
-    count: int
+    total: int  # total filings in the universe slice (was `count` pre-Phase-2d)
+    pending: int = 0  # subset with no v2_documents row → un-extracted
 
 
 @dataclass(frozen=True)
 class IndustryCount:
-    """A YAML industry entry and the count of filings whose company SIC code
-    is in that industry's sic_codes list."""
+    """A YAML industry entry with the universe total and pending-extraction
+    count of filings whose company SIC code is in that industry's sic_codes
+    list."""
 
     key: str  # canonical industry name from YAML (e.g. "biotech")
     label: str  # humanised (e.g. "Biotech") — same shape as `_industry_options()`
-    count: int
+    total: int  # total filings in the universe slice
+    pending: int = 0  # subset un-extracted (no v2_documents row)
 
 
 def _industry_label(key: str) -> str:
@@ -840,15 +845,19 @@ def _industry_label(key: str) -> str:
 
 _YEAR_COUNTS_SQL = """
 SELECT EXTRACT(YEAR FROM f.filing_date)::int AS yr,
-       COUNT(*)::int AS cnt
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE v.doc_id IS NULL)::int AS pending
 FROM filings f
 JOIN companies c ON c.company_id = f.company_id
+LEFT JOIN v2_documents v ON v.filing_id = f.filing_id
 WHERE 1=1
 """
 
 _YEAR_COUNTS_INDUSTRY_GATE = "  AND c.industry_code = ANY(%(sic_codes)s)\n"
 
 _YEAR_COUNTS_FORM_TYPE_GATE = "  AND f.form_type = ANY(%(form_types)s)\n"
+
+_YEAR_COUNTS_PHASE1_GATE = "  AND f.is_in_scope_phase1 = TRUE\n"
 
 _YEAR_COUNTS_TAIL = """GROUP BY yr
 ORDER BY yr DESC
@@ -861,7 +870,11 @@ def query_universe_year_counts(
     sic_codes: list[str] | None = None,
     form_types: list[str] | None = None,
 ) -> list[YearCount]:
-    """Return distinct years in `filings` with their row count, DESC.
+    """Return distinct years in `filings` with universe total + pending counts.
+
+    Each row carries:
+        total   — filings in the slice (was the only count pre-Phase-2d).
+        pending — subset with no `v2_documents` row (i.e. un-extracted).
 
     Optional ``sic_codes`` restricts to filings whose
     ``companies.industry_code`` IS IN the list. ``form_types`` is a list of
@@ -869,9 +882,14 @@ def query_universe_year_counts(
     is responsible for resolving bundle keys via ``FORM_TYPE_BUNDLES``.
     None or empty for either means no filter on that axis.
 
-    Years with count==0 are not returned (they wouldn't have a row in
-    ``filings`` anyway).
+    The Phase-1 in-scope gate (``is_in_scope_phase1 = TRUE``) is applied
+    when ``form_types`` intersects ``S1F1_FORMS`` — same rule as
+    ``_build_discovery_sql`` — so facet counts agree with what Preview
+    would actually surface for that slice.
+
+    Years with no rows are not returned.
     """
+    include_phase1 = bool(form_types and (S1F1_FORMS & set(form_types)))
     sql = _YEAR_COUNTS_SQL
     params: dict[str, Any] = {}
     if sic_codes:
@@ -880,15 +898,20 @@ def query_universe_year_counts(
     if form_types:
         sql += _YEAR_COUNTS_FORM_TYPE_GATE
         params["form_types"] = list(form_types)
+    if include_phase1:
+        sql += _YEAR_COUNTS_PHASE1_GATE
     sql += _YEAR_COUNTS_TAIL
     rows = db.query(sql, params)
-    return [YearCount(year=int(r["yr"]), count=int(r["cnt"])) for r in rows]
+    return [
+        YearCount(year=int(r["yr"]), total=int(r["total"]), pending=int(r["pending"])) for r in rows
+    ]
 
 
 _INDUSTRY_COUNTS_SQL_TEMPLATE = """
 SELECT industry_sic.industry_key,
        industry_sic.industry_label,
-       COUNT(f.filing_id)::int AS cnt
+       COUNT(f.filing_id)::int AS total,
+       COUNT(f.filing_id) FILTER (WHERE f.filing_id IS NOT NULL AND v.doc_id IS NULL)::int AS pending
 FROM unnest(
     %(keys)s::text[],
     %(labels)s::text[],
@@ -897,6 +920,7 @@ FROM unnest(
 LEFT JOIN companies c ON c.industry_code = industry_sic.sic
 LEFT JOIN filings  f ON f.company_id = c.company_id
     {filing_join_extra}
+LEFT JOIN v2_documents v ON v.filing_id = f.filing_id
 GROUP BY industry_sic.industry_key, industry_sic.industry_label
 ORDER BY industry_sic.industry_label
 """
@@ -909,11 +933,16 @@ def query_universe_industry_counts(
     years: list[int] | None = None,
     form_types: list[str] | None = None,
 ) -> list[IndustryCount]:
-    """For every industry in *industry_map*, return its filing count.
+    """For every industry in *industry_map*, return its filing total + pending.
+
+    Each row carries:
+        total   — filings in the slice (was `count` pre-Phase-2d).
+        pending — subset with no `v2_documents` row (i.e. un-extracted).
 
     Implementation: a single SQL query joins filings → companies → an inline
     relation built from ``unnest()`` of three parallel arrays
-    ``(industry_key, industry_label, sic)`` derived from the YAML.
+    ``(industry_key, industry_label, sic)`` derived from the YAML, with a
+    LEFT JOIN to ``v2_documents`` so the COUNT FILTER can compute pending.
 
     SIC-code overlap across industries is handled cleanly: a filing whose
     ``companies.industry_code`` matches multiple industries contributes one
@@ -921,10 +950,15 @@ def query_universe_industry_counts(
 
     Optional ``years`` and ``form_types`` restrict to filings matching those
     criteria. ``form_types`` is a list of canonical form-type strings (the
-    caller resolves bundle keys via ``FORM_TYPE_BUNDLES``). Both filters
-    apply on the LEFT JOIN to filings, not in WHERE, so industries with
-    zero matching filings are still returned (count=0). The endpoint /
-    template decides whether to display zero-count entries.
+    caller resolves bundle keys via ``FORM_TYPE_BUNDLES``). Filters apply
+    on the LEFT JOIN to filings, not in WHERE, so industries with zero
+    matching filings are still returned (total=0, pending=0). The endpoint
+    / template decides whether to display zero-total entries.
+
+    The Phase-1 in-scope gate (``is_in_scope_phase1 = TRUE``) is applied
+    when ``form_types`` intersects ``S1F1_FORMS`` — same rule as
+    ``_build_discovery_sql`` — so facet counts agree with what Preview
+    would actually surface.
 
     Sorted alphabetically by ``label``.
     """
@@ -945,11 +979,15 @@ def query_universe_industry_counts(
     if not keys:
         return []
 
+    include_phase1 = bool(form_types and (S1F1_FORMS & set(form_types)))
+
     extra_clauses = []
     if years:
         extra_clauses.append("AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)")
     if form_types:
         extra_clauses.append("AND f.form_type = ANY(%(form_types)s)")
+    if include_phase1:
+        extra_clauses.append("AND f.is_in_scope_phase1 = TRUE")
     filing_join_extra = "\n    ".join(extra_clauses)
 
     sql = _INDUSTRY_COUNTS_SQL_TEMPLATE.format(filing_join_extra=filing_join_extra)
@@ -964,7 +1002,8 @@ def query_universe_industry_counts(
         IndustryCount(
             key=str(r["industry_key"]),
             label=str(r["industry_label"]),
-            count=int(r["cnt"]),
+            total=int(r["total"]),
+            pending=int(r["pending"]),
         )
         for r in rows
     ]
@@ -977,28 +1016,40 @@ def query_universe_industry_counts(
 
 @dataclass(frozen=True)
 class FormTypeCount:
-    """A FORM_TYPE_BUNDLES entry and the count of filings whose form_type
-    is in the bundle's list of canonical form types."""
+    """A FORM_TYPE_BUNDLES entry with the universe total and pending-extraction
+    count of filings whose form_type is in the bundle's list of canonical
+    form types."""
 
     key: str  # bundle key from FORM_TYPE_BUNDLES (e.g. "s1f1", "10k", "8k")
     label: str  # human label (e.g. "S-1 / F-1 (IPO filings)")
-    count: int
+    total: int
+    pending: int = 0
 
 
 _FORM_TYPE_COUNTS_SQL_TEMPLATE = """
 SELECT bundle.bundle_key,
        bundle.bundle_label,
        COUNT(f.filing_id) FILTER (
-           WHERE f.filing_id IS NOT NULL {company_filter_clause}
-       )::int AS cnt
+           WHERE f.filing_id IS NOT NULL
+             {company_filter_clause}
+             AND (NOT bundle.requires_phase1 OR f.is_in_scope_phase1 = TRUE)
+       )::int AS total,
+       COUNT(f.filing_id) FILTER (
+           WHERE f.filing_id IS NOT NULL
+             AND v.doc_id IS NULL
+             {company_filter_clause}
+             AND (NOT bundle.requires_phase1 OR f.is_in_scope_phase1 = TRUE)
+       )::int AS pending
 FROM unnest(
     %(keys)s::text[],
     %(labels)s::text[],
-    %(form_types)s::text[]
-) AS bundle(bundle_key, bundle_label, form_type)
+    %(form_types)s::text[],
+    %(requires_phase1)s::bool[]
+) AS bundle(bundle_key, bundle_label, form_type, requires_phase1)
 LEFT JOIN filings f ON f.form_type = bundle.form_type
     {year_clause}
 LEFT JOIN companies c ON c.company_id = f.company_id
+LEFT JOIN v2_documents v ON v.filing_id = f.filing_id
 GROUP BY bundle.bundle_key, bundle.bundle_label
 """
 
@@ -1010,19 +1061,23 @@ def query_universe_form_type_counts(
     years: list[int] | None = None,
     sic_codes: list[str] | None = None,
 ) -> list[FormTypeCount]:
-    """Return [{key, label, count}] for every form-type bundle.
+    """Return [{key, label, total, pending}] for every form-type bundle.
 
     *bundles* maps bundle_key → (label, [canonical_form_types]). When None,
     defaults to the visible-form-row bundles (s1f1, 10k, 8k) — the same
     set rendered in the discovery form's checkbox row. Each filing whose
     ``form_type`` matches any of the bundle's canonical types contributes
-    +1 to that bundle's count. A filing's ``form_type`` matches at most
-    one bundle in our YAML (S-1 → s1f1, 10-K → 10k, etc.), so no DISTINCT
-    is needed.
+    +1 to that bundle's total; the pending count is the subset with no
+    ``v2_documents`` row.
+
+    The Phase-1 in-scope gate is applied **per bundle**: bundles whose
+    canonical form types intersect ``S1F1_FORMS`` (i.e. s1f1) only count
+    filings where ``is_in_scope_phase1 = TRUE``. 10-K / 8-K bundles bypass
+    the gate. Mirrors ``_build_discovery_sql``'s ``include_phase1`` rule.
 
     Optional ``years`` restricts by filing year; optional ``sic_codes``
     restricts by company SIC. Filters apply on the LEFT JOIN so bundles
-    with zero matches still appear (count=0).
+    with zero matches still appear (total=0, pending=0).
 
     Sorted by bundle key for stable output (s1f1 → 10k → 8k).
     """
@@ -1038,15 +1093,18 @@ def query_universe_form_type_counts(
     keys: list[str] = []
     labels: list[str] = []
     form_types_flat: list[str] = []
+    requires_phase1: list[bool] = []
     label_by_key: dict[str, str] = {}
     bundle_order: list[str] = []
     for bundle_key, (label, form_types_list) in bundles.items():
         label_by_key[bundle_key] = label
         bundle_order.append(bundle_key)
+        gate = bool(S1F1_FORMS & set(form_types_list))
         for ft in form_types_list:
             keys.append(bundle_key)
             labels.append(label)
             form_types_flat.append(ft)
+            requires_phase1.append(gate)
 
     if not keys:
         return []
@@ -1062,6 +1120,7 @@ def query_universe_form_type_counts(
         "keys": keys,
         "labels": labels,
         "form_types": form_types_flat,
+        "requires_phase1": requires_phase1,
     }
     if years:
         params["years"] = [int(y) for y in years]
@@ -1069,7 +1128,13 @@ def query_universe_form_type_counts(
         params["sic_codes"] = list(sic_codes)
 
     rows = db.query(sql, params)
-    by_key = {str(r["bundle_key"]): int(r["cnt"]) for r in rows}
+    by_key = {str(r["bundle_key"]): (int(r["total"]), int(r["pending"])) for r in rows}
     return [
-        FormTypeCount(key=k, label=label_by_key[k], count=by_key.get(k, 0)) for k in bundle_order
+        FormTypeCount(
+            key=k,
+            label=label_by_key[k],
+            total=by_key.get(k, (0, 0))[0],
+            pending=by_key.get(k, (0, 0))[1],
+        )
+        for k in bundle_order
     ]

--- a/src/web/routes/api_ingest.py
+++ b/src/web/routes/api_ingest.py
@@ -276,12 +276,14 @@ def filter_options():
         return jsonify({"status": "error", "message": "Database error"}), 500
 
     payload = {
-        "years": [{"year": yc.year, "count": yc.count} for yc in year_rows],
+        "years": [{"year": yc.year, "total": yc.total, "pending": yc.pending} for yc in year_rows],
         "industries": [
-            {"key": ic.key, "label": ic.label, "count": ic.count} for ic in industry_rows
+            {"key": ic.key, "label": ic.label, "total": ic.total, "pending": ic.pending}
+            for ic in industry_rows
         ],
         "form_types": [
-            {"key": ftc.key, "label": ftc.label, "count": ftc.count} for ftc in form_type_rows
+            {"key": ftc.key, "label": ftc.label, "total": ftc.total, "pending": ftc.pending}
+            for ftc in form_type_rows
         ],
     }
     return jsonify(payload), 200

--- a/src/web/routes/ingest.py
+++ b/src/web/routes/ingest.py
@@ -58,26 +58,53 @@ _PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 # ---------------------------------------------------------------------------
 
 
-def _industry_options() -> list[dict[str, Any]]:
-    """Return industry options annotated with universe filing counts.
+def _resolve_form_type_keys(form_type_keys: list[str]) -> list[str]:
+    """Resolve a list of bundle keys (e.g. ['s1f1', '10k']) to their flat
+    canonical form-type strings via FORM_TYPE_BUNDLES, deduped."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in form_type_keys:
+        for ft in FORM_TYPE_BUNDLES.get(key, []):
+            if ft not in seen:
+                out.append(ft)
+                seen.add(ft)
+    return out
 
-    Industries with no filings in the universe (count == 0) are still
+
+def _industry_options(form_types: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return industry options annotated with universe total + pending counts.
+
+    *form_types* is a list of canonical form-type strings (already resolved
+    via ``FORM_TYPE_BUNDLES``); when None, falls back to the form's default
+    selection (s1f1 canonical types) so server-side render aligns with what
+    the JS cascade fetches on first user interaction.
+
+    Industries with no filings in the universe (total == 0) are still
     returned so the JS facet cascade can show them as disabled rather than
     making them disappear when years narrow the result. The template
-    decides whether to hide zero-count rows on initial render.
+    decides whether to hide zero-total rows on initial render.
     """
+    if form_types is None:
+        form_types = list(FORM_TYPE_BUNDLES["s1f1"])
     try:
         ind_map = load_industry_map()
-        rows = query_universe_industry_counts(get_db(), ind_map)
-        return [{"key": r.key, "label": r.label, "count": r.count} for r in rows]
+        rows = query_universe_industry_counts(get_db(), ind_map, form_types=form_types)
+        return [
+            {"key": r.key, "label": r.label, "total": r.total, "pending": r.pending} for r in rows
+        ]
     except Exception:  # noqa: BLE001
         logger.warning("Failed to load industry options with counts", exc_info=True)
-        # Fall back to YAML-only list with count=0 so the form still renders.
+        # Fall back to YAML-only list with total=pending=0 so the form still renders.
         try:
             ind_map = load_industry_map()
             return sorted(
                 [
-                    {"key": k, "label": k.replace("_", " ").title(), "count": 0}
+                    {
+                        "key": k,
+                        "label": k.replace("_", " ").title(),
+                        "total": 0,
+                        "pending": 0,
+                    }
                     for k in ind_map["industries"]
                 ],
                 key=lambda x: x["label"],
@@ -86,11 +113,18 @@ def _industry_options() -> list[dict[str, Any]]:
             return []
 
 
-def _year_options() -> list[dict[str, int]]:
-    """Return [{year, count}] for every year present in `filings`, DESC."""
+def _year_options(form_types: list[str] | None = None) -> list[dict[str, int]]:
+    """Return [{year, total, pending}] for every year present in `filings`, DESC.
+
+    *form_types* aligns SSR counts with the form's default checkbox state
+    (defaults to s1f1 canonical types) so the first JS cascade fetch
+    doesn't visibly recompute the numbers.
+    """
+    if form_types is None:
+        form_types = list(FORM_TYPE_BUNDLES["s1f1"])
     try:
-        rows = query_universe_year_counts(get_db())
-        return [{"year": r.year, "count": r.count} for r in rows]
+        rows = query_universe_year_counts(get_db(), form_types=form_types)
+        return [{"year": r.year, "total": r.total, "pending": r.pending} for r in rows]
     except Exception:  # noqa: BLE001
         logger.warning("Failed to load year options with counts", exc_info=True)
         return []
@@ -98,7 +132,7 @@ def _year_options() -> list[dict[str, int]]:
 
 # Static labels for the form-type checkbox row. Counts are added dynamically
 # by `_form_type_options()`; the static fallback (DB unavailable in tests)
-# preserves the legacy labels with count=0.
+# preserves the legacy labels with total=pending=0.
 _FORM_TYPE_STATIC_LABELS: dict[str, str] = {
     "s1f1": "S-1 / F-1 (IPO filings)",
     "10k": "10-K (Annual reports)",
@@ -107,19 +141,26 @@ _FORM_TYPE_STATIC_LABELS: dict[str, str] = {
 
 
 def _form_type_options() -> list[dict[str, Any]]:
-    """Return [{key, label, count}] for the form-type checkbox row.
+    """Return [{key, label, total, pending}] for the form-type checkbox row.
 
-    Counts come from ``query_universe_form_type_counts`` (no axis filter
-    on initial render — JS facet cascade refreshes them as the user
-    selects years/industries). Falls back to count=0 when the DB is
-    unavailable so the form still renders during tests.
+    Counts come from ``query_universe_form_type_counts`` (no year/industry
+    filter on initial render — JS facet cascade refreshes them as the user
+    selects years/industries). The Phase-1 gate is applied per bundle
+    inside the SQL: s1f1 only counts in-scope filings; 10k/8k count all.
+    Falls back to total=pending=0 when the DB is unavailable so the form
+    still renders during tests.
     """
     try:
         rows = query_universe_form_type_counts(get_db())
-        return [{"key": r.key, "label": r.label, "count": r.count} for r in rows]
+        return [
+            {"key": r.key, "label": r.label, "total": r.total, "pending": r.pending} for r in rows
+        ]
     except Exception:  # noqa: BLE001
         logger.warning("Failed to load form-type options with counts", exc_info=True)
-        return [{"key": k, "label": v, "count": 0} for k, v in _FORM_TYPE_STATIC_LABELS.items()]
+        return [
+            {"key": k, "label": v, "total": 0, "pending": 0}
+            for k, v in _FORM_TYPE_STATIC_LABELS.items()
+        ]
 
 
 def _parse_form_criteria() -> dict[str, Any]:
@@ -194,15 +235,23 @@ def _volume_band_message(band: VolumeBand, total: int) -> str:
 def _render_ingest_form(form_state: dict[str, Any] | None = None, status: int = 200):
     """Render the criteria form. When *form_state* is given, the template
     repopulates fields so a validation error doesn't wipe user input.
+
+    SSR Phase-1 alignment: pass the form's currently-selected (or default)
+    form_types into ``_year_options`` / ``_industry_options`` so initial
+    counts mirror what the JS cascade will fetch on first user interaction.
+    Without this, the first checkbox/listbox click would visibly
+    re-compute every count.
     """
     state = form_state or {}
     reviewer_name = state.get("_reviewer_name") or request.cookies.get("ingest_reviewer", "")
+    selected_bundle_keys = state.get("form_types") or ["s1f1"]
+    selected_form_types = _resolve_form_type_keys(selected_bundle_keys)
     return (
         render_template(
             "ingest_form.html",
             reviewer_name=reviewer_name,
-            industries=_industry_options(),
-            years_available=_year_options(),
+            industries=_industry_options(form_types=selected_form_types),
+            years_available=_year_options(form_types=selected_form_types),
             form_types_available=_form_type_options(),
             form_state=state,
         ),
@@ -333,36 +382,18 @@ def ingest_start():
             "Add more criteria to narrow the scope.",
             "danger",
         )
-        return (
-            render_template(
-                "ingest_form.html",
-                reviewer_name=reviewer_name,
-                industries=_industry_options(),
-                form_types_available=[
-                    {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)"},
-                    {"key": "10k", "label": "10-K (Annual reports)"},
-                    {"key": "8k", "label": "8-K (Current reports)"},
-                ],
-            ),
-            400,
+        return _render_ingest_form(
+            form_state={"_reviewer_name": reviewer_name},
+            status=400,
         )
     if band == VolumeBand.HARD_WARN and not hard_warn_ack:
         flash(
             "Large batch acknowledgement required. Please check the confirmation box.",
             "danger",
         )
-        return (
-            render_template(
-                "ingest_form.html",
-                reviewer_name=reviewer_name,
-                industries=_industry_options(),
-                form_types_available=[
-                    {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)"},
-                    {"key": "10k", "label": "10-K (Annual reports)"},
-                    {"key": "8k", "label": "8-K (Current reports)"},
-                ],
-            ),
-            400,
+        return _render_ingest_form(
+            form_state={"_reviewer_name": reviewer_name},
+            status=400,
         )
 
     # Determine per-filing bucket and reextract flag.

--- a/src/web/static/js/ingest_form_facets.js
+++ b/src/web/static/js/ingest_form_facets.js
@@ -60,9 +60,9 @@
   }
 
   /**
-   * Update a <select>'s options in place from a `[{value, label, count}]` list.
-   * Selected options stay enabled even when count == 0 so the user can
-   * deselect them. Zero-count, unselected options are hidden.
+   * Update a <select>'s options in place from a `[{value, label, total, pending}]` list.
+   * Selected options stay interactive even at zero so the user can deselect.
+   * Zero-total, unselected options are hidden. Label format: "{label} ({pending}/{total})".
    */
   function applyCounts(selectEl, items, valueKey, labelTemplate) {
     var byValue = {};
@@ -75,16 +75,19 @@
       var opt = options[i];
       var item = byValue[opt.value];
       if (!item) {
-        opt.setAttribute("data-count", "0");
-        opt.text = labelTemplate(opt.value, 0);
+        opt.setAttribute("data-pending", "0");
+        opt.setAttribute("data-total", "0");
+        opt.text = labelTemplate(opt.value, 0, 0);
         opt.hidden = !opt.selected;
         opt.disabled = !opt.selected;
         continue;
       }
-      var count = parseInt(item.count, 10) || 0;
-      opt.setAttribute("data-count", String(count));
-      opt.text = labelTemplate(item, count);
-      opt.hidden = count === 0 && !opt.selected;
+      var total = parseInt(item.total, 10) || 0;
+      var pending = parseInt(item.pending, 10) || 0;
+      opt.setAttribute("data-pending", String(pending));
+      opt.setAttribute("data-total", String(total));
+      opt.text = labelTemplate(item, pending, total);
+      opt.hidden = total === 0 && !opt.selected;
       opt.disabled = false;
     }
   }
@@ -92,10 +95,10 @@
   /**
    * Update form-type checkbox row counts + disabled state.
    *
-   * Per UX choice: zero-count unchecked checkboxes are disabled+greyed
-   * (not hidden) so the small fixed set of form-types stays visually
-   * stable. Checked checkboxes always stay enabled so the user can
-   * uncheck them.
+   * Zero-total unchecked checkboxes are disabled+greyed (not hidden) so the
+   * small fixed set of form-types stays visually stable. Checked checkboxes
+   * always stay enabled so the user can uncheck them. Label format:
+   * "{label} ({pending}/{total})".
    */
   function applyFormTypeCounts(items) {
     var byKey = {};
@@ -105,14 +108,24 @@
     for (var j = 0; j < formTypeEls.length; j++) {
       var input = formTypeEls[j];
       var item = byKey[input.value];
-      var count = item ? parseInt(item.count, 10) || 0 : 0;
+      var total = item ? parseInt(item.total, 10) || 0 : 0;
+      var pending = item ? parseInt(item.pending, 10) || 0 : 0;
       var label = input.parentNode.querySelector("label.form-check-label");
-      var baseLabel = item ? item.label : (label ? label.textContent.replace(/\s*\(\d+\)\s*$/, "") : input.value);
-      input.setAttribute("data-count", String(count));
-      if (label) {
-        label.textContent = baseLabel + " (" + count + ")";
+      var baseLabel;
+      if (item) {
+        baseLabel = item.label;
+      } else if (label) {
+        // Strip a trailing "(N)" or "(N/M)" suffix to recover the label
+        baseLabel = label.textContent.replace(/\s*\(\d+(\/\d+)?\)\s*$/, "");
+      } else {
+        baseLabel = input.value;
       }
-      var shouldDisable = count === 0 && !input.checked;
+      input.setAttribute("data-pending", String(pending));
+      input.setAttribute("data-total", String(total));
+      if (label) {
+        label.textContent = baseLabel + " (" + pending + "/" + total + ")";
+      }
+      var shouldDisable = total === 0 && !input.checked;
       input.disabled = shouldDisable;
       if (label) {
         if (shouldDisable) {
@@ -139,15 +152,15 @@
         return r.json();
       })
       .then(function (data) {
-        applyCounts(yearEl, data.years || [], "year", function (item, count) {
+        applyCounts(yearEl, data.years || [], "year", function (item, pending, total) {
           var year = typeof item === "object" ? item.year : item;
-          return year + " (" + count + ")";
+          return year + " (" + pending + "/" + total + ")";
         });
-        applyCounts(industriesEl, data.industries || [], "key", function (item, count) {
+        applyCounts(industriesEl, data.industries || [], "key", function (item, pending, total) {
           if (typeof item !== "object") {
             return String(item);
           }
-          return item.label + " (" + count + ")";
+          return item.label + " (" + pending + "/" + total + ")";
         });
         applyFormTypeCounts(data.form_types || []);
       })

--- a/src/web/templates/ingest_form.html
+++ b/src/web/templates/ingest_form.html
@@ -79,12 +79,13 @@
           <select id="industries" name="industries" class="form-select" multiple size="8">
             {% for ind in industries %}
             <option value="{{ ind.key }}"
-                    data-count="{{ ind.count }}"
+                    data-pending="{{ ind.pending }}"
+                    data-total="{{ ind.total }}"
                     {% if ind.key in selected_industries %}selected{% endif %}
-                    {% if ind.count == 0 and ind.key not in selected_industries %}hidden{% endif %}>{{ ind.label }} ({{ ind.count }})</option>
+                    {% if ind.total == 0 and ind.key not in selected_industries %}hidden{% endif %}>{{ ind.label }} ({{ ind.pending }}/{{ ind.total }})</option>
             {% endfor %}
           </select>
-          <div class="form-text">Hold Ctrl / Cmd to select multiple. List narrows to industries with rows in the selected year(s).</div>
+          <div class="form-text">Hold Ctrl / Cmd to select multiple. Counts shown as <em>pending/total</em> — pending = un-extracted filings in the slice. List narrows to industries with rows in the selected year(s).</div>
         </div>
 
         <div class="col-md-6">
@@ -106,9 +107,9 @@
             for (var i = 0; i < options.length; i++) {
               var opt = options[i];
               var match = opt.textContent.toLowerCase().indexOf(term) !== -1;
-              // Preserve the facet-cascade `hidden` when count==0; only hide when search excludes
+              // Preserve the facet-cascade `hidden` when total==0; only hide when search excludes
               if (term === '') {
-                opt.hidden = (parseInt(opt.getAttribute('data-count') || '0', 10) === 0 && !opt.selected);
+                opt.hidden = (parseInt(opt.getAttribute('data-total') || '0', 10) === 0 && !opt.selected);
               } else {
                 opt.hidden = !match;
               }
@@ -124,13 +125,14 @@
         <select id="year" name="year" class="form-select" multiple size="6">
           {% for yr in years_available %}
           <option value="{{ yr.year }}"
-                  data-count="{{ yr.count }}"
-                  {% if yr.year in selected_years %}selected{% endif %}>{{ yr.year }} ({{ yr.count }})</option>
+                  data-pending="{{ yr.pending }}"
+                  data-total="{{ yr.total }}"
+                  {% if yr.year in selected_years %}selected{% endif %}>{{ yr.year }} ({{ yr.pending }}/{{ yr.total }})</option>
           {% endfor %}
           {# Render any selected years that aren't in years_available (defensive — covers stale form_state and DB-unavailable test conditions) #}
           {% for sy in selected_years %}
             {% if sy not in _year_keys %}
-            <option value="{{ sy }}" data-count="0" selected>{{ sy }} (0)</option>
+            <option value="{{ sy }}" data-pending="0" data-total="0" selected>{{ sy }} (0/0)</option>
             {% endif %}
           {% endfor %}
         </select>
@@ -142,16 +144,18 @@
         <label class="form-label fw-semibold">Form Types</label>
         <div>
           {% for ft in form_types_available %}
-          {% set ft_count = ft.get('count', 0) %}
+          {% set ft_pending = ft.get('pending', 0) %}
+          {% set ft_total = ft.get('total', 0) %}
           {% set ft_checked = ft.key in selected_form_types %}
-          {% set ft_disabled = ft_count == 0 and not ft_checked %}
+          {% set ft_disabled = ft_total == 0 and not ft_checked %}
           <div class="form-check form-check-inline">
             <input class="form-check-input" type="checkbox"
                    id="ft_{{ ft.key }}" name="form_types" value="{{ ft.key }}"
-                   data-count="{{ ft_count }}"
+                   data-pending="{{ ft_pending }}"
+                   data-total="{{ ft_total }}"
                    {% if ft_checked %}checked{% endif %}
                    {% if ft_disabled %}disabled{% endif %}>
-            <label class="form-check-label{% if ft_disabled %} text-muted{% endif %}" for="ft_{{ ft.key }}">{{ ft.label }} ({{ ft_count }})</label>
+            <label class="form-check-label{% if ft_disabled %} text-muted{% endif %}" for="ft_{{ ft.key }}">{{ ft.label }} ({{ ft_pending }}/{{ ft_total }})</label>
           </div>
           {% endfor %}
         </div>

--- a/tests/unit/universe/test_onboarding.py
+++ b/tests/unit/universe/test_onboarding.py
@@ -597,17 +597,25 @@ def test_load_industry_map_resolves_new_aliases(alias: str, target: str) -> None
 def test_query_universe_year_counts_returns_dataclass_list() -> None:
     db = _FakeDB(
         rows=[
-            {"yr": 2018, "cnt": 412},
-            {"yr": 2017, "cnt": 380},
-            {"yr": 2016, "cnt": 215},
+            {"yr": 2018, "total": 412, "pending": 10},
+            {"yr": 2017, "total": 380, "pending": 380},
+            {"yr": 2016, "total": 215, "pending": 215},
         ]
     )
     out = query_universe_year_counts(db)
     assert out == [
-        YearCount(year=2018, count=412),
-        YearCount(year=2017, count=380),
-        YearCount(year=2016, count=215),
+        YearCount(year=2018, total=412, pending=10),
+        YearCount(year=2017, total=380, pending=380),
+        YearCount(year=2016, total=215, pending=215),
     ]
+
+
+def test_query_universe_year_counts_includes_pending_filter_clause() -> None:
+    """The SQL must compute pending via FILTER (WHERE v.doc_id IS NULL)."""
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db)
+    assert "v.doc_id IS NULL" in db.last_sql
+    assert "LEFT JOIN v2_documents v" in db.last_sql
 
 
 def test_query_universe_year_counts_empty_universe_returns_empty_list() -> None:
@@ -623,10 +631,30 @@ def test_query_universe_year_counts_no_industry_filter_omits_clause() -> None:
 
 
 def test_query_universe_year_counts_with_industry_filter_includes_clause() -> None:
-    db = _FakeDB(rows=[{"yr": 2018, "cnt": 1}])
+    db = _FakeDB(rows=[{"yr": 2018, "total": 1, "pending": 0}])
     query_universe_year_counts(db, sic_codes=["6020", "6021"])
     assert "industry_code" in db.last_sql
     assert db.last_params["sic_codes"] == ["6020", "6021"]
+
+
+def test_query_universe_year_counts_phase1_gate_applied_for_s1f1() -> None:
+    """When form_types includes any S-1/F-1 type, the Phase-1 gate is added."""
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db, form_types=["S-1", "S-1/A"])
+    assert "f.is_in_scope_phase1 = TRUE" in db.last_sql
+
+
+def test_query_universe_year_counts_phase1_gate_skipped_for_10k_only() -> None:
+    """A 10-K-only selection bypasses the Phase-1 gate (matches discovery SQL)."""
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db, form_types=["10-K", "10-K/A"])
+    assert "is_in_scope_phase1" not in db.last_sql
+
+
+def test_query_universe_year_counts_phase1_gate_skipped_when_no_form_types() -> None:
+    db = _FakeDB(rows=[])
+    query_universe_year_counts(db)
+    assert "is_in_scope_phase1" not in db.last_sql
 
 
 # ---------------------------------------------------------------------------
@@ -645,23 +673,48 @@ def test_query_universe_industry_counts_builds_unnest_arrays() -> None:
     }
     db = _FakeDB(
         rows=[
-            {"industry_key": "biotech", "industry_label": "Biotech", "cnt": 28},
+            {"industry_key": "biotech", "industry_label": "Biotech", "total": 28, "pending": 3},
             {
                 "industry_key": "commercial_banking",
                 "industry_label": "Commercial Banking",
-                "cnt": 12,
+                "total": 12,
+                "pending": 12,
             },
         ]
     )
     out = query_universe_industry_counts(db, industry_map)
     assert out == [
-        IndustryCount(key="biotech", label="Biotech", count=28),
-        IndustryCount(key="commercial_banking", label="Commercial Banking", count=12),
+        IndustryCount(key="biotech", label="Biotech", total=28, pending=3),
+        IndustryCount(key="commercial_banking", label="Commercial Banking", total=12, pending=12),
     ]
     # The arrays passed to unnest carry one row per (industry, sic) tuple
     assert db.last_params["keys"] == ["biotech", "biotech", "commercial_banking"]
     assert db.last_params["labels"] == ["Biotech", "Biotech", "Commercial Banking"]
     assert db.last_params["sics"] == ["2836", "8731", "6020"]
+
+
+def test_query_universe_industry_counts_includes_pending_filter() -> None:
+    """The SQL must LEFT JOIN v2_documents and FILTER for pending."""
+    industry_map = {"industries": {"biotech": {"sic_codes": ["2836"]}}, "aliases": {}}
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map)
+    assert "LEFT JOIN v2_documents v" in db.last_sql
+    assert "v.doc_id IS NULL" in db.last_sql
+
+
+def test_query_universe_industry_counts_phase1_gate_for_s1f1() -> None:
+    """form_types intersecting S-1/F-1 → Phase-1 gate goes on the filings JOIN."""
+    industry_map = {"industries": {"biotech": {"sic_codes": ["2836"]}}, "aliases": {}}
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, form_types=["S-1"])
+    assert "f.is_in_scope_phase1 = TRUE" in db.last_sql
+
+
+def test_query_universe_industry_counts_phase1_gate_skipped_for_10k_only() -> None:
+    industry_map = {"industries": {"biotech": {"sic_codes": ["2836"]}}, "aliases": {}}
+    db = _FakeDB(rows=[])
+    query_universe_industry_counts(db, industry_map, form_types=["10-K"])
+    assert "is_in_scope_phase1" not in db.last_sql
 
 
 def test_query_universe_industry_counts_with_year_filter_includes_clause() -> None:
@@ -700,7 +753,7 @@ def test_query_universe_industry_counts_empty_yaml_returns_empty_list() -> None:
 
 
 def test_query_universe_year_counts_with_form_types_filter() -> None:
-    db = _FakeDB(rows=[{"yr": 2018, "cnt": 1}])
+    db = _FakeDB(rows=[{"yr": 2018, "total": 1, "pending": 0}])
     query_universe_year_counts(db, form_types=["S-1", "S-1/A"])
     assert "f.form_type = ANY(%(form_types)s)" in db.last_sql
     assert db.last_params["form_types"] == ["S-1", "S-1/A"]
@@ -751,28 +804,71 @@ def test_query_universe_form_type_counts_default_bundles() -> None:
     """Without explicit bundles, returns counts for s1f1 / 10k / 8k in that order."""
     db = _FakeDB(
         rows=[
-            {"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 467},
-            {"bundle_key": "10k", "bundle_label": "10-K (Annual reports)", "cnt": 0},
-            {"bundle_key": "8k", "bundle_label": "8-K (Current reports)", "cnt": 0},
+            {
+                "bundle_key": "s1f1",
+                "bundle_label": "S-1 / F-1 (IPO filings)",
+                "total": 467,
+                "pending": 5,
+            },
+            {
+                "bundle_key": "10k",
+                "bundle_label": "10-K (Annual reports)",
+                "total": 0,
+                "pending": 0,
+            },
+            {
+                "bundle_key": "8k",
+                "bundle_label": "8-K (Current reports)",
+                "total": 0,
+                "pending": 0,
+            },
         ]
     )
     out = query_universe_form_type_counts(db)
     keys = [c.key for c in out]
     assert keys == ["s1f1", "10k", "8k"]
     by_key = {c.key: c for c in out}
-    assert by_key["s1f1"].count == 467
-    assert by_key["10k"].count == 0
-    assert by_key["8k"].count == 0
+    assert by_key["s1f1"].total == 467
+    assert by_key["s1f1"].pending == 5
+    assert by_key["10k"].total == 0
+    assert by_key["8k"].total == 0
 
 
 def test_query_universe_form_type_counts_zero_count_bundles_preserved() -> None:
-    """A bundle with no matching filings still appears in the result with count=0."""
-    db = _FakeDB(rows=[{"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 5}])
+    """A bundle with no matching filings still appears in the result with total=0."""
+    db = _FakeDB(
+        rows=[
+            {
+                "bundle_key": "s1f1",
+                "bundle_label": "S-1 / F-1 (IPO filings)",
+                "total": 5,
+                "pending": 5,
+            }
+        ]
+    )
     out = query_universe_form_type_counts(db)
-    by_key = {c.key: c.count for c in out}
+    by_key = {c.key: c.total for c in out}
     assert by_key["s1f1"] == 5
     assert by_key["10k"] == 0
     assert by_key["8k"] == 0
+
+
+def test_query_universe_form_type_counts_per_bundle_phase1_gate() -> None:
+    """The unnest VALUES list passes a `requires_phase1` boolean per bundle:
+    True for s1f1, False for 10k/8k. The SQL applies the gate via a CASE
+    inside the COUNT FILTER (`NOT bundle.requires_phase1 OR is_in_scope_phase1`).
+    """
+    db = _FakeDB(rows=[])
+    query_universe_form_type_counts(db)
+    assert "requires_phase1" in db.last_sql
+    assert "is_in_scope_phase1" in db.last_sql
+    # The Python-side flag list must align: s1f1=True, 10k=False, 8k=False
+    flags = db.last_params["requires_phase1"]
+    keys = db.last_params["keys"]
+    by_key = {keys[i]: flags[i] for i in range(len(keys))}
+    assert by_key["s1f1"] is True
+    assert by_key["10k"] is False
+    assert by_key["8k"] is False
 
 
 def test_query_universe_form_type_counts_with_year_filter() -> None:
@@ -797,9 +893,19 @@ def test_query_universe_form_type_counts_no_filters_omits_clauses() -> None:
 
 
 def test_query_universe_form_type_counts_returns_dataclass_instances() -> None:
-    db = _FakeDB(rows=[{"bundle_key": "s1f1", "bundle_label": "S-1 / F-1 (IPO filings)", "cnt": 3}])
+    db = _FakeDB(
+        rows=[
+            {
+                "bundle_key": "s1f1",
+                "bundle_label": "S-1 / F-1 (IPO filings)",
+                "total": 3,
+                "pending": 1,
+            }
+        ]
+    )
     out = query_universe_form_type_counts(db)
     assert all(isinstance(c, FormTypeCount) for c in out)
     assert out[0].key == "s1f1"
     assert out[0].label == "S-1 / F-1 (IPO filings)"
-    assert out[0].count == 3
+    assert out[0].total == 3
+    assert out[0].pending == 1

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -155,21 +155,22 @@ def test_ingest_form_loads_facet_cascade_js(client):
     assert "ingest_form_facets.js" in body
 
 
-def test_ingest_form_form_types_show_counts_and_disable_zero(client):
-    """Form-type checkboxes carry data-count, show "(N)" in the label, and the
-    disabled+text-muted style applies when count==0 and the option isn't
-    pre-checked. With the DB unavailable in tests _form_type_options() falls
-    back to count=0 for every bundle, so all three should be disabled."""
+def test_ingest_form_form_types_show_pending_total_and_disable_zero(client):
+    """Form-type checkboxes carry data-pending + data-total, show "(P/T)"
+    in the label, and the disabled+text-muted style applies when total==0
+    and the option isn't pre-checked. With the DB unavailable in tests
+    _form_type_options() falls back to total=pending=0 for every bundle,
+    so 10k and 8k (unchecked) must be marked disabled; s1f1 stays checked
+    by default and remains enabled."""
     resp = client.get("/ingest/")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    # Every form-type checkbox carries data-count="0" in the test environment
-    assert 'data-count="0"' in body
-    # The "(0)" suffix appears in at least one form-type label
-    assert "(0)" in body
-    # In the test environment all three bundles default to count=0 with no
-    # pre-selection (the form_state defaults to selected=['s1f1']), so 10k
-    # and 8k must be marked disabled.
+    # Every form-type checkbox carries data-pending and data-total in the test environment
+    assert 'data-pending="0"' in body
+    assert 'data-total="0"' in body
+    # The "(0/0)" suffix appears in at least one form-type label
+    assert "(0/0)" in body
+    # All three bundles default to pending=total=0 with no pre-selection beyond s1f1
     assert 'id="ft_10k"' in body
     assert 'id="ft_8k"' in body
     # Find the input for ft_10k and confirm it's disabled
@@ -255,27 +256,32 @@ def test_parse_form_criteria_single_year_multi_select(app):
 
 def test_filter_options_endpoint_no_filters_returns_three_axes(client):
     """GET /api/v2/ingest/filter-options without query params returns all-time
-    counts on all three axes, derived from the mocked DB rows."""
+    counts on all three axes (total + pending), derived from the mocked DB rows."""
     from src.universe.onboarding import FormTypeCount, IndustryCount, YearCount
 
     with (
         patch(
             "src.web.routes.api_ingest.query_universe_year_counts",
-            return_value=[YearCount(year=2018, count=412), YearCount(year=2017, count=380)],
+            return_value=[
+                YearCount(year=2018, total=412, pending=10),
+                YearCount(year=2017, total=380, pending=380),
+            ],
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
             return_value=[
-                IndustryCount(key="biotech", label="Biotech", count=28),
-                IndustryCount(key="commercial_banking", label="Commercial Banking", count=12),
+                IndustryCount(key="biotech", label="Biotech", total=28, pending=3),
+                IndustryCount(
+                    key="commercial_banking", label="Commercial Banking", total=12, pending=12
+                ),
             ],
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_form_type_counts",
             return_value=[
-                FormTypeCount(key="s1f1", label="S-1 / F-1 (IPO filings)", count=467),
-                FormTypeCount(key="10k", label="10-K (Annual reports)", count=0),
-                FormTypeCount(key="8k", label="8-K (Current reports)", count=0),
+                FormTypeCount(key="s1f1", label="S-1 / F-1 (IPO filings)", total=467, pending=5),
+                FormTypeCount(key="10k", label="10-K (Annual reports)", total=0, pending=0),
+                FormTypeCount(key="8k", label="8-K (Current reports)", total=0, pending=0),
             ],
         ),
     ):
@@ -283,17 +289,17 @@ def test_filter_options_endpoint_no_filters_returns_three_axes(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["years"] == [
-        {"year": 2018, "count": 412},
-        {"year": 2017, "count": 380},
+        {"year": 2018, "total": 412, "pending": 10},
+        {"year": 2017, "total": 380, "pending": 380},
     ]
     assert data["industries"] == [
-        {"key": "biotech", "label": "Biotech", "count": 28},
-        {"key": "commercial_banking", "label": "Commercial Banking", "count": 12},
+        {"key": "biotech", "label": "Biotech", "total": 28, "pending": 3},
+        {"key": "commercial_banking", "label": "Commercial Banking", "total": 12, "pending": 12},
     ]
     assert data["form_types"] == [
-        {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)", "count": 467},
-        {"key": "10k", "label": "10-K (Annual reports)", "count": 0},
-        {"key": "8k", "label": "8-K (Current reports)", "count": 0},
+        {"key": "s1f1", "label": "S-1 / F-1 (IPO filings)", "total": 467, "pending": 5},
+        {"key": "10k", "label": "10-K (Annual reports)", "total": 0, "pending": 0},
+        {"key": "8k", "label": "8-K (Current reports)", "total": 0, "pending": 0},
     ]
 
 
@@ -305,12 +311,12 @@ def test_filter_options_endpoint_year_param_passes_through(client):
 
     def fake_industry_counts(db, industry_map, *, years=None, form_types=None):
         captured["years"] = years
-        return [IndustryCount(key="biotech", label="Biotech", count=5)]
+        return [IndustryCount(key="biotech", label="Biotech", total=5, pending=2)]
 
     with (
         patch(
             "src.web.routes.api_ingest.query_universe_year_counts",
-            return_value=[YearCount(year=2016, count=10)],
+            return_value=[YearCount(year=2016, total=10, pending=10)],
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
@@ -335,7 +341,7 @@ def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
 
     def fake_year_counts(db, *, sic_codes=None, form_types=None):
         captured["sic_codes"] = sic_codes
-        return [YearCount(year=2018, count=3)]
+        return [YearCount(year=2018, total=3, pending=3)]
 
     with (
         patch(
@@ -344,7 +350,7 @@ def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
-            return_value=[IndustryCount(key="biotech", label="Biotech", count=3)],
+            return_value=[IndustryCount(key="biotech", label="Biotech", total=3, pending=3)],
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_form_type_counts",
@@ -397,11 +403,11 @@ def test_filter_options_endpoint_form_type_param_resolves_bundle(client):
 
     def fake_year_counts(db, *, sic_codes=None, form_types=None):
         year_captured["form_types"] = form_types
-        return [YearCount(year=2015, count=467)]
+        return [YearCount(year=2015, total=467, pending=5)]
 
     def fake_industry_counts(db, industry_map, *, years=None, form_types=None):
         industry_captured["form_types"] = form_types
-        return [IndustryCount(key="biotech", label="Biotech", count=5)]
+        return [IndustryCount(key="biotech", label="Biotech", total=5, pending=2)]
 
     with (
         patch(
@@ -432,7 +438,7 @@ def test_filter_options_endpoint_multiple_form_types_union(client):
 
     def fake_year_counts(db, *, sic_codes=None, form_types=None):
         year_captured["form_types"] = form_types
-        return [YearCount(year=2015, count=10)]
+        return [YearCount(year=2015, total=10, pending=2)]
 
     with (
         patch(
@@ -441,7 +447,7 @@ def test_filter_options_endpoint_multiple_form_types_union(client):
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_industry_counts",
-            return_value=[IndustryCount(key="biotech", label="Biotech", count=1)],
+            return_value=[IndustryCount(key="biotech", label="Biotech", total=1, pending=0)],
         ),
         patch(
             "src.web.routes.api_ingest.query_universe_form_type_counts",


### PR DESCRIPTION
Each facet option label changes from `(N)` to `(pending/total)` so the
operator can see at a glance how many filings in a slice are still
un-extracted vs. already done. The form's job — sizing extraction
batches without round-tripping through Preview — is now answered by
the labels themselves.

Renamed `count` → `total` on YearCount/IndustryCount/FormTypeCount
dataclasses and added `pending: int`. The three count helpers now LEFT
JOIN v2_documents and FILTER for `v.doc_id IS NULL` to compute pending.
The /api/v2/ingest/filter-options response shape adds `pending` per
option in all three axes; JS rewrites both numbers on every cascade
update. Zero-total options keep prior visibility rules; total>0 +
pending=0 (fully extracted) stays enabled and shows "(0/N)" so the
slice can be re-picked intentionally.

Phase-1 in-scope alignment: facet counts now apply the same
`is_in_scope_phase1=TRUE` gate that `_build_discovery_sql` does — when
the selected form-types intersect S-1/F-1, only Phase-1 in-scope
filings are counted. This eliminates the "9 in facet → 0 in preview"
surprise for SPAC-heavy slices. 10-K and 8-K bundles bypass the gate
(those filings are out-of-scope-phase1 by design). The form-type axis
applies the gate per-bundle via a `requires_phase1` boolean unnested
alongside the other arrays.

SSR alignment: route helpers default form_types to s1f1 canonical
types so initial server-side counts match the form's default checked
state — first JS cascade fetch no longer visibly recomputes numbers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
