### PR TITLE
feat: add Suggested actions panel to Text Patterns tab

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -56,6 +56,22 @@ The script writes findings to three tables — it does NOT mutate `v2_review_dec
 
 **View persistence**: the new "Text Patterns" tab (`#patterns-tab` → `#patterns-stats`) does not currently persist to localStorage. If you add a key for it, follow the `cmasb:` namespace convention documented under "View persistence (localStorage)" below.
 
+### Recommendation rules
+
+The Patterns-tab expanded row also renders a **Suggested actions** callout above the per-decision-type phrase columns. Recommendations are computed at render time by `src/web/text_pattern_recommendations.py::compute_recommendations(summaries, findings)` from the same DB rows the table iterates — no schema change, no separate analysis pass. This keeps rule thresholds tweakable without rerunning the script.
+
+Three rules in v1; a metric may fire multiple. Output is sorted by severity DESC then rule name ASC. Each recommendation dict carries `rule`, `severity` (`high` / `medium`), `title`, `evidence`, `action`.
+
+| Rule | Trigger | Severity bands |
+|---|---|---|
+| **`exclusion_pattern`** | A `text_decision_phrase_findings` row with `decision_type='reject'`, `source_field IN ('rejection_reason', 'segment_text')`, `phrase_ngram_size >= 2`, `pct_of_decisions >= 30` | high if `pct >= 50`, else medium |
+| **`keyword_overlap`** | A `top_correction_targets` entry with `count >= 5` | high if `count >= 10`, else medium |
+| **`fp_filter_gap`** | `rejection_categories['wrong_value'] / reject_count >= 0.5` AND `reject_count >= 5` | high if ratio `>= 0.7`, else medium |
+
+Constants live at the top of the helper module (`EXCL_PCT_LOW`, `EXCL_PCT_HIGH`, `EXCL_NGRAM_MIN`, `EXCL_SOURCE_FIELDS`, `OVERLAP_COUNT_LOW`, `OVERLAP_COUNT_HIGH`, `FP_REJECT_FLOOR`, `FP_PCT_LOW`, `FP_PCT_HIGH`). Adding a fourth rule is a Python edit only — append a `_rule_<name>(...)` helper and call it from `compute_recommendations`.
+
+The helper handles `psycopg`'s `Decimal` return for `pct_of_decisions NUMERIC(5,2)` via `float()` coercion at the boundary. Empty inputs return `{}` — the existing `_stub_analytics_helpers` test fixtures rely on this no-op behavior.
+
 ## Image-confirmation reviewer notes
 
 `v2_image_metric_confirmations` has a `reviewer_notes TEXT` column (nullable, Phase 4a). Free-text observation captured per-batch — one `#image-reviewer-notes` textarea on the image card, applied to every per-metric row submitted in the same POST. Validated at the API layer to ≤1000 chars; mirrors the text-side `v2_review_decisions.reviewer_notes` contract. JS clears the textarea after a successful submit. Bulk-reject and the "Reject all (no relevant metrics)" sentinel writes leave the column NULL — by design, no free-text capture for bulk actions. The deferred LLM "Top Reviewer Themes" panel (Phase 4b) will read this column for image-side themes.

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -264,6 +264,10 @@ def stats():
         text_metric_summary = []
         text_phrase_findings = []
 
+    from src.web.text_pattern_recommendations import compute_recommendations
+
+    text_recommendations = compute_recommendations(text_metric_summary, text_phrase_findings)
+
     return render_template(
         "unified_stats.html",
         per_company=text_data["per_company"],
@@ -296,6 +300,7 @@ def stats():
         text_analysis_button_active=text_analysis_button_active,
         text_metric_summary=text_metric_summary,
         text_phrase_findings=text_phrase_findings,
+        text_recommendations=text_recommendations,
     )
 
 

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1069,6 +1069,28 @@
                 </tr>
                 <tr class="collapse" id="patterns-row-{{ loop.index }}">
                   <td colspan="7" class="bg-light">
