### PR TITLE
feat: rename Statistics → Metric Analytics + add Summary tab scaffold

### DIFF
--- a/docs/known-issues/gh-383-delete-orphan-v2-stats-templates.md
+++ b/docs/known-issues/gh-383-delete-orphan-v2-stats-templates.md
@@ -1,0 +1,24 @@
+---
+id: 383
+source: gh
+slug: delete-orphan-v2-stats-templates
+title: Delete orphan legacy templates v2_stats.html and v2_filing_list.html
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-01
+updated: 2026-05-01
+gh_issue: 383
+note: orphan templates not referenced anywhere; safe to delete in cleanup PR
+---
+
+### Problem
+
+`src/web/templates/v2_stats.html` and `src/web/templates/v2_filing_list.html` exist but are not referenced from any `src/` or `tests/` code path. Discovered while building the Metric Analytics Summary tab — they still surface in grep results and create noise during template-related work.
+
+### Next Steps
+
+- Confirm via grep that no Python or template includes them: `grep -rn "v2_stats.html\|v2_filing_list.html" src/ tests/`.
+- Delete both files in a docs/cleanup PR.

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -35,7 +35,7 @@
                         <a class="nav-link" href="{{ url_for('review_unified.filing_list') }}">Review</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('review_unified.stats') }}">Statistics</a>
+                        <a class="nav-link" href="{{ url_for('review_unified.stats') }}">Metric Analytics</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('ingest.ingest_form') }}">Ingest</a>

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Review Statistics - {{ super() }}{% endblock %}
+{% block title %}Metric Analytics - {{ super() }}{% endblock %}
 
 {% block content %}
 <div class="row mb-4">
   <div class="col-12 d-flex justify-content-between align-items-center">
     <div>
-      <h1>Review Statistics</h1>
+      <h1>Metric Analytics</h1>
       <p class="text-muted mb-0">Aggregate review progress across text facts and images</p>
     </div>
     <a href="{{ url_for('review_unified.filing_list') }}" class="btn btn-outline-secondary">
@@ -15,11 +15,17 @@
   </div>
 </div>
 
