### PR TITLE
feat(auth): CSRF middleware gated on auth_enforcement_enabled flag (A4)

### DIFF
--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,1 @@
+# src/auth — authorization and CSRF protection package

--- a/src/auth/csrf.py
+++ b/src/auth/csrf.py
@@ -1,0 +1,122 @@
+"""
+CSRF protection middleware for the review application.
+
+Implements a before_request hook (csrf_protect) that:
+  - Is a no-op for safe HTTP methods (GET, HEAD, OPTIONS).
+  - Is a no-op for paths starting with /auth/ (OAuth callbacks use state param).
+  - Is a no-op when the auth_enforcement_enabled feature flag is off or missing.
+  - When the flag is on: allows requests with Sec-Fetch-Site: same-origin header,
+    then falls back to Origin/Referer same-origin check via _is_same_origin().
+  - Returns 403 JSON for definitively cross-origin state-changing requests.
+
+Flag value is cached for ~5 seconds (module-level tuple) to avoid a DB
+round-trip on every request. The cache is cleared whenever the TTL expires so
+a flag flip takes effect within one cache window.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from flask import jsonify, request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level flag cache: (value: bool, cached_at: float) | None
+# ---------------------------------------------------------------------------
+_FLAG_CACHE: tuple[bool, float] | None = None
+_FLAG_CACHE_TTL: float = 5.0  # seconds
+
+
+def _read_enforcement_flag() -> bool:
+    """
+    Read the auth_enforcement_enabled flag from the feature_flags table.
+
+    Caches the result for _FLAG_CACHE_TTL seconds. Returns False if the row
+    is absent or if the DB read fails (safe default — no-op during pre-enforcement
+    stages of the rollout).
+    """
+    global _FLAG_CACHE
+
+    now = time.monotonic()
+    if _FLAG_CACHE is not None:
+        value, cached_at = _FLAG_CACHE
+        if now - cached_at < _FLAG_CACHE_TTL:
+            return value
+
+    # Cache miss or expired — re-read from DB.
+    try:
+        from src.web.app import get_db
+
+        db = get_db()
+        rows = db.query(
+            "SELECT value FROM feature_flags WHERE key = 'auth_enforcement_enabled' LIMIT 1"
+        )
+        if not rows:
+            # Row absent — default off (safe for pre-enforcement deployment).
+            logger.debug(
+                "auth_enforcement_enabled flag row absent in feature_flags; defaulting to False"
+            )
+            enabled = False
+        else:
+            enabled = rows[0]["value"] == "true"
+    except Exception as exc:
+        # Any DB error (connection failure, table not yet applied, etc.) —
+        # default off and warn rather than raising. This keeps the middleware
+        # safe to register before the DB is fully available.
+        logger.warning(
+            "csrf_protect: failed to read auth_enforcement_enabled flag (defaulting to False): %s",
+            exc,
+        )
+        enabled = False
+
+    _FLAG_CACHE = (enabled, now)
+    return enabled
+
+
+def csrf_protect() -> Any:
+    """
+    Flask before_request hook: reject cross-origin state-changing requests when
+    auth_enforcement_enabled is on.
+
+    Called automatically for every request via app.before_request(csrf_protect).
+    Returns None to allow the request to proceed, or a 403 JSON response to
+    reject it before any route handler runs.
+    """
+    # Safe methods carry no state-changing side effects — never block.
+    if request.method in ("GET", "HEAD", "OPTIONS"):
+        return None
+
+    # /auth/ prefix is exempt: OAuth callback relies on the state parameter
+    # for CSRF protection rather than this header-based mechanism.
+    if request.path.startswith("/auth/"):
+        return None
+
+    # If enforcement is off (or flag is missing), this middleware is a no-op.
+    if not _read_enforcement_flag():
+        return None
+
+    # Sec-Fetch-Site is set by modern browsers for all cross-site navigations and
+    # is not forgeable by cross-origin JavaScript. If it says same-origin, allow.
+    sec_fetch_site = request.headers.get("Sec-Fetch-Site", "")
+    if sec_fetch_site == "same-origin":
+        return None
+
+    # Fallback: Origin / Referer host comparison (same logic as API-key bypass).
+    from src.web.middleware import _is_same_origin
+
+    if _is_same_origin():
+        return None
+
+    # Definitively cross-origin — reject.
+    logger.warning(
+        "csrf_protect: cross-origin %s %s blocked (Sec-Fetch-Site=%r, remote=%s)",
+        request.method,
+        request.path,
+        sec_fetch_site,
+        request.remote_addr,
+    )
+    return jsonify({"error": "CSRF check failed"}), 403

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -298,6 +298,12 @@ def create_app(
     # Register blueprints (routes will be added in later tasks)
     _register_blueprints(app)
 
+    # Register CSRF protection middleware (A4).
+    # No-op when auth_enforcement_enabled flag is off or missing (safe default).
+    from src.auth.csrf import csrf_protect
+
+    app.before_request(csrf_protect)
+
     # Register error handlers
     _register_error_handlers(app)
 

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -20,6 +20,35 @@ from flask import Blueprint, current_app, g, jsonify, request, session
 logger = logging.getLogger(__name__)
 
 
+def _is_same_origin() -> bool:
+    """
+    Return True if the request originates from the same host as the server.
+
+    Checks Origin header first (reliable for POST fetch() calls; scheme-independent
+    comparison handles HTTPS-terminating proxies where Flask sees http:// but the
+    browser sends https://). Falls back to Referer header (sent for GET and
+    same-origin navigations; browsers omit Origin for same-origin no-CORS
+    GET/HEAD requests).
+
+    Returns False if both headers are absent or point to a different host.
+    """
+    # Origin header check (scheme-independent host comparison).
+    origin = request.headers.get("Origin", "")
+    if origin and origin.split("://", 1)[-1] == request.host:
+        return True
+
+    # Referer fallback (scheme-independent host comparison — under
+    # HTTPS-terminating proxies like Render, the Referer is https:// while
+    # request.host_url is http://, so a startswith match would miss).
+    referer = request.headers.get("Referer", "")
+    if referer:
+        referer_host = urllib.parse.urlsplit(referer).netloc
+        if referer_host and referer_host == request.host:
+            return True
+
+    return False
+
+
 def _verify_api_key() -> Any:
     """
     Core API-key check. Returns None to pass, or a Flask response tuple
