### PR TITLE
feat(auth): production dev-bypass startup guard (A6)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,11 @@ SECRET_KEY=
 # Set to 'production' to enforce strict validation
 APP_ENV=development
 
+# Auth dev-bypass guard
+# NEVER set this in production (APP_ENV=production). Setting AUTH_DEV_BYPASS=1
+# in production causes the app to refuse to start (safety guard in create_app).
+# AUTH_DEV_BYPASS=1
+
 # API Authentication
 # REQUIRED for production. Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 # In development, API key authentication is disabled by default

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,4 @@
+# src/auth — Authentication and authorization package.
+# Stage A (foundation): dev-bypass guard only.
+# Session management (A3), permission catalog (A2), and enforcement (A4+)
+# land in subsequent PRs.

--- a/src/auth/dev_bypass.py
+++ b/src/auth/dev_bypass.py
@@ -1,0 +1,80 @@
+"""
+Dev-bypass guard for the auth system.
+
+AUTH_DEV_BYPASS=1 allows unauthenticated access in local development.
+It must NEVER be set in production (APP_ENV=production). The guard in
+verify_dev_bypass_safe() enforces this — it is called at the top of
+create_app() before any Flask config is loaded, so a misconfigured
+production deploy fails fast at startup rather than silently allowing
+unrestricted access.
+
+Once A3 (session management) lands, dev_bypass_user() should import
+SessionUser from src.auth.sessions rather than using the local dataclass.
+"""
+
+import os
+import sys
+import types
+from dataclasses import dataclass, field
+
+
+def is_dev_bypass_enabled() -> bool:
+    """Return True if AUTH_DEV_BYPASS is set to exactly '1'."""
+    return os.environ.get("AUTH_DEV_BYPASS", "").strip() == "1"
+
+
+def verify_dev_bypass_safe() -> None:
+    """
+    Raise RuntimeError if both APP_ENV=production and AUTH_DEV_BYPASS=1 are set.
+
+    Called at the very top of create_app() (before config load) so a
+    misconfigured production container refuses to start rather than silently
+    opening every route to anonymous access.
+    """
+    is_prod = os.environ.get("APP_ENV", "development") == "production"
+    if is_prod and is_dev_bypass_enabled():
+        msg = (
+            "FATAL: AUTH_DEV_BYPASS=1 is set in a production environment (APP_ENV=production). "
+            "This is a security misconfiguration. Unset AUTH_DEV_BYPASS before starting in production."
+        )
+        print(msg, file=sys.stderr)
+        raise RuntimeError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Placeholder SessionUser for dev-bypass local/test use.
+# TODO(A3): replace this with an import from src.auth.sessions once that
+# module ships.  Keep the field names aligned with whatever A3 defines so
+# callers need only update the import line.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DevBypassUser:
+    """Synthetic admin user injected when AUTH_DEV_BYPASS=1 in development."""
+
+    user_id: str = "dev-bypass"
+    email: str = "dev@localhost"
+    name: str = "Dev Bypass User"
+    roles: list[str] = field(default_factory=lambda: ["admin"])
+    is_authenticated: bool = True
+
+
+def dev_bypass_user() -> types.SimpleNamespace:
+    """
+    Return a synthetic admin-role user for local development / tests.
+
+    This is only valid when is_dev_bypass_enabled() is True; callers are
+    responsible for that check.  The returned object is a SimpleNamespace
+    so downstream code can read attributes without importing a specific class.
+
+    Once A3 lands, this function should return a proper SessionUser instance.
+    """
+    user = _DevBypassUser()
+    return types.SimpleNamespace(
+        user_id=user.user_id,
+        email=user.email,
+        name=user.name,
+        roles=user.roles,
+        is_authenticated=user.is_authenticated,
+    )

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -223,6 +223,12 @@ def create_app(
         # Custom configuration
         app = create_app(config_override={'DATABASE_URL': 'postgresql://...'})
     """
+    # Guard: refuse to start if production env + dev bypass are both active.
+    # Import inside the function to avoid circular-import issues at module load time.
+    from src.auth.dev_bypass import verify_dev_bypass_safe
+
+    verify_dev_bypass_safe()
+
     # Determine configuration
     if config_name is None:
         config_name = os.environ.get("APP_ENV", "development")

--- a/tests/unit/auth/test_dev_bypass_guard.py
+++ b/tests/unit/auth/test_dev_bypass_guard.py
@@ -1,0 +1,110 @@
+"""Unit tests for src/auth/dev_bypass.py."""
+
+import pytest
+
+from src.auth.dev_bypass import dev_bypass_user, is_dev_bypass_enabled, verify_dev_bypass_safe
+
+# ---------------------------------------------------------------------------
+# is_dev_bypass_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_bypass_enabled_when_set_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    assert is_dev_bypass_enabled() is True
+
+
+def test_bypass_disabled_when_set_to_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "0")
+    assert is_dev_bypass_enabled() is False
+
+
+def test_bypass_disabled_when_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "")
+    assert is_dev_bypass_enabled() is False
+
+
+def test_bypass_disabled_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTH_DEV_BYPASS", raising=False)
+    assert is_dev_bypass_enabled() is False
+
+
+def test_bypass_disabled_when_set_to_true_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only the exact string "1" enables bypass.
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "true")
+    assert is_dev_bypass_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# verify_dev_bypass_safe
+# ---------------------------------------------------------------------------
+
+
+def test_raises_in_production_with_bypass_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production + bypass set => RuntimeError (security misconfiguration)."""
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    with pytest.raises(RuntimeError, match="AUTH_DEV_BYPASS=1"):
+        verify_dev_bypass_safe()
+
+
+def test_no_raise_in_production_without_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production + bypass unset => safe, returns None."""
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("AUTH_DEV_BYPASS", raising=False)
+    result = verify_dev_bypass_safe()
+    assert result is None
+
+
+def test_no_raise_in_development_with_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dev + bypass set => allowed (local development use case)."""
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    result = verify_dev_bypass_safe()
+    assert result is None
+
+
+def test_no_raise_when_app_env_unset_with_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """APP_ENV unset defaults to development => bypass is safe."""
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    result = verify_dev_bypass_safe()
+    assert result is None
+
+
+def test_no_raise_in_testing_with_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Testing env + bypass => allowed (CI / test suite use case)."""
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    result = verify_dev_bypass_safe()
+    assert result is None
+
+
+def test_error_message_mentions_app_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RuntimeError message should mention APP_ENV so operators know what to fix."""
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("AUTH_DEV_BYPASS", "1")
+    with pytest.raises(RuntimeError, match="APP_ENV=production"):
+        verify_dev_bypass_safe()
+
+
+# ---------------------------------------------------------------------------
+# dev_bypass_user
+# ---------------------------------------------------------------------------
+
+
+def test_dev_bypass_user_has_admin_role() -> None:
+    user = dev_bypass_user()
+    assert "admin" in user.roles
+
+
+def test_dev_bypass_user_is_authenticated() -> None:
+    user = dev_bypass_user()
+    assert user.is_authenticated is True
+
+
+def test_dev_bypass_user_has_expected_attrs() -> None:
+    user = dev_bypass_user()
+    assert hasattr(user, "user_id")
+    assert hasattr(user, "email")
+    assert hasattr(user, "name")


### PR DESCRIPTION
## Summary

- Adds `src/auth/dev_bypass.py` with `assert_dev_bypass_safe()` — raises `RuntimeError` at app startup if `AUTH_DEV_BYPASS=1` is set when `APP_ENV=production`, making it structurally impossible to ship the bypass flag enabled in prod
- Introduces `DevBypassUser` stub (authenticated, admin role) returned when the dev bypass is active, providing a concrete identity for request context without any database lookup
- Wires `assert_dev_bypass_safe()` into `src/web/app.py` `create_app()` so the guard fires before any request is served
- Documents `AUTH_DEV_BYPASS` in `.env.template` with an explicit note that it is blocked in production

## Changed files

| File | Change |
|------|--------|
| `src/auth/__init__.py` | New package init |
| `src/auth/dev_bypass.py` | Guard + `DevBypassUser` stub |
| `src/web/app.py` | Call `assert_dev_bypass_safe()` at startup |
| `.env.template` | Document `AUTH_DEV_BYPASS` |
| `tests/unit/auth/test_dev_bypass_guard.py` | 14 unit tests covering all bypass/production combinations |

## Test plan

- [x] `pytest tests/unit/auth/ -x -q` — 14/14 passed locally
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)

## Auth rollout context

This is Stage A6 per `docs/architecture/auth-rollout-implementation-plan.md`. The guard is a prerequisite before any auth enforcement middleware (Stage B) is wired in — it ensures the dev escape hatch cannot accidentally remain open when enforcement goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)