### PR TITLE
fix(image-features): escalate load-failure log to ERROR + eager-load on triage gate (gh-419)

### DIFF
--- a/src/extraction_v2/stages/image_triage.py
+++ b/src/extraction_v2/stages/image_triage.py
@@ -46,6 +46,36 @@ logger = logging.getLogger(__name__)
 _USE_LEARNED_TRIAGE: bool = os.environ.get("USE_LEARNED_TRIAGE", "false").lower() == "true"
 _LEARNED_TRIAGE_MIN: float = float(os.environ.get("LEARNED_TRIAGE_MIN", "0.4"))
 
+# Set on first triage stage run per worker process to emit a one-shot
+# load-status log. Persists across `ImageTriageStage` instances within a worker
+# (intentional — one log per worker cold-start, not per filing). Tests reset it.
+_LOGGED_TRIAGE_MODEL_STATUS: bool = False
+
+
+def _log_triage_model_status_once() -> None:
+    """Eager-load the relevance model on first stage run. One log line per worker process.
+
+    Surfaces silent degradation at pipeline construction time rather than waiting
+    for the first per-image predict call. The cached `_load_model()` ensures the
+    actual per-image call inside the loop is free.
+
+    No-op when `USE_LEARNED_TRIAGE` is false — operators who haven't opted into
+    the gate don't get noise from it.
+    """
+    global _LOGGED_TRIAGE_MODEL_STATUS
+    if _LOGGED_TRIAGE_MODEL_STATUS or not _USE_LEARNED_TRIAGE:
+        return
+    _LOGGED_TRIAGE_MODEL_STATUS = True
+    from src.shared.image_features import _load_model
+
+    if _load_model() is None:
+        logger.error(
+            "USE_LEARNED_TRIAGE=true but image relevance model could not be loaded; "
+            "every image will fall back to heuristic scoring until next worker restart."
+        )
+    else:
+        logger.info("USE_LEARNED_TRIAGE=true; image relevance model loaded successfully")
+
 
 class ImageTriageStage:
     """
@@ -668,6 +698,12 @@ class ImageTriageStage:
         """
         # Import here to avoid circular import
         from src.extraction_v2.pipeline import PipelineStage, StageResult
+
+        # One-shot eager-load + status log on first stage run per worker.
+        # Runs even when context.images is empty so the operator signal fires
+        # for every worker that crosses the triage gate, not just those that
+        # process a non-empty filing first.
+        _log_triage_model_status_once()
 
         start_time = datetime.now(UTC)
         errors: list[str] = []

--- a/src/shared/image_features.py
+++ b/src/shared/image_features.py
@@ -145,8 +145,10 @@ def _load_joblib_into_cache(local_path: Path, cache_key: str) -> Any | None:
       dev environment with no trained model). Returns None silently — the caller
       falls back to heuristic scoring.
     - Any other exception (corrupt joblib, sklearn version mismatch, etc.): logs
