### PR TITLE
fix(vision): swap deprecated gemini-2.0-flash default to gemini-2.5-flash-lite (gh-359)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -110,9 +110,9 @@ Rules for any DB-touching command in this repo:
 | `VISION_CLASSIFY_MODEL` | With `ENABLE_METRIC_CLASSIFY` | Model id (default `gemini-2.5-flash-lite`, per 2026-04-23 bake-off). |
 | `VISION_CLASSIFY_THRESHOLD` | With `ENABLE_METRIC_CLASSIFY` | Confidence floor (default `0.5`) for the downstream `predicted_relevant` signal. Records below the floor are still persisted. |
 | `VISION_PROVIDER_FULL_PAGE_OCR` | Optional | Provider for the full-page-scan OCR triage site (default `gemini`). Independent of `VISION_PROVIDER`. See `docs/operations/vision-model-selection.md`. |
-| `VISION_MODEL_FULL_PAGE_OCR` | Optional | Model for the full-page-scan OCR triage site (default `gemini-2.0-flash`). |
+| `VISION_MODEL_FULL_PAGE_OCR` | Optional | Model for the full-page-scan OCR triage site (default `gemini-2.5-flash-lite`). |
 | `VISION_PROVIDER_PRESCAN` | Optional | Provider for the image-level keyword pre-scan site (default `gemini`). Independent of `VISION_PROVIDER`. |
-| `VISION_MODEL_PRESCAN` | Optional | Model for the keyword pre-scan site (default `gemini-2.0-flash`). |
+| `VISION_MODEL_PRESCAN` | Optional | Model for the keyword pre-scan site (default `gemini-2.5-flash-lite`). |
 | `GEMINI_API_KEY` | With `VISION_CLASSIFY_PROVIDER=gemini` | Google AI Studio key for Gemini vision calls. Set manually in Render. |
 | `FILINGS_REVIEWER_ALLOW_PROD_WRITES` | Required for `R2Storage.put_bytes` | Must be set to `"1"` for any process that writes image bytes to R2. Refused otherwise. Reads (`get_bytes`, `exists`) are unaffected. Set on Render services that run extraction/ingestion (`filings-reviewer`, `filings-extraction`, `filings-onboarding-runner`); leave unset on local dev to prevent accidental prod writes when prod creds are sourced for one-off CLI work. |
 

--- a/.claude/rules/v2-pipeline.md
+++ b/.claude/rules/v2-pipeline.md
@@ -84,7 +84,7 @@ verification SQL.
 
 Per-site model knobs are documented in `docs/operations/vision-model-selection.md`.
 Triage sites (`process_full_page_scan`, `_prescan_ambiguous_images`) default
-to Gemini (`gemini-2.0-flash`) regardless of `VISION_PROVIDER`. The
+to Gemini (`gemini-2.5-flash-lite`) regardless of `VISION_PROVIDER`. The
 two-stage chart-read site defaults to Haiku-4.5 with a Sonnet fallback
 that rescues low-confidence chart responses (PR 3). Cost is observed via
 `PipelineResult.vision_spend_usd_by_site`; fallback rate via

--- a/.env.template
+++ b/.env.template
@@ -72,9 +72,9 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 #
 # ---- PR 2: Per-site overrides for triage OCR (default: Gemini regardless of VISION_PROVIDER) ----
 # VISION_PROVIDER_FULL_PAGE_OCR=gemini
-# VISION_MODEL_FULL_PAGE_OCR=gemini-2.0-flash
+# VISION_MODEL_FULL_PAGE_OCR=gemini-2.5-flash-lite
 # VISION_PROVIDER_PRESCAN=gemini
-# VISION_MODEL_PRESCAN=gemini-2.0-flash
+# VISION_MODEL_PRESCAN=gemini-2.5-flash-lite
 #
 # ---- PR 3: Chart-read fallback escalation (default: Sonnet rescues low-conf Haiku) ----
 # VISION_CHART_FALLBACK_MODEL=claude-sonnet-4-6

