### PR TITLE
docs(known-issues): log issues #481-#484 — PR-C1 follow-ups

### DIFF
--- a/docs/known-issues/gh-481-route-enforcement-integration-test.md
+++ b/docs/known-issues/gh-481-route-enforcement-integration-test.md
@@ -1,0 +1,28 @@
+---
+id: 481
+source: gh
+slug: route-enforcement-integration-test
+title: "auth: add tests/integration/auth/test_route_enforcement.py (deferred from PR-C1)"
+status: open
+severity: low
+autonomy: skip
+estimated: M
+touches:
+  - tests/integration/auth/test_route_enforcement.py
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 481
+pr_refs:
+  - 479
+note: per-route-module integration suite for the flag-on enforcement contract; unit tests cover the decorator in isolation but not the wiring on every route
+---
+
+### Problem
+
+PR-C1 (#479) added `@require(<perm>)` to 39 routes across 6 modules. The brief required `tests/integration/auth/test_route_enforcement.py` to exercise the flag-on enforcement contract end-to-end against a real DB, but the test was deferred — unit tests in `tests/unit/auth/test_require_flag_aware.py` and `test_legacy_session_bound.py` already pin the decorator behavior in isolation. Without an integration suite, removing a decorator or wiring the wrong permission on a future route would not be caught by tests.
+
+### Next Steps
+
+- For each protected route module (`api_unified`, `api_ingest`, `ingest`, `review_unified`, `review_pres_images`, `image_cache`): assert that an unauthenticated request returns 401/redirect, viewer→`decision.write` returns 403, reviewer→`decision.undo.any` returns 403, admin→200, with `auth_enforcement_enabled=true` forced via monkeypatch.
+- Use the dev-bypass route or monkeypatch to set `g.user`; force `feature_flags.is_enabled('auth_enforcement_enabled')=True` per test via the same fixture pattern as `tests/unit/auth/test_middleware.py`.
+- Run via `pytest tests/integration/auth/test_route_enforcement.py` and ensure CI's Integration Tests job picks it up.

--- a/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
+++ b/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
@@ -1,0 +1,29 @@
+---
+id: 482
+source: gh
+slug: stacked-require-admin-cleanup
+title: "auth: remove stacked @require_admin from retrain/analysis endpoints (PR-C1 cleanup)"
+status: open
+severity: low
+autonomy: skip
+estimated: S
+touches:
+  - src/web/routes/api_unified.py
+  - src/web/middleware.py
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 482
+pr_refs:
+  - 479
+note: four admin endpoints carry both @require_admin and @require(INGEST_RUN); remove the legacy decorator once Stage-C enforcement has soaked
+---
+
+### Problem
+
+PR-C1 (#479) added `@require(INGEST_RUN)` to four admin-style endpoints in `src/web/routes/api_unified.py` (`/models/image-classifier/retrain`, `/extraction/analyze-text-decisions`, `/extraction/recommendation-decisions` POST + DELETE) but left the legacy `@require_admin` decorator stacked above them to avoid behavior changes during the transition. Both gates resolve to admin-only, so they're functionally redundant once `auth_enforcement_enabled=true`. `require_admin`'s docstring explicitly says it is meant to be replaced 1:1 by `@require('<permission>')` once Stage A2 lands — Stage A2 has shipped, so this cleanup is unblocked.
+
+### Next Steps
+
+- After Stage-C enforcement has been live for at least one soak window, remove `@require_admin` from the four endpoints above.
+- Confirm no other call sites still use `require_admin`; remove the import where it's the only consumer.
+- If `ADMIN_USER_IDS` env var is no longer read anywhere, delete `require_admin` from `src/web/middleware.py` entirely.

--- a/docs/known-issues/gh-483-api-key-caller-migration-post-flip.md
+++ b/docs/known-issues/gh-483-api-key-caller-migration-post-flip.md
@@ -1,0 +1,31 @@
+---
+id: 483
+source: gh
+slug: api-key-caller-migration-post-flip
+title: "auth: API-key-caller migration plan for post-flip (Stage D adjacent)"
+status: open
+severity: medium
+autonomy: skip
+estimated: M
+touches:
+  - src/web/middleware.py
+  - tests/deployment/test_smoke.py
+  - docs/operations/auth-stage-c-runbook.md
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 483
+pr_refs:
+  - 479
+note: post-flip, Authorization ApiKey callers lose access to /api/v2/* because @require() needs g.user which _verify_api_key does not populate; runbook claim that API-key callers still work is not yet true
+---
+
+### Problem
+
+PR-C1 (#479) replaced the blueprint-wide `register_api_auth` gate with per-route `@require(<perm>)` decorators that read `g.user`. `_verify_api_key()` validates the API key but does not populate `g.user`, so once `auth_enforcement_enabled=true`, a valid `Authorization: ApiKey ...` request to `/api/v2/*` is rejected by `@require()` with a 401. The Stage-C runbook (`docs/operations/auth-stage-c-runbook.md`) currently claims "API-key-only callers still work via Authorization: ApiKey header" in the post-flip verification — that claim only holds if a service-account bridge is added before the flip. The smoke test `tests/deployment/test_smoke.py::TestApiAuth::test_api_accepts_valid_key` will fail post-flip without it.
+
+### Next Steps
+
+- Pick one of three options before the operator flips the flag: (1) service-account bridge in `_verify_api_key()` that synthesizes a `SessionUser` when api-key validates, (2) migrate external callers to session tokens via OAuth or a service-account login, or (3) drop the api-key path entirely (Stage D scope).
+- Audit external callers: Render cron jobs (nightly sweeper, onboarding watcher) and any hand-rolled integrations against `/api/v2/*`.
+- Update `docs/operations/auth-stage-c-runbook.md` post-flip-verification step to reflect the chosen option.
+- Re-enable the smoke tests at `tests/deployment/test_smoke.py::TestApiAuth` (currently `pytest.skip`'d with a pointer to this issue).

--- a/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
+++ b/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
@@ -1,0 +1,29 @@
+---
+id: 484
+source: gh
+slug: auth-readiness-report-a8-followups
+title: "auth: three A8 follow-ups in auth_readiness_report.py"
+status: open
+severity: low
+autonomy: skip
+estimated: S
+touches:
+  - scripts/auth_readiness_report.py
+  - tests/unit/auth/test_readiness_report.py
+discovered: 2026-05-04
+updated: 2026-05-04
+gh_issue: 484
+pr_refs:
+  - 479
+note: dev-bypass guard checks local env not prod, dev-bypass predicate duplicated instead of imported, JSON serialization only tested with empty data
+---
+
+### Problem
+
+Three minor issues in `scripts/auth_readiness_report.py` were surfaced during the Wave-4 critical eval and explicitly deferred out of Stage C per the orchestrator brief. (1) `--check` reads dev-bypass env vars from the local environment running the script — when operators run from a dev machine before flipping the flag, the check passes locally even if dev-bypass would be on in prod. (2) The dev-bypass predicate is re-implemented inline rather than importing `src.auth.dev_bypass.is_dev_bypass_enabled()`; the two implementations could drift. (3) Unit tests for `--json` output only exercise the empty-DB case — schema or serialization regressions in the populated case won't be caught.
+
+### Next Steps
+
+- Add a `--target-env` flag that reads env vars from a deploy config (or document the limitation and tell operators to run `--check` from inside the production container).
+- Replace the inline dev-bypass predicate with `from src.auth.dev_bypass import is_dev_bypass_enabled` and a single call.
+- Add a unit test that seeds 2-3 `auth_users` and 1-2 `auth_legacy_aliases`, runs `--json`, and asserts the output shape matches the expected schema.


### PR DESCRIPTION
## Summary

Files four known-issues fragments under `docs/known-issues/` for the follow-ups surfaced during the Stage-C orchestration cycle. All four were deferred out of PR-C1 (#479) and PR-C2 (#480) per the orchestrator brief and now have matching GH issues + fragments so the nightly sweeper can pick them up if any get reclassified to `autonomy: safe`.

| Issue | Fragment | Severity | Theme |
|---|---|---|---|
| #481 | gh-481-route-enforcement-integration-test | low | per-route flag-on integration suite |
| #482 | gh-482-stacked-require-admin-cleanup | low | drop redundant @require_admin once Stage-C soaks |
| #483 | gh-483-api-key-caller-migration-post-flip | medium | API-key callers lose access post-flip; runbook claim depends on a fix |
| #484 | gh-484-auth-readiness-report-a8-followups | low | three minor cleanups in auth_readiness_report.py |

All fragments use `autonomy: skip` (default for new issues — the sweeper won't pick them up until they're triaged and reclassified).

## Test plan

- [x] `pre-commit` validator passes on all four fragments
- [x] `pre-push` unit tests pass
- [ ] CI: Lint, Known-issues rollup artifact, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)