### PR TITLE
fix(tests): add autouse _MODEL_CACHE isolation fixture on TestLearnedTriageGate (gh-445, gh-456)

### DIFF
--- a/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
+++ b/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
@@ -3,7 +3,7 @@ id: 445
 source: gh
 slug: image-triage-test-pollution-from-cache-dir
 title: test_gate_on_but_model_absent_falls_back_to_heuristic fails under full pytest run due to data/image_model/_cache/ pollution
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: —
@@ -25,3 +25,7 @@ Pre-existing on clean main (verified via `git stash` + rerun on `worktree-gh-426
 - Identify which test in the suite creates / leaves behind `data/image_model/_cache/` (likely a retrain or score test).
 - Either isolate that test's writes to `tmp_path` or have `test_gate_on_but_model_absent_falls_back_to_heuristic` monkeypatch the model-loader path to a guaranteed-empty location.
 - Add a session-level fixture / autouse cleanup if the cache dir is intended to be writable in tests.
+
+### Resolution
+
+The root cause was `_MODEL_CACHE` — a module-scope dict in `src/shared/image_features.py` — persisting across test instances. An earlier test that loaded a real model artifact would populate this cache, defeating the "model absent" precondition. The fix (see also gh-456) adds a class-level `autouse=True` fixture (`reset_model_cache`) to `TestLearnedTriageGate` in `tests/unit/extraction_v2/test_image_triage.py` that calls `image_features._MODEL_CACHE.clear()` both before and after every test in the class — mirroring the pattern already in place on `TestTriageGateEagerLoadStatusLog` (commit `b165ae31`). No production code was modified.

--- a/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
+++ b/docs/known-issues/gh-445-image-triage-test-pollution-from-cache-dir.md
@@ -11,6 +11,8 @@ touches: []
 discovered: 2026-05-04
 updated: 2026-05-04
 gh_issue: 445
+pr_refs:
+- 491
 note: image-triage model-absent test passes in isolation but fails under full pytest -x -q because a sibling test leaves data/image_model/_cache/ populated; masks regression coverage on the model-absent fallback path
 ---
 

--- a/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
+++ b/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
@@ -3,7 +3,7 @@ id: 456
 source: gh
 slug: test-image-triage-model-absent-order-dependent
 title: "test_image_triage: TestLearnedTriageGate::test_gate_on_but_model_absent_falls_back_to_heuristic order-dependent on data/image_model/ filesystem state"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
@@ -22,3 +22,7 @@ note: passes in isolation, fails in full-suite — earlier test leaves model fil
 
 - Identify the earlier test that seeds `data/image_model/` and tighten its cleanup, OR
 - Pin model-loading via `tmp_path` / `monkeypatch` so this test does not rely on the shared `data/image_model/` directory
+
+### Resolution
+
+The root cause was `_MODEL_CACHE` — a module-scope dict in `src/shared/image_features.py` — persisting across test instances in the same pytest process. An earlier test that loaded a real model artifact would populate this cache, so `test_gate_on_but_model_absent_falls_back_to_heuristic` found a cached result even when `DEFAULT_MODEL_PATH` pointed to an absent file. The fix (see also gh-445) adds a class-level `autouse=True` fixture (`reset_model_cache`) to `TestLearnedTriageGate` in `tests/unit/extraction_v2/test_image_triage.py` that calls `image_features._MODEL_CACHE.clear()` both before and after every test — mirroring the existing pattern on `TestTriageGateEagerLoadStatusLog` (commit `b165ae31`). No production code was modified.

--- a/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
+++ b/docs/known-issues/gh-456-test-image-triage-model-absent-order-dependent.md
@@ -11,6 +11,8 @@ touches: []
 discovered: 2026-05-04
 updated: 2026-05-04
 gh_issue: 456
+pr_refs:
+- 491
 note: passes in isolation, fails in full-suite — earlier test leaves model files under data/image_model/ that defeat the "absent" precondition
 ---
 

--- a/tests/unit/extraction_v2/test_image_triage.py
+++ b/tests/unit/extraction_v2/test_image_triage.py
@@ -966,7 +966,23 @@ class TestLearnedTriageGate:
 
     Post gh-477, the gate is read per-call from `os.environ`, so tests use
     `monkeypatch.setenv` rather than patching module attributes.
+
+    `_MODEL_CACHE` in `src/shared/image_features` is module-scope and persists
+    across test instances in the same process — earlier tests that load a real
+    model artifact would otherwise satisfy the "model absent" precondition in
+    `test_gate_on_but_model_absent_falls_back_to_heuristic`. The autouse fixture
+    below wipes the cache before and after every test in this class to guarantee
+    order-independence (gh-445, gh-456).
     """
+
+    @pytest.fixture(autouse=True)
+    def reset_model_cache(self) -> None:
+        """Clear _MODEL_CACHE before and after each test to prevent cross-test pollution."""
+        from src.shared import image_features
+
+        image_features._MODEL_CACHE.clear()
+        yield
+        image_features._MODEL_CACHE.clear()
 
     @pytest.fixture
     def stage(self) -> ImageTriageStage:


### PR DESCRIPTION
`_MODEL_CACHE` in `src/shared/image_features` is module-scope and persists
across test instances in the same pytest process. Earlier tests that load a
real model artifact populate the cache, defeating the "model absent"
precondition in `test_gate_on_but_model_absent_falls_back_to_heuristic`.

Adds a class-level `autouse=True` fixture (`reset_model_cache`) to
`TestLearnedTriageGate` that clears `_MODEL_CACHE` before and after every
test — mirroring the existing pattern on `TestTriageGateEagerLoadStatusLog`
(commit b165ae31). No production code modified.

Closes gh-445, closes gh-456.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
