### PR TITLE
feat(retrain): enforce sklearn version match against requirements.lock (gh-406)

### DIFF
--- a/docs/known-issues/gh-406-retrain-sklearn-version-check.md
+++ b/docs/known-issues/gh-406-retrain-sklearn-version-check.md
@@ -11,6 +11,8 @@ touches: []
 discovered: 2026-05-01
 updated: 2026-05-01
 gh_issue: 406
+pr_refs:
+  - 420
 note: silent unpickle failure on Render when local-venv sklearn major drifts from requirements.lock pin (1.8.0)
 ---
 

--- a/docs/known-issues/gh-406-retrain-sklearn-version-check.md
+++ b/docs/known-issues/gh-406-retrain-sklearn-version-check.md
@@ -3,9 +3,9 @@ id: 406
 source: gh
 slug: retrain-sklearn-version-check
 title: retrain_image_triage.py should enforce sklearn version match against requirements.lock
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches: []
 discovered: 2026-05-01
@@ -25,3 +25,18 @@ Discovered while implementing the model-score sort UI (PR for image-model-sort, 
 - At the top of `scripts/retrain_image_triage.py`, exit with a clear error if `sklearn.__version__` doesn't match the version in `requirements.lock`. Print installed, expected, and the suggested `pip install -r requirements.lock` fix.
 - Same check belongs in the worker-spawned retrain when gh-400 (queue + worker pattern) lands.
 - Optionally gate behind `--allow-version-mismatch` for experimental local runs that don't intend to ship the artifact to prod.
+
+### Resolution
+
+Added two helpers to `scripts/retrain_image_triage.py`:
+
+- `_read_pinned_sklearn_version()` — reads the pin from `requirements.lock` at runtime (single source of truth; no hardcoded version in the script).
+- `check_sklearn_version(*, allow_mismatch: bool = False)` — imports sklearn, compares `sklearn.__version__` against the pin, and calls `sys.exit(1)` on mismatch with a clear operator message (installed, expected, and fix command). Logs a warning instead when `allow_mismatch=True`.
+
+Added `--allow-version-mismatch` argparse flag to `main()` for local experimentation. The guard is called in `main()` after `configure_logging()` and before the database URL validation, so it fires early before any expensive work.
+
+The `sys.exit(1)` path is captured by the existing `except SystemExit` block in run-id mode (line 232), so the `model_training_runs` row is correctly marked `failed`. The guard covers all production invocation paths (CLI and web endpoint via `_spawn_retrain_runner`) — no change to `train_image_relevance_model.py` or `api_unified.py` was needed.
+
+When gh-400 (retrain queue + worker pattern) lands, the orchestrator script still runs as a subprocess from the worker, so the guard placement remains valid.
+
+Tests added at `tests/unit/scripts/test_retrain_image_triage.py` (4 cases: semver sanity, match passes, mismatch exits, allow_mismatch warns-not-exits).

--- a/docs/known-issues/gh-419-predict-relevance-silent-load-error.md
+++ b/docs/known-issues/gh-419-predict-relevance-silent-load-error.md
@@ -1,0 +1,27 @@
+---
+id: 419
+source: gh
+slug: predict-relevance-silent-load-error
+title: predict_relevance() silently swallows joblib load errors — runtime failure indistinguishable from model absent
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-01
+updated: 2026-05-01
+gh_issue: 419
+note: _load_model() catches all exceptions and returns None; corrupt or unloadable artifact degrades silently to heuristic
+---
+
+### Problem
+
+`src/shared/image_features.py::_load_model()` catches all exceptions on `joblib.load()` and returns `None`. `predict_relevance()` treats `None` as "no model trained" and falls back to heuristic scoring. This makes a corrupt artifact, failed R2 download, or unexpected joblib format produce no observable error — the image sort silently degrades to heuristic without any log signal.
+
+Surfaced while adding the sklearn version guard in `scripts/retrain_image_triage.py` (gh-406). The new guard prevents version mismatch at train time, but other load failure modes at runtime remain silent.
+
+### Next Steps
+
+- Add a specific `except` clause distinguishing "file not found" (model absent, expected) from other load failures (unexpected — should warn or raise).
+- Log at `WARNING` or `ERROR` level when load fails for a reason other than missing file so operators can detect silent degradation.
+- Consider a startup or health-check validation that confirms the artifact loads cleanly when `USE_LEARNED_TRIAGE=true`.

--- a/scripts/retrain_image_triage.py
+++ b/scripts/retrain_image_triage.py
@@ -153,6 +153,41 @@ def _finalize_run(args: argparse.Namespace) -> None:
     )
 
 