-      a WARNING so operators can detect silent production degradation, then returns
-      None so the heuristic fallback still runs.
+      an ERROR so operators can detect silent production degradation, then returns
+      None so the heuristic fallback still runs. The cache is poisoned with the
+      _MODEL_ABSENT sentinel until the next worker restart, so the message hints
+      at that recovery path.
     """
     try:
         import joblib  # optional heavy import; only at prediction time
@@ -160,12 +162,13 @@ def _load_joblib_into_cache(local_path: Path, cache_key: str) -> Any | None:
         # or was never present. Silent fallback — not an operator-actionable event.
         _MODEL_CACHE[cache_key] = _MODEL_ABSENT
         return None
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "Failed to load image relevance model from %s: %s — falling back to heuristic",
+    except Exception as exc:  # noqa: BLE001 — joblib surfaces many exception types
+        logger.error(
+            "Failed to load image relevance model from %s (%s): %s — "
+            "predictions will fall back to heuristic until next worker restart",
             local_path,
+            type(exc).__name__,
             exc,
-            exc_info=True,
         )
         _MODEL_CACHE[cache_key] = _MODEL_ABSENT
         return None

--- a/src/shared/image_features.py
+++ b/src/shared/image_features.py
@@ -138,7 +138,16 @@ def _reset_active_run_id_cache() -> None:
 
 
 def _load_joblib_into_cache(local_path: Path, cache_key: str) -> Any | None:
-    """joblib.load + cache write + sentinel-on-failure. Caller holds _MODEL_LOCK."""
+    """joblib.load + cache write + sentinel-on-failure. Caller holds _MODEL_LOCK.
+
+    Two failure modes are handled differently:
+    - FileNotFoundError: model artifact is simply absent (expected on first boot /
+      dev environment with no trained model). Returns None silently — the caller
+      falls back to heuristic scoring.
+    - Any other exception (corrupt joblib, sklearn version mismatch, etc.): logs
+      a WARNING so operators can detect silent production degradation, then returns
+      None so the heuristic fallback still runs.
+    """
     try:
         import joblib  # optional heavy import; only at prediction time
 
@@ -146,8 +155,18 @@ def _load_joblib_into_cache(local_path: Path, cache_key: str) -> Any | None:
         _MODEL_CACHE[cache_key] = pipeline
         logger.info("Loaded image relevance model from %s", local_path)
         return pipeline
+    except FileNotFoundError:
+        # Model file vanished between the existence check and the load (TOCTOU),
+        # or was never present. Silent fallback — not an operator-actionable event.
+        _MODEL_CACHE[cache_key] = _MODEL_ABSENT
+        return None
     except Exception as exc:  # noqa: BLE001
-        logger.warning("Failed to load image relevance model from %s: %s", local_path, exc)
+        logger.warning(
+            "Failed to load image relevance model from %s: %s — falling back to heuristic",
+            local_path,
+            exc,
+            exc_info=True,
+        )
         _MODEL_CACHE[cache_key] = _MODEL_ABSENT
         return None
 

--- a/tests/unit/extraction_v2/test_image_triage.py
+++ b/tests/unit/extraction_v2/test_image_triage.py
@@ -1180,3 +1180,140 @@ class TestA1ReorderBehavior:
         )
         result = stage.classify_image(asset)
         assert result == ImageClassification.TABLE_IMAGE
+
+
+class TestTriageGateEagerLoadStatusLog:
+    """One-shot eager-load status log fired on first triage stage run per worker.
+
+    The eager-load surfaces silent degradation at pipeline construction time
+    rather than waiting for the first per-image predict call. The flag is
+    module-level (`image_triage._LOGGED_TRIAGE_MODEL_STATUS`) so it persists
+    across `ImageTriageStage` instances within a worker process — that's
+    intentional (one log per worker cold-start, not per filing). Tests must
+    reset both the flag and `image_features._MODEL_CACHE` to keep order
+    independence.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Reset the once-per-worker flag and the model cache around every test."""
+        from src.extraction_v2.stages import image_triage
+        from src.shared import image_features
+
+        monkeypatch.setattr(image_triage, "_LOGGED_TRIAGE_MODEL_STATUS", False)
+        # Wipe the model cache so a previous test's load doesn't satisfy this one.
+        image_features._MODEL_CACHE.clear()
+        # Make sure no R2 path is exercised — _load_model resolves to disk.
+        monkeypatch.delenv("R2_BUCKET", raising=False)
+        yield
+        image_features._MODEL_CACHE.clear()
+
+    def _empty_context(self):
+        from pathlib import Path
+
+        from src.extraction_v2.pipeline import PipelineContext
+
+        context = PipelineContext(
+            filing_id=1,
+            html_path=Path("/tmp/test.html"),
+            config=None,  # type: ignore
+        )
+        context.images = []
+        return context
+
+    def test_triage_gate_logs_error_once_when_model_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """USE_LEARNED_TRIAGE=true + missing model → exactly one ERROR per worker."""
+        import logging
+
+        from src.extraction_v2.stages import image_triage
+        from src.shared import image_features
+
+        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", True)
+        # Point the loader at a non-existent file so _load_model returns None silently.
+        monkeypatch.setattr(image_features, "DEFAULT_MODEL_PATH", tmp_path / "no_such_model.joblib")
+
+        with caplog.at_level(logging.INFO, logger="src.extraction_v2.stages.image_triage"):
+            ImageTriageStage().process(self._empty_context())
+
+        triage_errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and r.name == "src.extraction_v2.stages.image_triage"
+        ]
+        assert len(triage_errors) == 1, (
+            f"Expected exactly one ERROR from image_triage, got "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
+        assert "USE_LEARNED_TRIAGE=true" in triage_errors[0].message
+
+        # Second .process() on a fresh stage instance — the flag is module-level
+        # so no additional ERROR record should fire.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="src.extraction_v2.stages.image_triage"):
+            ImageTriageStage().process(self._empty_context())
+
+        assert [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and r.name == "src.extraction_v2.stages.image_triage"
+        ] == [], "Eager-load ERROR must fire only once per worker process"
+
+    def test_triage_gate_logs_info_once_when_model_loads(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """USE_LEARNED_TRIAGE=true + loadable model → INFO log, no ERROR."""
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from src.extraction_v2.stages import image_triage
+        from src.shared import image_features
+
+        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", True)
+        # Provide a real existing path; patch joblib.load to return a fake pipeline.
+        model_file = tmp_path / "model.joblib"
+        model_file.write_bytes(b"placeholder")
+        monkeypatch.setattr(image_features, "DEFAULT_MODEL_PATH", model_file)
+
+        fake_pipeline = MagicMock(name="fake_pipeline")
+
+        with caplog.at_level(logging.INFO, logger="src.extraction_v2.stages.image_triage"):
+            with patch("joblib.load", return_value=fake_pipeline):
+                ImageTriageStage().process(self._empty_context())
+
+        triage_records = [
+            r for r in caplog.records if r.name == "src.extraction_v2.stages.image_triage"
+        ]
+        info_records = [r for r in triage_records if r.levelno == logging.INFO]
+        error_records = [r for r in triage_records if r.levelno >= logging.ERROR]
+
+        assert error_records == [], (
+            f"No ERROR expected when model loads; got {[r.message for r in error_records]}"
+        )
+        assert any(
+            "image relevance model loaded successfully" in r.message for r in info_records
+        ), f"Expected INFO load-success log; got {[r.message for r in info_records]}"
+
+    def test_triage_gate_silent_when_flag_off(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """USE_LEARNED_TRIAGE=false → no eager-load log of any level."""
+        import logging
+
+        from src.extraction_v2.stages import image_triage
+
+        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", False)
+
+        with caplog.at_level(logging.DEBUG, logger="src.extraction_v2.stages.image_triage"):
+            ImageTriageStage().process(self._empty_context())
+
+        gate_messages = [
+            r.message
+            for r in caplog.records
+            if r.name == "src.extraction_v2.stages.image_triage"
+            and "USE_LEARNED_TRIAGE" in r.message
+        ]
+        assert gate_messages == [], (
+            f"Eager-load helper must be a no-op when the gate flag is off; got: {gate_messages}"
+        )

--- a/tests/unit/shared/test_image_features_predict.py
+++ b/tests/unit/shared/test_image_features_predict.py
@@ -113,6 +113,57 @@ def test_load_model_caches_absent_result(tmp_path: Path) -> None:
     assert image_features._MODEL_CACHE[resolved] is image_features._MODEL_ABSENT
 
 
+def test_load_model_missing_file_returns_none_silently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Missing model file (FileNotFoundError from joblib.load) returns None without WARNING.
+
+    The expected first-boot / dev-environment case: no model trained yet.
+    Operators should not receive noise for this condition.
+    """
+    import logging
+
+    model_path = tmp_path / "missing.joblib"
+    # File does not exist.
+    assert not model_path.exists()
+
+    with caplog.at_level(logging.WARNING, logger="src.shared.image_features"):
+        result = predict_relevance(_sample_features(), model_path=model_path)
+
+    assert result is None
+    # No WARNING log should have been emitted for a simple missing-file case.
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records == [], (
+        f"Expected no WARNING for missing model file, got: {[r.message for r in warning_records]}"
+    )
+
+
+def test_load_joblib_corrupt_bytes_emits_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Corrupt / unloadable joblib artifact returns None AND emits a WARNING.
+
+    This distinguishes a real production failure (corrupt artifact, sklearn
+    version mismatch) from the benign missing-file case so operators see it.
+    """
+    import logging
+
+    model_path = tmp_path / "corrupt.joblib"
+    # Write garbage bytes that joblib cannot deserialise.
+    model_path.write_bytes(b"\x00\x01\x02corrupt garbage not a joblib")
+
+    with caplog.at_level(logging.WARNING, logger="src.shared.image_features"):
+        result = predict_relevance(_sample_features(), model_path=model_path)
+
+    assert result is None
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warning_records) >= 1, "Expected at least one WARNING for corrupt joblib"
+    # Message should mention the path so operators know which artifact failed.
+    assert any(str(model_path) in r.message for r in warning_records), (
+        f"WARNING message should reference the model path; got: {[r.message for r in warning_records]}"
+    )
+
+
 def test_explicit_model_path_bypasses_storage_under_r2_bucket(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/shared/test_image_features_predict.py
+++ b/tests/unit/shared/test_image_features_predict.py
@@ -113,10 +113,10 @@ def test_load_model_caches_absent_result(tmp_path: Path) -> None:
     assert image_features._MODEL_CACHE[resolved] is image_features._MODEL_ABSENT
 
 
-def test_load_model_missing_file_returns_none_silently(
+def test_missing_file_logs_at_debug_not_error(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Missing model file (FileNotFoundError from joblib.load) returns None without WARNING.
+    """Missing model file (FileNotFoundError) returns None silently — no WARNING/ERROR.
 
     The expected first-boot / dev-environment case: no model trained yet.
     Operators should not receive noise for this condition.
