### PR TITLE
fix(test): use db.execute for INSERT-without-RETURNING (gh-398 hotfix #2)

### DIFF
--- a/tests/integration/test_analyze_text_decision_patterns.py
+++ b/tests/integration/test_analyze_text_decision_patterns.py
@@ -283,7 +283,7 @@ def test_success_path_writes_summary_findings_and_updates_run(clean_db, cli):
     db_url = __import__("os").environ["TEST_DATABASE_URL"]
     # Pre-insert the run row ourselves (simulates web-triggered invocation).
     pre_inserted_run_id = str(uuid.uuid4())
-    clean_db.query(
+    clean_db.execute(
         """
         INSERT INTO text_decision_analysis_runs (id, status, triggered_by)
         VALUES (%(id)s, 'running', 'test')
@@ -328,7 +328,7 @@ def test_exception_path_flips_status_to_failed(clean_db, cli):
 
     db_url = __import__("os").environ["TEST_DATABASE_URL"]
     pre_inserted_run_id = str(uuid.uuid4())
-    clean_db.query(
+    clean_db.execute(
         """
         INSERT INTO text_decision_analysis_runs (id, status, triggered_by)
         VALUES (%(id)s, 'running', 'test')


### PR DESCRIPTION
## Summary

Second post-merge hotfix to the gh-398 integration test added by PR #450. The first hotfix (#454) addressed two uniqueness-constraint violations in the seeder; this one addresses a `DatabaseAdapter` contract violation that was masked behind those failures.

## Failure on main (CI)

```
ValueError: db.query is SELECT-only (got INSERT without RETURNING).
Use db.execute(sql, params) for non-fetching writes, or add RETURNING to fetch result rows.
```

Surfaced in:
- `test_success_path_writes_summary_findings_and_updates_run` (line 286)
- `test_exception_path_flips_status_to_failed` (line 331)

Both pre-insert a row into `text_decision_analysis_runs` (no fetch needed) via `clean_db.query(...)` — wrong API. The adapter's runtime check rejects bare INSERTs to enforce that callers using `.query()` actually want rows back.

## Fix

Two-line `.query()` → `.execute()` swap. No other test logic changed. The two seeded rows still land identically.

## Test plan

- [x] `git push` pre-push unit tests passed.
- [ ] CI Integration Tests must now pass `test_analyze_text_decision_patterns.py` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)