### PR TITLE
fix(tests): update chart e2e mock call count for Wave B4 two-stage routing (gh-381)

### DIFF
--- a/docs/known-issues/gh-381-chart-e2e-mock-call-count-regression.md
+++ b/docs/known-issues/gh-381-chart-e2e-mock-call-count-regression.md
@@ -13,6 +13,8 @@ touches:
 discovered: 2026-05-01
 updated: 2026-05-01
 gh_issue: 381
+pr_refs:
+  - 417
 note: OCRExtractionStage now calls analyze_image twice per CHART asset; mock test expects one. Likely tied to PR #360 per-site vision env split.
 ---
 

--- a/docs/known-issues/gh-381-chart-e2e-mock-call-count-regression.md
+++ b/docs/known-issues/gh-381-chart-e2e-mock-call-count-regression.md
@@ -3,9 +3,9 @@ id: 381
 source: gh
 slug: chart-e2e-mock-call-count-regression
 title: "test_chart_extraction_produces_chart_data: MockVisionClient.call_count == 2 (expected 1)"
-status: open
+status: resolved
 severity: medium
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches:
   - src/extraction_v2/stages/ocr_extraction.py
@@ -26,3 +26,7 @@ Likely correlated with the recent per-site vision model env knobs (commit `7768c
 
 - Decide whether the second call is intentional (e.g. re-prompt with refined `detected_metrics`) or accidental (double-dispatch). If intentional, update the test's expected count + add a comment naming the two stages. If accidental, root-cause and fix in `OCRExtractionStage.process()` / chart sub-pipeline.
 - Until decided: this test masks future chart-pipeline regressions, so prioritise.
+
+### Resolution
+
+The second `analyze_image_targeted` call is intentional Wave B4 two-stage chart routing in `OCRExtractionStage.process_chart()`, gated by `VISION_ROUTING_MODE=two_stage`. When in two-stage mode, the chart path makes two vision calls: (1) `chart_ocr` — fast triage pass to extract axis labels / legends / annotation text, and (2) `chart_read` — premium reader with the OCR blob injected as grounding context. `two_stage` is the production default (documented in `.claude/rules/v2-pipeline.md`); the matching unit test `test_two_stage_mode_makes_two_calls_and_sums_cost` already expected 2 calls. PR #360 (named in the original note as "likely tied") affected full-page-scan / prescan only — not the chart path. The integration tests were stale, not the production code. Fix: extended the autouse fixture to pin `VISION_ROUTING_MODE=two_stage` (hermetic against `.env` drift, following gh-366 precedent) and updated both stale assertions (`call_count`, `chart_calls`, `total_api_calls`) to expect 2.

--- a/tests/integration/test_chart_e2e.py
+++ b/tests/integration/test_chart_e2e.py
@@ -27,12 +27,13 @@ from src.llm.vision_client import VisionResponse
 
 @pytest.fixture(autouse=True)
 def _route_image_cache_to_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Route LocalFilesystemStorage under tmp_path for all tests in this module."""
+    """Route LocalFilesystemStorage under tmp_path; pin VISION_ROUTING_MODE."""
     from src.infra.image_storage import get_image_storage
     from src.infra.paths import image_cache_dir
 
     monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path))
     monkeypatch.delenv("R2_BUCKET", raising=False)
+    monkeypatch.setenv("VISION_ROUTING_MODE", "two_stage")
     image_cache_dir.cache_clear()
     get_image_storage.cache_clear()
     yield
@@ -150,7 +151,8 @@ class TestChartExtractionE2E:
         result = stage.process(context)
 
         assert result.success is True
-        assert mock_client.call_count == 1
+        # Wave B4 two-stage chart routing: chart_ocr triage + chart_read premium
+        assert mock_client.call_count == 2
         assert asset.processed is True
         assert asset.chart_data is not None
         assert asset.chart_data.chart_type == ChartType.BAR


### PR DESCRIPTION
Pin VISION_ROUTING_MODE=two_stage in autouse fixture for hermeticity (gh-366 pattern).
Update test_chart_extraction_produces_chart_data to expect call_count==2 (chart_ocr
triage + chart_read premium). Close gh-381 fragment as resolved.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