@@ -30,23 +59,8 @@ def _verify_api_key() -> Any:
         return None
 
     # Allow browser fetch calls from the same server (same-origin AJAX).
-    # Check Origin first (reliable for POST fetch() calls; scheme-independent comparison
-    # handles HTTPS-terminating proxies where Flask sees http:// but browser sends https://).
-    origin = request.headers.get("Origin", "")
-    if origin and origin.split("://", 1)[-1] == request.host:
+    if _is_same_origin():
         return None
-
-    # Fallback: Referer header (sent for GET and same-origin navigations).
-    # Browsers omit Origin for same-origin no-CORS GET/HEAD requests, so this
-    # branch is the only same-origin signal for those. Compare hosts directly
-    # (scheme-independent) for parity with the Origin check above — under
-    # HTTPS-terminating proxies (Render) the page Referer is https:// while
-    # request.host_url is http://, so a startswith match would miss.
-    referer = request.headers.get("Referer", "")
-    if referer:
-        referer_host = urllib.parse.urlsplit(referer).netloc
-        if referer_host and referer_host == request.host:
-            return None
 
     api_key = request.headers.get("X-API-Key") or request.args.get("api_key")
     expected_key = current_app.config.get("API_KEY")

--- a/tests/unit/auth/test_csrf.py
+++ b/tests/unit/auth/test_csrf.py
@@ -1,0 +1,274 @@
+"""
+Unit tests for src/auth/csrf.py — csrf_protect() before_request hook.
+
+Tests exercise:
+  - GET requests are exempt regardless of flag state.
+  - /auth/ path prefix is exempt (even when flag on and cross-origin).
+  - Same-origin POST (Sec-Fetch-Site: same-origin) passes when flag on.
+  - Cross-origin POST (no Sec-Fetch-Site, cross-origin Origin) → 403 when flag on.
+  - Flag off (row missing OR enabled=false) → cross-origin POST passes.
+
+DB calls are mocked via unittest.mock.patch so no real database is required.
+The flag cache is reset between tests to prevent state leakage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.auth.csrf as csrf_module
+from src.web.app import create_app
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_flag_cache():
+    """Clear the module-level flag cache before each test."""
+    csrf_module._FLAG_CACHE = None
+    yield
+    csrf_module._FLAG_CACHE = None
+
+
+@pytest.fixture()
+def app():
+    """Minimal Flask test app with CSRF middleware registered."""
+    return create_app(
+        config_name="testing",
+        config_override={
+            "DATABASE_URL": "postgresql://test:test@localhost/test",
+            "API_KEY_REQUIRED": False,
+        },
+    )
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _mock_db_flag_enabled(rows: list[dict]) -> MagicMock:
+    """Return a MagicMock db whose query() returns the given rows."""
+    db = MagicMock()
+    db.query.return_value = rows
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Helper: patch get_db to return a mock that emits specified flag rows.
+# ---------------------------------------------------------------------------
+
+
+def _patch_flag(rows: list[dict]):
+    """Patch src.web.app.get_db (used by _read_enforcement_flag) to return mock.
+
+    _read_enforcement_flag does `from src.web.app import get_db` inside the
+    function body, so we patch at the source: src.web.app.get_db.
+    """
+    mock_db = _mock_db_flag_enabled(rows)
+    return patch("src.web.app.get_db", return_value=mock_db)
+
+
+# ---------------------------------------------------------------------------
+# Tests: safe methods are always exempt
+# ---------------------------------------------------------------------------
+
+
+class TestSafeMethodsExempt:
+    def test_get_passes_when_flag_off(self, client):
+        with _patch_flag([]):  # flag missing → off
+            resp = client.get(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        # /health returns 200 regardless of CSRF (GET is exempt)
+        assert resp.status_code != 403
+
+    def test_get_passes_when_flag_on(self, client):
+        with _patch_flag([{"value": "true"}]):
+            resp = client.get(
+                "/health",
+                headers={
+                    "Origin": "https://evil.example.com",
+                    "Sec-Fetch-Site": "cross-site",
+                },
+            )
+        assert resp.status_code != 403
+
+    def test_head_passes_when_flag_on(self, client):
+        with _patch_flag([{"value": "true"}]):
+            resp = client.head(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code != 403
+
+    def test_options_passes_when_flag_on(self, client):
+        with _patch_flag([{"value": "true"}]):
+            resp = client.options(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: /auth/ path prefix is always exempt
+# ---------------------------------------------------------------------------
+
+
+class TestAuthPathExempt:
+    def test_auth_callback_post_exempt_when_flag_on_cross_origin(self, client):
+        """POST /auth/callback must pass even when flag=on and cross-origin."""
+        with _patch_flag([{"value": "true"}]):
+            # No Sec-Fetch-Site, cross-origin Origin — would normally 403.
+            resp = client.post(
+                "/auth/callback",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        # /auth/callback doesn't exist (404) but CSRF must NOT produce 403.
+        assert resp.status_code != 403
+
+    def test_auth_login_post_exempt(self, client):
+        with _patch_flag([{"value": "true"}]):
+            resp = client.post(
+                "/auth/login",
+                headers={"Origin": "https://attacker.example.com"},
+            )
+        assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: flag on — same-origin passes, cross-origin blocked
+# ---------------------------------------------------------------------------
+
+
+class TestFlagOn:
+    def test_same_origin_sec_fetch_site_passes(self, client):
+        """Sec-Fetch-Site: same-origin → allowed when flag on."""
+        with _patch_flag([{"value": "true"}]):
+            resp = client.post(
+                "/health",
+                headers={"Sec-Fetch-Site": "same-origin"},
+            )
+        assert resp.status_code != 403
+
+    def test_same_origin_via_origin_header_passes(self, client, app):
+        """Origin header matching request.host → allowed when flag on."""
+        with app.test_request_context():
+            # Determine the host the test client uses
+            host = "localhost"
+
+        with _patch_flag([{"value": "true"}]):
+            resp = client.post(
+                "/health",
+                headers={"Origin": f"http://{host}"},
+            )
+        assert resp.status_code != 403
+
+    def test_cross_origin_post_blocked_when_flag_on(self, client):
+        """Cross-origin POST with no Sec-Fetch-Site header → 403."""
+        with _patch_flag([{"value": "true"}]):
+            resp = client.post(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data is not None
+        assert data.get("error") == "CSRF check failed"
+
+    def test_cross_origin_with_cross_site_sec_fetch_blocked(self, client):
+        """Sec-Fetch-Site: cross-site → 403 even when Origin matches nothing."""
+        with _patch_flag([{"value": "true"}]):
+            resp = client.post(
+                "/health",
+                headers={
+                    "Origin": "https://attacker.example.com",
+                    "Sec-Fetch-Site": "cross-site",
+                },
+            )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: flag off → cross-origin POST passes (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestFlagOff:
+    def test_flag_row_missing_cross_origin_passes(self, client):
+        """Row absent in feature_flags → middleware is no-op."""
+        with _patch_flag([]):  # empty result → flag absent
+            resp = client.post(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code != 403
+
+    def test_flag_value_false_cross_origin_passes(self, client):
+        """Row present with value='false' → middleware is no-op."""
+        with _patch_flag([{"value": "false"}]):
+            resp = client.post(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code != 403
+
+    def test_db_error_defaults_to_flag_off(self, client):
+        """DB read exception → flag defaults to False → cross-origin passes."""
+        mock_db = MagicMock()
+        mock_db.query.side_effect = Exception("connection refused")
+        with patch("src.web.app.get_db", return_value=mock_db):
+            resp = client.post(
+                "/health",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: flag cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFlagCache:
+    def test_flag_is_cached_within_ttl(self, client):
+        """DB should not be queried a second time within the cache TTL."""
+        mock_db = MagicMock()
+        mock_db.query.return_value = []  # flag off
+
+        with patch("src.web.app.get_db", return_value=mock_db):
+            # First request — reads DB.
+            client.post("/health", headers={"Origin": "https://evil.example.com"})
+            # Second request — should use cache.
+            client.post("/health", headers={"Origin": "https://evil.example.com"})
+
+        # query() should have been called only once.
+        assert mock_db.query.call_count == 1
+
+    def test_cache_refreshed_after_ttl(self, client):
+        """After TTL expires the DB is queried again."""
+        import src.auth.csrf as _csrf
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = []
+
+        with patch("src.web.app.get_db", return_value=mock_db):
+            # Prime cache.
+            client.post("/health", headers={"Origin": "https://evil.example.com"})
+
+        # Manually expire the cache.
+        assert _csrf._FLAG_CACHE is not None
+        value, _ = _csrf._FLAG_CACHE
+        _csrf._FLAG_CACHE = (value, 0.0)  # set timestamp to epoch → expired
+
+        with patch("src.web.app.get_db", return_value=mock_db):
+            client.post("/health", headers={"Origin": "https://evil.example.com"})
+
+        # query() should have been called a second time.
+        assert mock_db.query.call_count == 2


### PR DESCRIPTION
## Summary

- Adds `src/auth/csrf.py` with `csrf_protect()` before_request hook: no-op for safe methods (GET/HEAD/OPTIONS), exempt for `/auth/` paths (OAuth uses state param), blocked for cross-origin state-changing requests when `auth_enforcement_enabled` feature flag is on
- Extracts `_is_same_origin()` from inline duplication to `src/web/middleware.py` for shared use by both the CSRF hook and the existing API-key bypass
- Registers `csrf_protect` in `create_app()` via `app.before_request()` (A4 middleware wiring)
- Flag value is cached ~5s at module level to avoid a DB round-trip on every request; cache auto-expires and defaults to False on DB error

## Test plan

- [x] 15 unit tests in `tests/unit/auth/test_csrf.py` covering: safe-method exemptions, `/auth/` path exemption, flag-on same-origin pass (Sec-Fetch-Site and Origin header), flag-on cross-origin 403, flag-off/missing no-op, DB error fallback, and flag TTL cache behavior
- [x] `ruff check` and `ruff format --check` pass on all modified files
- [x] Pre-commit hooks pass (ruff, secrets, extraction guard)
- [x] Pre-push pytest unit tests pass

## Auth rollout stage

A4 — CSRF middleware. Middleware is a no-op until `auth_enforcement_enabled` flag is set to `'true'` in `feature_flags` table. Safe to deploy before Stage C (session auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)