### PR TITLE
feat: admin-only Accept/Dismiss/Defer on Suggested-actions panel

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -72,6 +72,24 @@ Constants live at the top of the helper module (`EXCL_PCT_LOW`, `EXCL_PCT_HIGH`,
 
 The helper handles `psycopg`'s `Decimal` return for `pct_of_decisions NUMERIC(5,2)` via `float()` coercion at the boundary. Empty inputs return `{}` — the existing `_stub_analytics_helpers` test fixtures rely on this no-op behavior.
 
+### Recommendation decisions
+
+Each Suggested-actions card renders three buttons (Accept / Dismiss / Defer) plus an optional reviewer-note textarea. Clicks persist to `text_pattern_recommendation_decisions` via two endpoints:
+
+- `POST /api/v2/extraction/recommendation-decisions` — upsert on `(metric_id, rule, decision_key, reviewer_id)`. Body: `{metric_id, rule, decision_key, decision, reviewer_id, reviewer_note?}`. `decision ∈ {accepted, dismissed, deferred}`. Returns the upserted row.
+- `DELETE /api/v2/extraction/recommendation-decisions/<uuid:decision_id>` — owner-scoped undo. Returns 404 when the row is missing OR exists but belongs to a different reviewer (so admins don't accidentally undo each other's decisions).
+
+Both endpoints are gated by `_require_reviewer_id` + `require_admin` (`src/web/middleware.py`). The admin gate reads a comma-separated allowlist from env var `ADMIN_USER_IDS` and returns HTTP 403 `{error: "admin_required"}` when missing or unmatched. **Transitional** — to be replaced by `src/auth/middleware.py::require(<permission>)` against `auth_users.role` once Stage A2 of the auth rollout lands (`docs/architecture/auth-rollout-implementation-plan.md`). Migration is one-line per call site.
+
+`decision_key` is the stable identifier across analysis reruns:
+- `exclusion_pattern` → the phrase (e.g. `"accounts receivable"`)
+- `keyword_overlap` → the target metric_id (e.g. `"cm_active_customers_total"`)
+- `fp_filter_gap` → literal `"wrong_value"`
+
+The recommendation helper (`compute_recommendations`) takes an optional third `decisions` arg (default `None`) — when provided, each rec dict gains a `decision` field looked up by `(metric_id, rule, decision_key)`. The DB reader returns rows ordered DESC by `updated_at`, so when multiple reviewers have decided the same rec, the freshest decision wins (helper uses `setdefault`).
+
+`pr_number` and `pr_url` columns on the table stay NULL through PR 1 (bookkeeping-only). They populate in PR 2 when an `exclusion_pattern` accept opens an auto-PR. Don't read them yet.
+
 ## Image-confirmation reviewer notes
 
 `v2_image_metric_confirmations` has a `reviewer_notes TEXT` column (nullable, Phase 4a). Free-text observation captured per-batch — one `#image-reviewer-notes` textarea on the image card, applied to every per-metric row submitted in the same POST. Validated at the API layer to ≤1000 chars; mirrors the text-side `v2_review_decisions.reviewer_notes` contract. JS clears the textarea after a successful submit. Bulk-reject and the "Reject all (no relevant metrics)" sentinel writes leave the column NULL — by design, no free-text capture for bulk actions. The deferred LLM "Top Reviewer Themes" panel (Phase 4b) will read this column for image-side themes.

--- a/.env.template
+++ b/.env.template
@@ -16,6 +16,13 @@ FILINGS_API_KEY=
 # Set to 'true' to require API key authentication (always true in production)
 API_KEY_REQUIRED=false
 
+# Admin allowlist for /v2/review/stats Suggested-actions decisions
+# (POST/DELETE /api/v2/extraction/recommendation-decisions). Comma-separated
+# reviewer IDs. Empty (or unset) = endpoint returns 403 for everyone.
+# Transitional — replaced by auth_users.role lookup when Stage A2 of the auth
+# rollout lands (docs/architecture/auth-rollout-implementation-plan.md).
+ADMIN_USER_IDS=
+
 # OpenAI API Configuration
 # Get your API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-proj-your-key-here

--- a/sql/202605012056_add_recommendation_decisions.sql
+++ b/sql/202605012056_add_recommendation_decisions.sql
@@ -1,0 +1,42 @@
+-- Migration 202605012056: add_recommendation_decisions
+--
+-- Adds text_pattern_recommendation_decisions to track admin actions on
+-- the Suggested-actions surface in /v2/review/stats. Each row is one
+-- (metric, rule, decision_key, reviewer) tuple, upserted whenever an
+-- admin clicks Accept / Dismiss / Defer or undoes a prior decision.
+--
+-- decision_key is the stable identifier across analysis runs:
+--   exclusion_pattern: the phrase (e.g. "accounts receivable")
+--   keyword_overlap:   the target metric_id (e.g. "cm_active_customers_total")
+--   fp_filter_gap:     literal "wrong_value"
+--
+-- pr_number / pr_url are populated only when an exclusion_pattern accept
+-- triggers an auto-PR (Stage 2 / PR 2 of the rollout). They stay NULL
+-- through PR 1 (bookkeeping-only).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS text_pattern_recommendation_decisions (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    metric_id     TEXT NOT NULL,
+    rule          TEXT NOT NULL
+        CHECK (rule IN ('exclusion_pattern', 'keyword_overlap', 'fp_filter_gap')),
+    decision_key  TEXT NOT NULL,
+    decision      TEXT NOT NULL
+        CHECK (decision IN ('accepted', 'dismissed', 'deferred')),
+    reviewer_id   TEXT NOT NULL,
+    reviewer_note TEXT,
+    pr_number     INTEGER,
+    pr_url        TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tprd_unique
+    ON text_pattern_recommendation_decisions
+    (metric_id, rule, decision_key, reviewer_id);
+
+CREATE INDEX IF NOT EXISTS idx_tprd_reviewer
+    ON text_pattern_recommendation_decisions (reviewer_id);
+
+COMMIT;

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2858,6 +2858,92 @@ class DatabaseAdapter:
         return [dict(r) for r in rows]
 
     # =============================================================================
+    # Recommendation-decision readers/writers (text_pattern_recommendation_decisions)
+    # =============================================================================
+
+    def upsert_recommendation_decision(
+        self,
+        *,
+        metric_id: str,
+        rule: str,
+        decision_key: str,
+        decision: str,
+        reviewer_id: str,
+        reviewer_note: str | None = None,
+    ) -> dict:
+        """Insert or update a recommendation decision row.
+
+        Unique on (metric_id, rule, decision_key, reviewer_id) so a same-
+        reviewer change-of-mind upserts cleanly. Returns the resulting row.
+        """
+        sql = """
+            INSERT INTO text_pattern_recommendation_decisions
+                (metric_id, rule, decision_key, decision, reviewer_id, reviewer_note)
+            VALUES
+                (%(metric_id)s, %(rule)s, %(decision_key)s, %(decision)s,
+                 %(reviewer_id)s, %(reviewer_note)s)
+            ON CONFLICT (metric_id, rule, decision_key, reviewer_id) DO UPDATE
+               SET decision      = EXCLUDED.decision,
+                   reviewer_note = EXCLUDED.reviewer_note,
+                   updated_at    = NOW()
+            RETURNING id, metric_id, rule, decision_key, decision,
+                      reviewer_id, reviewer_note, pr_number, pr_url,
+                      created_at, updated_at
+        """
+        rows = self.query(
+            sql,
+            {
+                "metric_id": metric_id,
+                "rule": rule,
+                "decision_key": decision_key,
+                "decision": decision,
+                "reviewer_id": reviewer_id,
+                "reviewer_note": reviewer_note,
+            },
+        )
+        return dict(rows[0])
+
+    def delete_recommendation_decision(self, decision_id: str, reviewer_id: str) -> bool:
+        """Delete a decision row scoped to its owning reviewer.
+
+        Returns True when a row was deleted, False when nothing matched
+        (id unknown OR row exists but belongs to a different reviewer —
+        admins shouldn't accidentally undo each other's decisions).
+        """
+        sql = """
+            DELETE FROM text_pattern_recommendation_decisions
+             WHERE id = %(id)s AND reviewer_id = %(reviewer_id)s
+            RETURNING id
+        """
+        rows = self.query(sql, {"id": decision_id, "reviewer_id": reviewer_id})
+        return bool(rows)
+
+    def get_recommendation_decisions(self, metric_ids: list[str] | None = None) -> list[dict]:
+        """Return all recommendation decision rows, optionally filtered by metric.
+
+        Used at render time by `review_unified.stats()` to merge decisions
+        into the freshly computed recommendation list. Sorted newest-first
+        per (metric, rule) so the UI can show "Accepted by RGM 2 hours ago"
+        with the latest reviewer's action.
+        """
+        params: dict[str, Any] = {}
+        where_clause = ""
+        if metric_ids:
+            where_clause = " WHERE metric_id = ANY(%(metric_ids)s)"
+            params["metric_ids"] = list(metric_ids)
+        sql = f"""
+            SELECT id, metric_id, rule, decision_key, decision,
+                   reviewer_id, reviewer_note, pr_number, pr_url,
+                   created_at, updated_at
+              FROM text_pattern_recommendation_decisions
+             {where_clause}
+             ORDER BY metric_id ASC, rule ASC, decision_key ASC,
+                      updated_at DESC
+        """
+        rows = self.query(sql, params)
+        return [dict(r) for r in rows]
+
+    # =============================================================================
     # V2 Image Metric Confirmation Methods (v2_image_metric_confirmations)
     # =============================================================================
 

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -3,6 +3,9 @@ Shared Flask middleware for the review application.
 
 Provides reusable before_request/after_request hooks for:
 - API key authentication
+- Admin gate (transitional — will be replaced by role lookup against
+  auth_users when Stage A2 of the auth rollout lands; see
+  docs/architecture/auth-rollout-implementation-plan.md)
 - Request timing
 - Audit log insertion
 """
@@ -10,6 +13,7 @@ Provides reusable before_request/after_request hooks for:
 import functools
 import hmac
 import logging
+import os
 import time
 import urllib.parse
 from collections.abc import Callable
@@ -96,6 +100,48 @@ def require_api_key(view: Callable) -> Callable:
         rejection = _verify_api_key()
         if rejection is not None:
             return rejection
+        return view(*args, **kwargs)
+
+    return wrapper
+
+
+def require_admin(view: Callable) -> Callable:
+    """Gate a view to admin reviewers only.
+
+    Reads the comma-separated allowlist from env var ``ADMIN_USER_IDS``
+    and matches against ``reviewer_id`` from the JSON body, query string,
+    or ``X-Reviewer-Id`` header (in that order, mirroring the per-metric
+    image-confirmation contract). Returns HTTP 403 ``{error:
+    "admin_required"}`` when the env var is unset/empty or the reviewer
+    isn't on the list.
+
+    **Transitional.** This is a stop-gap admin gate until Stage A2 of
+    the auth rollout lands (`src/auth/middleware.py::require(<permission>)`,
+    role lookup against ``auth_users``). Migration is mechanical — swap
+    ``@require_admin`` for ``@require('<permission>')`` on each call site.
+    See ``docs/architecture/auth-rollout-implementation-plan.md``.
+    """
+
+    @functools.wraps(view)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        data = request.get_json(silent=True) or {}
+        reviewer = (
+            data.get("reviewer_id")
+            or request.args.get("reviewer_id")
+            or request.headers.get("X-Reviewer-Id")
+            or ""
+        ).strip()
+
+        admins_csv = os.environ.get("ADMIN_USER_IDS", "")
+        admins = frozenset(e.strip() for e in admins_csv.split(",") if e.strip())
+
+        if not admins or reviewer not in admins:
+            logger.warning(
+                "Admin-only endpoint blocked: reviewer=%r path=%s",
+                reviewer or "<missing>",
+                request.path,
+            )
+            return jsonify({"error": "admin_required"}), 403
         return view(*args, **kwargs)
 
     return wrapper

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -19,7 +19,12 @@ from flask import Blueprint, current_app, jsonify, request
 
 from src.shared.keyword_config import _load_config
 from src.web.app import get_db
-from src.web.middleware import insert_audit_log_entry, register_api_auth, register_timing
+from src.web.middleware import (
+    insert_audit_log_entry,
+    register_api_auth,
+    register_timing,
+    require_admin,
+)
 
 api_unified_bp = Blueprint("api_unified", __name__, url_prefix="/api/v2")
 logger = logging.getLogger(__name__)
@@ -1472,6 +1477,106 @@ def get_text_analysis_run_status(run_id):
     if row.get("completed_at"):
         row["completed_at"] = row["completed_at"].isoformat()
     return jsonify(row), 200
+
+
+# =============================================================================
+# Recommendation decisions (admin-only Accept/Dismiss/Defer on Suggested actions)
+# =============================================================================
+
+
+_RECOMMENDATION_RULES = ("exclusion_pattern", "keyword_overlap", "fp_filter_gap")
+_RECOMMENDATION_DECISIONS = ("accepted", "dismissed", "deferred")
+_REVIEWER_NOTE_MAX_CHARS = 1000
+
+
+def _serialize_recommendation_decision(row: dict) -> dict:
+    """JSON-friendly shape for a decision row."""
+    out = dict(row)
+    out["id"] = str(out["id"])
+    if out.get("created_at"):
+        out["created_at"] = out["created_at"].isoformat()
+    if out.get("updated_at"):
+        out["updated_at"] = out["updated_at"].isoformat()
+    return out
+
+
+@api_unified_bp.route("/extraction/recommendation-decisions", methods=["POST"])
+@require_admin
+def upsert_recommendation_decision():
+    """Record an admin's Accept/Dismiss/Defer click on a Suggested-actions row.
+
+    Upserts on (metric_id, rule, decision_key, reviewer_id) so a same-
+    reviewer change-of-mind replaces the prior decision in place.
+
+    Body:
+        {
+          "metric_id": str,
+          "rule": "exclusion_pattern" | "keyword_overlap" | "fp_filter_gap",
+          "decision_key": str,
+          "decision": "accepted" | "dismissed" | "deferred",
+          "reviewer_id": str,        # required by _require_reviewer_id + require_admin
+          "reviewer_note": str?      # optional, <= 1000 chars
+        }
+
+    Returns 200 + the upserted row.
+    """
+    data = request.get_json(silent=True) or {}
+    reviewer_id, gate_reject = _require_reviewer_id(data)
+    if gate_reject is not None:
+        return gate_reject
+
+    metric_id = (data.get("metric_id") or "").strip()
+    rule = (data.get("rule") or "").strip()
+    decision_key = (data.get("decision_key") or "").strip()
+    decision = (data.get("decision") or "").strip()
+    reviewer_note = data.get("reviewer_note")
+    if isinstance(reviewer_note, str):
+        reviewer_note = reviewer_note.strip() or None
+    elif reviewer_note is not None:
+        return jsonify({"error": "reviewer_note must be a string"}), 400
+
+    errors = {}
+    if not metric_id:
+        errors["metric_id"] = "required"
+    if rule not in _RECOMMENDATION_RULES:
+        errors["rule"] = f"must be one of {list(_RECOMMENDATION_RULES)}"
+    if not decision_key:
+        errors["decision_key"] = "required"
+    if decision not in _RECOMMENDATION_DECISIONS:
+        errors["decision"] = f"must be one of {list(_RECOMMENDATION_DECISIONS)}"
+    if reviewer_note is not None and len(reviewer_note) > _REVIEWER_NOTE_MAX_CHARS:
+        errors["reviewer_note"] = f"must be <= {_REVIEWER_NOTE_MAX_CHARS} chars"
+    if errors:
+        return jsonify({"error": "validation_failed", "fields": errors}), 400
+
+    db = get_db()
+    row = db.upsert_recommendation_decision(
+        metric_id=metric_id,
+        rule=rule,
+        decision_key=decision_key,
+        decision=decision,
+        reviewer_id=reviewer_id,
+        reviewer_note=reviewer_note,
+    )
+    return jsonify(_serialize_recommendation_decision(row)), 200
+
+
+@api_unified_bp.route("/extraction/recommendation-decisions/<uuid:decision_id>", methods=["DELETE"])
+@require_admin
+def delete_recommendation_decision(decision_id):
+    """Undo a recommendation decision. Reviewer-scoped — admins can't undo
+    each other's decisions; the row only deletes when reviewer_id matches.
+    """
+    data = request.get_json(silent=True) or {}
+    reviewer_id, gate_reject = _require_reviewer_id(data)
+    if gate_reject is not None:
+        return gate_reject
+
+    db = get_db()
+    deleted = db.delete_recommendation_decision(str(decision_id), reviewer_id)
+    if not deleted:
+        return jsonify({"error": "not_found_or_not_owner"}), 404
+    return jsonify({"ok": True, "id": str(decision_id)}), 200
 
 
 # =============================================================================

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -266,7 +266,12 @@ def stats():
 
     from src.web.text_pattern_recommendations import compute_recommendations
 
-    text_recommendations = compute_recommendations(text_metric_summary, text_phrase_findings)
+    text_recommendation_decisions = db.get_recommendation_decisions(
+        [s["metric_id"] for s in text_metric_summary] or None
+    )
+    text_recommendations = compute_recommendations(
+        text_metric_summary, text_phrase_findings, text_recommendation_decisions
+    )
 
     return render_template(
         "unified_stats.html",

--- a/src/web/static/js/analytics.js
+++ b/src/web/static/js/analytics.js
@@ -214,5 +214,160 @@
             const runningId = textStatusEl.dataset.runningId;
             if (runningId) pollTextAnalysisStatus(runningId);
         }
+
+        // ----------------------------------------------------------------
+        // Recommendation decisions: Accept / Dismiss / Defer / Undo
+        // Event-delegated so the handlers also work for cards rendered
+        // after the initial load (e.g. after a future re-render).
+        // ----------------------------------------------------------------
+        document.addEventListener("click", function (e) {
+            const decideBtn = e.target.closest(".rec-decide-btn");
+            if (decideBtn) {
+                handleRecommendationDecide(decideBtn);
+                return;
+            }
+            const undoBtn = e.target.closest(".rec-undo-btn");
+            if (undoBtn) {
+                handleRecommendationUndo(undoBtn);
+                return;
+            }
+            const noteToggle = e.target.closest(".rec-note-toggle-btn");
+            if (noteToggle) {
+                const card = noteToggle.closest(".rec-card");
+                if (!card) return;
+                const wrap = card.querySelector(".rec-note-wrap");
+                if (wrap) wrap.classList.toggle("d-none");
+                return;
+            }
+        });
     });
+
+    // ----------------------------------------------------------------
+    // Recommendation decision handlers
+    // ----------------------------------------------------------------
+
+    function handleRecommendationDecide(btn) {
+        const reviewer = window.requireReviewerName ? window.requireReviewerName() : null;
+        if (!reviewer) return;
+
+        const card = btn.closest(".rec-card");
+        if (!card) return;
+        const note = (card.querySelector(".rec-note-input")?.value || "").trim();
+        const payload = {
+            metric_id: card.dataset.metricId,
+            rule: card.dataset.rule,
+            decision_key: card.dataset.decisionKey,
+            decision: btn.dataset.decision,
+            reviewer_id: reviewer,
+        };
+        if (note) payload.reviewer_note = note;
+
+        // Disable buttons while in flight to prevent double-click duplicates.
+        card.querySelectorAll(".rec-decide-btn, .rec-note-toggle-btn").forEach((b) => {
+            b.disabled = true;
+        });
+
+        fetch("/api/v2/extraction/recommendation-decisions", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}));
+                if (!r.ok) {
+                    const msg = body.error === "admin_required"
+                        ? "Admin access required for recommendation decisions."
+                        : (body.error || `HTTP ${r.status}`);
+                    alert(`Could not record decision: ${msg}`);
+                    card.querySelectorAll(".rec-decide-btn, .rec-note-toggle-btn").forEach((b) => {
+                        b.disabled = false;
+                    });
+                    return;
+                }
+                renderDecidedCard(card, body);
+            })
+            .catch((err) => {
+                alert(`Network error: ${err.message}`);
+                card.querySelectorAll(".rec-decide-btn, .rec-note-toggle-btn").forEach((b) => {
+                    b.disabled = false;
+                });
+            });
+    }
+
+    function handleRecommendationUndo(btn) {
+        const reviewer = window.requireReviewerName ? window.requireReviewerName() : null;
+        if (!reviewer) return;
+
+        const card = btn.closest(".rec-card");
+        if (!card) return;
+        const decisionId = btn.dataset.decisionId;
+        btn.disabled = true;
+
+        fetch(`/api/v2/extraction/recommendation-decisions/${decisionId}`, {
+            method: "DELETE",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ reviewer_id: reviewer }),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}));
+                if (!r.ok) {
+                    const msg = body.error === "not_found_or_not_owner"
+                        ? "Decision not found or owned by another reviewer."
+                        : (body.error || `HTTP ${r.status}`);
+                    alert(`Could not undo decision: ${msg}`);
+                    btn.disabled = false;
+                    return;
+                }
+                // Reload the page to re-render the rec in its undecided state
+                // alongside any other server-side state that may have shifted
+                // (e.g. PR-related fields in PR 2). Cheap and reliable.
+                window.location.reload();
+            })
+            .catch((err) => {
+                alert(`Network error: ${err.message}`);
+                btn.disabled = false;
+            });
+    }
+
+    function renderDecidedCard(card, decisionRow) {
+        // Replace the action area with a "Decided by ..." line + Undo button.
+        // Mirrors the server-rendered shape for r.decision in unified_stats.html
+        // so the visual is consistent without a full reload.
+        const actionArea = card.querySelector(".btn-group");
+        const noteWrap = card.querySelector(".rec-note-wrap");
+        if (actionArea) actionArea.remove();
+        if (noteWrap) noteWrap.remove();
+
+        const decisionLabel = decisionRow.decision;
+        const badgeClass =
+            decisionLabel === "accepted"
+                ? "success"
+                : decisionLabel === "deferred"
+                    ? "secondary"
+                    : "dark";
+        const noteHTML = decisionRow.reviewer_note
+            ? ` — <span class="fst-italic">"${escapeHtml(decisionRow.reviewer_note)}"</span>`
+            : "";
+
+        const div = document.createElement("div");
+        div.className = "mt-1 small";
+        div.innerHTML =
+            `<span class="badge bg-${badgeClass}">${decisionLabel}</span> ` +
+            `by ${escapeHtml(decisionRow.reviewer_id)}${noteHTML} ` +
+            `<button type="button" class="btn btn-link btn-sm p-0 ms-2 rec-undo-btn" ` +
+            `data-decision-id="${decisionRow.id}">Undo</button>`;
+        card.appendChild(div);
+        card.classList.add("rec-card--decided", "text-muted");
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
 })();

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1080,13 +1080,53 @@
                         <span class="badge bg-secondary ms-1">{{ recs|length }}</span>
                       </strong>
                       {% for r in recs %}
-                      <div class="mb-2">
-                        <span class="badge bg-{{ 'danger' if r.severity == 'high' else 'warning text-dark' }} me-1">
-                          {{ r.severity }}
-                        </span>
-                        <strong>{{ r.title }}</strong>
-                        <div class="text-muted">{{ r.evidence }}</div>
-                        <div><em>{{ r.action }}</em></div>
+                      {# rec-card: data attributes drive the JS click handlers
+                         in static/js/analytics.js. Decision state, when set,
+                         dims the card and swaps the action buttons for an
+                         Undo affordance. #}
+                      <div class="rec-card mb-3 {% if r.decision %}rec-card--decided text-muted{% endif %}"
+                           data-metric-id="{{ s.metric_id }}"
+                           data-rule="{{ r.rule }}"
+                           data-decision-key="{{ r.decision_key }}">
+                        <div>
+                          <span class="badge bg-{{ 'danger' if r.severity == 'high' else 'warning text-dark' }} me-1">
+                            {{ r.severity }}
+                          </span>
+                          <strong>{{ r.title }}</strong>
+                        </div>
+                        <div class="text-muted small">{{ r.evidence }}</div>
+                        <div class="small"><em>{{ r.action }}</em></div>
+                        {% if r.decision %}
+                          {% set d = r.decision %}
+                          <div class="mt-1 small">
+                            <span class="badge bg-{{ 'success' if d.decision == 'accepted' else ('secondary' if d.decision == 'deferred' else 'dark') }}">
+                              {{ d.decision }}
+                            </span>
+                            by {{ d.reviewer_id }}
+                            {% if d.reviewer_note %}
+                            — <span class="fst-italic">"{{ d.reviewer_note }}"</span>
+                            {% endif %}
+                            <button type="button"
+                                    class="btn btn-link btn-sm p-0 ms-2 rec-undo-btn"
+                                    data-decision-id="{{ d.id }}">Undo</button>
+                          </div>
+                        {% else %}
+                          <div class="btn-group btn-group-sm mt-1" role="group" aria-label="Decision">
+                            <button type="button" class="btn btn-outline-success rec-decide-btn"
+                                    data-decision="accepted">✓ Accept</button>
+                            <button type="button" class="btn btn-outline-danger rec-decide-btn"
+                                    data-decision="dismissed">✗ Dismiss</button>
+                            <button type="button" class="btn btn-outline-secondary rec-decide-btn"
+                                    data-decision="deferred">⏸ Defer</button>
+                            <button type="button" class="btn btn-outline-secondary rec-note-toggle-btn"
+                                    title="Add a note">📝</button>
+                          </div>
+                          <div class="rec-note-wrap mt-1 d-none">
+                            <textarea class="form-control form-control-sm rec-note-input"
+                                      maxlength="1000" rows="2"
+                                      placeholder="Optional note (≤1000 chars)"></textarea>
+                          </div>
+                        {% endif %}
                       </div>
                       {% endfor %}
                     </div>

--- a/src/web/text_pattern_recommendations.py
+++ b/src/web/text_pattern_recommendations.py
@@ -49,6 +49,7 @@ _SEVERITY_RANK = {"high": 0, "medium": 1}
 def compute_recommendations(
     summaries: list[dict[str, Any]],
     findings: list[dict[str, Any]],
+    decisions: list[dict[str, Any]] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Map metric_id -> list of recommendation dicts.
 
@@ -60,10 +61,20 @@ def compute_recommendations(
         {
           "rule": "exclusion_pattern" | "keyword_overlap" | "fp_filter_gap",
           "severity": "high" | "medium",
+          "decision_key": str,    # stable identifier across reruns
           "title": str,
           "evidence": str,
           "action": str,
+          "decision": dict | None,  # populated when `decisions` arg matches
         }
+
+    When ``decisions`` is provided (a list of recommendation-decision rows
+    from `db.get_recommendation_decisions()`), each rec gets a ``decision``
+    field looked up by ``(metric_id, rule, decision_key)``. The decisions
+    list may contain multiple reviewers' rows for the same key — the
+    most-recent one (by ``updated_at``) wins. Skipping/omitting the arg
+    leaves ``decision`` as ``None`` on every rec, preserving the prior
+    contract.
     """
     if not summaries and not findings:
         return {}
@@ -74,6 +85,15 @@ def compute_recommendations(
     for f in findings:
         findings_by_metric[f["metric_id"]].append(f)
 
+    # Index decisions by (metric_id, rule, decision_key); keep the row with
+    # the latest updated_at when multiple reviewers have decided. The DB
+    # reader returns rows ordered DESC by updated_at within each key, so
+    # the first row we see is the freshest — only insert if absent.
+    decision_index: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for d in decisions or []:
+        key = (d["metric_id"], d["rule"], d["decision_key"])
+        decision_index.setdefault(key, d)
+
     out: dict[str, list[dict[str, Any]]] = {}
     for s in summaries:
         metric_id = s["metric_id"]
@@ -82,6 +102,8 @@ def compute_recommendations(
         recs.extend(_rule_keyword_overlap(metric_id, s))
         recs.extend(_rule_fp_filter_gap(metric_id, s))
         if recs:
+            for r in recs:
+                r["decision"] = decision_index.get((metric_id, r["rule"], r["decision_key"]))
             recs.sort(key=lambda r: (_SEVERITY_RANK[r["severity"]], r["rule"]))
             out[metric_id] = recs
     return out
@@ -110,6 +132,7 @@ def _rule_exclusion_pattern(
             {
                 "rule": "exclusion_pattern",
                 "severity": severity,
+                "decision_key": phrase,
                 "title": f'Add exclusion pattern matching "{phrase}"',
                 "evidence": (
                     f'"{phrase}" appears in {count} rejects ({pct:.1f}%) '
@@ -139,6 +162,7 @@ def _rule_keyword_overlap(metric_id: str, summary: dict[str, Any]) -> list[dict[
             {
                 "rule": "keyword_overlap",
                 "severity": severity,
+                "decision_key": target_metric,
                 "title": f"Review keyword overlap with {target_metric}",
                 "evidence": (f"Reviewers corrected {metric_id} → {target_metric} {count} times."),
                 "action": (
@@ -167,6 +191,7 @@ def _rule_fp_filter_gap(metric_id: str, summary: dict[str, Any]) -> list[dict[st
         {
             "rule": "fp_filter_gap",
             "severity": severity,
+            "decision_key": "wrong_value",
             "title": "Check FP filter for value-extraction bug",
             "evidence": (
                 f"{wrong_value} of {reject_count} rejects ({pct * 100:.1f}%) "

--- a/tests/unit/web/test_recommendation_decisions_api.py
+++ b/tests/unit/web/test_recommendation_decisions_api.py
@@ -1,0 +1,221 @@
+"""Unit tests for the recommendation-decisions endpoints.
+
+Covers:
+  - POST /api/v2/extraction/recommendation-decisions — admin gate, reviewer gate,
+    field validation, upsert wiring, change-of-mind path.
+  - DELETE /api/v2/extraction/recommendation-decisions/<uuid> — owner scope
+    (reviewer A can't undo reviewer B's decision via 404), admin gate.
+
+The admin gate is the new transitional `require_admin` decorator on
+`src.web.middleware`; tests set ADMIN_USER_IDS via monkeypatch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.web.app import create_app
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("ADMIN_USER_IDS", "RGM,admin@example.com")
+    app = create_app("testing")
+    app.config["TESTING"] = True
+    app.config["DATABASE_URL"] = "postgresql://test"
+    app.config["_db_pool"] = None
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def mock_db():
+    with patch("src.web.routes.api_unified.get_db") as mock_get_db:
+        db = MagicMock()
+        db.upsert_recommendation_decision.return_value = {
+            "id": uuid.uuid4(),
+            "metric_id": "cm_x",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "created_at": datetime(2026, 5, 1, 20, tzinfo=UTC),
+            "updated_at": datetime(2026, 5, 1, 20, tzinfo=UTC),
+        }
+        db.delete_recommendation_decision.return_value = True
+        db.insert_audit_log.return_value = None
+        mock_get_db.return_value = db
+        yield db
+
+
+_POST = "/api/v2/extraction/recommendation-decisions"
+
+
+def _delete_url(decision_id: str) -> str:
+    return f"/api/v2/extraction/recommendation-decisions/{decision_id}"
+
+
+_VALID_BODY = {
+    "metric_id": "cm_x",
+    "rule": "exclusion_pattern",
+    "decision_key": "accounts receivable",
+    "decision": "accepted",
+    "reviewer_id": "RGM",
+}
+
+
+# ---------------------------------------------------------------------------
+# POST gates
+# ---------------------------------------------------------------------------
+
+
+class TestPostGates:
+    def test_missing_reviewer_id_returns_403(self, client, mock_db):
+        body = {k: v for k, v in _VALID_BODY.items() if k != "reviewer_id"}
+        resp = client.post(_POST, json=body)
+        assert resp.status_code == 403
+        assert resp.get_json()["error"] in {"admin_required", "reviewer_name_required"}
+        mock_db.upsert_recommendation_decision.assert_not_called()
+
+    def test_blocklisted_reviewer_returns_403(self, client, mock_db):
+        resp = client.post(_POST, json={**_VALID_BODY, "reviewer_id": "anonymous"})
+        assert resp.status_code == 403
+        mock_db.upsert_recommendation_decision.assert_not_called()
+
+    def test_non_admin_returns_403(self, client, mock_db, monkeypatch):
+        monkeypatch.setenv("ADMIN_USER_IDS", "OTHER_ADMIN")
+        resp = client.post(_POST, json=_VALID_BODY)
+        assert resp.status_code == 403
+        body = resp.get_json()
+        assert body["error"] == "admin_required"
+        mock_db.upsert_recommendation_decision.assert_not_called()
+
+    def test_missing_admin_env_returns_403(self, client, mock_db, monkeypatch):
+        monkeypatch.delenv("ADMIN_USER_IDS", raising=False)
+        resp = client.post(_POST, json=_VALID_BODY)
+        assert resp.status_code == 403
+        assert resp.get_json()["error"] == "admin_required"
+
+
+# ---------------------------------------------------------------------------
+# POST validation
+# ---------------------------------------------------------------------------
+
+
+class TestPostValidation:
+    def test_unknown_rule_returns_400(self, client, mock_db):
+        resp = client.post(_POST, json={**_VALID_BODY, "rule": "made_up_rule"})
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["error"] == "validation_failed"
+        assert "rule" in body["fields"]
+
+    def test_unknown_decision_returns_400(self, client, mock_db):
+        resp = client.post(_POST, json={**_VALID_BODY, "decision": "wishywashy"})
+        assert resp.status_code == 400
+        assert "decision" in resp.get_json()["fields"]
+
+    def test_missing_metric_id_returns_400(self, client, mock_db):
+        body = {k: v for k, v in _VALID_BODY.items() if k != "metric_id"}
+        resp = client.post(_POST, json=body)
+        assert resp.status_code == 400
+        assert "metric_id" in resp.get_json()["fields"]
+
+    def test_missing_decision_key_returns_400(self, client, mock_db):
+        body = {k: v for k, v in _VALID_BODY.items() if k != "decision_key"}
+        resp = client.post(_POST, json=body)
+        assert resp.status_code == 400
+        assert "decision_key" in resp.get_json()["fields"]
+
+    def test_oversized_note_returns_400(self, client, mock_db):
+        big = "x" * 1001
+        resp = client.post(_POST, json={**_VALID_BODY, "reviewer_note": big})
+        assert resp.status_code == 400
+        assert "reviewer_note" in resp.get_json()["fields"]
+
+    def test_non_string_note_returns_400(self, client, mock_db):
+        resp = client.post(_POST, json={**_VALID_BODY, "reviewer_note": 123})
+        assert resp.status_code == 400
+        assert "reviewer_note must be a string" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST happy path / upsert wiring
+# ---------------------------------------------------------------------------
+
+
+class TestPostUpsert:
+    def test_returns_200_with_serialized_row(self, client, mock_db):
+        resp = client.post(_POST, json=_VALID_BODY)
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["decision"] == "accepted"
+        assert body["reviewer_id"] == "RGM"
+        # ID and timestamps are JSON-serialized strings.
+        uuid.UUID(body["id"])
+        assert "T" in body["created_at"]
+
+    def test_calls_db_upsert_with_correct_args(self, client, mock_db):
+        client.post(_POST, json={**_VALID_BODY, "reviewer_note": "looks right"})
+        mock_db.upsert_recommendation_decision.assert_called_once_with(
+            metric_id="cm_x",
+            rule="exclusion_pattern",
+            decision_key="accounts receivable",
+            decision="accepted",
+            reviewer_id="RGM",
+            reviewer_note="looks right",
+        )
+
+    def test_empty_note_string_passes_none_to_db(self, client, mock_db):
+        client.post(_POST, json={**_VALID_BODY, "reviewer_note": "   "})
+        kwargs = mock_db.upsert_recommendation_decision.call_args.kwargs
+        assert kwargs["reviewer_note"] is None
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_returns_200_when_owner_deletes(self, client, mock_db):
+        decision_id = str(uuid.uuid4())
+        resp = client.delete(_delete_url(decision_id), json={"reviewer_id": "RGM"})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["id"] == decision_id
+        mock_db.delete_recommendation_decision.assert_called_once_with(decision_id, "RGM")
+
+    def test_returns_404_when_not_owner_or_missing(self, client, mock_db):
+        mock_db.delete_recommendation_decision.return_value = False
+        decision_id = str(uuid.uuid4())
+        resp = client.delete(_delete_url(decision_id), json={"reviewer_id": "RGM"})
+        assert resp.status_code == 404
+        assert resp.get_json()["error"] == "not_found_or_not_owner"
+
+    def test_non_admin_returns_403(self, client, mock_db, monkeypatch):
+        monkeypatch.setenv("ADMIN_USER_IDS", "OTHER_ADMIN")
+        resp = client.delete(_delete_url(str(uuid.uuid4())), json={"reviewer_id": "RGM"})
+        assert resp.status_code == 403
+        mock_db.delete_recommendation_decision.assert_not_called()
+
+    def test_non_uuid_path_returns_404(self, client, mock_db):
+        resp = client.delete(
+            "/api/v2/extraction/recommendation-decisions/not-a-uuid",
+            json={"reviewer_id": "RGM"},
+        )
+        # Flask <uuid:> converter rejects before handler.
+        assert resp.status_code == 404
+        mock_db.delete_recommendation_decision.assert_not_called()

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -90,6 +90,10 @@ def _stub_analytics_helpers(mock_db) -> None:
     mock_db.is_text_analysis_running.return_value = (False, None)
     mock_db.get_text_decision_metric_summary.return_value = []
     mock_db.get_text_decision_phrase_findings.return_value = []
+    # Recommendation decisions (PR 1 of the auto-PR rollout). Default empty
+    # so recs render with their action buttons; tests that exercise the
+    # decided-state path stub a non-empty list explicitly.
+    mock_db.get_recommendation_decisions.return_value = []
 
 
 def test_stats_renders_empty(client, mock_db):
@@ -259,6 +263,7 @@ def test_stats_summary_renders_recent_activity(client, mock_db):
     mock_db.is_text_analysis_running.return_value = (False, None)
     mock_db.get_text_decision_metric_summary.return_value = []
     mock_db.get_text_decision_phrase_findings.return_value = []
+    mock_db.get_recommendation_decisions.return_value = []
 
     resp = client.get("/v2/review/stats")
     assert resp.status_code == 200
@@ -345,6 +350,103 @@ def test_patterns_tab_renders_recommendation_alert(client, mock_db):
     assert "accounts receivable" in body
     # Severity badge for medium (45.20 < 50 threshold).
     assert "medium" in body
+    # Action buttons present (no decision yet).
+    assert "rec-decide-btn" in body
+    assert "Accept" in body and "Dismiss" in body and "Defer" in body
+
+
+def test_patterns_tab_renders_decided_recommendation(client, mock_db):
+    """When a decision row exists for a rec, the card renders the dimmed
+    decided state with reviewer attribution + Undo button instead of the
+    Accept/Dismiss/Defer buttons.
+    """
+    import uuid as _uuid
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {"wrong_metric": 18, "wrong_value": 13},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "rejection_reason",
+            "occurrence_count": 14,
+            "pct_of_decisions": 45.20,
+            "examples": [],
+        }
+    ]
+    decision_id = _uuid.uuid4()
+    mock_db.get_recommendation_decisions.return_value = [
+        {
+            "id": decision_id,
+            "metric_id": "cm_new_customers_acquired",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": "looks right",
+            "pr_number": None,
+            "pr_url": None,
+            "created_at": ts,
+            "updated_at": ts,
+        }
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Decided-state badge + reviewer attribution.
+    assert "rec-card--decided" in body
+    assert "accepted" in body
+    assert "by RGM" in body
+    assert "looks right" in body
+    # Undo button visible.
+    assert "rec-undo-btn" in body
+    assert str(decision_id) in body
+    # Action buttons NOT present for the decided rec.
+    assert "rec-decide-btn" not in body
 
 
 def test_stats_does_not_swallow_db_errors(app, mock_db):

--- a/tests/unit/web/test_text_pattern_recommendations.py
+++ b/tests/unit/web/test_text_pattern_recommendations.py
@@ -266,3 +266,115 @@ class TestEmpty:
         # No summary for cm_z → rule should not run on it.
         out = compute_recommendations([_summary("cm_x")], [_finding(metric_id="cm_z")])
         assert "cm_z" not in out
+
+
+# ---------------------------------------------------------------------------
+# decision_key field on rec output (PR 1 prep for decision-merge)
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionKey:
+    def test_exclusion_pattern_key_is_phrase(self):
+        out = compute_recommendations([_summary()], [_finding(phrase="accounts receivable")])
+        excl = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"][0]
+        assert excl["decision_key"] == "accounts receivable"
+
+    def test_keyword_overlap_key_is_target_metric(self):
+        s = _summary(top_correction_targets=[{"target_metric_id": "cm_y", "count": 12}])
+        out = compute_recommendations([s], [])
+        ovl = [r for r in out["cm_x"] if r["rule"] == "keyword_overlap"][0]
+        assert ovl["decision_key"] == "cm_y"
+
+    def test_fp_filter_gap_key_is_literal(self):
+        s = _summary(reject=10, rejection_categories={"wrong_value": 7})
+        out = compute_recommendations([s], [])
+        gap = [r for r in out["cm_x"] if r["rule"] == "fp_filter_gap"][0]
+        assert gap["decision_key"] == "wrong_value"
+
+
+# ---------------------------------------------------------------------------
+# Decision merging — `decisions` arg attaches matching decision rows
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionMerging:
+    def test_omitted_decisions_arg_leaves_decision_none(self):
+        out = compute_recommendations([_summary()], [_finding()])
+        rec = out["cm_x"][0]
+        assert rec["decision"] is None
+
+    def test_empty_decisions_list_leaves_decision_none(self):
+        out = compute_recommendations([_summary()], [_finding()], [])
+        rec = out["cm_x"][0]
+        assert rec["decision"] is None
+
+    def test_matching_decision_attaches(self):
+        decision = {
+            "id": "d1",
+            "metric_id": "cm_x",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "updated_at": "2026-05-01T20:00:00+00:00",
+        }
+        out = compute_recommendations([_summary()], [_finding()], [decision])
+        rec = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"][0]
+        assert rec["decision"] is not None
+        assert rec["decision"]["decision"] == "accepted"
+        assert rec["decision"]["reviewer_id"] == "RGM"
+
+    def test_decision_for_different_key_does_not_attach(self):
+        decision = {
+            "id": "d2",
+            "metric_id": "cm_x",
+            "rule": "exclusion_pattern",
+            "decision_key": "different phrase",
+            "decision": "dismissed",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "updated_at": "2026-05-01T20:00:00+00:00",
+        }
+        out = compute_recommendations([_summary()], [_finding()], [decision])
+        rec = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"][0]
+        assert rec["decision"] is None
+
+    def test_first_decision_in_list_wins_when_keys_collide(self):
+        # The DB reader returns rows ordered DESC by updated_at, so the
+        # caller passes the freshest row first. compute_recommendations
+        # uses `setdefault` to honor that — first wins.
+        decisions = [
+            {
+                "id": "d-fresh",
+                "metric_id": "cm_x",
+                "rule": "exclusion_pattern",
+                "decision_key": "accounts receivable",
+                "decision": "accepted",
+                "reviewer_id": "RGM",
+                "reviewer_note": None,
+                "pr_number": None,
+                "pr_url": None,
+                "updated_at": "2026-05-01T20:00:00+00:00",
+            },
+            {
+                "id": "d-old",
+                "metric_id": "cm_x",
+                "rule": "exclusion_pattern",
+                "decision_key": "accounts receivable",
+                "decision": "dismissed",
+                "reviewer_id": "OTHER",
+                "reviewer_note": None,
+                "pr_number": None,
+                "pr_url": None,
+                "updated_at": "2026-04-01T20:00:00+00:00",
+            },
+        ]
+        out = compute_recommendations([_summary()], [_finding()], decisions)
+        rec = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"][0]
+        assert rec["decision"]["id"] == "d-fresh"
+        assert rec["decision"]["reviewer_id"] == "RGM"


### PR DESCRIPTION
Stage 1 of the recommendation-decisions rollout. Admins can now record
their action on each Suggested-actions row in the Text Patterns tab —
the rec re-renders dimmed with reviewer attribution and an Undo button,
and the same rec stays decided across analysis reruns.

- New table text_pattern_recommendation_decisions keyed on
  (metric_id, rule, decision_key, reviewer_id) for upsert + undo.
- New endpoints POST/DELETE /api/v2/extraction/recommendation-decisions.
- New transitional require_admin decorator reading ADMIN_USER_IDS env
  var; to be replaced by src/auth/middleware.py::require(perm) when
  Stage A2 of the auth rollout lands.
- Recommendation helper extended with optional decisions= arg that
  attaches the matching decision row to each rec; existing tests pass
  unchanged because the arg defaults to None.
- Each rec dict now carries a stable decision_key (phrase / target
  metric / 'wrong_value') so decisions match across analysis reruns.

Bookkeeping only — no YAML edit, no GH calls. Stage 2 (auto-PR for
exclusion_pattern accepts) follows in a separate PR.

26 new unit tests; 4323 unit suite passes.
