### PR TITLE
fix(stats): cast since-anchor params to ::timestamptz to fix /v2/review/stats 500

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2583,7 +2583,7 @@ class DatabaseAdapter:
                 COUNT(*) FILTER (WHERE decision IN ('accept', 'correct', 'add'))    AS positive,
                 COUNT(*) FILTER (WHERE decision = 'reject')                         AS negative
               FROM v2_image_metric_confirmations
-             WHERE (%(ts)s IS NULL OR created_at > %(ts)s)
+             WHERE (%(ts)s::timestamptz IS NULL OR created_at > %(ts)s::timestamptz)
         """
         rows = self.query(sql, {"ts": ts})
         if not rows:
@@ -2605,7 +2605,7 @@ class DatabaseAdapter:
         sql = """
             SELECT COUNT(*) AS n
               FROM v2_review_decisions
-             WHERE (%(ts)s IS NULL OR created_at > %(ts)s)
+             WHERE (%(ts)s::timestamptz IS NULL OR created_at > %(ts)s::timestamptz)
         """
         rows = self.query(sql, {"ts": ts})
         return int(rows[0]["n"]) if rows else 0
@@ -2741,7 +2741,7 @@ class DatabaseAdapter:
                       FROM v2_review_decisions
                      WHERE decision = 'reject'
                        AND rejection_category IS NOT NULL
-                       AND (%(since)s IS NULL OR created_at > %(since)s)
+                       AND (%(since)s::timestamptz IS NULL OR created_at > %(since)s::timestamptz)
                 )
                 SELECT
                     reason,
@@ -2761,7 +2761,7 @@ class DatabaseAdapter:
                       FROM v2_image_metric_confirmations
                      WHERE decision = 'reject'
                        AND rejection_reason IS NOT NULL
-                       AND (%(since)s IS NULL OR created_at > %(since)s)
+                       AND (%(since)s::timestamptz IS NULL OR created_at > %(since)s::timestamptz)
                 )
                 SELECT
                     reason,

--- a/tests/integration/test_db_analytics_since_helpers.py
+++ b/tests/integration/test_db_analytics_since_helpers.py
@@ -1,0 +1,64 @@
+"""Integration regression test for the Phase-2/3/4 since-anchor helpers.
+
+These helpers all build SQL like:
+
+    WHERE (%(ts)s IS NULL OR created_at > %(ts)s)
+
+which throws `psycopg.errors.AmbiguousParameter` against a real Postgres
+when ts=None — the planner cannot infer the parameter type from a NULL
+literal in `IS NULL` + `>`. The fix is an explicit `::timestamptz` cast
+on each parameter reference. Unit tests mock `db.query`, so they never
+exercise this path; this test runs the actual SQL against
+TEST_DATABASE_URL to catch a regression if the cast is ever stripped.
+
+Triggered by a prod 500 on /v2/review/stats after Phase 4 deployed
+(2026-05-01).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.infra.db import DatabaseAdapter
+
+
+def test_count_image_decisions_since_handles_none(test_db_adapter: DatabaseAdapter) -> None:
+    """ts=None must NOT raise AmbiguousParameter. Lifetime-totals branch."""
+    result = test_db_adapter.count_image_decisions_since(None)
+    assert set(result.keys()) == {"total", "positive", "negative"}
+    # Empty DB or seed: counts must be non-negative ints.
+    assert all(isinstance(v, int) and v >= 0 for v in result.values())
+
+
+def test_count_text_decisions_since_handles_none(test_db_adapter: DatabaseAdapter) -> None:
+    """ts=None must NOT raise. Returns plain int (lifetime total)."""
+    result = test_db_adapter.count_text_decisions_since(None)
+    assert isinstance(result, int)
+    assert result >= 0
+
+
+def test_rejection_reason_rollup_text_handles_none(
+    test_db_adapter: DatabaseAdapter,
+) -> None:
+    """get_rejection_reason_rollup('text', since=None) must NOT raise."""
+    rows = test_db_adapter.get_rejection_reason_rollup("text", since=None)
+    assert isinstance(rows, list)
+    for r in rows:
+        assert "reason" in r
+        assert "count" in r
+        assert "percent" in r
+
+
+def test_rejection_reason_rollup_image_handles_none(
+    test_db_adapter: DatabaseAdapter,
+) -> None:
+    """get_rejection_reason_rollup('image', since=None) must NOT raise."""
+    rows = test_db_adapter.get_rejection_reason_rollup("image", since=None)
+    assert isinstance(rows, list)
+
+
+def test_rejection_reason_rollup_rejects_unknown_side(
+    test_db_adapter: DatabaseAdapter,
+) -> None:
+    with pytest.raises(ValueError, match="Unknown side"):
+        test_db_adapter.get_rejection_reason_rollup("audio", since=None)