--- a/docs/known-issues/gh-359-gemini-2-0-flash-deprecated-default.md
+++ b/docs/known-issues/gh-359-gemini-2-0-flash-deprecated-default.md
@@ -3,25 +3,34 @@ id: 359
 source: gh
 slug: gemini-2-0-flash-deprecated-default
 title: Default gemini-2.0-flash model deprecated for new Gemini API accounts
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: —
 touches:
   - src/extraction_v2/pipeline.py
+  - src/llm/vision_client.py
+  - src/llm/providers/gemini.py
   - .env.template
 discovered: 2026-04-29
-updated: 2026-04-29
+updated: 2026-05-02
 gh_issue: 359
-note: change vision_full_page_ocr_model and vision_prescan_model defaults to a non-deprecated Gemini model
+note: defaults swapped to gemini-2.5-flash-lite (already in use by metric-classify path); gemini-2.0-flash pricing entry retained for historical cost-reporting on legacy runs
 ---
 
 ### Problem
 
 The PR 2 triage-OCR defaults (`vision_full_page_ocr_model`, `vision_prescan_model`) are set to `gemini-2.0-flash`. During unit testing, this model returned `404 NOT_FOUND: "no longer available to new users"` when a newer Gemini API account was used. Production appears unaffected (legacy account key), but any contributor onboarding with a new API key will see silent extraction failures on the full-page-scan and prescan sites.
 
-### Next Steps
+### Resolution
 
-- Evaluate `gemini-2.0-flash-lite` or `gemini-2.5-flash-lite` as replacement defaults
-- Update `PipelineConfig` defaults and `.env.template` once a stable model is confirmed
-- Consider a startup-time model availability check or graceful fallback in `_build_cheap_ocr_client`
+Swapped the deprecated default to `gemini-2.5-flash-lite` — the same model already in use by the metric-classify path (`PipelineConfig.vision_classify_model`) and the two-stage OCR site (`_TWO_STAGE_DEFAULT_OCR_MODEL` in `vision_client.py`). Updates:
+
+- `src/extraction_v2/pipeline.py` — `vision_full_page_ocr_model`, `vision_prescan_model` defaults
+- `src/llm/vision_client.py` — `_PROVIDER_DEFAULT_MODELS["gemini"]["ocr"]`
+- `src/llm/providers/gemini.py` — module docstring, `GeminiVisionProvider.__init__` default, pricing-map entry for `gemini-2.5-flash-lite` ($0.10/$0.40 per 1M tokens). `gemini-2.0-flash` pricing entry retained so historical `model_training_runs` rows referencing the deprecated id still resolve a price.
+- `.env.template` — commented examples for `VISION_MODEL_FULL_PAGE_OCR`, `VISION_MODEL_PRESCAN`
+- `tests/unit/extraction_v2/test_vision_env_overrides.py` — default assertions + env-override test now uses `gemini-2.0-flash-lite` so override semantics remain meaningful
+- `.claude/rules/infrastructure.md`, `.claude/rules/v2-pipeline.md`, `docs/operations/vision-model-selection.md` — docs aligned with the new default
+
+A startup-time model-availability probe was scoped out — single-line fall-through is sufficient given Gemini deprecations are infrequent. Track separately if a second deprecation lands.

--- a/docs/operations/vision-model-selection.md
+++ b/docs/operations/vision-model-selection.md
@@ -9,8 +9,8 @@ One-page reference for which model each vision call site uses, what env var cont
 | 1 | Table OCR | OCRExtraction | `process_table_image` | `VISION_MODEL_OCR` (two_stage) / `VISION_PROVIDER`+`VISION_MODEL_OCR` (legacy) | `gemini-2.5-flash-lite` (two_stage) / `gpt-4o` (legacy) | ≤5 calls/filing |
 | 2 | Chart OCR fast | OCRExtraction | `process_chart` (first pass) | `VISION_MODEL_OCR` (two_stage only) | `gemini-2.5-flash-lite` | 5–15 calls/filing |
 | 3 | Chart read premium | OCRExtraction | `process_chart` (second pass) | `VISION_MODEL_CHART` (two_stage) / inherits VISION_PROVIDER (legacy) | `claude-haiku-4-5-20251001` (two_stage), Sonnet fallback on conf<0.7 / `gpt-4o` (legacy) | 5–15 calls/filing, $0.25 budget cap |
