### PR TITLE
docs(known-issues): close gh-426 (resolved by #446)

### DIFF
--- a/docs/known-issues/gh-426-export-without-retrain-stale-model.md
+++ b/docs/known-issues/gh-426-export-without-retrain-stale-model.md
@@ -3,15 +3,17 @@ id: 426
 source: gh
 slug: export-without-retrain-stale-model
 title: Export-without-retrain leaves data/image_model/relevance_model.joblib stale
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
 touches: []
 discovered: 2026-05-01
-updated: 2026-05-01
+updated: 2026-05-04
 gh_issue: 426
-note: re-running export_image_training_data.py without retrain leaves the deployed joblib lagging the CSV; benign while USE_LEARNED_TRIAGE=false, becomes a silent staleness bug the moment that flag flips on
+pr_refs:
+  - 446
+note: resolved by PR #446 (Option C — stderr banner at end of export, suppressed when retrain_image_triage.py sets RETRAIN_CHAINED=1)
 ---
 
 ### Problem


### PR DESCRIPTION
## Summary

Flips `docs/known-issues/gh-426-export-without-retrain-stale-model.md` from `status: open` to `status: resolved` with `pr_refs: [446]`. PR #446 (merged as `4250a4a8`) implemented Option C — the export script now prints a stderr banner unless `RETRAIN_CHAINED=1`, and `retrain_image_triage.py` sets that env var before invoking the export step.

Fragment-only closure PR (matches the precedent set by #232–#234, #240).

## Test plan

- [x] `Validate known-issue fragment frontmatter` pre-commit hook passes
- [x] Required CI checks (Lint will run the same validator)

Generated with [Claude Code](https://claude.com/claude-code)