### PR TITLE
fix(extraction_v2): per-call env reads in image_triage gate (gh-477)

### DIFF
--- a/docs/known-issues/gh-477-image-triage-env-vars-module-scope.md
+++ b/docs/known-issues/gh-477-image-triage-env-vars-module-scope.md
@@ -1,0 +1,64 @@
+---
+id: 477
+source: gh
+slug: image-triage-env-vars-module-scope
+title: image_triage.py reads USE_LEARNED_TRIAGE at module scope — env-var changes silently require worker restart
+status: resolved
+severity: high
+autonomy: review
+estimated: S
+touches:
+  - src/extraction_v2/stages/image_triage.py
+  - tests/unit/extraction_v2/test_image_triage.py
+discovered: '2026-05-04'
+updated: '2026-05-04'
+gh_issue: 477
+note: Refactored to per-call helpers `_use_learned_triage()` / `_learned_triage_min()`; env-var flips on long-running workers now take effect on the next request, no restart needed. Added regression test that constructs the stage with the env unset, flips `USE_LEARNED_TRIAGE=true`, and asserts the next triage call uses the learned gate.
+---
+
+### Problem
+
+`src/extraction_v2/stages/image_triage.py:46` reads:
+
+```python
+_USE_LEARNED_TRIAGE = os.environ.get("USE_LEARNED_TRIAGE", "false").lower() == "true"
+_LEARNED_TRIAGE_MIN = float(os.environ.get("LEARNED_TRIAGE_MIN", "0.4"))
+```
+
+Both are **module-level** assignments. They evaluate exactly once, at first import of the module. After that the values are baked into the worker process for its entire lifetime — env-var changes have no effect until the process restarts.
+
+This created a hidden landmine when gh-469 (PR #471) added `USE_LEARNED_TRIAGE=true` to `filings-onboarding-runner` in `render.yaml`. Render *should* restart the worker on YAML changes, but a long-running worker process never re-imports the module, so the gate stays off silently.
+
+Invisible to PR review (the YAML looks correct), invisible to operators (no log signal that the gate is off), invisible to monitoring (`v2_image_assets.predicted_relevance` is legitimately allowed to be NULL when the gate is intentionally off, so the absence isn't an alert).
+
+Compare to `src/extraction_v2/pipeline.py:502`: `_env_truthy("ENABLE_METRIC_CLASSIFY")` is read inside `_setup_stages()`, which runs per-pipeline-instance per filing — restart-immune. The image_triage path needs the same pattern.
+
+### Repro
+
+2026-05-04 22:25 UTC: filing 1529 was re-extracted on the `filings-onboarding-runner` worker after gh-469 merged and `GOOGLE_API_KEY` was set. Text extraction produced 349 new `v2_segments` rows. The image stage upserted the existing `v2_image_assets` row but did NOT populate `predicted_relevance` — confirming the module-level gate was still `False` from the worker's original import.
+
+### Next Steps
+
+Two layered fixes:
+
+1. **Refactor `image_triage.py` to read env vars per-call.** Move the `_USE_LEARNED_TRIAGE` / `_LEARNED_TRIAGE_MIN` reads into the gate site (around lines 600-640 where the gate fires). Match the `_env_truthy("ENABLE_METRIC_CLASSIFY")` pattern in `pipeline.py:502`. After this, env-var changes take effect on the next request, no restart needed.
+2. **Document the trap** in `.claude/rules/infrastructure.md` env-vars table — until the refactor lands, operators must manually restart workers after any env-var change. The "Render auto-applies env vars" assumption is half-true.
+
+### Test coverage
+
+A new unit test should verify: monkeypatch `os.environ["USE_LEARNED_TRIAGE"] = "true"` AFTER import, then call the gate function, expect the gate to be active. Today's module-level pattern would fail this test (the value was already read at import); the refactor makes it pass.
+
+### Same-shaped trap to scan for
+
+Audit other module-level `os.environ.get(...)` reads in `src/extraction_v2/stages/` and `src/extraction_v2/pipeline.py`. Any that gate behavior should move to per-call. Quick pass:
+
+```bash
+grep -rn '^_[A-Z_]* = os\.environ' src/extraction_v2/
+```
+
+Out of scope here unless the audit finds something equally consequential — file separately if so.
+
+### Verification
+
+- Apply the refactor; in a worker shell, set `USE_LEARNED_TRIAGE=true`, trigger a filing through the pipeline, confirm `predicted_relevance IS NOT NULL`. Then set `=false`, trigger again, confirm new images get NULL. Both transitions should work without restarting the worker.
+- After fix lands and worker redeploys: re-extract filing 1529 (`POST /ingest/batch/c0f070ce-e062-4724-8916-c31e05050087/reextract`), confirm the upserted `v2_image_assets` row gets `predicted_relevance` populated and a `v2_image_classifications` row appears.

--- a/src/extraction_v2/stages/image_triage.py
+++ b/src/extraction_v2/stages/image_triage.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 # ---------------------------------------------------------------------------
 # Learned triage feature flags
 # ---------------------------------------------------------------------------
@@ -43,8 +44,18 @@ logger = logging.getLogger(__name__)
 # LEARNED_TRIAGE_MIN controls the minimum predicted score (default 0.4).
 # When false (default), or when the model is absent, existing heuristic
 # behavior is preserved exactly.
-_USE_LEARNED_TRIAGE: bool = os.environ.get("USE_LEARNED_TRIAGE", "false").lower() == "true"
-_LEARNED_TRIAGE_MIN: float = float(os.environ.get("LEARNED_TRIAGE_MIN", "0.4"))
+#
+# Reads happen per-call (not at module import) so env-var flips on a
+# long-running worker take effect on the next request — no restart needed.
+# Mirrors the `_env_truthy("ENABLE_METRIC_CLASSIFY")` pattern at
+# `src/extraction_v2/pipeline.py:502`. See gh-477.
+def _use_learned_triage() -> bool:
+    return os.environ.get("USE_LEARNED_TRIAGE", "false").lower() == "true"
+
+
+def _learned_triage_min() -> float:
+    return float(os.environ.get("LEARNED_TRIAGE_MIN", "0.4"))
+
 
 # Set on first triage stage run per worker process to emit a one-shot
 # load-status log. Persists across `ImageTriageStage` instances within a worker
@@ -63,7 +74,7 @@ def _log_triage_model_status_once() -> None:
     the gate don't get noise from it.
     """
     global _LOGGED_TRIAGE_MODEL_STATUS
-    if _LOGGED_TRIAGE_MODEL_STATUS or not _USE_LEARNED_TRIAGE:
+    if _LOGGED_TRIAGE_MODEL_STATUS or not _use_learned_triage():
         return
     _LOGGED_TRIAGE_MODEL_STATUS = True
     from src.shared.image_features import _load_model
@@ -644,7 +655,7 @@ class ImageTriageStage:
             # the asset and use it in place of the heuristic threshold check.
             # Falls back transparently to heuristic when model is absent.
             queued: bool
-            if _USE_LEARNED_TRIAGE:
+            if _use_learned_triage():
                 features = v2_row_to_features_input(
                     {
                         "nearby_text": asset.nearby_text,
@@ -658,7 +669,7 @@ class ImageTriageStage:
                 score = predict_relevance(features)
                 if score is not None:
                     asset.predicted_relevance = score
-                    queued = score >= _LEARNED_TRIAGE_MIN
+                    queued = score >= _learned_triage_min()
                 else:
                     # Model absent — fall back to heuristic
                     queued = asset.relevance_score >= self.MIN_RELEVANCE_FOR_PROCESSING

--- a/tests/unit/extraction_v2/test_image_triage.py
+++ b/tests/unit/extraction_v2/test_image_triage.py
@@ -964,8 +964,8 @@ class TestPromoteToFullPageScan:
 class TestLearnedTriageGate:
     """Tests for the USE_LEARNED_TRIAGE feature-flag gate (Wave B3 Stage 1).
 
-    The gate is a module-level flag evaluated at import, so tests patch the
-    module attribute directly rather than setting env and reloading.
+    Post gh-477, the gate is read per-call from `os.environ`, so tests use
+    `monkeypatch.setenv` rather than patching module attributes.
     """
 
     @pytest.fixture
@@ -986,10 +986,7 @@ class TestLearnedTriageGate:
         self, stage: ImageTriageStage, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """USE_LEARNED_TRIAGE=false (default): behavior matches heuristic path."""
-        monkeypatch.setattr(
-            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
-            False,
-        )
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "false")
 
         asset = self._make_chart_asset()
         result = stage.triage_images([asset])
@@ -1011,10 +1008,11 @@ class TestLearnedTriageGate:
         This is the critical fallback path — if the model artifact never ships
         or fails to load, the pipeline must not crash or silently drop images.
         """
-        monkeypatch.setattr(
-            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
-            True,
-        )
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
+        # Force the local-disk resolution path; with R2_BUCKET set, _load_model
+        # would materialize the live model from storage and bypass the patched
+        # DEFAULT_MODEL_PATH below (see image_features._load_model:194).
+        monkeypatch.delenv("R2_BUCKET", raising=False)
         # Point the loader at a non-existent path so predict_relevance returns None.
         monkeypatch.setattr(
             "src.shared.image_features.DEFAULT_MODEL_PATH",
@@ -1046,10 +1044,7 @@ class TestLearnedTriageGate:
         asset should be queued regardless of its heuristic relevance_score and
         predicted_relevance should land on the asset.
         """
-        monkeypatch.setattr(
-            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
-            True,
-        )
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
         monkeypatch.setattr(
             "src.extraction_v2.stages.image_triage.predict_relevance",
             lambda features: 0.8,
@@ -1067,10 +1062,7 @@ class TestLearnedTriageGate:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """USE_LEARNED_TRIAGE=true + predicted_relevance < LEARNED_TRIAGE_MIN: skip."""
-        monkeypatch.setattr(
-            "src.extraction_v2.stages.image_triage._USE_LEARNED_TRIAGE",
-            True,
-        )
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
         # Default LEARNED_TRIAGE_MIN is 0.4; 0.2 is below threshold.
         monkeypatch.setattr(
             "src.extraction_v2.stages.image_triage.predict_relevance",
@@ -1084,6 +1076,34 @@ class TestLearnedTriageGate:
         # Asset was classified but not queued (below learned threshold).
         assert asset.classification == ImageClassification.CHART
         assert len(result) == 0
+
+    def test_env_var_change_after_stage_construction_takes_effect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Flipping USE_LEARNED_TRIAGE after import picks up on the next call (gh-477).
+
+        Pre-refactor the gate was read at module import, so a long-running worker
+        would never see a Render env-var flip until restart. This test pins the
+        per-call read by constructing the stage with the var unset, then flipping
+        it on AFTER construction, and asserting the next triage call exercises
+        the learned gate path.
+        """
+        monkeypatch.delenv("USE_LEARNED_TRIAGE", raising=False)
+        stage = ImageTriageStage()
+
+        # Flip the gate ON after the stage already exists.
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
+        monkeypatch.setattr(
+            "src.extraction_v2.stages.image_triage.predict_relevance",
+            lambda features: 0.9,
+        )
+
+        asset = self._make_chart_asset()
+        result = stage.triage_images([asset])
+
+        # If the read were still module-scoped, predicted_relevance would stay None.
+        assert asset.predicted_relevance == 0.9
+        assert len(result) == 1
 
 
 # ============================================================================
@@ -1227,10 +1247,9 @@ class TestTriageGateEagerLoadStatusLog:
         """USE_LEARNED_TRIAGE=true + missing model → exactly one ERROR per worker."""
         import logging
 
-        from src.extraction_v2.stages import image_triage
         from src.shared import image_features
 
-        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", True)
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
         # Point the loader at a non-existent file so _load_model returns None silently.
         monkeypatch.setattr(image_features, "DEFAULT_MODEL_PATH", tmp_path / "no_such_model.joblib")
 
@@ -1267,10 +1286,9 @@ class TestTriageGateEagerLoadStatusLog:
         import logging
         from unittest.mock import MagicMock, patch
 
-        from src.extraction_v2.stages import image_triage
         from src.shared import image_features
 
-        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", True)
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "true")
         # Provide a real existing path; patch joblib.load to return a fake pipeline.
         model_file = tmp_path / "model.joblib"
         model_file.write_bytes(b"placeholder")
@@ -1301,9 +1319,7 @@ class TestTriageGateEagerLoadStatusLog:
         """USE_LEARNED_TRIAGE=false → no eager-load log of any level."""
         import logging
 
-        from src.extraction_v2.stages import image_triage
-
-        monkeypatch.setattr(image_triage, "_USE_LEARNED_TRIAGE", False)
+        monkeypatch.setenv("USE_LEARNED_TRIAGE", "false")
 
         with caplog.at_level(logging.DEBUG, logger="src.extraction_v2.stages.image_triage"):
             ImageTriageStage().process(self._empty_context())


### PR DESCRIPTION
USE_LEARNED_TRIAGE / LEARNED_TRIAGE_MIN were read at module import, so
long-running workers (filings-extraction, filings-onboarding-runner)
kept the import-time value for their entire lifetime — Render env-var
flips silently required a worker restart. Refactor to per-call helpers
matching the _env_truthy("ENABLE_METRIC_CLASSIFY") pattern at
pipeline.py:502; env flips now take effect on the next request.

Also fix a pre-existing test-isolation bug in
test_gate_on_but_model_absent_falls_back_to_heuristic where the loader's
R2 path bypassed the patched DEFAULT_MODEL_PATH when a prior test had
populated the model cache.
