### PR TITLE
fix(css): stack bulk-action-bar below sticky review header (gh-464)

### DIFF
--- a/docs/known-issues/gh-464-sticky-bulk-bar-overlap-on-scroll.md
+++ b/docs/known-issues/gh-464-sticky-bulk-bar-overlap-on-scroll.md
@@ -3,14 +3,18 @@ id: 464
 source: gh
 slug: sticky-bulk-bar-overlap-on-scroll
 title: "Sticky review header and bulk-action-bar overlap each other on scroll (z-index 1010 vs 1011, same top)"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
-touches: []
+touches:
+  - src/web/static/css/review.css
+  - src/web/templates/unified_review.html
 discovered: 2026-05-04
 updated: 2026-05-04
 gh_issue: 464
+pr_refs:
+  - 488
 note: bulk-action-bar sticks at the same top as the sticky review header; overlaps visually when a thumbnail is selected and the page is scrolled
 ---
 
@@ -22,3 +26,9 @@ On `/v2/review/<filing_id>` image tab, when the page is scrolled both `#bulk-act
 
 - Either move `#bulk-action-bar` so its `top` is offset by the sticky-header's height (calc-based or via a JS-measured CSS variable), or
 - Drop the sticky positioning on the bulk-action-bar and let it scroll with the sidebar
+
+### Resolution
+
+Fixed in PR #488. Added `--review-sticky-header-height: 130px` CSS variable to `:root` in `src/web/static/css/review.css`, then changed `#bulk-action-bar`'s `top` from `var(--navbar-height)` to `calc(var(--navbar-height) + var(--review-sticky-header-height))`. The bulk-action bar now stacks below the sticky review header (navbar + 130px offset) instead of overlapping it. Z-index values were not changed. The `130px` value accounts for the filing title row + tab bar + image filter bar + padding in the sticky header on the images tab; a comment in the CSS advises calibrating in DevTools if the header layout changes.
+
+No Playwright stickiness assertion was added — the existing `tests/ui/review.spec.js` covers images-tab presence but has no scroll/sticky assertions. A scroll-based stickiness test would require a longer viewport scroll simulation; left as a follow-up.

--- a/src/web/static/css/review.css
+++ b/src/web/static/css/review.css
@@ -54,6 +54,12 @@
     /* Sticky-offset constant — matches the compact navbar (padding-y 0.25rem).
        Calibrate against DevTools if navbar styling changes. See KNOWN_ISSUES #41. */
     --navbar-height: 48px;
+
+    /* Approximate rendered height of .review-sticky-header (filing title row +
+       tab bar + filter bar + padding).  The bulk-action-bar uses this to stack
+       below the header instead of overlapping it (gh-464).  Calibrate in
+       DevTools if the header layout changes (e.g. pill-row wraps to two lines). */
+    --review-sticky-header-height: 130px;
 }
 
 /* Compact the primary navbar — shaves ~4px top + ~4px bottom vs Bootstrap default. */
@@ -1170,12 +1176,12 @@
     flex-shrink: 0;
 }
 
-/* Pin the bulk action bar so Undo / Reject stay visible (and on top of the
-   sticky review header at z-index 1010) while the reviewer scrolls the
-   thumbnail column. */
+/* Pin the bulk action bar so Undo / Reject stay visible while the reviewer
+   scrolls the thumbnail column.  top is offset past the sticky review header
+   (gh-464: both elements shared the same top, causing visual overlap). */
 #bulk-action-bar {
     position: sticky;
-    top: var(--navbar-height);
+    top: calc(var(--navbar-height) + var(--review-sticky-header-height));
     z-index: 1011;
     background: var(--bs-white, #fff);
 }


### PR DESCRIPTION
## Summary

- `#bulk-action-bar` and `.review-sticky-header` both used `top: var(--navbar-height)`, causing the bulk-action bar to float in front of the sticky filing header / tabs / filter bar whenever thumbnails are checkbox-selected and the page is scrolled.
- Added `--review-sticky-header-height: 130px` CSS variable to `:root` in `review.css`.
- Changed `#bulk-action-bar` `top` from `var(--navbar-height)` to `calc(var(--navbar-height) + var(--review-sticky-header-height))` so the bar stacks below the header instead of overlapping it. Z-index values unchanged.
- Closes gh-464; fragment flipped to `status: resolved`, `touches:` populated.

## Test plan

- [ ] Unit tests: all 4564 pass (verified pre-push)
- [ ] Open `/v2/review/<filing_id>?tab=images`, select one or more thumbnails via checkbox, scroll down — bulk-action bar should appear below the sticky review header, not in front of it
- [ ] Verify at both narrow (<900px) and wide viewports
- [ ] Verify no knock-on layout breakage of thumbnail grid or filter chips

## Notes

- `--review-sticky-header-height: 130px` is a static estimate for the images-tab header (title row + tab bar + filter bar + padding). A comment in the CSS advises calibrating in DevTools if the header layout changes.
- The adjacent `.image-thumbnail-sidebar .card { top: 80px }` hardcoded value may also be stale relative to the full sticky-header height, but is out of scope for this PR.
- No Playwright stickiness assertion added — existing `tests/ui/review.spec.js` covers images-tab presence but has no scroll/sticky assertions; a scroll simulation test is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)