### PR TITLE
claude/refactor remove redundant text line

### DIFF
--- a/docs/known-issues/gh-455-test-analyze-text-decisions-fixture-residue.md
+++ b/docs/known-issues/gh-455-test-analyze-text-decisions-fixture-residue.md
@@ -1,0 +1,24 @@
+---
+id: 455
+source: gh
+slug: test-analyze-text-decisions-fixture-residue
+title: "Integration test: v2_review_decisions fixture leaves residue causing UniqueViolation in test_analyze_text_decision_patterns"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 455
+note: full-suite run hits UniqueViolation on v2_review_decisions_unique_fact — fixture residue across tests
+---
+
+### Problem
+
+`tests/integration/test_analyze_text_decision_patterns.py::test_first_run_anchor_null_processes_all_decisions` fails with `psycopg.errors.UniqueViolation` on constraint `v2_review_decisions_unique_fact` when run as part of the full suite (`pytest -x -q`). The fact_id the fixture inserts already exists from a prior test's residue. Test passes in isolation. Reproduces on `origin/main` without any code changes.
+
+### Next Steps
+
+- Audit `tests/integration/conftest.py` and the test's local fixtures for `v2_review_decisions` cleanup ordering
+- Either truncate `v2_review_decisions` in the per-test fixture or generate unique fact_ids per test

--- a/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
+++ b/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
@@ -1,0 +1,24 @@
+---
+id: 456
+source: gh
+slug: test-image-triage-model-absent-order-dependent
+title: "test_image_triage: TestLearnedTriageGate::test_gate_on_but_model_absent_falls_back_to_heuristic order-dependent on data/image_model/ filesystem state"
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 456
+note: passes in isolation, fails in full-suite — earlier test leaves model files under data/image_model/ that defeat the "absent" precondition
+---
+
+### Problem
+
+`tests/unit/extraction_v2/test_image_triage.py::TestLearnedTriageGate::test_gate_on_but_model_absent_falls_back_to_heuristic` passes in isolation but fails when run as part of the full unit suite. An earlier test appears to create files under `data/image_model/` (or equivalent) that defeat the "model absent" precondition this test asserts on.
+
+### Next Steps
+
+- Identify the earlier test that seeds `data/image_model/` and tighten its cleanup, OR
+- Pin model-loading via `tmp_path` / `monkeypatch` so this test does not rely on the shared `data/image_model/` directory

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -214,7 +214,6 @@ def stats():
     last_run = db.get_last_training_run("image_relevance")
     since_ts = last_run.get("completed_at") if last_run else None
     image_decisions_since = db.count_image_decisions_since(since_ts)
-    text_decisions_since = db.count_text_decisions_since(since_ts)
 
     recent_text_corrections = db.get_recent_text_corrections(limit=10)
     recent_text_additions = db.get_recent_text_additions(limit=10)
@@ -291,7 +290,6 @@ def stats():
         rejection_reason_labels=IMAGE_REJECTION_REASON_LABELS,
         last_training_run=last_run,
         image_decisions_since=image_decisions_since,
-        text_decisions_since=text_decisions_since,
         recent_text_corrections=recent_text_corrections,
         recent_text_additions=recent_text_additions,
         recent_image_additions=recent_image_additions,

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -80,10 +80,6 @@
                   <span class="text-success">({{ image_decisions_since.positive or 0 }} positive / {{ threshold_positive }}</span>,
                   <span class="text-danger">{{ image_decisions_since.negative or 0 }} negative</span>)
                 </p>
-                <p class="mb-0 small text-muted">
-                  Text decisions since same anchor: {{ text_decisions_since or 0 }}
-                  (informational — text extraction is rule-based, no retrain pipeline).
-                </p>
                 <div id="retrain-status" class="small mt-2"
                      {% if retrain_running %}data-running-id="{{ running_run_id }}"{% endif %}>
                   {% if retrain_running %}


### PR DESCRIPTION
- **refactor(web): drop redundant text-decisions line from image-classifier card**
- **docs(known-issues): log issues #455, #456 — pre-existing test failures surfaced during refactor**