@@ -124,43 +124,59 @@ def test_load_model_missing_file_returns_none_silently(
     import logging
 
     model_path = tmp_path / "missing.joblib"
-    # File does not exist.
     assert not model_path.exists()
 
-    with caplog.at_level(logging.WARNING, logger="src.shared.image_features"):
+    with caplog.at_level(logging.DEBUG, logger="src.shared.image_features"):
         result = predict_relevance(_sample_features(), model_path=model_path)
 
     assert result is None
-    # No WARNING log should have been emitted for a simple missing-file case.
-    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert warning_records == [], (
-        f"Expected no WARNING for missing model file, got: {[r.message for r in warning_records]}"
+    high_severity = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert high_severity == [], (
+        f"Expected no WARNING/ERROR for missing model file, got: "
+        f"{[(r.levelname, r.message) for r in high_severity]}"
     )
 
 
-def test_load_joblib_corrupt_bytes_emits_warning(
+def test_load_failure_logs_at_error_with_exception_type(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Corrupt / unloadable joblib artifact returns None AND emits a WARNING.
+    """Corrupt / unloadable joblib artifact returns None AND logs at ERROR.
 
-    This distinguishes a real production failure (corrupt artifact, sklearn
-    version mismatch) from the benign missing-file case so operators see it.
+    Distinguishes a real production failure (corrupt artifact, sklearn version
+    mismatch) from the benign missing-file case. The message must include the
+    exception type name so log-grep can discriminate failure modes
+    (`UnpicklingError`, `ModuleNotFoundError`, `EOFError`, etc.).
     """
     import logging
+    from unittest.mock import patch
 
     model_path = tmp_path / "corrupt.joblib"
-    # Write garbage bytes that joblib cannot deserialise.
-    model_path.write_bytes(b"\x00\x01\x02corrupt garbage not a joblib")
+    # File must exist so resolution doesn't short-circuit on stat — we patch
+    # joblib.load itself to raise a deterministic exception type the test
+    # can assert on. Real production failures may surface as different
+    # types depending on the corruption; the contract under test is that
+    # *whatever* the type is, it appears in the log message.
+    model_path.write_bytes(b"placeholder")
 
-    with caplog.at_level(logging.WARNING, logger="src.shared.image_features"):
-        result = predict_relevance(_sample_features(), model_path=model_path)
+    boom = EOFError("simulated truncated joblib")
+
+    with caplog.at_level(logging.ERROR, logger="src.shared.image_features"):
+        with patch("joblib.load", side_effect=boom):
+            result = predict_relevance(_sample_features(), model_path=model_path)
 
     assert result is None
-    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert len(warning_records) >= 1, "Expected at least one WARNING for corrupt joblib"
-    # Message should mention the path so operators know which artifact failed.
-    assert any(str(model_path) in r.message for r in warning_records), (
-        f"WARNING message should reference the model path; got: {[r.message for r in warning_records]}"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(error_records) == 1, (
+        f"Expected exactly one ERROR record, got "
+        f"{[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    msg = error_records[0].message
+    # Plan rationale: log-grep discriminability — type token must be in the message.
+    assert "EOFError" in msg, f"ERROR message should name the exception type; got: {msg!r}"
+    assert str(model_path) in msg, f"ERROR message should reference the path; got: {msg!r}"
+    # Operator-facing recovery hint — distinguishes from transient-network errors.
+    assert "worker restart" in msg, (
+        f"ERROR message should include worker-restart recovery hint; got: {msg!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Closes gh-419. Surfaces silent image-relevance model load failures so operators can detect production degradation.

**`src/shared/image_features.py`**
- `_load_joblib_into_cache`: split `FileNotFoundError` (silent — expected on first boot / dev) from other exceptions (corrupt joblib, sklearn version drift, partial download).
- Non-missing failures now log at **ERROR** (was WARNING) so they surface in Render's error-log alerts.
- Message includes `type(exc).__name__` for log-grep discriminability and a "next worker restart" recovery hint (the `_MODEL_ABSENT` sentinel poisons the cache for the worker's lifetime).

**`src/extraction_v2/stages/image_triage.py`**
- New `_log_triage_model_status_once()` helper. When `USE_LEARNED_TRIAGE=true`, the first `ImageTriageStage.process()` call per worker eager-loads the model and emits one INFO (loaded) or ERROR (failed) log.
- Module-level `_LOGGED_TRIAGE_MODEL_STATUS` flag persists across `ImageTriageStage` instances within a worker — one log per worker cold-start, not per filing.
- Surfaces silent gate degradation at pipeline construction time rather than waiting for the first per-image predict call.
- Web routes (`review_unified.py`, `api_unified.py`) keep their existing lazy-load behavior; they don't gate on `USE_LEARNED_TRIAGE` and shouldn't pay a cold-start cost when the model isn't requested.

## Test plan

- [x] `pytest -x -q tests/unit/shared/test_image_features_predict.py tests/unit/extraction_v2/test_image_triage.py` — 83 passed.
- [x] New tests: missing-file silent fallback; ERROR with exception-type token; one-shot ERROR on triage-gate cold-start with absent model; one-shot INFO on successful load; silent no-op when gate flag is off.
- [ ] CI required checks (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)