### PR TITLE
feat(auth): idempotent seed scripts for users and legacy aliases (A7)

### DIFF
--- a/scripts/seed_auth_legacy_aliases.py
+++ b/scripts/seed_auth_legacy_aliases.py
@@ -1,0 +1,209 @@
+"""Seed legacy reviewer alias mappings into auth_legacy_aliases.
+
+Default invocation (no args): UPSERT the two spec aliases (RGM, Mayu).
+
+Usage:
+    python3 scripts/seed_auth_legacy_aliases.py
+    python3 scripts/seed_auth_legacy_aliases.py --add LEGACY email@example.com
+    python3 scripts/seed_auth_legacy_aliases.py --remove LEGACY
+    python3 scripts/seed_auth_legacy_aliases.py --list
+
+Environment:
+    DATABASE_URL  PostgreSQL connection string (required).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Make project root importable when run directly.
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.infra.db import DatabaseAdapter  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Spec aliases — edit here to add permanent seed aliases.
+# ---------------------------------------------------------------------------
+SEED_ALIASES: list[dict[str, str]] = [
+    {"legacy_reviewer_string": "RGM", "target_email": "rgmarkey@gmail.com"},
+    {"legacy_reviewer_string": "Mayu", "target_email": "mayujoiner@gmail.com"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_email(email: str) -> str:
+    return email.lower().strip()
+
+
+def _user_exists(db: DatabaseAdapter, normalized_email: str) -> bool:
+    rows = db.query(
+        "SELECT 1 FROM auth_users WHERE normalized_email = %(ne)s",
+        {"ne": normalized_email},
+    )
+    return len(rows) > 0
+
+
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
+
+
+def upsert_alias(
+    db: DatabaseAdapter,
+    legacy_reviewer_string: str,
+    target_email: str,
+    *,
+    require_user_exists: bool = False,
+    verbose: bool = True,
+) -> None:
+    """UPSERT one alias into auth_legacy_aliases.
+
+    If require_user_exists is True, the function errors when the target email
+    is not found in auth_users (used by --add to give a helpful error message).
+    """
+    ne = normalize_email(target_email)
+
+    if require_user_exists:
+        if not _user_exists(db, ne):
+            print(
+                f"ERROR: no user found with email '{ne}'. "
+                "Seed the user first (seed_auth_users.py --add ...).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Check existing row to detect change.
+    existing = db.query(
+        "SELECT * FROM auth_legacy_aliases WHERE legacy_reviewer_string = %(legacy)s",
+        {"legacy": legacy_reviewer_string},
+    )
+
+    db.execute(
+        """
+        INSERT INTO auth_legacy_aliases (legacy_reviewer_string, target_email)
+        VALUES (%(legacy)s, %(target_email)s)
+        ON CONFLICT (legacy_reviewer_string) DO UPDATE
+            SET target_email = EXCLUDED.target_email,
+                active       = TRUE,
+                updated_at   = NOW()
+        """,
+        {"legacy": legacy_reviewer_string, "target_email": ne},
+    )
+
+    if not existing:
+        verb = "INSERTED"
+    elif existing[0]["target_email"] != ne or not existing[0]["active"]:
+        verb = "UPDATED"
+    else:
+        verb = "NO CHANGE"
+
+    if verbose:
+        print(f"  {verb}: '{legacy_reviewer_string}' -> {ne}")
+
+
+def remove_alias(db: DatabaseAdapter, legacy_reviewer_string: str, *, verbose: bool = True) -> None:
+    """Hard-delete an alias row (aliases are easy to recreate)."""
+    db.execute(
+        "DELETE FROM auth_legacy_aliases WHERE legacy_reviewer_string = %(legacy)s",
+        {"legacy": legacy_reviewer_string},
+    )
+    if verbose:
+        print(f"  DELETED: '{legacy_reviewer_string}'")
+
+
+def list_aliases(db: DatabaseAdapter) -> None:
+    """Print current aliases table to stdout."""
+    rows = db.query(
+        "SELECT legacy_reviewer_string, target_email, active, created_at "
+        "FROM auth_legacy_aliases ORDER BY created_at"
+    )
+    if not rows:
+        print("(no aliases)")
+        return
+    header = f"{'legacy_reviewer_string':<30} {'target_email':<35} {'active'}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(f"{r['legacy_reviewer_string']:<30} {r['target_email']:<35} {r['active']}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Seed or manage auth_legacy_aliases. "
+            "Default (no flags): UPSERT the two spec aliases (RGM, Mayu)."
+        )
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--add",
+        nargs=2,
+        metavar=("LEGACY", "EMAIL"),
+        help="Add alias mapping LEGACY -> user by email. Errors if user not found.",
+    )
+    group.add_argument(
+        "--remove",
+        metavar="LEGACY",
+        help="Hard-delete the alias row.",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="Print current aliases table.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL environment variable not set.", file=sys.stderr)
+        return 1
+
+    db = DatabaseAdapter(db_url)
+
+    if args.list:
+        list_aliases(db)
+        return 0
+
+    if args.remove:
+        remove_alias(db, args.remove)
+        return 0
+
+    if args.add:
+        legacy, email = args.add
+        upsert_alias(db, legacy, email, require_user_exists=True)
+        return 0
+
+    # Default: seed spec aliases.
+    print("Seeding legacy aliases...")
+    for alias in SEED_ALIASES:
+        upsert_alias(
+            db,
+            alias["legacy_reviewer_string"],
+            alias["target_email"],
+            require_user_exists=False,
+        )
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_auth_users.py
+++ b/scripts/seed_auth_users.py
@@ -1,0 +1,316 @@
+"""Seed initial auth users and access entries into the database.
+
+Default invocation (no args): UPSERT the three spec users into auth_users and
+write corresponding auth_access_entries rows. Writes admin_audit_log entries
+only for rows that actually changed.
+
+Usage:
+    python3 scripts/seed_auth_users.py
+    python3 scripts/seed_auth_users.py --add email@example.com reviewer "Display Name"
+    python3 scripts/seed_auth_users.py --remove email@example.com
+    python3 scripts/seed_auth_users.py --list
+
+Environment:
+    DATABASE_URL  PostgreSQL connection string (required).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from uuid import UUID
+
+# Make project root importable when run directly.
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.infra.db import DatabaseAdapter  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Spec users — edit here to add permanent seed users.
+# ---------------------------------------------------------------------------
+SEED_USERS: list[dict[str, str]] = [
+    {
+        "email": "rgmarkey@gmail.com",
+        "role": "admin",
+        "display_name": "Rob Markey",
+    },
+    {
+        "email": "rob.markey@cmasb.org",
+        "role": "admin",
+        "display_name": "Rob Markey (CMASB)",
+    },
+    {
+        "email": "mayujoiner@gmail.com",
+        "role": "reviewer",
+        "display_name": "Mayu Joiner",
+    },
+]
+
+VALID_ROLES = {"admin", "reviewer", "viewer"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_email(email: str) -> str:
+    return email.lower().strip()
+
+
+def _row_to_dict(row: dict) -> dict:
+    """Convert a DB row to a JSON-serialisable dict for audit log state."""
+    result = {}
+    for k, v in row.items():
+        if isinstance(v, datetime):
+            result[k] = v.isoformat()
+        elif isinstance(v, UUID):
+            result[k] = str(v)
+        else:
+            result[k] = v
+    return result
+
+
+def _fetch_user_by_email(db: DatabaseAdapter, normalized_email: str) -> dict | None:
+    rows = db.query(
+        "SELECT * FROM auth_users WHERE normalized_email = %(ne)s",
+        {"ne": normalized_email},
+    )
+    return rows[0] if rows else None
+
+
+def _fetch_access_entry_by_email(db: DatabaseAdapter, normalized_email: str) -> dict | None:
+    rows = db.query(
+        "SELECT * FROM auth_access_entries WHERE normalized_email = %(ne)s",
+        {"ne": normalized_email},
+    )
+    return rows[0] if rows else None
+
+
+def _write_audit_log(
+    db: DatabaseAdapter,
+    action_type: str,
+    target_entity: str,
+    before_state: dict | None,
+    after_state: dict | None,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO admin_audit_log
+            (actor_user_id, actor_email, action_type, target_entity, before_state, after_state)
+        VALUES
+            (NULL, NULL, %(action_type)s, %(target_entity)s,
+             %(before_state)s::jsonb, %(after_state)s::jsonb)
+        """,
+        {
+            "action_type": action_type,
+            "target_entity": target_entity,
+            "before_state": json.dumps(before_state) if before_state is not None else None,
+            "after_state": json.dumps(after_state) if after_state is not None else None,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
+
+
+def upsert_user(
+    db: DatabaseAdapter,
+    email: str,
+    role: str,
+    display_name: str,
+    *,
+    verbose: bool = True,
+) -> None:
+    """UPSERT one user into auth_users and auth_access_entries.
+
+    Writes an admin_audit_log row only when the row actually changed.
+    """
+    ne = normalize_email(email)
+    before = _fetch_user_by_email(db, ne)
+
+    # UPSERT auth_users
+    rows = db.query(
+        """
+        INSERT INTO auth_users (normalized_email, role, display_name)
+        VALUES (%(ne)s, %(role)s, %(display_name)s)
+        ON CONFLICT (normalized_email) DO UPDATE
+            SET role         = EXCLUDED.role,
+                display_name = EXCLUDED.display_name,
+                updated_at   = NOW()
+        RETURNING *
+        """,
+        {"ne": ne, "role": role, "display_name": display_name},
+    )
+    after = rows[0]
+
+    # Detect change: new row OR role/display_name differ from before.
+    changed = (
+        before is None
+        or before["role"] != after["role"]
+        or before.get("display_name") != after.get("display_name")
+    )
+
+    if changed:
+        _write_audit_log(
+            db,
+            action_type="seed_users",
+            target_entity=ne,
+            before_state=_row_to_dict(before) if before is not None else None,
+            after_state=_row_to_dict(after),
+        )
+        verb = "INSERTED" if before is None else "UPDATED"
+        if verbose:
+            print(f"  {verb}: {ne} (role={role})")
+    else:
+        if verbose:
+            print(f"  NO CHANGE: {ne}")
+
+    # UPSERT auth_access_entries
+    db.execute(
+        """
+        INSERT INTO auth_access_entries (normalized_email, intended_role, status)
+        VALUES (%(ne)s, %(role)s, 'approved')
+        ON CONFLICT (normalized_email) DO UPDATE
+            SET intended_role = EXCLUDED.intended_role,
+                updated_at    = NOW()
+        """,
+        {"ne": ne, "role": role},
+    )
+
+
+def remove_user(db: DatabaseAdapter, email: str, *, verbose: bool = True) -> None:
+    """Soft-delete a user by setting account_status='disabled'."""
+    ne = normalize_email(email)
+    before = _fetch_user_by_email(db, ne)
+    if before is None:
+        print(f"  NOT FOUND: {ne}", file=sys.stderr)
+        sys.exit(1)
+
+    if before["account_status"] == "disabled":
+        if verbose:
+            print(f"  ALREADY DISABLED: {ne}")
+        return
+
+    rows = db.query(
+        """
+        UPDATE auth_users
+        SET account_status = 'disabled',
+            disabled_at    = NOW(),
+            updated_at     = NOW()
+        WHERE normalized_email = %(ne)s
+        RETURNING *
+        """,
+        {"ne": ne},
+    )
+    after = rows[0]
+    _write_audit_log(
+        db,
+        action_type="remove_user",
+        target_entity=ne,
+        before_state=_row_to_dict(before),
+        after_state=_row_to_dict(after),
+    )
+    if verbose:
+        print(f"  DISABLED: {ne}")
+
+
+def list_users(db: DatabaseAdapter) -> None:
+    """Print current users table to stdout."""
+    rows = db.query(
+        "SELECT normalized_email, role, account_status, display_name, created_at "
+        "FROM auth_users ORDER BY created_at"
+    )
+    if not rows:
+        print("(no users)")
+        return
+    header = f"{'email':<35} {'role':<10} {'status':<10} {'display_name'}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r['normalized_email']:<35} {r['role']:<10} {r['account_status']:<10} "
+            f"{r.get('display_name') or ''}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Seed or manage auth_users and auth_access_entries. "
+            "Default (no flags): UPSERT the three spec users."
+        )
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--add",
+        nargs=3,
+        metavar=("EMAIL", "ROLE", "DISPLAY_NAME"),
+        help="Add a new user. ROLE must be one of: admin, reviewer, viewer.",
+    )
+    group.add_argument(
+        "--remove",
+        metavar="EMAIL",
+        help="Soft-delete a user (sets account_status='disabled').",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="Print current users table.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL environment variable not set.", file=sys.stderr)
+        return 1
+
+    db = DatabaseAdapter(db_url)
+
+    if args.list:
+        list_users(db)
+        return 0
+
+    if args.remove:
+        remove_user(db, args.remove)
+        return 0
+
+    if args.add:
+        email, role, display_name = args.add
+        if role not in VALID_ROLES:
+            print(
+                f"ERROR: invalid role '{role}'. Must be one of: {', '.join(sorted(VALID_ROLES))}.",
+                file=sys.stderr,
+            )
+            return 1
+        upsert_user(db, email, role, display_name)
+        return 0
+
+    # Default: seed spec users.
+    print("Seeding auth users...")
+    for user in SEED_USERS:
+        upsert_user(db, user["email"], user["role"], user["display_name"])
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/auth/test_seed_scripts.py
+++ b/tests/integration/auth/test_seed_scripts.py
@@ -1,0 +1,360 @@
+"""Integration tests for scripts/seed_auth_users.py and scripts/seed_auth_legacy_aliases.py.
+
+Each test cleans auth tables before running so tests are isolated. The
+importlib pattern mirrors tests/integration/test_onboard_tickers_cli.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+SEED_USERS_SCRIPT = PROJECT_ROOT / "scripts" / "seed_auth_users.py"
+SEED_ALIASES_SCRIPT = PROJECT_ROOT / "scripts" / "seed_auth_legacy_aliases.py"
+
+
+# ---------------------------------------------------------------------------
+# Script loaders (importlib pattern)
+# ---------------------------------------------------------------------------
+
+
+def _load_module(script_path: Path, mod_name: str):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    spec = importlib.util.spec_from_file_location(mod_name, script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def users_cli():
+    return _load_module(SEED_USERS_SCRIPT, "seed_auth_users_integration")
+
+
+@pytest.fixture(scope="module")
+def aliases_cli():
+    return _load_module(SEED_ALIASES_SCRIPT, "seed_auth_legacy_aliases_integration")
+
+
+# ---------------------------------------------------------------------------
+# Per-test auth table cleanup fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_db(test_db_adapter):
+    """Yield the test DB adapter with auth tables truncated before/after each test.
+
+    The shared clean_db fixture does not cover auth tables, so we manage them
+    here to keep tests isolated.
+    """
+
+    def _truncate(adapter):
+        with adapter.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET CONSTRAINTS ALL DEFERRED")
+                cur.execute(
+                    """
+                    DO $$
+                    BEGIN
+                        TRUNCATE TABLE admin_audit_log CASCADE;
+                        TRUNCATE TABLE auth_legacy_aliases CASCADE;
+                        TRUNCATE TABLE auth_access_entries CASCADE;
+                        TRUNCATE TABLE auth_sessions CASCADE;
+                        TRUNCATE TABLE auth_users CASCADE;
+                    EXCEPTION WHEN undefined_table THEN
+                        NULL;
+                    END $$;
+                    """
+                )
+                cur.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+    _truncate(test_db_adapter)
+    yield test_db_adapter
+    _truncate(test_db_adapter)
+
+
+# ---------------------------------------------------------------------------
+# seed_auth_users.py tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedAuthUsers:
+    def test_default_seeds_three_users(self, auth_db, users_cli, monkeypatch):
+        """Default invocation inserts the 3 spec users."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+
+        rc = users_cli.main()
+
+        assert rc == 0
+        rows = auth_db.query(
+            "SELECT normalized_email, role, account_status FROM auth_users ORDER BY normalized_email"
+        )
+        emails = [r["normalized_email"] for r in rows]
+        assert "rgmarkey@gmail.com" in emails
+        assert "rob.markey@cmasb.org" in emails
+        assert "mayujoiner@gmail.com" in emails
+        assert len(rows) == 3
+
+        # Roles
+        by_email = {r["normalized_email"]: r for r in rows}
+        assert by_email["rgmarkey@gmail.com"]["role"] == "admin"
+        assert by_email["rob.markey@cmasb.org"]["role"] == "admin"
+        assert by_email["mayujoiner@gmail.com"]["role"] == "reviewer"
+
+        # All active
+        for r in rows:
+            assert r["account_status"] == "active"
+
+    def test_default_writes_access_entries(self, auth_db, users_cli, monkeypatch):
+        """Default invocation also populates auth_access_entries."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+
+        users_cli.main()
+
+        rows = auth_db.query(
+            "SELECT normalized_email, intended_role, status FROM auth_access_entries "
+            "ORDER BY normalized_email"
+        )
+        assert len(rows) == 3
+        by_email = {r["normalized_email"]: r for r in rows}
+        assert by_email["rgmarkey@gmail.com"]["intended_role"] == "admin"
+        assert by_email["rgmarkey@gmail.com"]["status"] == "approved"
+        assert by_email["mayujoiner@gmail.com"]["intended_role"] == "reviewer"
+
+    def test_default_idempotent(self, auth_db, users_cli, monkeypatch):
+        """Running default twice yields same 3 users — no duplicates, no errors."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+
+        rc1 = users_cli.main()
+        rc2 = users_cli.main()
+
+        assert rc1 == 0
+        assert rc2 == 0
+        rows = auth_db.query("SELECT normalized_email FROM auth_users")
+        assert len(rows) == 3
+
+    def test_default_writes_audit_log_on_insert(self, auth_db, users_cli, monkeypatch):
+        """First run writes audit log entries for each new user."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+
+        users_cli.main()
+
+        rows = auth_db.query(
+            "SELECT action_type, target_entity, before_state, after_state "
+            "FROM admin_audit_log WHERE action_type = 'seed_users' "
+            "ORDER BY target_entity"
+        )
+        assert len(rows) == 3
+        for r in rows:
+            assert r["before_state"] is None  # new rows have no before state
+            assert r["after_state"] is not None
+
+    def test_default_no_audit_log_on_second_run(self, auth_db, users_cli, monkeypatch):
+        """Second run (no changes) does not write new audit log entries."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+
+        users_cli.main()
+        count_after_first = auth_db.query("SELECT COUNT(*) AS n FROM admin_audit_log")[0]["n"]
+
+        users_cli.main()
+        count_after_second = auth_db.query("SELECT COUNT(*) AS n FROM admin_audit_log")[0]["n"]
+
+        assert count_after_first == count_after_second
+
+    def test_add_new_user(self, auth_db, users_cli, monkeypatch):
+        """--add inserts a 4th user."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+
+        # Seed the 3 spec users first.
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+        users_cli.main()
+
+        # Add a 4th.
+        monkeypatch.setattr(
+            "sys.argv",
+            ["seed_auth_users.py", "--add", "test@example.com", "reviewer", "Test User"],
+        )
+        rc = users_cli.main()
+        assert rc == 0
+
+        rows = auth_db.query(
+            "SELECT normalized_email, role FROM auth_users ORDER BY normalized_email"
+        )
+        assert len(rows) == 4
+        by_email = {r["normalized_email"]: r for r in rows}
+        assert "test@example.com" in by_email
+        assert by_email["test@example.com"]["role"] == "reviewer"
+
+    def test_remove_user_soft_deletes(self, auth_db, users_cli, monkeypatch):
+        """--remove sets account_status='disabled'; user row is not deleted."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+
+        # Seed + add test user.
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+        users_cli.main()
+        monkeypatch.setattr(
+            "sys.argv",
+            ["seed_auth_users.py", "--add", "test@example.com", "reviewer", "Test User"],
+        )
+        users_cli.main()
+
+        # Remove the test user.
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py", "--remove", "test@example.com"])
+        rc = users_cli.main()
+        assert rc == 0
+
+        rows = auth_db.query(
+            "SELECT account_status, disabled_at FROM auth_users "
+            "WHERE normalized_email = 'test@example.com'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["account_status"] == "disabled"
+        assert rows[0]["disabled_at"] is not None
+
+    def test_add_invalid_role_returns_error(self, auth_db, users_cli, monkeypatch):
+        """--add with an invalid role returns non-zero exit code."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["seed_auth_users.py", "--add", "test@example.com", "superadmin", "Test User"],
+        )
+        rc = users_cli.main()
+        assert rc != 0
+
+    def test_list_flag(self, auth_db, users_cli, monkeypatch, capsys):
+        """--list prints users without error."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+        users_cli.main()
+
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py", "--list"])
+        rc = users_cli.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "rgmarkey@gmail.com" in out
+        assert "admin" in out
+
+
+# ---------------------------------------------------------------------------
+# seed_auth_legacy_aliases.py tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedAuthLegacyAliases:
+    def _seed_users(self, auth_db, users_cli, monkeypatch):
+        """Helper: seed the 3 spec users (needed for alias tests)."""
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_users.py"])
+        users_cli.main()
+
+    def test_default_seeds_two_aliases(self, auth_db, users_cli, aliases_cli, monkeypatch):
+        """Default invocation inserts the 2 spec aliases."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py"])
+
+        rc = aliases_cli.main()
+
+        assert rc == 0
+        rows = auth_db.query(
+            "SELECT legacy_reviewer_string, target_email, active "
+            "FROM auth_legacy_aliases ORDER BY legacy_reviewer_string"
+        )
+        assert len(rows) == 2
+        by_legacy = {r["legacy_reviewer_string"]: r for r in rows}
+        assert "Mayu" in by_legacy
+        assert "RGM" in by_legacy
+        assert by_legacy["RGM"]["target_email"] == "rgmarkey@gmail.com"
+        assert by_legacy["Mayu"]["target_email"] == "mayujoiner@gmail.com"
+        assert by_legacy["RGM"]["active"] is True
+        assert by_legacy["Mayu"]["active"] is True
+
+    def test_default_idempotent(self, auth_db, users_cli, aliases_cli, monkeypatch):
+        """Running default twice yields same 2 aliases — no duplicates, no errors."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py"])
+
+        rc1 = aliases_cli.main()
+        rc2 = aliases_cli.main()
+
+        assert rc1 == 0
+        assert rc2 == 0
+        rows = auth_db.query("SELECT legacy_reviewer_string FROM auth_legacy_aliases")
+        assert len(rows) == 2
+
+    def test_add_alias_requires_existing_user(self, auth_db, users_cli, aliases_cli, monkeypatch):
+        """--add errors when the target email is not found in auth_users."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["seed_auth_legacy_aliases.py", "--add", "NEWLEG", "nonexistent@example.com"],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            aliases_cli.main()
+        assert exc_info.value.code != 0
+
+    def test_add_alias_for_existing_user(self, auth_db, users_cli, aliases_cli, monkeypatch):
+        """--add creates a new alias when the target user exists."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["seed_auth_legacy_aliases.py", "--add", "ROB", "rob.markey@cmasb.org"],
+        )
+        rc = aliases_cli.main()
+        assert rc == 0
+
+        rows = auth_db.query(
+            "SELECT target_email FROM auth_legacy_aliases WHERE legacy_reviewer_string = 'ROB'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["target_email"] == "rob.markey@cmasb.org"
+
+    def test_remove_alias_hard_deletes(self, auth_db, users_cli, aliases_cli, monkeypatch):
+        """--remove hard-deletes the alias row."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+
+        # Seed the 2 spec aliases.
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py"])
+        aliases_cli.main()
+
+        # Remove one.
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py", "--remove", "RGM"])
+        rc = aliases_cli.main()
+        assert rc == 0
+
+        rows = auth_db.query("SELECT legacy_reviewer_string FROM auth_legacy_aliases")
+        legacy_strings = [r["legacy_reviewer_string"] for r in rows]
+        assert "RGM" not in legacy_strings
+        assert "Mayu" in legacy_strings
+
+    def test_list_flag(self, auth_db, users_cli, aliases_cli, monkeypatch, capsys):
+        """--list prints aliases without error."""
+        self._seed_users(auth_db, users_cli, monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", auth_db.connection_string)
+
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py"])
+        aliases_cli.main()
+
+        monkeypatch.setattr("sys.argv", ["seed_auth_legacy_aliases.py", "--list"])
+        rc = aliases_cli.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "RGM" in out
+        assert "Mayu" in out


### PR DESCRIPTION
## Summary

- Add `scripts/seed_auth_users.py`: UPSERT three spec users into `auth_users` + `auth_access_entries`, write `admin_audit_log` entries only on real changes, full CLI with `--add` / `--remove` / `--list`
- Add `scripts/seed_auth_legacy_aliases.py`: UPSERT two spec aliases into `auth_legacy_aliases`, same CLI pattern, validates target user exists on `--add`
- Fix UUID-serialization bug in `_row_to_dict` (`UUID` objects from `auth_users.id` raised `TypeError` in `json.dumps`; coerce to `str`)
- Add 15 integration tests under `tests/integration/auth/test_seed_scripts.py` covering default seed, idempotency, audit-log writes, `--add` / `--remove` / `--list` for both scripts

## Test plan

- [x] `pytest -x -q tests/integration/auth/test_seed_scripts.py` — 15/15 passed
- [x] `ruff check` — clean on all three files
- [x] Pre-push unit test hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)