### PR TITLE
chore(infra): enable USE_LEARNED_TRIAGE on filings-extraction (gh-442)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -114,6 +114,8 @@ Rules for any DB-touching command in this repo:
 | `VISION_PROVIDER_PRESCAN` | Optional | Provider for the image-level keyword pre-scan site (default `gemini`). Independent of `VISION_PROVIDER`. |
 | `VISION_MODEL_PRESCAN` | Optional | Model for the keyword pre-scan site (default `gemini-2.5-flash-lite`). |
 | `GEMINI_API_KEY` | With `VISION_CLASSIFY_PROVIDER=gemini` | Google AI Studio key for Gemini vision calls. Set manually in Render. |
+| `USE_LEARNED_TRIAGE` | Optional | Feature gate for the learned image-relevance triage in `src/extraction_v2/stages/image_triage.py`. Default `false`; **set to `true` on `filings-extraction` in prod as of 2026-05-04 (gh-442)**. When on, `predict_relevance()` is called per-image and `v2_image_assets.predicted_relevance` is populated; images scoring below `LEARNED_TRIAGE_MIN` are dropped from OCR/Vision. Reads model via the R2 pointer at `models/image_relevance/latest_run_id.txt`. |
+| `LEARNED_TRIAGE_MIN` | With `USE_LEARNED_TRIAGE=true` | Minimum model score required for an image to pass the gate. Default `0.4`; **prod uses `0.32`** (gh-442) — slightly below the current `cba5e60f` model's ~80%-recall threshold (0.341). |
 | `FILINGS_REVIEWER_ALLOW_PROD_WRITES` | Required for `R2Storage.put_bytes` | Must be set to `"1"` for any process that writes image bytes to R2. Refused otherwise. Reads (`get_bytes`, `exists`) are unaffected. Set on Render services that run extraction/ingestion (`filings-reviewer`, `filings-extraction`, `filings-onboarding-runner`); leave unset on local dev to prevent accidental prod writes when prod creds are sourced for one-off CLI work. |
 
 ## Image Storage