-{# Bootstrap tab bar #}
+{# Bootstrap tab bar — Summary is default; Text Facts / Images keep existing per-document detail #}
 <ul class="nav nav-tabs mb-4" id="statsTab" role="tablist">
   <li class="nav-item" role="presentation">
-    <button class="nav-link active" id="text-tab" data-bs-toggle="tab" data-bs-target="#text-stats"
-            type="button" role="tab" aria-controls="text-stats" aria-selected="true">
+    <button class="nav-link active" id="summary-tab" data-bs-toggle="tab" data-bs-target="#summary-stats"
+            type="button" role="tab" aria-controls="summary-stats" aria-selected="true">
+      Summary
+    </button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="text-tab" data-bs-toggle="tab" data-bs-target="#text-stats"
+            type="button" role="tab" aria-controls="text-stats" aria-selected="false">
       Text Facts
     </button>
   </li>
@@ -34,9 +40,104 @@
 <div class="tab-content" id="statsTabContent">
 
   {# =====================================================================
+     SUMMARY TAB
+     ===================================================================== #}
+  <div class="tab-pane fade show active" id="summary-stats" role="tabpanel" aria-labelledby="summary-tab">
+
+    {# Side-by-side aggregate cards: text facts + image confirmations #}
+    <div class="row mb-4">
+      <div class="col-lg-6 mb-3">
+        <div class="card h-100">
+          <div class="card-header">
+            <h5 class="mb-0">Text Facts</h5>
+          </div>
+          <div class="card-body">
+            <div class="row text-center">
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-primary">{{ totals.fact_count or 0 }}</div>
+                <div class="text-muted small">Total</div>
+              </div>
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-warning">{{ totals.pending_count or 0 }}</div>
+                <div class="text-muted small">Pending</div>
+              </div>
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-success">{{ totals.accepted_count or 0 }}</div>
+                <div class="text-muted small">Accepted</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-danger">{{ totals.rejected_count or 0 }}</div>
+                <div class="text-muted small">Rejected</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-info">{{ totals.corrected_count or 0 }}</div>
+                <div class="text-muted small">Corrected</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-secondary">{{ totals.auto_accepted_count or 0 }}</div>
+                <div class="text-muted small">Auto-accepted</div>
+              </div>
+            </div>
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <button class="btn btn-link btn-sm p-0" type="button"
+                    onclick="document.getElementById('text-tab').click()">
+              View per-company breakdown &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-6 mb-3">
+        <div class="card h-100">
+          <div class="card-header">
+            <h5 class="mb-0">Image Confirmations</h5>
+          </div>
+          <div class="card-body">
+            {% set img = image_overall or {} %}
+            <div class="row text-center">
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-primary">{{ img.total_decisions or 0 }}</div>
+                <div class="text-muted small">Total Decisions</div>
+              </div>
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-success">{{ img.relevant_count or 0 }}</div>
+                <div class="text-muted small">Relevant</div>
+              </div>
+              <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-danger">{{ img.not_relevant_count or 0 }}</div>
+                <div class="text-muted small">Not Relevant</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-warning">{{ image_progress.pending_count or 0 }}</div>
+                <div class="text-muted small">Pending Images</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-info">{{ image_progress.reviewed_count or 0 }}</div>
+                <div class="text-muted small">Reviewed Images</div>
+              </div>
+              <div class="col-4">
+                <div class="fs-4 fw-bold text-secondary">{{ image_progress.skipped_count or 0 }}</div>
+                <div class="text-muted small">Skipped Images</div>
+              </div>
+            </div>
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <button class="btn btn-link btn-sm p-0" type="button"
+                    onclick="document.getElementById('images-tab').click()">
+              View tier &amp; rejection-reason breakdown &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div> {# end summary-stats tab pane #}
+
+  {# =====================================================================
      TEXT FACTS TAB
      ===================================================================== #}
-  <div class="tab-pane fade show active" id="text-stats" role="tabpanel" aria-labelledby="text-tab">
+  <div class="tab-pane fade" id="text-stats" role="tabpanel" aria-labelledby="text-tab">
 
     {# Aggregate Totals Cards #}
     <div class="row mb-4">

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -80,7 +80,7 @@ def test_stats_renders_empty(client, mock_db):
     resp = client.get("/v2/review/stats")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    assert "Review Statistics" in body
+    assert "Metric Analytics" in body
     # Empty-state alert in the images tab pane
     assert "No image review decisions yet" in body
 


### PR DESCRIPTION
## Summary

Phase 1 of the Metric Analytics rollout (4-phase plan). Pure UI restructure — no new SQL, no new endpoints, no schema.

- Renames the navbar label and page heading from "Statistics" → "Metric Analytics" (URL `/v2/review/stats` unchanged, no broken bookmarks)
- Adds a default-active **Summary** tab with two side-by-side aggregate cards: text-fact totals and image-confirmation totals, sourced from existing helpers (`get_v2_review_stats`, `get_image_decision_overall_v2`, `get_image_review_progress_v2`)
- Existing Text Facts and Images tabs are retained as drill-down detail (per-company breakdown, tier precision, rejection reasons)
- Cross-tab "View ..." footer buttons programmatically click the corresponding nav-tab so Bootstrap's Tab plugin updates `aria-selected` correctly

## Context

Sets the stage for the 3 follow-on PRs: Phase 2 (`model_training_runs` table + decision counters + recent-activity panels), Phase 3 (Update Image Classifier button + retrain endpoint, gated by `FILINGS_API_KEY`), Phase 4 (`reviewer_notes` on image confirmations + LLM theme summarization panel).

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/ui/ tests/unit/` — 4181 passed
- [ ] **Manual smoke test recommended** (I can't run a browser): load `/v2/review/stats`, confirm Summary is the default tab, click both "View ..." buttons, verify they switch tabs and the highlighted nav-tab updates correctly

## Out-of-scope follow-up

- gh-383: orphan legacy templates `v2_stats.html` / `v2_filing_list.html` (filed in this PR for follow-up cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)