### PR TITLE
feat(review): add Shift+A shortcut for add-missed-metric (gh-354)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -182,6 +182,7 @@ The unified review page (`unified_review.html`) binds shortcuts on both tabs. Cr
 | `X`        | Reject all (no relevant metrics) — fires regardless of row focus, triggers `#btn-reject-all-metrics` click |
 | `Shift+R`  | Reject all (deprecated alias for `X`, kept for muscle memory) |
 | `Shift+U`  | Re-open a fully-reviewed image (only effective when `#btn-reopen-image` is rendered) |
+| `Shift+A`  | Open "Add metric the classifier missed" panel and focus the metric search input (`#add-missed-detected-input`); plain `A` is per-row accept so a chord is required |
 | `M`        | Submit decisions and mark image complete — triggers `#btn-submit-and-finalize` click |
 
 **Image tab — per-metric row** (when `state.focusedRow` is set):

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -95,6 +95,20 @@
             return;
         }
 
+        // Shift+A — open the "Add metric the classifier missed" panel and
+        // focus the metric search input. Plain 'A' is the per-row accept
+        // binding, so we need the chord to avoid collision.
+        if (event.shiftKey && (event.key === 'A' || event.key === 'a')) {
+            const btn = document.getElementById('btn-add-missed-detected-metric');
+            if (btn) {
+                event.preventDefault();
+                btn.click();
+                const input = document.getElementById('add-missed-detected-input');
+                if (input) input.focus();
+            }
+            return;
+        }
+
         // M — submit decisions and mark image complete. Fires regardless of
         // per-metric row focus (M is unbound at the per-row level). Triggers
         // the button click since submitDecisions lives in the per-metric IIFE.

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -1028,7 +1028,7 @@
               <div class="mt-3 border-top pt-3">
                 <button type="button" class="btn btn-outline-secondary btn-sm"
                         id="btn-add-missed-detected-metric">
-                  + Add metric the classifier missed
+                  + Add metric the classifier missed <span class="kbd ms-1">⇧A</span>
                 </button>
                 <div id="add-missed-detected-expansion" class="mt-2" style="display: none;">
                   <label class="form-label small mb-1">Metric</label>


### PR DESCRIPTION
## Summary

Closes gh-354. Adds a `Shift+A` chord keyboard shortcut for the "Add metric the classifier missed" button on the unified review page (image tab). Power-users can now fire the action without leaving keyboard mode.

- `unified_review.html`: kbd badge `⇧A` on `#btn-add-missed-detected-metric`.
- `review_images_v2.js`: image-tab keydown handler for Shift+A — clicks the button then focuses the metric search input. Guarded by the existing `event.target.matches('input, textarea, select')` early-return so it doesn't fire while typing.
- `.claude/rules/web.md`: shortcut-table row.

`A` (per-row accept) is unchanged; `Shift+A` is the new chord, no collision.

## Test plan

- [x] `pytest -x -q tests/unit/web/` — 315 passed.
- [ ] Manual browser verification on the unified review page (Playwright suite covers `#btn-add-missed-detected-metric` but cannot be driven in the agent environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)