-| 4 | Full-page OCR | OCRExtraction | `process_full_page_scan` | `VISION_PROVIDER_FULL_PAGE_OCR`, `VISION_MODEL_FULL_PAGE_OCR` | `gemini` / `gemini-2.0-flash` | ≤30 calls/filing on full-page-scan filings |
-| 5 | Prescan | OCRExtraction | `_prescan_ambiguous_images` | `VISION_PROVIDER_PRESCAN`, `VISION_MODEL_PRESCAN` | `gemini` / `gemini-2.0-flash` | ≤10 calls/filing |
+| 4 | Full-page OCR | OCRExtraction | `process_full_page_scan` | `VISION_PROVIDER_FULL_PAGE_OCR`, `VISION_MODEL_FULL_PAGE_OCR` | `gemini` / `gemini-2.5-flash-lite` | ≤30 calls/filing on full-page-scan filings |
+| 5 | Prescan | OCRExtraction | `_prescan_ambiguous_images` | `VISION_PROVIDER_PRESCAN`, `VISION_MODEL_PRESCAN` | `gemini` / `gemini-2.5-flash-lite` | ≤10 calls/filing |
 | 6 | Metric classify | ImageClassify | `analyze_image_for_metric_classification` | `VISION_CLASSIFY_PROVIDER`, `VISION_CLASSIFY_MODEL` | `gemini` / `gemini-2.5-flash-lite` | 10–40 calls/filing when ENABLE_METRIC_CLASSIFY=true |
 
 ## Routing modes

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -211,9 +211,9 @@ class PipelineConfig:
     # recall/triage with no precision requirement, so they default to a cheap
     # Gemini model regardless of VISION_PROVIDER.
     vision_full_page_ocr_provider: str = "gemini"
-    vision_full_page_ocr_model: str = "gemini-2.0-flash"
+    vision_full_page_ocr_model: str = "gemini-2.5-flash-lite"
     vision_prescan_provider: str = "gemini"
-    vision_prescan_model: str = "gemini-2.0-flash"
+    vision_prescan_model: str = "gemini-2.5-flash-lite"
 
     # Chart-read fallback (PR 3). Default chart-read uses Haiku-4.5 for cost;
     # low-confidence chart responses re-call the fallback model (Sonnet) so

--- a/src/llm/providers/gemini.py
+++ b/src/llm/providers/gemini.py
@@ -4,7 +4,7 @@ Uses the ``google-genai`` SDK (``google.genai``) with ``GOOGLE_API_KEY``
 environment variable authentication.  No GCP project or Vertex AI dependency.
 
 Default models:
