### PR TITLE
fix(ci): add types to check_docs_sync stdlib allowlist

### DIFF
--- a/scripts/check_docs_sync.py
+++ b/scripts/check_docs_sync.py
@@ -185,6 +185,7 @@ class DocsChecker:
             "threading",
             "time",
             "traceback",
+            "types",
             "typing",
             "unittest",
             "urllib",


### PR DESCRIPTION
## Summary

- Adds `types` to the stdlib exclusion list in `scripts/check_docs_sync.py`
- `src/auth/dev_bypass.py` (merged in #409) uses `import types`, which is standard library — the checker was incorrectly flagging it as a missing third-party requirement on every PR since then

## Test plan

- [ ] `Check Documentation Freshness` passes in CI
- [ ] `python3 scripts/check_docs_sync.py --ci` exits 0 locally (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)