### PR TITLE
feat(retrain): persist image-relevance model artifacts to R2 (gh-391)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -179,7 +179,62 @@ remove them after the soak window.
 `R2FilingStorage.put_bytes` refuses to write unless
 `FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` is in the process environment, mirroring
 `R2Storage.put_bytes`. Reads (`get_bytes`, `exists`) remain open. The same env
-var gates both image and filing R2 writes.
+var gates image, filing, and model R2 writes.
+
+## Model Artifact Storage
+
+Image-relevance retrain artifacts (model joblib + training CSV + report)
+persist via `src/infra/model_storage.py` — same pattern as image and filing
+storage, parallel surface. Two backends selected at runtime via `R2_BUCKET`:
+
+- **Local filesystem** (default, dev/test): `LocalFilesystemModelStorage`
+  rooted at `<repo>/data/image_model/`.
+- **Cloudflare R2** (prod): `R2ModelStorage` shares the bucket with image and
+  filing bytes; key prefix `models/` separates from `pipeline/` (image cache),
+  `filings/` (filing HTML), and `ingestion/` (per-filing image cache).
+
+Keys (under prefix `models/image_relevance/`):
+
+```
+models/image_relevance/<run_id>/relevance_model.joblib
+models/image_relevance/<run_id>/model_report.txt
+models/image_relevance/<run_id>/training_data.csv
+models/image_relevance/latest_run_id.txt   # bare UUID string, single writer
+```
+
+`model_training_runs.model_path` and `report_path` store opaque storage keys
+post-gh-391 (e.g. `models/image_relevance/<uuid>/relevance_model.joblib`), not
+absolute filesystem paths. The columns are display-only — the loader
+(`src/shared/image_features._load_model`) does NOT read them; it goes straight
+to `latest_run_id.txt` to find the active model. Pre-cutover rows whose
+`model_path` is an absolute path remain readable as opaque text; no backfill
+is required.
+
+**Writer-side.** `scripts/retrain_image_triage.py::_finalize_run` uploads the
+three per-run artifacts via the storage abstraction and then writes
+`latest_run_id.txt` *last* (so a partial-upload failure leaves the previous
+pointer valid). Single-writer is guaranteed for web-triggered retrains by the
+concurrency gate in `src/web/routes/api_unified.py::trigger_image_classifier_retrain`
+— a `model_type='image_relevance' AND status='running'` row blocks a second
+attempt with HTTP 409. CLI users invoking the script directly bypass that
+gate; document, do not enforce.
+
+**Reader-side.** When `R2_BUCKET` is set, `_load_model(model_path=None)` reads
+the pointer key, uses the contained run-id as the in-memory cache key, and
+materializes the joblib bytes to `data/image_model/_cache/<run_id>/relevance_model.joblib`
+(atomic via tempfile + `os.replace`) before `joblib.load`. Run-id-keyed
+filenames sidestep concurrent-worker write races. When `R2_BUCKET` is unset,
+the loader uses `data/image_model/relevance_model.joblib` from local disk
+directly — identical behavior to pre-gh-391. Storage failures
+(`ClientError` / `EndpointConnectionError`) are caught and return `None` so
+extraction falls back to the heuristic instead of crashing.
+
+### Prod-write guard
+
+`R2ModelStorage.put_bytes` refuses to write unless
+`FILINGS_REVIEWER_ALLOW_PROD_WRITES=1` is in the process environment, mirroring
+the image and filing backends. Reads remain open. The same env var gates all
+three R2 write paths.
 
 ## SEC EDGAR Integration
 

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -26,7 +26,14 @@ Powers the **Update Image Classifier** button on `/v2/review/stats` (Metric Anal
 
 **Retrain script writeback** (`scripts/retrain_image_triage.py --run-id <uuid>`): the optional `--run-id` flag tells the script to UPDATE the row on completion — `status='succeeded'` plus `num_training_rows`, `num_positive_rows`, `model_path`, `report_path`, `completed_at`. A top-level try/except flips the row to `status='failed', error=<exc>` on any Python exception. **SIGKILL/OOM still leak past Python** — the signal handler is bypassed entirely — but the retrain endpoint sweeps stale rows on every attempt (gh-392): `UPDATE model_training_runs SET status='failed', error='auto-cleanup: stale running row (>1h, gh-392)' WHERE model_type='image_relevance' AND status='running' AND started_at < NOW() - INTERVAL '1 hour'` runs before the concurrency check. So a leaked row from a SIGKILL'd subprocess no longer permanently blocks future retrains — at worst the operator waits an hour and re-clicks. The same SQL is the manual escape hatch if you don't want to wait (scope to a specific id: `WHERE id = '<uuid>'`).
 
-**Render disk ephemerality**: the retrain writes to `data/image_model/`. On Render that disk is wiped on every deploy. Today this is harmless because `USE_LEARNED_TRIAGE=false` in prod (the model isn't loaded). The moment that flag flips on, retrains performed via the UI will silently disappear on the next deploy — persist artifacts to R2 first (tracked in known-issues).
+**Artifact persistence**: post-gh-391 the retrain wrapper uploads
+`relevance_model.joblib` + report + training CSV to R2 under
+`models/image_relevance/<run_id>/...` and writes a `latest_run_id.txt` pointer
+that the loader reads on cold start. `model_training_runs.model_path` /
+`report_path` columns now hold opaque storage keys, not absolute filesystem
+paths — see `.claude/rules/infrastructure.md#model-artifact-storage`. Render
+deploys no longer wipe retrains; `USE_LEARNED_TRIAGE=true` is safe to enable
+once the persistence path has been verified end-to-end in staging.
 
 Threshold env vars are surfaced to the template by `review_unified.stats()` so the helper text on the disabled button reads "Need N more total decisions" / "Need M more positive decisions". The `button_active` flag combines `not retrain_running AND total >= threshold_total AND positive >= threshold_positive`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ Image bytes live in Cloudflare R2 (prod) / local filesystem (dev) via `src/infra
 
 Filing HTML persists the same way via `src/infra/filing_storage.py` (gh-300). `filings.html_storage_path` stores an opaque storage key (e.g. `filings/<cik>/<accession>/primary.htm`). Post-gh-315, the fetcher writes R2 keys directly on every successful fetch; legacy filesystem paths from pre-gh-315 rows still resolve via the existing disk + `html_content` DB-blob fallback. See `.claude/rules/infrastructure.md#filing-html-storage`.
 
+Image-relevance retrain artifacts (model joblib + report + training CSV) persist the same way via `src/infra/model_storage.py` (gh-391). `model_training_runs.model_path` / `report_path` store opaque storage keys (e.g. `models/image_relevance/<run_id>/relevance_model.joblib`); a `models/image_relevance/latest_run_id.txt` pointer drives the loader. See `.claude/rules/infrastructure.md#model-artifact-storage`.
+
 ## Testing Standards
 
 - **Coverage**: 80% minimum (enforced)

--- a/scripts/retrain_image_triage.py
+++ b/scripts/retrain_image_triage.py
@@ -20,8 +20,22 @@ Operator notes:
     - Defaults to $TEST_DATABASE_URL (local Docker) so you must pass
       --database-url explicitly for production Neon (or set DATABASE_URL to the
       prod URL and pass --use-env-database-url).
-    - The trained artifact is written to data/image_model/relevance_model.joblib,
-      which src/shared/image_features.predict_relevance() loads at runtime.
+    - When R2_BUCKET is set (prod / staging), the wrapper uploads the joblib
+      + report + training CSV to ``models/image_relevance/<run_id>/...`` and
+      writes a ``models/image_relevance/latest_run_id.txt`` pointer last; the
+      loader (src/shared/image_features._load_model) reads the pointer on cold
+      start. Local dev (R2_BUCKET unset) writes only to data/image_model/ as
+      before. See .claude/rules/infrastructure.md#model-artifact-storage.
+    - model_training_runs.model_path / report_path columns hold opaque storage
+      keys post-gh-391 (e.g. ``models/image_relevance/<uuid>/relevance_model.joblib``),
+      not absolute filesystem paths.
+    - Single-writer to ``latest_run_id.txt`` is guaranteed for web-triggered
+      retrains by the concurrency gate in api_unified.py. CLI users invoking
+      this script directly bypass that gate; do not run two retrains against
+      the same R2 bucket concurrently.
+    - The trained artifact is also written to data/image_model/relevance_model.joblib
+      locally as scratch (subprocess output target); when R2 is the source of
+      truth the loader reads from R2, not from this file.
     - Set USE_LEARNED_TRIAGE=true in the environment to activate the model gate
       in the extraction pipeline.
 """
@@ -48,6 +62,56 @@ TRAIN_SCRIPT = ROOT / "scripts" / "train_image_relevance_model.py"
 DEFAULT_CSV = ROOT / "data" / "image_model" / "training_data.csv"
 DEFAULT_MODEL = ROOT / "data" / "image_model" / "relevance_model.joblib"
 DEFAULT_REPORT = ROOT / "data" / "image_model" / "model_report.txt"
+
+
+def _storage_keys_for_run(run_id: str) -> dict[str, str]:
+    """Return per-run storage keys. Stable shape for both backends."""
+    from src.infra.model_storage import model_key_for_run
+
+    return {
+        "model_key": model_key_for_run(run_id, "relevance_model.joblib"),
+        "report_key": model_key_for_run(run_id, "model_report.txt"),
+        "csv_key": model_key_for_run(run_id, "training_data.csv"),
+    }
+
+
+def _upload_artifacts(
+    run_id: str,
+    *,
+    model_path: str,
+    report_path: str,
+    csv_path: str,
+) -> dict[str, str]:
+    """Upload the three artifacts and the latest_run_id pointer (pointer last).
+
+    Returns the storage-key dict so the caller can write the per-run keys back
+    to model_training_runs. Errors propagate so the orchestrator's try/except
+    flips the run row to status='failed'. The pointer is uploaded last so a
+    partial-upload failure leaves the previous pointer valid.
+    """
+    # Local import keeps the wrapper snappy on --dry-run / --help paths.
+    from src.infra.model_storage import LATEST_POINTER_KEY, get_model_storage
+
+    storage = get_model_storage()
+    keys = _storage_keys_for_run(run_id)
+
+    uploads: list[tuple[str, Path, str]] = [
+        (keys["model_key"], Path(model_path), "application/octet-stream"),
+        (keys["report_key"], Path(report_path), "text/plain"),
+        (keys["csv_key"], Path(csv_path), "text/csv"),
+    ]
+    for key, path, content_type in uploads:
+        # Trust read_bytes() to raise FileNotFoundError with a clear traceback
+        # — pre-checking with path.exists() is TOCTOU and adds nothing.
+        data = path.read_bytes()
+        logger.info("Uploading %s -> %s (%d bytes)", path, key, len(data))
+        storage.put_bytes(key, data, content_type=content_type)
+
+    # Pointer last — a half-uploaded artifact set must not become "latest".
+    logger.info("Updating %s -> %s", LATEST_POINTER_KEY, run_id)
+    storage.put_bytes(LATEST_POINTER_KEY, run_id.encode("utf-8"), content_type="text/plain")
+
+    return keys
 
 
 def _run(cmd: list[str], *, dry_run: bool) -> None:
@@ -135,21 +199,34 @@ def _update_run_status(
 
 
 def _finalize_run(args: argparse.Namespace) -> None:
-    """Write status='succeeded' + metrics on a clean run."""
+    """Upload artifacts to storage, then write status='succeeded' + metrics.
+
+    The DB row's model_path / report_path columns receive opaque storage keys
+    (not local filesystem paths) — see .claude/rules/infrastructure.md#model-artifact-storage.
+    Pointer write happens inside _upload_artifacts so a failure there raises
+    before the DB row is finalized; the orchestrator's try/except then flips
+    status='failed'.
+    """
     if args.dry_run:
         # Dry-run produced no artifact; mark succeeded with zero rows so the row
         # doesn't sit forever, but skip path/metric fields.
         _update_run_status(args.database_url, args.run_id, status="succeeded")
         return
     total, positive = _count_training_rows(args.output_csv)
+    keys = _upload_artifacts(
+        args.run_id,
+        model_path=args.output_model,
+        report_path=args.output_report,
+        csv_path=args.output_csv,
+    )
     _update_run_status(
         args.database_url,
         args.run_id,
         status="succeeded",
         num_training_rows=total,
         num_positive_rows=positive,
-        model_path=args.output_model,
-        report_path=args.output_report,
+        model_path=keys["model_key"],
+        report_path=keys["report_key"],
     )
 
 

--- a/src/infra/model_storage.py
+++ b/src/infra/model_storage.py
@@ -1,0 +1,158 @@
+"""Model artifact storage backends: local filesystem (dev/test) or R2 (prod).
+
+Selects via ``R2_BUCKET`` env var. When set, :func:`get_model_storage` returns
+:class:`R2ModelStorage`; otherwise it falls back to
+:class:`LocalFilesystemModelStorage` rooted at :func:`src.infra.paths.model_cache_dir`.
+
+Persists the image-relevance retrain artifacts (model joblib + training CSV +
+report) so UI-triggered retrains survive the next Render deploy. ``data/image_model/``
+on Render is ephemeral; under ``USE_LEARNED_TRIAGE=true`` an artifact written to
+local disk would silently disappear on the next deploy. See gh-391.
+
+Keys (under prefix ``models/image_relevance/``):
+
+  ``models/image_relevance/<run_id>/relevance_model.joblib``
+  ``models/image_relevance/<run_id>/model_report.txt``
+  ``models/image_relevance/<run_id>/training_data.csv``
+  ``models/image_relevance/latest_run_id.txt``        # bare UUID, single writer
+
+The ``latest_run_id.txt`` pointer is written *last* by the retrain wrapper so a
+partial upload failure leaves the previous pointer valid. Single-writer is
+guaranteed for web-triggered retrains by the concurrency gate at
+``src/web/routes/api_unified.py``.
+
+Mirrors :mod:`src.infra.image_storage` and :mod:`src.infra.filing_storage`
+exactly; the only differences are the default ``content_type`` and the local
+backend's root directory.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol
+
+from src.infra.image_storage import InvalidStorageKeyError, validate_key  # noqa: F401
+from src.infra.paths import model_cache_dir
+
+# Storage layout — single source of truth, imported by both the writer
+# (scripts/retrain_image_triage.py) and the reader (src/shared/image_features.py).
+MODEL_KEY_PREFIX = "models/image_relevance"
+LATEST_POINTER_KEY = f"{MODEL_KEY_PREFIX}/latest_run_id.txt"
+
+
+def model_key_for_run(run_id: str, filename: str) -> str:
+    """Build the per-run storage key for one artifact (joblib / report / csv)."""
+    return f"{MODEL_KEY_PREFIX}/{run_id}/{filename}"
+
+
+class ModelStorage(Protocol):
+    def put_bytes(
+        self, key: str, data: bytes, content_type: str = "application/octet-stream"
+    ) -> None: ...
+    def get_bytes(self, key: str) -> bytes: ...
+    def exists(self, key: str) -> bool: ...
+
+
+class LocalFilesystemModelStorage:
+    """Filesystem backend. Keys map to ``<root>/<key>``."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def _path(self, key: str) -> Path:
+        validate_key(key)
+        return self._root / key
+
+    def put_bytes(
+        self, key: str, data: bytes, content_type: str = "application/octet-stream"
+    ) -> None:
+        p = self._path(key)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+
+    def get_bytes(self, key: str) -> bytes:
+        p = self._path(key)
+        if not p.exists():
+            raise FileNotFoundError(f"Model artifact not found: {key}")
+        return p.read_bytes()
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).exists()
+
+
+class R2ModelStorage:
+    """Cloudflare R2 (S3-compatible) backend."""
+
+    def __init__(self, bucket: str, endpoint: str, access_key: str, secret_key: str) -> None:
+        import boto3
+        from botocore.config import Config
+
+        self._bucket = bucket
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            config=Config(signature_version="s3v4", retries={"max_attempts": 3}),
+            region_name="auto",
+        )
+
+    def put_bytes(
+        self, key: str, data: bytes, content_type: str = "application/octet-stream"
+    ) -> None:
+        if os.environ.get("FILINGS_REVIEWER_ALLOW_PROD_WRITES") != "1":
+            raise RuntimeError(
+                "Refusing R2 write — set FILINGS_REVIEWER_ALLOW_PROD_WRITES=1 to allow. "
+                "This guard prevents accidental prod R2 mutations when running CLI tools "
+                "with prod credentials in the environment."
+            )
+        validate_key(key)
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+        )
+
+    def get_bytes(self, key: str) -> bytes:
+        from botocore.exceptions import ClientError
+
+        validate_key(key)
+        try:
+            resp = self._client.get_object(Bucket=self._bucket, Key=key)
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                raise FileNotFoundError(f"Model artifact not found: {key}") from exc
+            raise
+        return resp["Body"].read()
+
+    def exists(self, key: str) -> bool:
+        from botocore.exceptions import ClientError
+
+        validate_key(key)
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=key)
+            return True
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                return False
+            raise
+
+
+@lru_cache(maxsize=1)
+def get_model_storage() -> ModelStorage:
+    """Return the active backend. R2 if ``R2_BUCKET`` is set; else local filesystem.
+
+    Callers that mutate ``R2_*`` env vars (tests) must call ``cache_clear()``.
+    """
+    bucket = os.environ.get("R2_BUCKET")
+    if bucket:
+        return R2ModelStorage(
+            bucket=bucket,
+            endpoint=os.environ["R2_ENDPOINT_URL"],
+            access_key=os.environ["R2_ACCESS_KEY_ID"],
+            secret_key=os.environ["R2_SECRET_ACCESS_KEY"],
+        )
+    return LocalFilesystemModelStorage(model_cache_dir())

--- a/src/infra/paths.py
+++ b/src/infra/paths.py
@@ -14,6 +14,23 @@ def image_cache_dir() -> Path:
     that mutate the env var must call ``image_cache_dir.cache_clear()``.
     """
     override = os.environ.get("IMAGE_CACHE_DIR")
-    root = Path(override) if override else Path(__file__).resolve().parents[2] / "data" / "image_cache"
+    root = (
+        Path(override) if override else Path(__file__).resolve().parents[2] / "data" / "image_cache"
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@lru_cache(maxsize=1)
+def model_cache_dir() -> Path:
+    """Return the model-artifact cache root, creating it on first access.
+
+    Used by :mod:`src.infra.model_storage` as the local backend root and by
+    :func:`src.shared.image_features._load_model` as the materialization
+    scratch directory (``_cache/<run_id>/``) when R2 is the source of truth.
+    No env-var override — the path is fixed at ``<repo>/data/image_model/`` so
+    Render's ephemeral disk semantics are explicit.
+    """
+    root = Path(__file__).resolve().parents[2] / "data" / "image_model"
     root.mkdir(parents=True, exist_ok=True)
     return root

--- a/src/shared/image_features.py
+++ b/src/shared/image_features.py
@@ -22,7 +22,9 @@ Expected row dict keys (common format):
 from __future__ import annotations
 
 import logging
+import os
 import re
+import tempfile
 import threading
 from pathlib import Path
 from typing import Any
@@ -36,8 +38,14 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MODEL_LOCK = threading.Lock()
-_MODEL_CACHE: dict[str, Any] = {}  # path → loaded pipeline (or sentinel None)
+_MODEL_CACHE: dict[str, Any] = {}  # cache-key → loaded pipeline (or sentinel)
 _MODEL_ABSENT: object = object()  # sentinel: model file was not found
+# Cached "active run_id" resolved from the latest_run_id pointer. Set once per
+# worker per cold start, reused for the worker's lifetime to avoid one R2 GET
+# per predict call. Workers naturally rotate on Render deploy / cron run, so
+# the staleness window is bounded — see docs/known-issues/gh-391 closure.
+_ACTIVE_RUN_ID: str | None = None
+_ACTIVE_RUN_ID_RESOLVED = False
 
 DEFAULT_MODEL_PATH = (
     Path(__file__).resolve().parent.parent.parent
@@ -47,13 +55,137 @@ DEFAULT_MODEL_PATH = (
 )
 
 
-def _load_model(model_path: Path | None = None) -> Any | None:
-    """Load (and cache) the sklearn pipeline from disk.
+def _materialize_from_storage(run_id: str) -> Path | None:
+    """Ensure the per-run joblib exists locally; return its path or None on failure.
 
-    Returns the fitted pipeline, or None if the file is missing or fails to
-    load.  The result is cached per resolved path so subsequent calls are
-    free of I/O.
+    Uses ``data/image_model/_cache/<run_id>/relevance_model.joblib`` as the
+    materialization target. Run-id-keyed filenames sidestep races between
+    concurrent gunicorn workers writing the same cache path. Atomic via
+    tempfile + os.replace.
+
+    Storage failures (ClientError, EndpointConnectionError, FileNotFoundError)
+    are caught and return None — the caller treats that as "model absent" and
+    falls back to the heuristic.
     """
+    from src.infra.model_storage import get_model_storage, model_key_for_run
+    from src.infra.paths import model_cache_dir
+
+    target_dir = model_cache_dir() / "_cache" / run_id
+    target = target_dir / "relevance_model.joblib"
+    if target.exists():
+        return target
+
+    storage = get_model_storage()
+    model_key = model_key_for_run(run_id, "relevance_model.joblib")
+    try:
+        data = storage.get_bytes(model_key)
+    except FileNotFoundError:
+        logger.warning(
+            "Pointer references run_id=%s but %s is missing in storage", run_id, model_key
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — boto3 surfaces many exception types
+        logger.warning("Failed to fetch %s from storage: %s", model_key, exc)
+        return None
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling tempfile and rename — concurrent loaders never see a
+    # half-written joblib.
+    with tempfile.NamedTemporaryFile(
+        dir=target_dir, prefix=".relevance_model.", suffix=".joblib.tmp", delete=False
+    ) as tmp:
+        tmp.write(data)
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, target)
+    logger.info("Materialized %s -> %s (%d bytes)", model_key, target, len(data))
+    return target
+
+
+def _resolve_active_run_id() -> str | None:
+    """Read latest_run_id from storage; cached for the worker's lifetime.
+
+    First call per worker reads the pointer; subsequent calls return the cached
+    value. Reset via :func:`_reset_active_run_id_cache` (tests only). Workers
+    rotate on Render deploy / cron run, bounding staleness — see gh-391.
+    """
+    global _ACTIVE_RUN_ID, _ACTIVE_RUN_ID_RESOLVED
+    if _ACTIVE_RUN_ID_RESOLVED:
+        return _ACTIVE_RUN_ID
+
+    from src.infra.model_storage import LATEST_POINTER_KEY, get_model_storage
+
+    storage = get_model_storage()
+    try:
+        run_id: str | None = storage.get_bytes(LATEST_POINTER_KEY).decode("utf-8").strip()
+    except FileNotFoundError:
+        logger.debug("No %s pointer in storage — falling back to heuristic", LATEST_POINTER_KEY)
+        run_id = None
+    except Exception as exc:  # noqa: BLE001
+        # Don't memoize transient errors — a future call should retry.
+        logger.warning("Failed to read %s: %s", LATEST_POINTER_KEY, exc)
+        return None
+
+    _ACTIVE_RUN_ID = run_id
+    _ACTIVE_RUN_ID_RESOLVED = True
+    return run_id
+
+
+def _reset_active_run_id_cache() -> None:
+    """Clear the cached pointer resolution. Tests only."""
+    global _ACTIVE_RUN_ID, _ACTIVE_RUN_ID_RESOLVED
+    _ACTIVE_RUN_ID = None
+    _ACTIVE_RUN_ID_RESOLVED = False
+
+
+def _load_joblib_into_cache(local_path: Path, cache_key: str) -> Any | None:
+    """joblib.load + cache write + sentinel-on-failure. Caller holds _MODEL_LOCK."""
+    try:
+        import joblib  # optional heavy import; only at prediction time
+
+        pipeline = joblib.load(local_path)
+        _MODEL_CACHE[cache_key] = pipeline
+        logger.info("Loaded image relevance model from %s", local_path)
+        return pipeline
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load image relevance model from %s: %s", local_path, exc)
+        _MODEL_CACHE[cache_key] = _MODEL_ABSENT
+        return None
+
+
+def _load_model(model_path: Path | None = None) -> Any | None:
+    """Load (and cache) the sklearn pipeline.
+
+    Resolution order:
+
+    1. Explicit ``model_path`` always loads from local disk (test fixtures
+       and ad-hoc CLI use this path).
+    2. With ``R2_BUCKET`` set, read the ``latest_run_id.txt`` pointer from
+       storage, materialize the per-run joblib to
+       ``data/image_model/_cache/<run_id>/relevance_model.joblib``, load.
+    3. Otherwise fall back to ``DEFAULT_MODEL_PATH`` on local disk
+       (pre-gh-391 behavior, dev mode).
+
+    Returns the fitted pipeline, or None if the model is absent or fails to
+    load — callers fall back to the heuristic. Cached per resolved key so
+    subsequent calls are free of I/O.
+    """
+    use_storage = model_path is None and os.environ.get("R2_BUCKET") is not None
+
+    if use_storage:
+        run_id = _resolve_active_run_id()
+        if run_id is None:
+            return None
+        cache_key = f"r2:{run_id}"
+        with _MODEL_LOCK:
+            if cache_key in _MODEL_CACHE:
+                cached = _MODEL_CACHE[cache_key]
+                return None if cached is _MODEL_ABSENT else cached
+            local_path = _materialize_from_storage(run_id)
+            if local_path is None:
+                _MODEL_CACHE[cache_key] = _MODEL_ABSENT
+                return None
+            return _load_joblib_into_cache(local_path, cache_key)
+
     resolved = str((model_path or DEFAULT_MODEL_PATH).resolve())
     with _MODEL_LOCK:
         if resolved in _MODEL_CACHE:
@@ -66,17 +198,7 @@ def _load_model(model_path: Path | None = None) -> Any | None:
             )
             _MODEL_CACHE[resolved] = _MODEL_ABSENT
             return None
-        try:
-            import joblib  # optional heavy import; only at prediction time
-
-            pipeline = joblib.load(path)
-            _MODEL_CACHE[resolved] = pipeline
-            logger.info("Loaded image relevance model from %s", resolved)
-            return pipeline
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Failed to load image relevance model from %s: %s", resolved, exc)
-            _MODEL_CACHE[resolved] = _MODEL_ABSENT
-            return None
+        return _load_joblib_into_cache(path, resolved)
 
 
 def predict_relevance(features: dict, *, model_path: Path | None = None) -> float | None:

--- a/tests/integration/test_retrain_image_triage_upload.py
+++ b/tests/integration/test_retrain_image_triage_upload.py
@@ -1,0 +1,209 @@
+"""Integration test for scripts/retrain_image_triage.py R2 upload flow (gh-391).
+
+Exercises the wrapper end-to-end with a seeded model_training_runs row,
+mocked export+train subprocesses, and a moto-backed R2 bucket. Verifies that
+on success the per-run keys land in storage, the pointer is updated, and the
+DB row's model_path/report_path columns hold opaque storage keys (not
+filesystem paths).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.infra.db import DatabaseAdapter
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "retrain_image_triage.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    spec = importlib.util.spec_from_file_location("retrain_image_triage_integration", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["retrain_image_triage_integration"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script_module()
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_cache():
+    from src.infra.model_storage import get_model_storage
+    from src.infra.paths import model_cache_dir
+
+    get_model_storage.cache_clear()
+    model_cache_dir.cache_clear()
+    yield
+    get_model_storage.cache_clear()
+    model_cache_dir.cache_clear()
+
+
+@pytest.fixture
+def _moto_bucket(monkeypatch: pytest.MonkeyPatch):
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    original_client = boto3.client
+
+    def patched_client(service, **kwargs):
+        kwargs.pop("endpoint_url", None)
+        kwargs["region_name"] = "us-east-1"
+        return original_client(service, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", patched_client)
+    monkeypatch.setenv("R2_BUCKET", "retrain-integration-bucket")
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://example.com")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+
+    with moto.mock_aws():
+        original_client(
+            "s3",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        ).create_bucket(Bucket="retrain-integration-bucket")
+        yield
+
+
+def _seed_running_row(db: DatabaseAdapter, run_id: str) -> None:
+    """Insert a 'running' row that the wrapper will UPDATE to 'succeeded'."""
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO model_training_runs (id, model_type, status, triggered_by)
+                VALUES (%(id)s, 'image_relevance', 'running', 'pytest')
+                """,
+                {"id": run_id},
+            )
+            conn.commit()
+
+
+def _read_row(db: DatabaseAdapter, run_id: str) -> dict:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT * FROM model_training_runs WHERE id = %(id)s", {"id": run_id})
+            return dict(cur.fetchone())
+
+
+def _delete_row(db: DatabaseAdapter, run_id: str) -> None:
+    with db.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM model_training_runs WHERE id = %(id)s", {"id": run_id})
+            conn.commit()
+
+
+def _make_subprocess_stub(model_path: Path, report_path: Path, csv_path: Path):
+    """Return a subprocess.run drop-in that creates the expected artifact files.
+
+    The wrapper invokes export_image_training_data.py (writes csv_path) then
+    train_image_relevance_model.py (writes model_path + report_path). We
+    distinguish by inspecting the script name in the cmd list.
+    """
+
+    def stub_run(cmd, **kwargs):
+        cmd_str = " ".join(str(c) for c in cmd)
+        if "export_image_training_data.py" in cmd_str:
+            csv_path.parent.mkdir(parents=True, exist_ok=True)
+            csv_path.write_text("decision,relevance_score\nrelevant,0.9\nnot_relevant,0.1\n")
+        elif "train_image_relevance_model.py" in cmd_str:
+            model_path.parent.mkdir(parents=True, exist_ok=True)
+            model_path.write_bytes(b"fake-trained-joblib-bytes")
+            report_path.write_text("Image Relevance Model Report\n")
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    return stub_run
+
+
+def test_main_uploads_artifacts_and_writes_storage_keys(
+    script,
+    clean_db: DatabaseAdapter,
+    _moto_bucket,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: main() with --run-id uploads to R2 and writes keys to the DB row."""
+    run_id = str(uuid.uuid4())
+    _seed_running_row(clean_db, run_id)
+
+    csv_path = tmp_path / "training_data.csv"
+    model_path = tmp_path / "relevance_model.joblib"
+    report_path = tmp_path / "model_report.txt"
+
+    stub = _make_subprocess_stub(model_path, report_path, csv_path)
+    db_url = os.environ["TEST_DATABASE_URL"]
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--database-url",
+            db_url,
+            "--run-id",
+            run_id,
+            "--output-csv",
+            str(csv_path),
+            "--output-model",
+            str(model_path),
+            "--output-report",
+            str(report_path),
+        ],
+    )
+
+    try:
+        with patch.object(subprocess, "run", side_effect=stub):
+            script.main()
+
+        # ---- Storage assertions ----
+        from src.infra.model_storage import get_model_storage
+
+        storage = get_model_storage()
+        prefix = f"models/image_relevance/{run_id}"
+        assert storage.exists(f"{prefix}/relevance_model.joblib")
+        assert storage.exists(f"{prefix}/model_report.txt")
+        assert storage.exists(f"{prefix}/training_data.csv")
+        assert storage.get_bytes(f"{prefix}/relevance_model.joblib") == b"fake-trained-joblib-bytes"
+        # Pointer resolves to this run.
+        assert storage.get_bytes("models/image_relevance/latest_run_id.txt") == run_id.encode(
+            "utf-8"
+        )
+
+        # ---- DB assertions ----
+        row = _read_row(clean_db, run_id)
+        assert row["status"] == "succeeded"
+        # model_path / report_path are storage keys, NOT filesystem paths.
+        assert row["model_path"] == f"{prefix}/relevance_model.joblib"
+        assert row["report_path"] == f"{prefix}/model_report.txt"
+        assert not row["model_path"].startswith("/")
+        # Counts populated from the CSV stub (1 relevant, 1 not_relevant).
+        assert row["num_training_rows"] == 2
+        assert row["num_positive_rows"] == 1
+        assert row["completed_at"] is not None
+    finally:
+        _delete_row(clean_db, run_id)

--- a/tests/unit/infra/test_model_storage.py
+++ b/tests/unit/infra/test_model_storage.py
@@ -1,0 +1,193 @@
+"""Tests for src.infra.model_storage — backends + factory + prod-write guard.
+
+Mirrors tests/unit/infra/test_image_storage.py. Key validation is reused from
+image_storage and tested there; we re-confirm the rejection path in the new
+backends so a future refactor can't silently drop it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.infra.image_storage import InvalidStorageKeyError
+from src.infra.model_storage import (
+    LocalFilesystemModelStorage,
+    R2ModelStorage,
+    get_model_storage,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_cache():
+    get_model_storage.cache_clear()
+    from src.infra.paths import model_cache_dir
+
+    model_cache_dir.cache_clear()
+    yield
+    get_model_storage.cache_clear()
+    model_cache_dir.cache_clear()
+
+
+class TestLocalFilesystemModelStorage:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        storage = LocalFilesystemModelStorage(tmp_path)
+        storage.put_bytes("models/image_relevance/run1/relevance_model.joblib", b"joblib-bytes")
+        assert (
+            storage.get_bytes("models/image_relevance/run1/relevance_model.joblib")
+            == b"joblib-bytes"
+        )
+        assert storage.exists("models/image_relevance/run1/relevance_model.joblib")
+
+    def test_pointer_file_round_trip(self, tmp_path: Path) -> None:
+        """The latest_run_id pointer is just bytes — no special handling."""
+        storage = LocalFilesystemModelStorage(tmp_path)
+        storage.put_bytes("models/image_relevance/latest_run_id.txt", b"abc-123")
+        assert storage.get_bytes("models/image_relevance/latest_run_id.txt") == b"abc-123"
+
+    def test_exists_false_before_put(self, tmp_path: Path) -> None:
+        storage = LocalFilesystemModelStorage(tmp_path)
+        assert not storage.exists("models/image_relevance/nope.joblib")
+
+    def test_get_missing_raises_file_not_found(self, tmp_path: Path) -> None:
+        storage = LocalFilesystemModelStorage(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            storage.get_bytes("models/image_relevance/ghost.joblib")
+
+    def test_put_creates_nested_dirs(self, tmp_path: Path) -> None:
+        storage = LocalFilesystemModelStorage(tmp_path)
+        storage.put_bytes("models/image_relevance/uuid-x/relevance_model.joblib", b"x")
+        assert (
+            tmp_path / "models" / "image_relevance" / "uuid-x" / "relevance_model.joblib"
+        ).exists()
+
+    def test_invalid_key_rejected(self, tmp_path: Path) -> None:
+        storage = LocalFilesystemModelStorage(tmp_path)
+        with pytest.raises(InvalidStorageKeyError):
+            storage.put_bytes("../evil.joblib", b"x")
+
+
+@pytest.fixture
+def _moto_s3(monkeypatch: pytest.MonkeyPatch):
+    """Boot moto's S3 mock + create a test bucket. Yields nothing — backends create their own client."""
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    original_client = boto3.client
+
+    def patched_client(service, **kwargs):
+        kwargs.pop("endpoint_url", None)
+        kwargs["region_name"] = "us-east-1"
+        return original_client(service, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", patched_client)
+
+    with moto.mock_aws():
+        original_client(
+            "s3",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        ).create_bucket(Bucket="model-test-bucket")
+        yield
+
+
+class TestR2ModelStorage:
+    @pytest.fixture
+    def r2(self, _moto_s3, monkeypatch: pytest.MonkeyPatch) -> R2ModelStorage:
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+        return R2ModelStorage(
+            bucket="model-test-bucket",
+            endpoint="https://example.com",  # stripped by patched_client
+            access_key="test",
+            secret_key="test",
+        )
+
+    def test_round_trip(self, r2: R2ModelStorage) -> None:
+        r2.put_bytes("models/image_relevance/run1/relevance_model.joblib", b"joblib-bytes")
+        assert r2.get_bytes("models/image_relevance/run1/relevance_model.joblib") == b"joblib-bytes"
+
+    def test_pointer_file_round_trip(self, r2: R2ModelStorage) -> None:
+        r2.put_bytes(
+            "models/image_relevance/latest_run_id.txt", b"abc-123", content_type="text/plain"
+        )
+        assert r2.get_bytes("models/image_relevance/latest_run_id.txt") == b"abc-123"
+
+    def test_exists_true_after_put(self, r2: R2ModelStorage) -> None:
+        r2.put_bytes("models/image_relevance/run2/model_report.txt", b"report")
+        assert r2.exists("models/image_relevance/run2/model_report.txt")
+
+    def test_exists_false_before_put(self, r2: R2ModelStorage) -> None:
+        assert not r2.exists("models/image_relevance/never/relevance_model.joblib")
+
+    def test_get_missing_raises_file_not_found(self, r2: R2ModelStorage) -> None:
+        with pytest.raises(FileNotFoundError):
+            r2.get_bytes("models/image_relevance/ghost/relevance_model.joblib")
+
+    def test_invalid_key_rejected(self, r2: R2ModelStorage) -> None:
+        with pytest.raises(InvalidStorageKeyError):
+            r2.put_bytes("/leading.joblib", b"x")
+
+
+class TestR2ModelStorageProdWriteGuard:
+    @pytest.fixture
+    def r2_no_writes_allowed(self, _moto_s3, monkeypatch: pytest.MonkeyPatch) -> R2ModelStorage:
+        monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+        return R2ModelStorage(
+            bucket="model-test-bucket",
+            endpoint="https://example.com",
+            access_key="test",
+            secret_key="test",
+        )
+
+    def test_put_bytes_raises_when_env_var_unset(
+        self, r2_no_writes_allowed: R2ModelStorage
+    ) -> None:
+        with pytest.raises(RuntimeError, match="FILINGS_REVIEWER_ALLOW_PROD_WRITES"):
+            r2_no_writes_allowed.put_bytes(
+                "models/image_relevance/run1/relevance_model.joblib", b"data"
+            )
+
+    def test_put_bytes_raises_when_env_var_not_1(
+        self, r2_no_writes_allowed: R2ModelStorage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "true")
+        with pytest.raises(RuntimeError, match="FILINGS_REVIEWER_ALLOW_PROD_WRITES"):
+            r2_no_writes_allowed.put_bytes(
+                "models/image_relevance/run1/relevance_model.joblib", b"data"
+            )
+
+    def test_get_bytes_allowed_without_env_var(
+        self, r2_no_writes_allowed: R2ModelStorage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+        r2_no_writes_allowed.put_bytes("models/image_relevance/run1/read_test.joblib", b"readable")
+        monkeypatch.delenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", raising=False)
+        assert (
+            r2_no_writes_allowed.get_bytes("models/image_relevance/run1/read_test.joblib")
+            == b"readable"
+        )
+
+
+class TestGetModelStorageFactory:
+    def test_returns_local_when_r2_bucket_unset(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("R2_BUCKET", raising=False)
+        # model_cache_dir() is path-fixed; we can't override it via env, so we just
+        # confirm the type. The actual root is <repo>/data/image_model/, which exists.
+        storage = get_model_storage()
+        assert isinstance(storage, LocalFilesystemModelStorage)
+
+    def test_returns_r2_when_r2_bucket_set(self, _moto_s3, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("R2_BUCKET", "model-test-bucket")
+        monkeypatch.setenv("R2_ENDPOINT_URL", "https://example.com")
+        monkeypatch.setenv("R2_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test")
+        storage = get_model_storage()
+        assert isinstance(storage, R2ModelStorage)
+
+    def test_memoized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("R2_BUCKET", raising=False)
+        first = get_model_storage()
+        second = get_model_storage()
+        assert first is second

--- a/tests/unit/scripts/test_retrain_image_triage_upload.py
+++ b/tests/unit/scripts/test_retrain_image_triage_upload.py
@@ -1,0 +1,187 @@
+"""Unit tests for the R2 upload helper in scripts/retrain_image_triage.py (gh-391).
+
+The full orchestrate-then-finalize flow is exercised in
+tests/integration/test_retrain_image_triage_upload.py — this file covers the
+storage-side behavior in isolation, without spawning subprocesses or touching
+the DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "retrain_image_triage.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    spec = importlib.util.spec_from_file_location("retrain_image_triage_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["retrain_image_triage_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script_module()
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_cache():
+    from src.infra.model_storage import get_model_storage
+    from src.infra.paths import model_cache_dir
+
+    get_model_storage.cache_clear()
+    model_cache_dir.cache_clear()
+    yield
+    get_model_storage.cache_clear()
+    model_cache_dir.cache_clear()
+
+
+@pytest.fixture
+def _moto_bucket(monkeypatch: pytest.MonkeyPatch):
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    original_client = boto3.client
+
+    def patched_client(service, **kwargs):
+        kwargs.pop("endpoint_url", None)
+        kwargs["region_name"] = "us-east-1"
+        return original_client(service, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", patched_client)
+    monkeypatch.setenv("R2_BUCKET", "retrain-upload-bucket")
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://example.com")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+
+    with moto.mock_aws():
+        original_client(
+            "s3",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        ).create_bucket(Bucket="retrain-upload-bucket")
+        yield
+
+
+def _seed_local_artifacts(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Drop the three artifact files at the local paths the wrapper expects."""
+    model = tmp_path / "relevance_model.joblib"
+    report = tmp_path / "model_report.txt"
+    csv = tmp_path / "training_data.csv"
+    model.write_bytes(b"fake-joblib-bytes")
+    report.write_text("model report\n")
+    csv.write_text("decision,feature_x\nrelevant,0.9\nnot_relevant,0.1\n")
+    return model, report, csv
+
+
+class TestStorageKeysForRun:
+    def test_returns_three_keys(self, script) -> None:
+        keys = script._storage_keys_for_run("abc-123")
+        assert keys == {
+            "model_key": "models/image_relevance/abc-123/relevance_model.joblib",
+            "report_key": "models/image_relevance/abc-123/model_report.txt",
+            "csv_key": "models/image_relevance/abc-123/training_data.csv",
+        }
+
+
+class TestUploadArtifacts:
+    def test_uploads_all_three_plus_pointer(self, script, _moto_bucket, tmp_path: Path) -> None:
+        from src.infra.model_storage import get_model_storage
+
+        model, report, csv = _seed_local_artifacts(tmp_path)
+        run_id = "run-upload-1111"
+
+        keys = script._upload_artifacts(
+            run_id, model_path=str(model), report_path=str(report), csv_path=str(csv)
+        )
+
+        storage = get_model_storage()
+        # Per-run artifacts byte-identical to local fixtures.
+        assert storage.get_bytes(keys["model_key"]) == b"fake-joblib-bytes"
+        assert storage.get_bytes(keys["report_key"]) == b"model report\n"
+        assert (
+            storage.get_bytes(keys["csv_key"])
+            == b"decision,feature_x\nrelevant,0.9\nnot_relevant,0.1\n"
+        )
+        # Pointer points at this run.
+        assert storage.get_bytes("models/image_relevance/latest_run_id.txt") == run_id.encode(
+            "utf-8"
+        )
+
+    def test_returned_keys_are_storage_keys_not_paths(
+        self, script, _moto_bucket, tmp_path: Path
+    ) -> None:
+        """The keys flipped into model_training_runs.model_path must NOT have a leading slash."""
+        model, report, csv = _seed_local_artifacts(tmp_path)
+        keys = script._upload_artifacts(
+            "run-keys-2222",
+            model_path=str(model),
+            report_path=str(report),
+            csv_path=str(csv),
+        )
+        for value in keys.values():
+            assert not value.startswith("/"), f"storage key looks like a filesystem path: {value}"
+            assert value.startswith("models/image_relevance/"), value
+
+    def test_missing_local_artifact_raises(self, script, _moto_bucket, tmp_path: Path) -> None:
+        """Pre-upload existence check fails-loud so the orchestrator can mark status='failed'."""
+        # Only seed two of three.
+        model = tmp_path / "relevance_model.joblib"
+        model.write_bytes(b"x")
+        report = tmp_path / "report.txt"
+        report.write_text("ok\n")
+        ghost_csv = tmp_path / "missing.csv"
+
+        with pytest.raises(FileNotFoundError, match="missing.csv"):
+            script._upload_artifacts(
+                "run-missing-3333",
+                model_path=str(model),
+                report_path=str(report),
+                csv_path=str(ghost_csv),
+            )
+
+    def test_pointer_uploaded_last(self, script, _moto_bucket, tmp_path: Path) -> None:
+        """Regression: a per-run upload failure must NOT update the pointer.
+
+        Stash the previous pointer, then trigger a failure mid-upload, then
+        confirm the pointer still resolves to the previous value.
+        """
+        from src.infra.model_storage import get_model_storage
+
+        storage = get_model_storage()
+        # Seed a previous successful pointer.
+        storage.put_bytes(
+            "models/image_relevance/latest_run_id.txt",
+            b"run-previous",
+            content_type="text/plain",
+        )
+
+        # Try a new upload where one artifact is missing.
+        model = tmp_path / "relevance_model.joblib"
+        model.write_bytes(b"new-bytes")
+        report = tmp_path / "report.txt"
+        report.write_text("new report\n")
+        ghost_csv = tmp_path / "ghost.csv"
+
+        with pytest.raises(FileNotFoundError):
+            script._upload_artifacts(
+                "run-failed-4444",
+                model_path=str(model),
+                report_path=str(report),
+                csv_path=str(ghost_csv),
+            )
+
+        # Pointer must be untouched.
+        assert storage.get_bytes("models/image_relevance/latest_run_id.txt") == b"run-previous"

--- a/tests/unit/shared/test_image_features_predict.py
+++ b/tests/unit/shared/test_image_features_predict.py
@@ -111,3 +111,37 @@ def test_load_model_caches_absent_result(tmp_path: Path) -> None:
     resolved = str(missing.resolve())
     assert resolved in image_features._MODEL_CACHE
     assert image_features._MODEL_CACHE[resolved] is image_features._MODEL_ABSENT
+
+
+def test_explicit_model_path_bypasses_storage_under_r2_bucket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for gh-391: an explicit model_path must short-circuit the R2 branch.
+
+    Test fixtures pass a tmp joblib via model_path; if R2_BUCKET happens to be set
+    in the environment (e.g. integration test contamination, accidental leak), the
+    loader must still read from the explicit path, not attempt a storage lookup.
+    """
+    monkeypatch.setenv("R2_BUCKET", "should-not-be-touched")
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://example.com")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test")
+
+    model_path = tmp_path / "relevance_model.joblib"
+    model_path.write_bytes(b"sentinel")
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.predict_proba.return_value = np.array([[0.2, 0.8]])
+
+    # Patch get_model_storage so any accidental call surfaces as an explicit
+    # failure — the explicit-path branch must never reach this.
+    with patch("src.infra.model_storage.get_model_storage") as mock_storage_factory:
+        mock_storage_factory.side_effect = AssertionError(
+            "explicit model_path should bypass storage abstraction"
+        )
+        with patch("joblib.load", return_value=mock_pipeline):
+            result = predict_relevance(_sample_features(), model_path=model_path)
+
+    assert result == pytest.approx(0.8)
+    # Cache key in the local-FS branch is the resolved string path, not "r2:<run_id>".
+    assert str(model_path.resolve()) in image_features._MODEL_CACHE

--- a/tests/unit/shared/test_image_features_r2_load.py
+++ b/tests/unit/shared/test_image_features_r2_load.py
@@ -1,0 +1,237 @@
+"""R2-backed model load path for src.shared.image_features._load_model (gh-391).
+
+Covers the post-gh-391 cold-start fetch flow: pointer file → run-id → joblib
+materialized to a local cache → joblib.load. Also exercises the failure-mode
+branches that must return None so extraction falls back to the heuristic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.shared import image_features
+from src.shared.image_features import predict_relevance
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Reset module + factory caches; redirect model_cache_dir into tmp_path.
+
+    Teardown of monkeypatch undoes the patch and clears caches so the next
+    test starts clean — no manual cache_clear needed in the post-yield path.
+    """
+    from src.infra import model_storage, paths
+
+    image_features._MODEL_CACHE.clear()
+    image_features._reset_active_run_id_cache()
+    model_storage.get_model_storage.cache_clear()
+    paths.model_cache_dir.cache_clear()
+
+    # The materialization scratch must land inside tmp_path so each test starts
+    # clean. model_cache_dir() is path-fixed (no env override by design); patch
+    # the function on its source module — _materialize_from_storage does a local
+    # `from src.infra.paths import model_cache_dir` per call, which re-resolves
+    # the attribute and picks up this override.
+    monkeypatch.setattr(paths, "model_cache_dir", lambda: tmp_path)
+
+    yield
+
+    image_features._MODEL_CACHE.clear()
+    image_features._reset_active_run_id_cache()
+    model_storage.get_model_storage.cache_clear()
+
+
+@pytest.fixture
+def _moto_bucket(monkeypatch: pytest.MonkeyPatch):
+    """Boot moto S3 + create the R2 bucket. Wires the four R2_* env vars."""
+    moto = pytest.importorskip("moto")
+    import boto3
+
+    original_client = boto3.client
+
+    def patched_client(service, **kwargs):
+        kwargs.pop("endpoint_url", None)
+        kwargs["region_name"] = "us-east-1"
+        return original_client(service, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", patched_client)
+    monkeypatch.setenv("R2_BUCKET", "model-r2-load-bucket")
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://example.com")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("FILINGS_REVIEWER_ALLOW_PROD_WRITES", "1")
+
+    with moto.mock_aws():
+        original_client(
+            "s3",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        ).create_bucket(Bucket="model-r2-load-bucket")
+        yield
+
+
+def _sample_features() -> dict:
+    return {
+        "nearby_text": "Customer retention cohort",
+        "relevance_score": 0.75,
+        "width": 800,
+        "height": 600,
+        "classification": "chart",
+        "filename": "chart.png",
+    }
+
+
+def _seed_storage(run_id: str, model_bytes: bytes = b"sentinel-joblib") -> None:
+    """Upload latest_run_id.txt + per-run joblib via the storage factory."""
+    from src.infra.model_storage import get_model_storage
+
+    storage = get_model_storage()
+    storage.put_bytes(
+        f"models/image_relevance/{run_id}/relevance_model.joblib",
+        model_bytes,
+        content_type="application/octet-stream",
+    )
+    storage.put_bytes(
+        "models/image_relevance/latest_run_id.txt",
+        run_id.encode("utf-8"),
+        content_type="text/plain",
+    )
+
+
+class TestR2LoadCold:
+    def test_predict_relevance_fetches_from_r2_on_cold_start(
+        self, _moto_bucket, tmp_path: Path
+    ) -> None:
+        """Pointer → run-id → fetch joblib → joblib.load → predict_proba."""
+        run_id = "run-aaaa-1111"
+        _seed_storage(run_id)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.predict_proba.return_value = np.array([[0.3, 0.7]])
+
+        with patch("joblib.load", return_value=mock_pipeline):
+            result = predict_relevance(_sample_features())
+
+        assert result == pytest.approx(0.7)
+        # Materialized to <model_cache_dir>/_cache/<run_id>/relevance_model.joblib.
+        assert (tmp_path / "_cache" / run_id / "relevance_model.joblib").exists()
+        # In-memory cache key is "r2:<run_id>".
+        assert f"r2:{run_id}" in image_features._MODEL_CACHE
+
+    def test_warm_cache_does_not_redownload(self, _moto_bucket, tmp_path: Path) -> None:
+        """Second predict call hits _MODEL_CACHE — no extra storage GETs.
+
+        Both the pointer resolution (_resolve_active_run_id) AND the loaded
+        pipeline (_MODEL_CACHE) are cached for the worker's lifetime — at the
+        cost of stale-window-bounded-by-worker-rotation, we save ~1 GET per
+        image at extraction scale.
+        """
+        run_id = "run-bbbb-2222"
+        _seed_storage(run_id)
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.predict_proba.return_value = np.array([[0.5, 0.5]])
+
+        from src.infra.model_storage import get_model_storage
+
+        storage = get_model_storage()
+        with (
+            patch.object(storage, "get_bytes", wraps=storage.get_bytes) as wrapped_get,
+            patch("joblib.load", return_value=mock_pipeline),
+        ):
+            predict_relevance(_sample_features())  # cold
+            cold_calls = wrapped_get.call_count
+            predict_relevance(_sample_features())  # warm
+            warm_calls = wrapped_get.call_count
+
+        # Cold: 1 pointer GET + 1 joblib GET = 2. Warm: 0 additional.
+        assert cold_calls == 2, f"expected 2 cold GETs (pointer + model), got {cold_calls}"
+        assert warm_calls == cold_calls, "warm call must not re-fetch from storage"
+
+    def test_pointer_change_triggers_redownload_after_worker_restart(
+        self, _moto_bucket, tmp_path: Path
+    ) -> None:
+        """A new run_id materializes only after the active-run-id cache resets.
+
+        The cache reset models a worker process restart (Render deploy or cron
+        run). Within a single worker, _resolve_active_run_id is sticky — see
+        the docstring on _resolve_active_run_id for the why.
+        """
+        first = "run-cccc-3333"
+        second = "run-dddd-4444"
+
+        _seed_storage(first, model_bytes=b"first-joblib")
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.predict_proba.return_value = np.array([[0.4, 0.6]])
+
+        with patch("joblib.load", return_value=mock_pipeline):
+            predict_relevance(_sample_features())
+
+        assert (tmp_path / "_cache" / first / "relevance_model.joblib").exists()
+
+        # Second retrain replaces the pointer + uploads a new per-run joblib.
+        _seed_storage(second, model_bytes=b"second-joblib")
+        # Without a worker restart, the cached run_id stays as `first` — the
+        # second retrain is invisible to this process.
+        with patch("joblib.load", return_value=mock_pipeline):
+            predict_relevance(_sample_features())
+        assert not (tmp_path / "_cache" / second / "relevance_model.joblib").exists()
+
+        # Simulate worker restart: clear the run_id cache + the model cache.
+        image_features._reset_active_run_id_cache()
+        image_features._MODEL_CACHE.clear()
+
+        with patch("joblib.load", return_value=mock_pipeline):
+            predict_relevance(_sample_features())
+
+        assert (tmp_path / "_cache" / second / "relevance_model.joblib").exists()
+        assert f"r2:{second}" in image_features._MODEL_CACHE
+
+
+class TestR2LoadFailureModes:
+    def test_missing_pointer_falls_back_to_none(self, _moto_bucket) -> None:
+        """No latest_run_id.txt in storage → None (heuristic fallback)."""
+        # Bucket exists but is empty.
+        result = predict_relevance(_sample_features())
+        assert result is None
+
+    def test_pointer_references_missing_joblib_falls_back(self, _moto_bucket) -> None:
+        """Pointer present, but the per-run joblib is missing → None."""
+        from src.infra.model_storage import get_model_storage
+
+        storage = get_model_storage()
+        storage.put_bytes(
+            "models/image_relevance/latest_run_id.txt",
+            b"orphan-run-id",
+            content_type="text/plain",
+        )
+        # No per-run joblib upload.
+
+        result = predict_relevance(_sample_features())
+        assert result is None
+        # Sentinel cached so a second call doesn't re-attempt the fetch.
+        assert image_features._MODEL_CACHE["r2:orphan-run-id"] is image_features._MODEL_ABSENT
+
+    def test_endpoint_connection_error_falls_back(
+        self, _moto_bucket, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Network outage on pointer GET → None (no crash)."""
+        from botocore.exceptions import EndpointConnectionError
+
+        from src.infra.model_storage import get_model_storage
+
+        storage = get_model_storage()
+
+        def boom(*_args, **_kwargs):
+            raise EndpointConnectionError(endpoint_url="https://example.com")
+
+        monkeypatch.setattr(storage, "get_bytes", boom)
+
+        result = predict_relevance(_sample_features())
+        assert result is None


### PR DESCRIPTION
Render's disk is ephemeral — UI-triggered retrains under USE_LEARNED_TRIAGE=true
silently disappeared on the next deploy. This change uploads the joblib + report
+ training CSV to R2 under models/image_relevance/<run_id>/, writes a
latest_run_id.txt pointer (last, for atomicity), and teaches the loader to fetch
from R2 via the pointer on cold start.

- src/infra/model_storage.py — new Protocol + Local + R2 backends, mirrors the
  filing_storage / image_storage pattern. Reuses validate_key + the existing
  FILINGS_REVIEWER_ALLOW_PROD_WRITES guard.
- src/shared/image_features._load_model — adds R2 branch keyed on the cached
  active run-id; explicit model_path still bypasses storage. Storage failures
  return None so extraction falls back to the heuristic instead of crashing.
- scripts/retrain_image_triage.py — _upload_artifacts() helper called from
  _finalize_run; model_training_runs.model_path / report_path now hold opaque
  storage keys (not absolute filesystem paths). Pre-cutover rows are
  display-only; the loader doesn't read them.
- Docs: CLAUDE.md, .claude/rules/infrastructure.md (new Model Artifact Storage
  section), .claude/rules/web.md (drop ephemerality caveat).
