### PR TITLE
docs(known-issues): flip 5 stale fragments to resolved

### DIFF
--- a/docs/known-issues/gh-354-add-metric-keyboard-shortcut.md
+++ b/docs/known-issues/gh-354-add-metric-keyboard-shortcut.md
@@ -3,7 +3,7 @@ id: 354
 source: gh
 slug: add-metric-keyboard-shortcut
 title: Add keyboard shortcut for "Add metric the classifier missed" button
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: XS
@@ -12,9 +12,11 @@ touches:
   - src/web/templates/unified_review.html
   - .claude/rules/web.md
 discovered: 2026-04-29
-updated: 2026-04-29
+updated: 2026-05-04
 gh_issue: 354
-note: User-noted gap surfaced during gh-352; every other image-tab action has a kbd binding except + Add metric.
+pr_refs:
+  - 447
+note: Shift+A keyboard shortcut shipped in PR #447 — image-level keydown handler triggers #btn-add-missed-detected-metric.click(), kbd badge added to button, .claude/rules/web.md table updated.
 ---
 
 ### Problem

--- a/docs/known-issues/gh-383-delete-orphan-v2-stats-templates.md
+++ b/docs/known-issues/gh-383-delete-orphan-v2-stats-templates.md
@@ -3,15 +3,17 @@ id: 383
 source: gh
 slug: delete-orphan-v2-stats-templates
 title: Delete orphan legacy templates v2_stats.html and v2_filing_list.html
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
 touches: []
 discovered: 2026-05-01
-updated: 2026-05-01
+updated: 2026-05-04
 gh_issue: 383
-note: orphan templates not referenced anywhere; safe to delete in cleanup PR
+pr_refs:
+  - 448
+note: Orphan templates v2_stats.html and v2_filing_list.html deleted in PR #448 (zero references confirmed via grep before deletion).
 ---
 
 ### Problem

--- a/docs/known-issues/gh-389-phase2-analytics-integration-tests.md
+++ b/docs/known-issues/gh-389-phase2-analytics-integration-tests.md
@@ -3,15 +3,17 @@ id: 389
 source: gh
 slug: phase2-analytics-integration-tests
 title: Add integration tests for Phase-2 Metric Analytics helpers
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
 touches: []
 discovered: 2026-05-01
-updated: 2026-05-01
+updated: 2026-05-04
 gh_issue: 389
-note: 7 new db.py helpers landed with unit tests only; add integration tests against TEST_DATABASE_URL
+pr_refs:
+  - 449
+note: Integration tests for Phase-2 analytics helpers (get_last_training_run, get_recent_text_corrections/_additions, get_recent_image_corrections/_additions) shipped in PR #449.
 ---
 
 ### Problem

--- a/docs/known-issues/gh-398-integration-test-for-text-pattern-script.md
+++ b/docs/known-issues/gh-398-integration-test-for-text-pattern-script.md
@@ -3,15 +3,19 @@ id: 398
 source: gh
 slug: integration-test-for-text-pattern-script
 title: "Add integration test for scripts/analyze_text_decision_patterns.py"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
 touches: []
 discovered: 2026-05-01
-updated: 2026-05-01
+updated: 2026-05-04
 gh_issue: 398
-note: DB-touching script needs tests/integration/test_<script>.py per scripts.md
+pr_refs:
+  - 450
+  - 454
+  - 459
+note: Integration test for analyze_text_decision_patterns.py shipped in PR #450; hotfixes #454 (seed two facts to satisfy v2_review_decisions_unique_fact) and #459 (use db.execute for INSERT-without-RETURNING) followed.
 ---
 
 ### Problem

--- a/docs/known-issues/gh-441-enable-metric-classify-in-prod.md
+++ b/docs/known-issues/gh-441-enable-metric-classify-in-prod.md
@@ -1,0 +1,39 @@
+---
+id: 441
+source: gh
+slug: enable-metric-classify-in-prod
+title: Enable Vision-API metric classifier in prod (ENABLE_METRIC_CLASSIFY=true)
+status: resolved
+severity: medium
+autonomy: review
+estimated: S
+touches:
+  - render.yaml
+discovered: '2026-05-04'
+updated: '2026-05-04'
+gh_issue: 441
+pr_refs:
+  - 444
+note: ENABLE_METRIC_CLASSIFY=true enabled in prod via PR #444; v2_image_classifications now populated by the filings-extraction cron with Gemini Flash Lite predictions.
+---
+
+### Problem
+
+`v2_image_classifications` is empty in prod. The Vision-API metric classifier (Tripod Leg B from #92) is fully wired in `src/extraction_v2/stages/image_classify.py` and the bake-off model (`gemini-2.5-flash-lite`) is the confirmed default — but the gate in `render.yaml:63` (`filings-extraction` cron) is set to `"false"` with the comment "Flip to 'true' after smoke-test."
+
+The "smoke-test" deferral has outlasted its original premise. Cost is the cheapest Gemini Flash Lite tier (per 2026-04-23 bake-off), errors are caught and non-fatal (the stage doesn't block other pipeline stages on failure), and the data is needed to build downstream reviewer surfaces (per-metric prediction confidence in the image card UI, training data for any future ID classifier work).
+
+### Next Steps
+
+1. Brief local smoke test: run `scripts/batch_v2_extraction.py` on ~3 filings with `ENABLE_METRIC_CLASSIFY=true` locally (against `TEST_DATABASE_URL`). Verify rows land in `v2_image_classifications` with non-NULL `predicted_metrics` and `confidence` populated.
+2. Flip `render.yaml:63` value to `"true"` (just the value, not the comment — preserve the historical pointer to #92 for context).
+3. Monitor first nightly batch: row count growth in `v2_image_classifications`, no error spike in `filings-extraction` worker logs.
+4. Decide whether `VISION_CLASSIFY_THRESHOLD=0.5` warrants tuning before flip — note from `.claude/rules/infrastructure.md` env table: "Records below the floor are still persisted with their true confidence." The threshold only affects the downstream `predicted_relevant` projection, not the row write. Default 0.5 is fine for the initial flip.
+
+### Verification
+
+- A new nightly batch produces rows in `v2_image_classifications` for chart and table_image assets.
+- `confidence` distribution looks reasonable (not all 0.0, not all 1.0).
+- `predicted_metrics` references valid metric IDs from `v2_metric_definitions`.
+- No spike in `filings-extraction` worker error logs.
+- Per-filing extraction runtime increase is bounded (one Gemini Flash Lite call per chart/table image; for a typical 10-chart filing, ~3-5s added).


### PR DESCRIPTION
Status drift on main — work shipped but fragments never updated.
Same failure mode tracked by gh-258.

- gh-354 → resolved (PR #447, Shift+A keyboard shortcut)
- gh-383 → resolved (PR #448, orphan templates deleted)
- gh-389 → resolved (PR #449, Phase-2 analytics integration tests)
- gh-398 → resolved (PR #450 + hotfixes #454, #459)
- gh-441 → resolved (PR #444, ENABLE_METRIC_CLASSIFY=true in prod)

gh-441 fragment was local-only and never pushed; now committed
as resolved alongside the other four flips for symmetry with
gh-442 (closed via #466 with the fragment on main).