-  OCR  : ``gemini-2.0-flash`` (fast, cheap)
+  OCR  : ``gemini-2.5-flash-lite`` (fast, cheap)
   Chart: ``gemini-2.5-pro-preview-05-06`` (high-quality reasoning)
 
 The ``VISION_MODEL_OCR`` / ``VISION_MODEL_CHART`` env vars override these
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 _MODEL_PRICING: dict[str, tuple[float, float]] = {
     "gemini-2.5-pro-preview-05-06": (1.25, 10.00),
     "gemini-2.5-pro": (1.25, 10.00),
+    "gemini-2.5-flash-lite": (0.10, 0.40),
     "gemini-2.0-flash": (0.10, 0.40),
     "gemini-2.0-flash-lite": (0.075, 0.30),
     "gemini-1.5-pro": (1.25, 5.00),
@@ -76,11 +77,11 @@ class GeminiVisionProvider(VisionProvider):
     No GCP project / Application Default Credentials required.
     """
 
-    def __init__(self, model: str = "gemini-2.0-flash") -> None:
+    def __init__(self, model: str = "gemini-2.5-flash-lite") -> None:
         """Initialize the Gemini vision provider.
 
         Args:
-            model: Gemini model identifier. Defaults to ``gemini-2.0-flash``
+            model: Gemini model identifier. Defaults to ``gemini-2.5-flash-lite``
                 for cost-effective OCR work.
         """
         self.model = model

--- a/src/llm/vision_client.py
+++ b/src/llm/vision_client.py
@@ -191,7 +191,7 @@ _VALID_CHART_HINTS = frozenset({"bar", "line", "pie", "area", "stacked_bar", "sc
 # Per-provider default models
 _PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "openai": {"ocr": "gpt-4o", "chart": "gpt-4o"},
-    "gemini": {"ocr": "gemini-2.0-flash", "chart": "gemini-2.5-pro-preview-05-06"},
+    "gemini": {"ocr": "gemini-2.5-flash-lite", "chart": "gemini-2.5-pro-preview-05-06"},
     "anthropic": {"ocr": "claude-sonnet-4-6", "chart": "claude-sonnet-4-6"},
 }
 

--- a/tests/unit/extraction_v2/test_vision_env_overrides.py
+++ b/tests/unit/extraction_v2/test_vision_env_overrides.py
@@ -105,12 +105,12 @@ class TestDefaultConfig:
     def test_full_page_ocr_defaults_to_gemini(self) -> None:
         cfg = PipelineConfig()
         assert cfg.vision_full_page_ocr_provider == "gemini"
-        assert cfg.vision_full_page_ocr_model == "gemini-2.0-flash"
+        assert cfg.vision_full_page_ocr_model == "gemini-2.5-flash-lite"
 
     def test_prescan_defaults_to_gemini(self) -> None:
         cfg = PipelineConfig()
         assert cfg.vision_prescan_provider == "gemini"
-        assert cfg.vision_prescan_model == "gemini-2.0-flash"
+        assert cfg.vision_prescan_model == "gemini-2.5-flash-lite"
 
 
 # ---------------------------------------------------------------------------
@@ -122,10 +122,10 @@ class TestEnvOverrides:
     def test_vision_model_full_page_ocr_env_flows_into_config(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("VISION_MODEL_FULL_PAGE_OCR", "gemini-2.5-flash-lite")
+        monkeypatch.setenv("VISION_MODEL_FULL_PAGE_OCR", "gemini-2.0-flash-lite")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         pipeline = V2Pipeline()
-        assert pipeline.config.vision_full_page_ocr_model == "gemini-2.5-flash-lite"
+        assert pipeline.config.vision_full_page_ocr_model == "gemini-2.0-flash-lite"
 
     def test_vision_provider_prescan_env_flows_into_config(
         self, monkeypatch: pytest.MonkeyPatch
@@ -276,7 +276,7 @@ class TestEnvRestore:
             lambda self: None,
         )
 
-        _build_cheap_ocr_client("gemini", "gemini-2.0-flash")
+        _build_cheap_ocr_client("gemini", "gemini-2.5-flash-lite")
 
         assert os.environ.get("VISION_PROVIDER") == "openai"
         assert os.environ.get("VISION_MODEL_OCR") == "gpt-4o"
@@ -292,7 +292,7 @@ class TestEnvRestore:
             lambda self: None,
         )
 
-        _build_cheap_ocr_client("gemini", "gemini-2.0-flash")
+        _build_cheap_ocr_client("gemini", "gemini-2.5-flash-lite")
 
         assert "VISION_PROVIDER" not in os.environ
         assert "VISION_MODEL_OCR" not in os.environ


### PR DESCRIPTION
The PR-2 triage-OCR sites (full_page_ocr, prescan) defaulted to
gemini-2.0-flash, which Google has deprecated for new Gemini API
accounts (404 NOT_FOUND on fresh keys). Prod was masked by a legacy
account; new contributors saw silent extraction failures.

Swap defaults to gemini-2.5-flash-lite — already in active use by the
metric-classify path and two-stage OCR site, so this aligns the codebase
on a single non-deprecated cheap-OCR model. Pricing-map entry for
gemini-2.5-flash-lite added; gemini-2.0-flash entry retained so
historical model_training_runs cost-resolve correctly.

https://claude.ai/code/session_017anELAFZMjjSMfKHjWneAj