### PR TITLE
fix(ingest): plumb include_other flag through year/form-type facet counts (gh-387)

### DIFF
--- a/docs/known-issues/gh-387-ingest-facet-other-cross-axis-drift.md
+++ b/docs/known-issues/gh-387-ingest-facet-other-cross-axis-drift.md
@@ -3,14 +3,16 @@ id: 387
 source: gh
 slug: ingest-facet-other-cross-axis-drift
 title: "/ingest/ facet cascade does not restrict year/form-type tiles to the 'Other' partition"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
 touches: []
 discovered: 2026-04-30
-updated: 2026-04-30
+updated: 2026-05-04
 gh_issue: 387
+pr_refs:
+- 480
 note: When __other__ is the only selected industry, year/form-type tiles in the cascade JSON show full-universe counts, not Other-partition counts.
 ---
 
@@ -24,3 +26,7 @@ The discovery query itself is correct (verified by integration tests in `tests/i
 
 - Plumb an `include_other`/`mapped_sic_codes` axis through `query_universe_year_counts` and `query_universe_form_type_counts` (mirroring the discovery SQL partition).
 - Or accept the drift as the documented behaviour of "Other" being a derived/complement bucket.
+
+### Resolution
+
+Fixed in PR #480. Plumbed `include_other: bool` and `mapped_sic_codes` parameters into `query_universe_year_counts` and `query_universe_form_type_counts` in `src/universe/onboarding.py`. The `filter_options` route in `src/web/routes/api_ingest.py` now detects `__other__` in `raw_industries`, strips it before SIC resolution, computes `mapped_sic_codes` (union of every YAML-mapped SIC), and passes `include_other=True` to both query functions. Year and form-type tile counts for an `__other__`-only selection are now correctly restricted to the Other partition (NULL or unmapped `industry_code`) rather than the full universe. Integration test `test_year_counts_other_only_excludes_mapped_sic` added to verify the fix.

--- a/docs/known-issues/gh-387-ingest-facet-other-cross-axis-drift.md
+++ b/docs/known-issues/gh-387-ingest-facet-other-cross-axis-drift.md
@@ -12,7 +12,7 @@ discovered: 2026-04-30
 updated: 2026-05-04
 gh_issue: 387
 pr_refs:
-- 480
+- 492
 note: When __other__ is the only selected industry, year/form-type tiles in the cascade JSON show full-universe counts, not Other-partition counts.
 ---
 
@@ -29,4 +29,4 @@ The discovery query itself is correct (verified by integration tests in `tests/i
 
 ### Resolution
 
-Fixed in PR #480. Plumbed `include_other: bool` and `mapped_sic_codes` parameters into `query_universe_year_counts` and `query_universe_form_type_counts` in `src/universe/onboarding.py`. The `filter_options` route in `src/web/routes/api_ingest.py` now detects `__other__` in `raw_industries`, strips it before SIC resolution, computes `mapped_sic_codes` (union of every YAML-mapped SIC), and passes `include_other=True` to both query functions. Year and form-type tile counts for an `__other__`-only selection are now correctly restricted to the Other partition (NULL or unmapped `industry_code`) rather than the full universe. Integration test `test_year_counts_other_only_excludes_mapped_sic` added to verify the fix.
+Fixed in PR #492. Plumbed `include_other: bool` and `mapped_sic_codes` parameters into `query_universe_year_counts` and `query_universe_form_type_counts` in `src/universe/onboarding.py`. The `filter_options` route in `src/web/routes/api_ingest.py` now detects `__other__` in `raw_industries`, strips it before SIC resolution, computes `mapped_sic_codes` (union of every YAML-mapped SIC), and passes `include_other=True` to both query functions. Year and form-type tile counts for an `__other__`-only selection are now correctly restricted to the Other partition (NULL or unmapped `industry_code`) rather than the full universe. Integration test `test_year_counts_other_only_excludes_mapped_sic` added to verify the fix.

--- a/src/universe/onboarding.py
+++ b/src/universe/onboarding.py
@@ -950,11 +950,23 @@ ORDER BY yr DESC
 """
 
 
+_YEAR_COUNTS_OTHER_GATE_ALONE = (
+    "  AND (c.industry_code IS NULL OR c.industry_code <> ALL(%(mapped_sic_codes)s))\n"
+)
+_YEAR_COUNTS_OTHER_GATE_UNION = (
+    "  AND (c.industry_code = ANY(%(sic_codes)s) "
+    "OR c.industry_code IS NULL "
+    "OR c.industry_code <> ALL(%(mapped_sic_codes)s))\n"
+)
+
+
 def query_universe_year_counts(
     db: DatabaseAdapter,
     *,
     sic_codes: list[str] | None = None,
     form_types: list[str] | None = None,
+    include_other: bool = False,
+    mapped_sic_codes: list[str] | None = None,
 ) -> list[YearCount]:
     """Return distinct years in `filings` with universe total + pending counts.
 
@@ -968,6 +980,12 @@ def query_universe_year_counts(
     is responsible for resolving bundle keys via ``FORM_TYPE_BUNDLES``.
     None or empty for either means no filter on that axis.
 
+    When ``include_other`` is True the clause restricts to rows whose
+    ``industry_code`` is NULL or is not present in ``mapped_sic_codes``
+    (the complement of every named-bucket SIC).  When ``sic_codes`` is also
+    non-empty the two predicates are OR-combined (union).  This mirrors the
+    ``_industry_clause`` logic used by ``discover_candidates``.
+
     The Phase-1 in-scope gate (``is_in_scope_phase1 = TRUE``) is applied
     when ``form_types`` intersects ``S1F1_FORMS`` — same rule as
     ``_build_discovery_sql`` — so facet counts agree with what Preview
@@ -978,7 +996,14 @@ def query_universe_year_counts(
     include_phase1 = bool(form_types and (S1F1_FORMS & set(form_types)))
     sql = _YEAR_COUNTS_SQL
     params: dict[str, Any] = {}
-    if sic_codes:
+    if include_other:
+        if sic_codes:
+            sql += _YEAR_COUNTS_OTHER_GATE_UNION
+            params["sic_codes"] = list(sic_codes)
+        else:
+            sql += _YEAR_COUNTS_OTHER_GATE_ALONE
+        params["mapped_sic_codes"] = list(mapped_sic_codes or [])
+    elif sic_codes:
         sql += _YEAR_COUNTS_INDUSTRY_GATE
         params["sic_codes"] = list(sic_codes)
     if form_types:
@@ -1213,6 +1238,8 @@ def query_universe_form_type_counts(
     *,
     years: list[int] | None = None,
     sic_codes: list[str] | None = None,
+    include_other: bool = False,
+    mapped_sic_codes: list[str] | None = None,
 ) -> list[FormTypeCount]:
     """Return [{key, label, total, pending}] for every form-type bundle.
 
@@ -1229,8 +1256,12 @@ def query_universe_form_type_counts(
     the gate. Mirrors ``_build_discovery_sql``'s ``include_phase1`` rule.
 
     Optional ``years`` restricts by filing year; optional ``sic_codes``
-    restricts by company SIC. Filters apply on the LEFT JOIN so bundles
-    with zero matches still appear (total=0, pending=0).
+    restricts by company SIC.  When ``include_other`` is True the SIC
+    filter is replaced by the Other-partition predicate
+    (``industry_code IS NULL OR NOT IN mapped_sic_codes``); when both
+    ``sic_codes`` and ``include_other`` are set the two are OR-combined.
+    Filters apply on the LEFT JOIN so bundles with zero matches still
+    appear (total=0, pending=0).
 
     Sorted by bundle key for stable output (s1f1 → 10k → 8k).
     """
@@ -1263,7 +1294,23 @@ def query_universe_form_type_counts(
         return []
 
     year_clause = "AND EXTRACT(YEAR FROM f.filing_date) = ANY(%(years)s)" if years else ""
-    company_filter_clause = "AND c.industry_code = ANY(%(sic_codes)s)" if sic_codes else ""
+
+    # Build the company-filter clause for the FILTER expressions.
+    if include_other:
+        if sic_codes:
+            company_filter_clause = (
+                "AND (c.industry_code = ANY(%(sic_codes)s) "
+                "OR c.industry_code IS NULL "
+                "OR c.industry_code <> ALL(%(mapped_sic_codes)s))"
+            )
+        else:
+            company_filter_clause = (
+                "AND (c.industry_code IS NULL OR c.industry_code <> ALL(%(mapped_sic_codes)s))"
+            )
+    elif sic_codes:
+        company_filter_clause = "AND c.industry_code = ANY(%(sic_codes)s)"
+    else:
+        company_filter_clause = ""
 
     sql = _FORM_TYPE_COUNTS_SQL_TEMPLATE.format(
         year_clause=year_clause,
@@ -1279,6 +1326,8 @@ def query_universe_form_type_counts(
         params["years"] = [int(y) for y in years]
     if sic_codes:
         params["sic_codes"] = list(sic_codes)
+    if include_other:
+        params["mapped_sic_codes"] = list(mapped_sic_codes or [])
 
     rows = db.query(sql, params)
     by_key = {str(r["bundle_key"]): (int(r["total"]), int(r["pending"])) for r in rows}

--- a/src/web/routes/api_ingest.py
+++ b/src/web/routes/api_ingest.py
@@ -23,6 +23,7 @@ from src.auth.permissions import (
 )
 from src.universe.onboarding import (
     FORM_TYPE_BUNDLES,
+    OTHER_INDUSTRY_KEY,
     load_industry_map,
     query_universe_form_type_counts,
     query_universe_industry_counts,
@@ -240,8 +241,15 @@ def filter_options():
             continue  # ignore malformed input rather than 400 — facet is best-effort
 
     industry_map = load_industry_map()
+
+    # Detect whether the user selected the "Other" pseudo-industry sentinel.
+    # The sentinel is stripped before SIC resolution so it never reaches
+    # resolve_industry(); the include_other flag carries the signal instead.
+    include_other = OTHER_INDUSTRY_KEY in raw_industries
+    named_industries = [ind for ind in raw_industries if ind != OTHER_INDUSTRY_KEY]
+
     selected_sic_codes: list[str] = []
-    for ind_name in raw_industries:
+    for ind_name in named_industries:
         try:
             _, codes = resolve_industry(ind_name, industry_map)
         except ValueError:
@@ -250,6 +258,15 @@ def filter_options():
     # Dedupe SIC codes while preserving order
     seen: set[str] = set()
     selected_sic_codes = [s for s in selected_sic_codes if not (s in seen or seen.add(s))]
+
+    # Compute the union of every YAML-mapped SIC code (needed for the
+    # Other-partition negation predicate when include_other is True).
+    mapped_sic_codes: list[str] = []
+    if include_other:
+        all_mapped: set[str] = set()
+        for entry in (industry_map.get("industries") or {}).values():
+            all_mapped.update(entry.get("sic_codes") or [])
+        mapped_sic_codes = sorted(all_mapped)
 
     # Resolve form-type bundle keys (s1f1, 10k, 8k) to canonical form-type
     # strings (S-1, S-1/A, 10-K, ...). Unknown bundle keys are ignored.
@@ -266,10 +283,15 @@ def filter_options():
 
     try:
         # Each axis is filtered by the OTHER two axes' selections, ignoring its own.
+        # When include_other is True the year/form-type axes restrict to the
+        # Other partition (complement of every named-bucket SIC) instead of
+        # dropping the SIC predicate entirely.
         year_rows = query_universe_year_counts(
             db,
             sic_codes=selected_sic_codes or None,
             form_types=selected_form_types or None,
+            include_other=include_other,
+            mapped_sic_codes=mapped_sic_codes if include_other else None,
         )
         industry_rows = query_universe_industry_counts(
             db,
@@ -287,6 +309,8 @@ def filter_options():
             db,
             years=selected_years or None,
             sic_codes=selected_sic_codes or None,
+            include_other=include_other,
+            mapped_sic_codes=mapped_sic_codes if include_other else None,
         )
     except psycopg.DatabaseError as exc:
         logger.error("DB error in filter-options: %s", exc)

--- a/tests/integration/universe/test_discover_candidates_integration.py
+++ b/tests/integration/universe/test_discover_candidates_integration.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.universe.onboarding import discover_candidates
+from src.universe.onboarding import discover_candidates, query_universe_year_counts
 
 
 def _seed(db, *, cik: str, name: str, sic: str, accession: str, form_type: str = "S-1"):
@@ -168,3 +168,47 @@ def test_discover_candidates_sic_union_other_returns_all_three(clean_db):
 
     names = {c.company_name for c in results}
     assert names == {"Mapped Software Co", "Unmapped Manufacturing Co", "Null Industry Co"}
+
+
+@pytest.mark.integration
+def test_year_counts_other_only_excludes_mapped_sic(clean_db):
+    """query_universe_year_counts with include_other=True and sic_codes=None
+    returns year rows covering only the Other partition (NULL or unmapped
+    industry_code), not the full universe.
+
+    This is the cross-axis facet regression tested by gh-387: when the user
+    selects __other__ as the only industry, the year-axis counts must be
+    restricted to the Other partition instead of returning full-universe totals.
+    """
+    # Seed two companies: one with a mapped SIC, one with an unmapped SIC.
+    _seed(
+        clean_db,
+        cik="0000999501",
+        name="Mapped Tech Co",
+        sic="7372",
+        accession="0000999501-15-000001",
+    )
+    _seed(
+        clean_db,
+        cik="0000999502",
+        name="Unmapped Other Co",
+        sic="9999",  # not in mapped_sic_codes below
+        accession="0000999502-15-000001",
+    )
+
+    # With include_other=True and mapped=["7372"], the year row should count
+    # only the row with sic="9999" (Other partition). The mapped row is excluded.
+    mapped = ["7372"]
+    rows = query_universe_year_counts(
+        clean_db,
+        sic_codes=None,
+        include_other=True,
+        mapped_sic_codes=mapped,
+    )
+
+    assert len(rows) == 1, f"Expected 1 year row; got {rows}"
+    assert rows[0].year == 2015
+    # Only the unmapped company counts toward the Other partition.
+    assert rows[0].total == 1, (
+        f"Other partition year count should be 1 (unmapped only); got {rows[0].total}"
+    )

--- a/tests/unit/web/test_ingest_unit.py
+++ b/tests/unit/web/test_ingest_unit.py
@@ -373,7 +373,9 @@ def test_filter_options_endpoint_industry_param_resolves_to_sic(client):
 
     captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+    def fake_year_counts(
+        db, *, sic_codes=None, form_types=None, include_other=False, mapped_sic_codes=None
+    ):
         captured["sic_codes"] = sic_codes
         return [YearCount(year=2018, total=3, pending=3)]
 
@@ -403,7 +405,9 @@ def test_filter_options_endpoint_unknown_industry_silently_ignored(client):
     best-effort."""
     captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+    def fake_year_counts(
+        db, *, sic_codes=None, form_types=None, include_other=False, mapped_sic_codes=None
+    ):
         captured["sic_codes"] = sic_codes
         return []
 
@@ -437,7 +441,9 @@ def test_filter_options_endpoint_form_type_param_resolves_bundle(client):
     year_captured: dict = {}
     industry_captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+    def fake_year_counts(
+        db, *, sic_codes=None, form_types=None, include_other=False, mapped_sic_codes=None
+    ):
         year_captured["form_types"] = form_types
         return [YearCount(year=2015, total=467, pending=5)]
 
@@ -473,7 +479,9 @@ def test_filter_options_endpoint_multiple_form_types_union(client):
 
     year_captured: dict = {}
 
-    def fake_year_counts(db, *, sic_codes=None, form_types=None):
+    def fake_year_counts(
+        db, *, sic_codes=None, form_types=None, include_other=False, mapped_sic_codes=None
+    ):
         year_captured["form_types"] = form_types
         return [YearCount(year=2015, total=10, pending=2)]
 


### PR DESCRIPTION
## Summary

- When `__other__` was the only selected industry in `/ingest/`, `GET /api/v2/ingest/filter-options` returned full-universe year and form-type tile counts instead of Other-partition counts (gh-387).
- Added `include_other: bool` and `mapped_sic_codes` parameters to `query_universe_year_counts` and `query_universe_form_type_counts`; when set, restricts to rows whose `industry_code IS NULL OR NOT IN mapped_sic_codes`, OR-combined with named `sic_codes` when both are provided.
- `filter_options()` route now detects `OTHER_INDUSTRY_KEY` in `raw_industries`, strips it before SIC resolution, computes `mapped_sic_codes`, and passes `include_other=True` to both query functions.
- Closes gh-387. Fragment `docs/known-issues/gh-387-ingest-facet-other-cross-axis-drift.md` updated to `status: resolved`.

## Test plan

- [ ] All 5 integration tests in `tests/integration/universe/test_discover_candidates_integration.py` pass (including new `test_year_counts_other_only_excludes_mapped_sic`).
- [ ] All 47 unit tests in `tests/unit/web/test_ingest_unit.py` pass (updated 4 mock signatures for the new kwargs).
- [ ] Pre-push unit test hook passes (green pre-push output).
- [ ] CI: Lint, Unit Tests, Integration Tests, UI E2E, Docker Build & Smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)