--- a/tests/unit/infra/test_db_analytics.py
+++ b/tests/unit/infra/test_db_analytics.py
@@ -86,7 +86,10 @@ class TestCountImageDecisionsSince:
         db.query.return_value = []
         db.count_image_decisions_since(None)
         sql, params = db.query.call_args[0]
-        assert "%(ts)s IS NULL" in sql
+        # ::timestamptz cast is required so psycopg can infer the parameter
+        # type when ts=None — without it, real Postgres raises
+        # AmbiguousParameter (regression caught in prod 2026-05-01).
+        assert "%(ts)s::timestamptz IS NULL" in sql
         assert params == {"ts": None}
 
     def test_zero_when_no_rows(self, db):

--- a/tests/unit/infra/test_db_rejection_rollup.py
+++ b/tests/unit/infra/test_db_rejection_rollup.py
@@ -71,8 +71,10 @@ class TestRejectionRollup:
         db.query.return_value = []
         db.get_rejection_reason_rollup("image", since=None)
         sql, params = db.query.call_args[0]
-        # The %(since)s IS NULL branch unwraps the time filter.
-        assert "%(since)s IS NULL" in sql
+        # ::timestamptz cast is required so psycopg can infer the parameter
+        # type when since=None — without it, real Postgres raises
+        # AmbiguousParameter (regression caught in prod 2026-05-01).
+        assert "%(since)s::timestamptz IS NULL" in sql
         assert params == {"since": None}
 
     def test_orders_by_count_desc(self, db):


### PR DESCRIPTION
## Summary

**Hotfix.** `/v2/review/stats` is currently 500'ing on prod. Root cause: the four since-anchor SQL helpers added in Phases 2/3/4 use the pattern:

```sql
WHERE (%(ts)s IS NULL OR created_at > %(ts)s)
```

When `ts=None`, psycopg raises `AmbiguousParameter: could not determine data type of parameter $1` — Postgres can't infer a type from `IS NULL` + comparison alone. Result: every load of `/v2/review/stats` 500s once the new helpers shipped (Phase 2 deploy and onward).

Unit tests didn't catch it because they mock `db.query` — the SQL never actually compiled against Postgres.

## Fix

- Cast every `%(ts)s` / `%(since)s` reference to `::timestamptz` (4 helpers × 2 references = 8 sites in `src/infra/db.py`). With the cast, `None` flows through as `NULL::timestamptz` and non-null timestamps are unaffected.
- New `tests/integration/test_db_analytics_since_helpers.py` — 5 tests, runs actual SQL against `TEST_DATABASE_URL` with `since=None` for all four helpers. Strip the cast → tests fail. This is the regression net.
- Update the two existing unit tests that asserted on the old SQL string shape.

## Verification

- [x] `ruff check` clean
- [x] `pytest tests/ui/ tests/unit/` — 4248 passed
- [x] `pytest tests/integration/test_db_analytics_since_helpers.py` — 5 passed
- [x] Verified against prod (read-only): all four helpers return clean results with the cast in place. `count_image_decisions_since(None)` returns `{total: 770, positive: 58, negative: 712}`; rollup helpers return populated rows.

## Why this happened

Pattern is fragile: a SQL where-clause with `IS NULL` plus a comparison on the same param leaves Postgres without enough type info, even though the parameter binding has a Python type. Other places in the codebase that pass timestamp params don't hit this because they're inside non-null comparisons. Adding a `::timestamptz` cast at every parameter reference site is the canonical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)