+def _read_pinned_sklearn_version() -> str:
+    """Read the sklearn pin from requirements.lock (single source of truth)."""
+    lock_path = Path(__file__).resolve().parent.parent / "requirements.lock"
+    for line in lock_path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("scikit-learn==") and not stripped.startswith("#"):
+            return stripped.split("==", 1)[1].split()[0]
+    raise RuntimeError(
+        f"scikit-learn pin not found in {lock_path}. "
+        "Refusing to retrain without a known target version."
+    )
+
+
+def check_sklearn_version(*, allow_mismatch: bool = False) -> None:
+    """Exit with a clear error if local sklearn != requirements.lock pin."""
+    import sklearn  # noqa: PLC0415
+
+    pinned = _read_pinned_sklearn_version()
+    installed = sklearn.__version__
+    if installed == pinned:
+        return
+    msg = (
+        f"sklearn version mismatch: requirements.lock pins {pinned}, "
+        f"local venv has {installed}. A version-mismatched joblib "
+        "unpickles silently into None on Render — predict_relevance "
+        "returns None, no error is raised. Run: "
+        "uv pip install -r requirements.lock"
+    )
+    if allow_mismatch:
+        logger.warning("%s (continuing because --allow-version-mismatch was set)", msg)
+        return
+    logger.error(msg)
+    sys.exit(1)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Monthly retrain wrapper for the image relevance triage model",
@@ -214,9 +249,18 @@ def main() -> None:
             "leave this unset."
         ),
     )
+    parser.add_argument(
+        "--allow-version-mismatch",
+        action="store_true",
+        help=(
+            "Skip the sklearn version guard. For local experimentation only — "
+            "produced joblib will not load on Render."
+        ),
+    )
     args = parser.parse_args()
 
     configure_logging(level="INFO")
+    check_sklearn_version(allow_mismatch=args.allow_version_mismatch)
 
     if not args.database_url and args.source in ("sec", "all"):
         logger.error("No database URL available. Set $TEST_DATABASE_URL or pass --database-url.")

--- a/tests/unit/scripts/test_retrain_image_triage.py
+++ b/tests/unit/scripts/test_retrain_image_triage.py
@@ -1,0 +1,67 @@
+"""Unit tests for the sklearn version guard in scripts/retrain_image_triage.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "retrain_image_triage.py"
+
+
+def _load_module() -> Any:
+    root = str(_SCRIPT_PATH.parent.parent)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    spec = importlib.util.spec_from_file_location("retrain_image_triage", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["retrain_image_triage"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_module()
+
+
+def test_read_pinned_sklearn_version_returns_semver(script: Any) -> None:
+    version = script._read_pinned_sklearn_version()
+    parts = version.split(".")
+    assert len(parts) >= 2, f"Expected semver, got: {version!r}"
+    assert all(p.isdigit() for p in parts), f"Non-numeric version parts in: {version!r}"
+
+
+def test_check_sklearn_version_passes_on_match(
+    script: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pinned = script._read_pinned_sklearn_version()
+    monkeypatch.setattr("sklearn.__version__", pinned)
+    script.check_sklearn_version()  # must not raise or exit
+
+
+def test_check_sklearn_version_exits_on_mismatch(
+    script: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("sklearn.__version__", "0.0.0-mock")
+    with pytest.raises(SystemExit) as exc_info:
+        script.check_sklearn_version()
+    assert exc_info.value.code == 1
+
+
+def test_check_sklearn_version_allow_mismatch_warns_not_exits(
+    script: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr("sklearn.__version__", "0.0.0-mock")
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="retrain_image_triage"):
+        script.check_sklearn_version(allow_mismatch=True)
+
+    assert any("--allow-version-mismatch" in record.message for record in caplog.records), (
+        "Expected warning mentioning --allow-version-mismatch"
+    )


### PR DESCRIPTION
## Summary

- Adds `_read_pinned_sklearn_version()` and `check_sklearn_version()` helpers to `scripts/retrain_image_triage.py`
- Guard fires at the top of `main()` after `configure_logging()`, before the export step wastes time; calls `sys.exit(1)` on mismatch so the `model_training_runs` row is correctly marked `failed` via the existing `except SystemExit` handler
- Reads the sklearn pin from `requirements.lock` at runtime — no hardcoded version in the script
- `--allow-version-mismatch` flag for local experimentation (logs warning, does not exit)
- Closes gh-406; also logs gh-419 (silent-None swallow in `_load_model()`, deferred)

## Test plan

- [ ] `pytest tests/unit/scripts/test_retrain_image_triage.py -v` — 4 cases: semver sanity, match passes, mismatch exits(1), allow_mismatch warns-not-exits
- [ ] Full unit suite: 4892 passed locally
- [ ] Lint: ruff clean
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)