+                    {# Suggested actions panel — populated only when at least one
+                       rule fires for this metric. Rules + thresholds documented
+                       in src/web/text_pattern_recommendations.py. #}
+                    {% set recs = text_recommendations.get(s.metric_id, []) %}
+                    {% if recs %}
+                    <div class="alert alert-warning small mb-3 mt-2">
+                      <strong class="d-block mb-2">
+                        Suggested actions
+                        <span class="badge bg-secondary ms-1">{{ recs|length }}</span>
+                      </strong>
+                      {% for r in recs %}
+                      <div class="mb-2">
+                        <span class="badge bg-{{ 'danger' if r.severity == 'high' else 'warning text-dark' }} me-1">
+                          {{ r.severity }}
+                        </span>
+                        <strong>{{ r.title }}</strong>
+                        <div class="text-muted">{{ r.evidence }}</div>
+                        <div><em>{{ r.action }}</em></div>
+                      </div>
+                      {% endfor %}
+                    </div>
+                    {% endif %}
                     <div class="row">
                       {% for decision_type in ['reject', 'correct'] %}
                       <div class="col-md-6">

--- a/src/web/text_pattern_recommendations.py
+++ b/src/web/text_pattern_recommendations.py
@@ -1,0 +1,181 @@
+"""Translate text-decision pattern findings into actionable recommendations.
+
+Stateless render-time helper called from `review_unified.stats()`. Reads the
+already-loaded `text_decision_metric_summary` + `text_decision_phrase_findings`
+rows and returns one or more recommendation dicts per metric, each pointing
+the reviewer at a concrete edit (YAML exclusion, FP-rule audit, keyword-
+overlap review).
+
+Three rules in v1 — see `.claude/rules/web.md` for the canonical statement of
+their triggers and severity bands. Rules are independent: a metric may fire
+multiple, and the helper sorts the union by severity DESC then rule name ASC.
+
+Persisted findings vs. computed recommendations: deliberately render-time so
+threshold tweaks don't require an analysis rerun. Constants below are the
+only knobs.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+# --- Rule thresholds ---------------------------------------------------------
+# Single source of truth so a tweak is one edit + one PR. Documented in
+# .claude/rules/web.md "Recommendation rules".
+
+# exclusion_pattern: phrase appears in >= EXCL_PCT_LOW% of rejects sourced
+# from rejection_reason or segment_text. n-gram size >= EXCL_NGRAM_MIN
+# (single words are too aggressive for a YAML exclusion).
+EXCL_PCT_LOW = 30.0
+EXCL_PCT_HIGH = 50.0  # promotes severity from medium -> high
+EXCL_NGRAM_MIN = 2
+EXCL_SOURCE_FIELDS = ("rejection_reason", "segment_text")
+
+# keyword_overlap: count of corrections to one sibling metric.
+OVERLAP_COUNT_LOW = 5
+OVERLAP_COUNT_HIGH = 10
+
+# fp_filter_gap: wrong_value share of rejects (only fires when reject volume
+# is meaningful — see FP_REJECT_FLOOR).
+FP_REJECT_FLOOR = 5
+FP_PCT_LOW = 0.5
+FP_PCT_HIGH = 0.7
+
+# Sort key for severity-then-rule ordering.
+_SEVERITY_RANK = {"high": 0, "medium": 1}
+
+
+def compute_recommendations(
+    summaries: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Map metric_id -> list of recommendation dicts.
+
+    Empty inputs return {}; the existing stats-render tests pass empty
+    fixtures and rely on this no-op behavior.
+
+    Each recommendation dict has shape::
+
+        {
+          "rule": "exclusion_pattern" | "keyword_overlap" | "fp_filter_gap",
+          "severity": "high" | "medium",
+          "title": str,
+          "evidence": str,
+          "action": str,
+        }
+    """
+    if not summaries and not findings:
+        return {}
+
+    # Group findings by metric_id once so each rule's helper can scan
+    # locally without re-iterating the full list.
+    findings_by_metric: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for f in findings:
+        findings_by_metric[f["metric_id"]].append(f)
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for s in summaries:
+        metric_id = s["metric_id"]
+        recs: list[dict[str, Any]] = []
+        recs.extend(_rule_exclusion_pattern(metric_id, findings_by_metric.get(metric_id, [])))
+        recs.extend(_rule_keyword_overlap(metric_id, s))
+        recs.extend(_rule_fp_filter_gap(metric_id, s))
+        if recs:
+            recs.sort(key=lambda r: (_SEVERITY_RANK[r["severity"]], r["rule"]))
+            out[metric_id] = recs
+    return out
+
+
+def _rule_exclusion_pattern(
+    metric_id: str, metric_findings: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Surface phrases dominant enough to justify a YAML exclusion entry."""
+    recs: list[dict[str, Any]] = []
+    for f in metric_findings:
+        if f["decision_type"] != "reject":
+            continue
+        if f["source_field"] not in EXCL_SOURCE_FIELDS:
+            continue
+        if int(f["phrase_ngram_size"]) < EXCL_NGRAM_MIN:
+            continue
+        pct = float(f["pct_of_decisions"])
+        if pct < EXCL_PCT_LOW:
+            continue
+        severity = "high" if pct >= EXCL_PCT_HIGH else "medium"
+        phrase = f["phrase"]
+        count = int(f["occurrence_count"])
+        source_label = f["source_field"].replace("_", " ")
+        recs.append(
+            {
+                "rule": "exclusion_pattern",
+                "severity": severity,
+                "title": f'Add exclusion pattern matching "{phrase}"',
+                "evidence": (
+                    f'"{phrase}" appears in {count} rejects ({pct:.1f}%) '
+                    f"sourced from {source_label}."
+                ),
+                "action": (
+                    f"Add to the exclusions list under {metric_id} in config/metric_keywords.yaml."
+                ),
+            }
+        )
+    return recs
+
+
+def _rule_keyword_overlap(metric_id: str, summary: dict[str, Any]) -> list[dict[str, Any]]:
+    """Surface metrics that reviewers frequently re-route to a sibling."""
+    targets = summary.get("top_correction_targets") or []
+    recs: list[dict[str, Any]] = []
+    for t in targets:
+        count = int(t.get("count", 0))
+        if count < OVERLAP_COUNT_LOW:
+            continue
+        target_metric = t.get("target_metric_id")
+        if not target_metric:
+            continue
+        severity = "high" if count >= OVERLAP_COUNT_HIGH else "medium"
+        recs.append(
+            {
+                "rule": "keyword_overlap",
+                "severity": severity,
+                "title": f"Review keyword overlap with {target_metric}",
+                "evidence": (f"Reviewers corrected {metric_id} → {target_metric} {count} times."),
+                "action": (
+                    f"Tighten keywords on {metric_id} or expand {target_metric}'s "
+                    "in config/metric_keywords.yaml."
+                ),
+            }
+        )
+    return recs
+
+
+def _rule_fp_filter_gap(metric_id: str, summary: dict[str, Any]) -> list[dict[str, Any]]:
+    """Surface metrics whose rejects are dominated by wrong_value."""
+    reject_count = int(summary.get("reject_count") or 0)
+    if reject_count < FP_REJECT_FLOOR:
+        return []
+    cats = summary.get("rejection_categories") or {}
+    wrong_value = int(cats.get("wrong_value") or 0)
+    if wrong_value == 0:
+        return []
+    pct = wrong_value / reject_count
+    if pct < FP_PCT_LOW:
+        return []
+    severity = "high" if pct >= FP_PCT_HIGH else "medium"
+    return [
+        {
+            "rule": "fp_filter_gap",
+            "severity": severity,
+            "title": "Check FP filter for value-extraction bug",
+            "evidence": (
+                f"{wrong_value} of {reject_count} rejects ({pct * 100:.1f}%) "
+                f"cited wrong_value — looks like a value-extraction bug, "
+                "not a keyword bug."
+            ),
+            "action": (
+                f"Review {metric_id}'s handling in "
+                "src/extraction_v2/stages/false_positive_filter.py."
+            ),
+        }
+    ]

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -271,6 +271,82 @@ def test_stats_summary_renders_recent_activity(client, mock_db):
     assert "Acme" in body
 
 
+def test_patterns_tab_renders_recommendation_alert(client, mock_db):
+    """A metric whose findings fire a recommendation rule renders the
+    Suggested-actions callout in its expanded Patterns-tab row.
+
+    Pinning the wire-up between compute_recommendations() and the template.
+    Helper-rule logic itself is covered by test_text_pattern_recommendations.
+    """
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {"wrong_metric": 18, "wrong_value": 13},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "rejection_reason",
+            "occurrence_count": 14,
+            "pct_of_decisions": 45.20,
+            "examples": [],
+        }
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Recommendation panel rendered.
+    assert "Suggested actions" in body
+    # Phrase carried through to the title.
+    assert "Add exclusion pattern" in body
+    assert "accounts receivable" in body
+    # Severity badge for medium (45.20 < 50 threshold).
+    assert "medium" in body
+
+
 def test_stats_does_not_swallow_db_errors(app, mock_db):
     """A DB regression should propagate, not be swallowed by a flash + redirect.
 

--- a/tests/unit/web/test_text_pattern_recommendations.py
+++ b/tests/unit/web/test_text_pattern_recommendations.py
@@ -1,0 +1,268 @@
+"""Unit tests for src/web/text_pattern_recommendations.py.
+
+Pure-function tests — no Flask, no DB. Each rule has its own class; sorting
+and empty-input behavior get a class each. Empty-input behavior is
+load-bearing: existing stats-render tests pass empty fixtures and rely on
+compute_recommendations({}, {}) returning {}.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from src.web.text_pattern_recommendations import compute_recommendations
+
+
+def _summary(
+    metric_id: str = "cm_x",
+    *,
+    total: int = 50,
+    accept: int = 5,
+    reject: int = 31,
+    correct: int = 14,
+    rejection_categories: dict | None = None,
+    top_correction_targets: list | None = None,
+) -> dict:
+    return {
+        "metric_id": metric_id,
+        "total_decisions": total,
+        "accept_count": accept,
+        "reject_count": reject,
+        "correct_count": correct,
+        "rejection_categories": rejection_categories or {},
+        "top_correction_targets": top_correction_targets or [],
+    }
+
+
+def _finding(
+    *,
+    metric_id: str = "cm_x",
+    decision_type: str = "reject",
+    phrase: str = "accounts receivable",
+    ngram: int = 2,
+    source_field: str = "rejection_reason",
+    occurrences: int = 14,
+    pct: float | Decimal = 45.20,
+) -> dict:
+    return {
+        "metric_id": metric_id,
+        "decision_type": decision_type,
+        "phrase": phrase,
+        "phrase_ngram_size": ngram,
+        "source_field": source_field,
+        "occurrence_count": occurrences,
+        "pct_of_decisions": pct,
+        "examples": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rule: exclusion_pattern
+# ---------------------------------------------------------------------------
+
+
+class TestExclusionPatternRule:
+    def test_fires_at_30_pct_with_bigram(self):
+        out = compute_recommendations([_summary()], [_finding(pct=30.0)])
+        recs = out["cm_x"]
+        excl = [r for r in recs if r["rule"] == "exclusion_pattern"]
+        assert len(excl) == 1
+        assert excl[0]["severity"] == "medium"
+        assert "accounts receivable" in excl[0]["title"]
+        assert "config/metric_keywords.yaml" in excl[0]["action"]
+
+    def test_does_not_fire_below_30_pct(self):
+        out = compute_recommendations([_summary()], [_finding(pct=29.9)])
+        # No rules fire at all -> metric absent from output dict.
+        assert "cm_x" not in out
+
+    def test_severity_high_at_50_pct(self):
+        out = compute_recommendations([_summary()], [_finding(pct=50.0)])
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"]
+        assert excl[0]["severity"] == "high"
+
+    def test_severity_medium_just_below_50_pct(self):
+        out = compute_recommendations([_summary()], [_finding(pct=49.99)])
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"]
+        assert excl[0]["severity"] == "medium"
+
+    def test_ignores_unigrams(self):
+        out = compute_recommendations([_summary()], [_finding(ngram=1, pct=80.0)])
+        assert "cm_x" not in out
+
+    def test_ignores_reviewer_notes_source(self):
+        out = compute_recommendations(
+            [_summary()], [_finding(source_field="reviewer_notes", pct=80.0)]
+        )
+        assert "cm_x" not in out
+
+    def test_segment_text_source_qualifies(self):
+        out = compute_recommendations(
+            [_summary()], [_finding(source_field="segment_text", pct=40.0)]
+        )
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"]
+        assert len(excl) == 1
+        assert "segment text" in excl[0]["evidence"]
+
+    def test_correct_decision_type_does_not_fire(self):
+        # The exclusion rule only mines reject phrases.
+        out = compute_recommendations([_summary()], [_finding(decision_type="correct", pct=80.0)])
+        assert "cm_x" not in out
+
+    def test_decimal_pct_is_handled(self):
+        # psycopg returns NUMERIC(5,2) as Decimal; helper must coerce.
+        out = compute_recommendations([_summary()], [_finding(pct=Decimal("45.20"))])
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"]
+        assert excl[0]["severity"] == "medium"
+
+    def test_multiple_phrases_per_metric_each_emit(self):
+        findings = [
+            _finding(phrase="accounts receivable", pct=45.0),
+            _finding(phrase="bad debt", ngram=2, pct=35.0),
+        ]
+        out = compute_recommendations([_summary()], findings)
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"]
+        assert len(excl) == 2
+        assert {r["title"] for r in excl} == {
+            'Add exclusion pattern matching "accounts receivable"',
+            'Add exclusion pattern matching "bad debt"',
+        }
+
+
+# ---------------------------------------------------------------------------
+# Rule: keyword_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordOverlapRule:
+    def test_fires_at_count_5(self):
+        s = _summary(top_correction_targets=[{"target_metric_id": "cm_y", "count": 5}])
+        out = compute_recommendations([s], [])
+        recs = out["cm_x"]
+        ovl = [r for r in recs if r["rule"] == "keyword_overlap"]
+        assert len(ovl) == 1
+        assert ovl[0]["severity"] == "medium"
+        assert "cm_y" in ovl[0]["title"]
+
+    def test_does_not_fire_below_5(self):
+        s = _summary(top_correction_targets=[{"target_metric_id": "cm_y", "count": 4}])
+        out = compute_recommendations([s], [])
+        assert "cm_x" not in out
+
+    def test_severity_high_at_10(self):
+        s = _summary(top_correction_targets=[{"target_metric_id": "cm_y", "count": 10}])
+        out = compute_recommendations([s], [])
+        ovl = [r for r in out["cm_x"] if r["rule"] == "keyword_overlap"]
+        assert ovl[0]["severity"] == "high"
+
+    def test_multiple_targets_each_emit(self):
+        s = _summary(
+            top_correction_targets=[
+                {"target_metric_id": "cm_y", "count": 12},
+                {"target_metric_id": "cm_z", "count": 6},
+            ]
+        )
+        out = compute_recommendations([s], [])
+        ovl = [r for r in out["cm_x"] if r["rule"] == "keyword_overlap"]
+        assert len(ovl) == 2
+        assert {r["severity"] for r in ovl} == {"high", "medium"}
+
+    def test_handles_missing_target_metric_id(self):
+        # Defensive: malformed JSON shouldn't crash.
+        s = _summary(top_correction_targets=[{"count": 10}])
+        out = compute_recommendations([s], [])
+        assert "cm_x" not in out
+
+
+# ---------------------------------------------------------------------------
+# Rule: fp_filter_gap
+# ---------------------------------------------------------------------------
+
+
+class TestFpFilterGapRule:
+    def test_fires_at_50_pct_with_floor_volume(self):
+        s = _summary(reject=10, rejection_categories={"wrong_value": 5})
+        out = compute_recommendations([s], [])
+        gap = [r for r in out["cm_x"] if r["rule"] == "fp_filter_gap"]
+        assert len(gap) == 1
+        assert gap[0]["severity"] == "medium"
+        assert "false_positive_filter.py" in gap[0]["action"]
+
+    def test_severity_high_at_70_pct(self):
+        s = _summary(reject=10, rejection_categories={"wrong_value": 7})
+        out = compute_recommendations([s], [])
+        gap = [r for r in out["cm_x"] if r["rule"] == "fp_filter_gap"]
+        assert gap[0]["severity"] == "high"
+
+    def test_ignores_below_5_reject_floor(self):
+        # 100% wrong_value but only 4 rejects — too small to act on.
+        s = _summary(reject=4, rejection_categories={"wrong_value": 4})
+        out = compute_recommendations([s], [])
+        assert "cm_x" not in out
+
+    def test_does_not_fire_below_50_pct(self):
+        s = _summary(reject=10, rejection_categories={"wrong_value": 4})
+        out = compute_recommendations([s], [])
+        gap = [r for r in out.get("cm_x", []) if r["rule"] == "fp_filter_gap"]
+        assert gap == []
+
+    def test_handles_zero_wrong_value(self):
+        s = _summary(reject=20, rejection_categories={"not_a_metric": 20})
+        out = compute_recommendations([s], [])
+        assert "cm_x" not in out
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+
+class TestSorting:
+    def test_high_severity_first(self):
+        # exclusion_pattern medium + keyword_overlap high on same metric.
+        s = _summary(
+            top_correction_targets=[{"target_metric_id": "cm_y", "count": 12}],
+        )
+        out = compute_recommendations([s], [_finding(pct=35.0)])
+        recs = out["cm_x"]
+        assert recs[0]["severity"] == "high"
+        assert recs[0]["rule"] == "keyword_overlap"
+        assert recs[1]["severity"] == "medium"
+
+    def test_within_severity_sorted_by_rule_name(self):
+        # All three rules at medium severity → alphabetical: exclusion_pattern,
+        # fp_filter_gap, keyword_overlap.
+        s = _summary(
+            reject=10,
+            rejection_categories={"wrong_value": 6},
+            top_correction_targets=[{"target_metric_id": "cm_y", "count": 5}],
+        )
+        out = compute_recommendations([s], [_finding(pct=35.0)])
+        rules = [r["rule"] for r in out["cm_x"]]
+        assert rules == ["exclusion_pattern", "fp_filter_gap", "keyword_overlap"]
+
+
+# ---------------------------------------------------------------------------
+# Empty inputs
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_lists_return_empty_dict(self):
+        assert compute_recommendations([], []) == {}
+
+    def test_summaries_without_findings_can_still_fire(self):
+        # keyword_overlap and fp_filter_gap read from summary, not findings.
+        s = _summary(
+            reject=10,
+            rejection_categories={"wrong_value": 8},
+            top_correction_targets=[{"target_metric_id": "cm_y", "count": 11}],
+        )
+        out = compute_recommendations([s], [])
+        rules = sorted(r["rule"] for r in out["cm_x"])
+        assert rules == ["fp_filter_gap", "keyword_overlap"]
+
+    def test_findings_for_unknown_metric_are_ignored(self):
+        # No summary for cm_z → rule should not run on it.
+        out = compute_recommendations([_summary("cm_x")], [_finding(metric_id="cm_z")])
+        assert "cm_z" not in out


### PR DESCRIPTION
Translates n-gram findings into actionable prose recommendations alongside
the existing per-metric phrase tables. Render-time compute from the same DB
rows the table already iterates — no schema change, no separate analysis
pass, thresholds tweakable without rerun.

Three rules in v1 (severity bands documented in .claude/rules/web.md):
- exclusion_pattern: bigram+ phrases at >=30% of rejects on
  rejection_reason or segment_text. High at >=50%.
- keyword_overlap: corrections to one sibling metric >=5 times.
  High at >=10.
- fp_filter_gap: wrong_value share of rejects >=50% with
  reject_count >=5. High at >=70%.

Empty inputs return {} so existing _stub_analytics_helpers fixtures don't
break. Decimal -> float coercion at the boundary handles psycopg's
NUMERIC return shape.

26 new unit tests; 4297 unit suite passes.
