### PR TITLE
worktree dockerfile image model hotfix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,6 +45,12 @@ README.md
 **/filings_cache
 **/logs
 **/data
+# …but the image-relevance model artifact and its training report are
+# COPY'd into the runtime image by Dockerfile (loaded at request time by
+# src/shared/image_features.py for the "Model score" sort). Stopgap until
+# gh-391 (R2 artifact persistence) — until then they must ride in the image.
+!data/image_model/relevance_model.joblib
+!data/image_model/model_report.txt
 
 # Dev tooling, IDE, and AI assistant scaffolding — not read at runtime.
 **/.claude

--- a/docs/known-issues/gh-415-docker-build-not-required-regression.md
+++ b/docs/known-issues/gh-415-docker-build-not-required-regression.md
@@ -1,0 +1,27 @@
+---
+id: 415
+source: gh
+slug: docker-build-not-required-regression
+title: "Docker Build & Smoke should fail-closed (currently non-required, regressions sit on main)"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-01
+updated: 2026-05-01
+gh_issue: 415
+note: Dockerfile-vs-.dockerignore drift broke 4 PRs' CI silently because Docker Build isn't a required check
+---
+
+### Problem
+
+PR #407 added two `COPY` lines to `Dockerfile` for `data/image_model/relevance_model.joblib` and `data/image_model/model_report.txt`, but the existing `.dockerignore` had `**/data` excluding the entire `data/` tree from the BuildKit context. **Docker Build & Smoke** failed on every PR opened after #407 merged (#408, #409, #410, #411 all shipped today with red Docker Build checks). All four still merged because Docker Build & Smoke is not in the required-checks list (Lint / Unit Tests / Vulnerability Scan / Integration Tests / UI E2E (Playwright)).
+
+The hotfix in the accompanying PR adds `!` negation entries to `.dockerignore` so the COPY succeeds, but the deeper bug — a Dockerfile regression silently sitting on main for 6+ hours while every PR's CI signal turned red — needs an explicit guard.
+
+### Next Steps
+
+- Promote **Docker Build & Smoke** to a required check via GitHub branch protection rules so a Dockerfile-vs-`.dockerignore` drift blocks merge.
+- OR replace it with a faster pre-merge coherence check (hadolint with `CopyIgnoredFile` warnings as errors, or a custom script that scans Dockerfile `COPY` paths against the `.dockerignore`).
+- Decide which once Stages A–C of the auth rollout settle — auth team is currently shipping multiple PRs/day, so tightening required checks during high-throughput iteration risks blocking unrelated work.


### PR DESCRIPTION
- **fix(docker): un-ignore image_model artifacts so runtime COPY succeeds**
- **docs(known-issues): log issue #415 — docker build & smoke should be required**