--- a/docs/known-issues/gh-461-flaky-text-decision-patterns-unique-violation.md
+++ b/docs/known-issues/gh-461-flaky-text-decision-patterns-unique-violation.md
@@ -1,0 +1,27 @@
+---
+id: 461
+source: gh
+slug: flaky-text-decision-patterns-unique-violation
+title: Flaky test_first_run_anchor_null_processes_all_decisions — v2_review_decisions_unique_fact UniqueViolation under xdist
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 461
+note: integration test added by #450 intermittently fails on parallel xdist runs; fixture insert collides with a sibling test on (filing_id, metric_id)
+---
+
+### Problem
+
+`tests/integration/test_analyze_text_decision_patterns.py::test_first_run_anchor_null_processes_all_decisions` (added 2026-05-04 by #450, gh-398) intermittently fails with `psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "v2_review_decisions_unique_fact"` when run under `pytest -n auto`. The fixture is not isolating its `v2_review_decisions` inserts from sibling tests sharing the same `(filing_id, metric_id)` keyspace.
+
+Observed failures on `origin/main` runs `f25f209a` and `4250a4a8` (2026-05-04, 16:08 / 16:19 UTC), and on PR #451 — which cleared on a single `gh run rerun --failed`. Will keep blocking PRs at the required Integration Tests check until fixed.
+
+### Next Steps
+
+- Repro under `pytest -n auto tests/integration/test_analyze_text_decision_patterns.py tests/integration/test_*.py -x -q` to find the colliding sibling test.
+- Tighten fixture isolation: either use a unique `filing_id` / `metric_id` per worker (xdist `worker_id`), or wrap inserts in `ON CONFLICT DO NOTHING` if the test doesn't require the unique-constraint write to succeed.
+- Add the fixture-isolation pattern to `.claude/rules/tests.md` so future integration tests don't repeat the bug.

--- a/render.yaml
+++ b/render.yaml
@@ -71,6 +71,10 @@ services:
         sync: false  # Set manually in Render dashboard
       - key: FILINGS_REVIEWER_ALLOW_PROD_WRITES
         value: "1"  # R2Storage.put_bytes guard — required; cron writes chart images via ocr_extraction.py
+      - key: USE_LEARNED_TRIAGE
+        value: "true"  # gh-442: gate extraction on learned image-relevance model (R2 pointer in models/image_relevance/latest_run_id.txt)
+      - key: LEARNED_TRIAGE_MIN
+        value: "0.32"  # gh-442: tuned slightly below cba5e60f model's 80%-recall threshold (0.341); P=0.094 / R~0.82
 
   - type: worker
     name: filings-onboarding-runner


### PR DESCRIPTION
## Summary

Closes gh-442. Flips the learned image-relevance gate on the `filings-extraction` cron service in `render.yaml` and tunes `LEARNED_TRIAGE_MIN=0.32` (down from the `0.4` default).

Going forward `predict_relevance()` runs per candidate image during extraction, `v2_image_assets.predicted_relevance` gets populated, and images scoring below 0.32 are dropped from the OCR/Vision pipeline.

## Threshold rationale

Fetched directly from `models/image_relevance/cba5e60f-9a99-4231-82e0-fe232c9a9792/model_report.txt` in R2:

```
AUC-ROC                   0.843
Avg precision (AP)        0.409
Score @ ~80% recall       0.341
Precision @ 80% recall    0.094
Heuristic baseline        P=0.163, R=0.474
```

Picking **0.32** — just below the 0.341 cutoff — captures ~82% recall with a small noise margin. Precision at the chosen point is ~0.094, vs heuristic baseline 0.163 at recall 0.474. Trading ~7 precision points for **~35 absolute recall points** is the desired direction: the gate sits upstream of expensive OCR/Vision and reviewers still see per-image scores downstream, so a sloppier gate that catches more positives is correct shape for this corpus.

## Prerequisite

Blocked-on-prereq was **gh-419** (silent joblib load-error observability). Merged at `b165ae31` (PR #451) before this PR was opened. Without it, a corrupt R2 artifact or sklearn drift would have silently fallen back to the heuristic with no log signal — there'd have been no way to know whether the gate was actually active.

With gh-419 live, `_load_joblib_into_cache` failures now log at `ERROR` and `ImageTriageStage` emits a one-shot status line per worker on first call, so flipping the gate is observably safe.

## Scope

Only `filings-extraction` gets the env vars. `filings-onboarding-runner` / `filings-reviewer` / `filings-nightly-sweep` don't run the triage stage.

`src/extraction_v2/stages/image_triage.py` defaults stay `false` / `0.4` — prod overrides live in `render.yaml` so future operators see them explicitly. No code changes.

This PR also files a separate known-issue (#461) for a flaky integration test surfaced during gh-419 merging — fixture-isolation bug in `test_first_run_anchor_null_processes_all_decisions`, intermittent `v2_review_decisions_unique_fact` UniqueViolation under xdist. Out of scope to fix here.

## Verification (post-Render-deploy)

- Render dashboard → `filings-extraction` → Environment tab — confirm both env vars (`USE_LEARNED_TRIAGE=true`, `LEARNED_TRIAGE_MIN=0.32`) live.
- After next 06:00 UTC cron run:
  - `SELECT COUNT(*) FROM v2_image_assets WHERE created_at > NOW() - INTERVAL '24 hours' AND predicted_relevance IS NOT NULL;` should be `> 0`.
  - Per-batch candidate-image count drops ~10–20% pre-vs-post (gate doing its job).
  - 14-day A/B accept rate from `v2_image_metric_confirmations` post-flip ≥ pre-flip.
  - Zero `_load_joblib_into_cache` ERROR lines in `filings-extraction` worker logs (gh-419 sanity).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('render.yaml'))"` — YAML valid; `USE_LEARNED_TRIAGE` and `LEARNED_TRIAGE_MIN` present only on `filings-extraction`.
- [x] Pre-commit framework hooks pass clean (no test files staged so pytest skipped per project policy).
- [ ] CI required checks: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright). If Integration Tests trips on the documented flake (#461), apply re-run-once protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)