### PR TITLE
chore(scripts): warn when export_image_training_data.py runs standalone (gh-426)

### DIFF
--- a/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
+++ b/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
@@ -1,0 +1,27 @@
+---
+id: 445
+source: gh
+slug: image-triage-test-pollution-from-cache-dir
+title: test_gate_on_but_model_absent_falls_back_to_heuristic fails under full pytest run due to data/image_model/_cache/ pollution
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 445
+note: image-triage model-absent test passes in isolation but fails under full pytest -x -q because a sibling test leaves data/image_model/_cache/ populated; masks regression coverage on the model-absent fallback path
+---
+
+### Problem
+
+`tests/unit/extraction_v2/test_image_triage.py::TestLearnedTriageGate::test_gate_on_but_model_absent_falls_back_to_heuristic` passes in isolation but fails as part of `pytest -x -q` with `assert 0.9157916871700323 is None`. After a full run, `data/image_model/_cache/` exists in the worktree as an untracked artifact, indicating an earlier test in the suite produces a cached model that the loader subsequently finds when this test expects "model absent."
+
+Pre-existing on clean main (verified via `git stash` + rerun on `worktree-gh-426-export-retrain-sync`, no script changes applied). Surfaced during gh-426 implementation while running the full suite for `/commit-proj` step 7.
+
+### Next Steps
+
+- Identify which test in the suite creates / leaves behind `data/image_model/_cache/` (likely a retrain or score test).
+- Either isolate that test's writes to `tmp_path` or have `test_gate_on_but_model_absent_falls_back_to_heuristic` monkeypatch the model-loader path to a guaranteed-empty location.
+- Add a session-level fixture / autouse cleanup if the cache dir is intended to be writable in tests.

--- a/scripts/export_image_training_data.py
+++ b/scripts/export_image_training_data.py
@@ -2,6 +2,10 @@
 """
 Export image training data for relevance model development.
 
+If you intend to refresh the deployed model, use ``scripts/retrain_image_triage.py``
+(which chains export + train); running this script alone regenerates the CSV but
+leaves ``relevance_model.joblib`` reflecting the prior CSV. See gh-426.
+
 Unifies human review decisions from two sources:
   - SEC filing image decisions (PostgreSQL DB via image_review_decisions)
   - Presentation image decisions (file-based, data/presentation_gold_standard/)
@@ -428,6 +432,24 @@ def main() -> None:
             counts["relevant"],
             100 * counts["relevant"] / counts["total"],
         )
+
+    # gh-426: nudge operators who run this script standalone — without a
+    # follow-up retrain, relevance_model.joblib drifts from the regenerated CSV.
+    # retrain_image_triage.py sets RETRAIN_CHAINED=1 to suppress the warning.
+    if os.environ.get("RETRAIN_CHAINED") != "1":
+        banner = "=" * 70
+        print("\n" + banner, file=sys.stderr)
+        print("WARNING: Export complete but model NOT retrained.", file=sys.stderr)
+        print(
+            "If you intend to update data/image_model/relevance_model.joblib, run:",
+            file=sys.stderr,
+        )
+        print("  python3 scripts/retrain_image_triage.py --database-url ...", file=sys.stderr)
+        print(
+            "Otherwise the on-disk CSV will be out of sync with the joblib (gh-426).",
+            file=sys.stderr,
+        )
+        print(banner, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/retrain_image_triage.py
+++ b/scripts/retrain_image_triage.py
@@ -409,6 +409,9 @@ def _orchestrate(args: argparse.Namespace) -> None:
     if args.database_url:
         export_cmd += ["--database-url", args.database_url]
 
+    # gh-426: signal to the export script that the train step will follow,
+    # so it suppresses its standalone-run staleness warning.
+    os.environ["RETRAIN_CHAINED"] = "1"
     _run(export_cmd, dry_run=args.dry_run)
 
     if not args.dry_run and not Path(args.output_csv).exists():


### PR DESCRIPTION
## Summary

Closes gh-426. Operators (and CI) sometimes re-run `scripts/export_image_training_data.py` standalone, regenerating `data/image_model/training_data.csv` while `relevance_model.joblib` stays at the prior CSV's training set. Currently benign because `USE_LEARNED_TRIAGE=false` in prod (loader pulls from R2), but flips into a silent staleness bug the moment that flag is turned on.

Implements **Option C** from `docs/worker-prompts/PICK_gh-426_export-without-retrain-stale-model.md` — the minimal-path / dev-hygiene-only behavioral nudge:

- `scripts/export_image_training_data.py` prints a multi-line stderr banner at the end of `main()` warning that the model was NOT retrained and pointing operators at `scripts/retrain_image_triage.py`.
- The banner is suppressed when `RETRAIN_CHAINED=1` is set in the environment.
- `scripts/retrain_image_triage.py` sets `os.environ["RETRAIN_CHAINED"] = "1"` in `_orchestrate()` immediately before invoking the export subprocess, so the chained retrain workflow stays quiet.
- Module docstring on the export script gains a one-line nudge at the top.

No CLI surface changes, no test changes, no config changes. 2 files, 25 lines added.

## Test plan

- [x] `python3 -m py_compile scripts/export_image_training_data.py scripts/retrain_image_triage.py`
- [x] `python3 scripts/export_image_training_data.py --help` — argparse output unchanged
- [x] Manual env-gate verification: `RETRAIN_CHAINED` unset -> banner; `RETRAIN_CHAINED=1` -> suppressed
- [x] `pytest tests/unit/scripts/test_export_image_training_data.py -x -q` — 18/18 pass
- [x] `ruff check scripts/export_image_training_data.py scripts/retrain_image_triage.py` — clean
- [x] Required CI checks (Lint / Unit Tests / Vulnerability Scan / Integration Tests / UI E2E)

## Notes

- One pre-existing test failure surfaced during the full-suite run for /commit-proj — `test_gate_on_but_model_absent_falls_back_to_heuristic` fails after another test populates `data/image_model/_cache/`. Verified pre-existing on clean main (no script changes); filed as gh-445 in the follow-up commit on this PR.
- Per the worker prompt's escalation note: if gh-426 reopens because operators ignore the banner, the next step is Option B (chain by default with `--export-only` escape) under a new gh-N — not a re-open of this issue.

Generated with [Claude Code](https://claude.com/claude-code)