### PR TITLE
fix(web): unclip review-page breadcrumb and wrap bulk-action-bar buttons

### DIFF
--- a/docs/known-issues/gh-464-sticky-bulk-bar-overlap-on-scroll.md
+++ b/docs/known-issues/gh-464-sticky-bulk-bar-overlap-on-scroll.md
@@ -1,0 +1,24 @@
+---
+id: 464
+source: gh
+slug: sticky-bulk-bar-overlap-on-scroll
+title: "Sticky review header and bulk-action-bar overlap each other on scroll (z-index 1010 vs 1011, same top)"
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 464
+note: bulk-action-bar sticks at the same top as the sticky review header; overlaps visually when a thumbnail is selected and the page is scrolled
+---
+
+### Problem
+
+On `/v2/review/<filing_id>` image tab, when the page is scrolled both `#bulk-action-bar` (`position: sticky; top: var(--navbar-height); z-index: 1011`) and `.review-sticky-header` (same `top`, `z-index: 1010`) stick simultaneously to the same vertical position. They visually overlap — the bulk-action-bar sits in front of the sticky filing header / tabs / filter bar, partially obscuring them whenever a thumbnail is checkbox-selected.
+
+### Next Steps
+
+- Either move `#bulk-action-bar` so its `top` is offset by the sticky-header's height (calc-based or via a JS-measured CSS variable), or
+- Drop the sticky positioning on the bulk-action-bar and let it scroll with the sidebar

--- a/src/web/static/css/review.css
+++ b/src/web/static/css/review.css
@@ -1593,8 +1593,6 @@
     z-index: 1010; /* below modal (1050), above main content */
     background: #fff;
     border-bottom: 1px solid var(--color-border);
-    /* Absorb container mt-4 (1.5rem) to tighten the gap beneath the navbar. */
-    margin-top: -1.5rem;
     margin-left: calc(-1 * var(--bs-gutter-x, 0.75rem));
     margin-right: calc(-1 * var(--bs-gutter-x, 0.75rem));
     padding: 0.25rem var(--bs-gutter-x, 0.75rem) 0.25rem;

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -763,7 +763,7 @@
     {# Left Column: Thumbnail Sidebar #}
     <div class="col-auto image-thumbnail-sidebar">
       <div id="bulk-action-bar" class="mb-2 d-none">
-        <div class="d-flex align-items-center gap-2 p-2 bg-light border rounded">
+        <div class="d-flex flex-wrap align-items-center gap-2 p-2 bg-light border rounded">
           <span id="bulk-selected-count" class="small fw-bold">0 selected</span>
           <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-bulk-select-all">Select all</button>
           <button type="button" class="btn btn-sm btn-danger" id="btn-bulk-reject">Reject all</button>


### PR DESCRIPTION
Two visual fixes on /v2/review/<filing_id>:

- Breadcrumb: drop margin-top: -1.5rem on .review-sticky-header. The
  opaque-white sticky bar was being pulled up over the breadcrumb's
  bottom edge, clipping its descenders.
- Bulk-action-bar: add flex-wrap to the inner d-flex so the five
  buttons (1 selected / Select all / Reject all / Undo / Clear) stack
  to a second row inside the 220px sidebar instead of overflowing into
  the main image-card column.
