### PR TITLE
fix(web): spawn text-analysis subprocess unconditionally

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -46,7 +46,7 @@ Powers the **Update Text Pattern Analysis** button on `/v2/review/stats` (Metric
 
 The script writes findings to three tables — it does NOT mutate `v2_review_decisions` or any extraction config. Render-disk-ephemerality does not affect this surface because nothing is persisted to disk; the UI renders directly from DB rows.
 
-- `POST /api/v2/extraction/analyze-text-decisions` — kicks off `scripts/analyze_text_decision_patterns.py` as a detached subprocess via `_spawn_text_analysis_runner` (mirrors `_spawn_retrain_runner`). Returns `202 + {run_id, status: 'running'}`. Three server-side gates:
+- `POST /api/v2/extraction/analyze-text-decisions` — kicks off `scripts/analyze_text_decision_patterns.py` as a detached subprocess via `_spawn_text_analysis_runner`. Returns `202 + {run_id, status: 'running'}`. Spawn is unconditional — unlike retrain (which honours `RETRAIN_SPAWN_SUBPROCESS=false` and is drained by the `filings-onboarding-runner` worker), text analysis has no worker-side queue consumer and the job runs in well under a second on the lifetime corpus, so honoring `INGEST_SPAWN_SUBPROCESS=false` would silently strand the row at `'running'` forever (the prior shape until 2026-05-05). Three server-side gates:
   - `_require_reviewer_id` → 403 `{error: "reviewer_name_required"}`.
   - **Concurrency**: `is_text_analysis_running()` — any `text_decision_analysis_runs` row with `status='running'` → 409 `{error: "analysis_already_running", running_run_id}`.
   - **Threshold**: `count_text_decisions_since(last_succeeded_run.completed_at)` ≥ `TEXT_ANALYSIS_THRESHOLD_TOTAL` (default `50`). Below → 409 `{error: "below_threshold", count, threshold}`. Single gate (no positive/negative split — every text decision is signal for rule-based extraction).

--- a/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
+++ b/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
@@ -1,0 +1,25 @@
+---
+id: 497
+source: gh
+slug: stalled-analysis-runs-undetected
+title: No proactive alert on stalled text_decision_analysis_runs / model_training_runs / v2_ingest_batches rows
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-05
+updated: 2026-05-05
+gh_issue: 497
+note: stale-row sweeps are reactive; nightly-sweep digest could surface stranded jobs
+---
+
+### Problem
+
+Until 2026-05-05, every text-pattern-analysis run since the surface launched was stranded at `status='running'` because the prod web service no-op'd the spawn (`INGEST_SPAWN_SUBPROCESS=false` early-return with no worker-side queue consumer; fixed in commit `495ae43`). The "anchor: (lifetime, no prior succeeded run)" line on the manual-unblock log proved no run had ever succeeded since the surface was deployed. Nothing alerted — the 1-hour stale-row sweep at `src/web/routes/api_unified.py:1489-1498` is reactive (next click only), and the surface is button-driven, so the only signal was a reviewer noticing the spinner never resolved. The same observability gap applies to `model_training_runs` and `v2_ingest_batches`: their queue+worker pairs work today, but a worker that stops draining (OOM, env misconfig) would strand rows identically.
+
+### Next Steps
+
+- Add a scheduled check in `filings-nightly-sweep` (or a Metabase card) that flags `text_decision_analysis_runs.status='running' AND started_at < NOW() - INTERVAL '30 minutes'`, plus the lock-aware equivalents for `model_training_runs` and `v2_ingest_batches`.
+- Add a "no succeeded run in N days where reviewer activity exists" alert keyed off `count_text_decisions_since(last_succeeded_run.completed_at)` clearing the threshold.
+- Stretch: surface "last analysis: N days ago" in the `/v2/review/stats` header so reviewers see a passive signal.

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -1421,12 +1421,13 @@ def _text_analysis_threshold() -> int:
 def _spawn_text_analysis_runner(run_id: str, *, database_url: str) -> bool:
     """Spawn the text-decision pattern-analysis script as a detached subprocess.
 
-    Mirrors _spawn_retrain_runner. Fire-and-forget; the subprocess writes
-    status back to text_decision_analysis_runs via --run-id.
+    Fire-and-forget; the subprocess writes status back to
+    text_decision_analysis_runs via --run-id. Spawned unconditionally — unlike
+    retrain and ingest, there is no worker-side queue consumer for this surface
+    and the job runs in well under a second on the lifetime corpus, so honoring
+    INGEST_SPAWN_SUBPROCESS=false would silently strand the row at 'running'
+    forever (the prior shape — see manual-unblock run on 2026-05-05).
     """
-    if not current_app.config.get("INGEST_SPAWN_SUBPROCESS", True):
-        return True
-
     log_dir = _PROJECT_ROOT / "logs"
     log_dir.mkdir(exist_ok=True)
     log_path = log_dir / f"text_analysis_{run_id}.log"

--- a/tests/unit/web/test_text_analysis_api.py
+++ b/tests/unit/web/test_text_analysis_api.py
@@ -1,8 +1,10 @@
 """Unit tests for the text-decision pattern-analysis endpoints.
 
 Mirrors tests/unit/web/test_models_retrain.py for the parallel
-/api/v2/extraction/* endpoints. Subprocess spawn is suppressed via the
-INGEST_SPAWN_SUBPROCESS=False config flag.
+/api/v2/extraction/* endpoints. Subprocess spawn is patched out per-test.
+INGEST_SPAWN_SUBPROCESS is inert for this surface — the spawn runs
+unconditionally because the job is sub-second and has no worker-side
+queue consumer (2026-05-05).
 """
 
 from __future__ import annotations
@@ -92,7 +94,11 @@ class TestStaleRowSweep:
 
     def test_sweep_runs_before_concurrency_check(self, client, mock_db):
         mock_db.count_text_decisions_since.return_value = 100
-        with patch("src.web.routes.api_unified.subprocess.Popen"):
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen"),
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             resp = client.post(_TRIGGER, json=_VALID_REVIEWER)
         assert resp.status_code == 202
         sweep_sql = mock_db.execute.call_args_list[0].args[0]
@@ -101,7 +107,11 @@ class TestStaleRowSweep:
 
     def test_sweep_scoped_to_running_status_and_one_hour(self, client, mock_db):
         mock_db.count_text_decisions_since.return_value = 100
-        with patch("src.web.routes.api_unified.subprocess.Popen"):
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen"),
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             client.post(_TRIGGER, json=_VALID_REVIEWER)
         sweep_sql = mock_db.execute.call_args_list[0].args[0]
         assert "status = 'running'" in sweep_sql
@@ -121,7 +131,11 @@ class TestStaleRowSweep:
 class TestTriggerSpawn:
     def test_above_threshold_inserts_row_and_returns_run_id(self, client, mock_db):
         mock_db.count_text_decisions_since.return_value = 100
-        with patch("src.web.routes.api_unified.subprocess.Popen") as mock_popen:
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen") as mock_popen,
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             resp = client.post(_TRIGGER, json=_VALID_REVIEWER)
         assert resp.status_code == 202
         body = resp.get_json()
@@ -138,8 +152,9 @@ class TestTriggerSpawn:
         assert "INSERT INTO text_decision_analysis_runs" in sql
         assert params["id"] == run_id
         assert params["triggered_by"] == "RGM"
-        # INGEST_SPAWN_SUBPROCESS=False short-circuits before Popen.
-        mock_popen.assert_not_called()
+        # Spawn runs unconditionally — the prior INGEST_SPAWN_SUBPROCESS=False
+        # short-circuit was the bug that stranded rows at 'running' forever.
+        mock_popen.assert_called_once()
 
     def test_anchor_uses_last_run_completed_at(self, client, mock_db):
         ts = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
@@ -148,15 +163,18 @@ class TestTriggerSpawn:
             "completed_at": ts,
         }
         mock_db.count_text_decisions_since.return_value = 100
-        with patch("src.web.routes.api_unified.subprocess.Popen"):
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen"),
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             resp = client.post(_TRIGGER, json=_VALID_REVIEWER)
         assert resp.status_code == 202
         # Threshold helper called with that anchor.
         mock_db.count_text_decisions_since.assert_called_once_with(ts)
 
-    def test_spawn_failure_marks_row_failed(self, client, mock_db, app):
+    def test_spawn_failure_marks_row_failed(self, client, mock_db):
         mock_db.count_text_decisions_since.return_value = 100
-        app.config["INGEST_SPAWN_SUBPROCESS"] = True
         with (
             patch("src.web.routes.api_unified.subprocess.Popen") as mock_popen,
             patch("src.web.routes.api_unified.open", create=True) as mock_open,
@@ -217,13 +235,21 @@ class TestThresholdConfig:
         monkeypatch.setenv("TEXT_ANALYSIS_THRESHOLD_TOTAL", "5")
         # 7 decisions: would fail default 50, clears the override 5.
         mock_db.count_text_decisions_since.return_value = 7
-        with patch("src.web.routes.api_unified.subprocess.Popen"):
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen"),
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             resp = client.post(_TRIGGER, json=_VALID_REVIEWER)
         assert resp.status_code == 202
 
     def test_invalid_env_falls_back_to_default(self, client, mock_db, monkeypatch):
         monkeypatch.setenv("TEXT_ANALYSIS_THRESHOLD_TOTAL", "not-a-number")
         mock_db.count_text_decisions_since.return_value = 100
-        with patch("src.web.routes.api_unified.subprocess.Popen"):
+        with (
+            patch("src.web.routes.api_unified.subprocess.Popen"),
+            patch("src.web.routes.api_unified.open", create=True) as mock_open,
+        ):
+            mock_open.return_value = MagicMock()
             resp = client.post(_TRIGGER, json=_VALID_REVIEWER)
         assert resp.status_code == 202


### PR DESCRIPTION
## Summary

- Drop the `INGEST_SPAWN_SUBPROCESS=false` early-return in `_spawn_text_analysis_runner` (`src/web/routes/api_unified.py:1421-1428`). The text-decision pattern-analysis endpoint was modelled on the image-classifier retrain endpoint and inherited the same flag-gated short-circuit, but unlike retrain there is no worker-side queue consumer for `text_decision_analysis_runs` — so in prod every click silently stranded a `running` row until the next click swept it to `failed` an hour later.
- Update the unit test that codified the buggy short-circuit (`mock_popen.assert_not_called()` → `assert_called_once()`) and patch `open()` in the four other spawn-active tests so they don't write real log files.
- Update `.claude/rules/web.md` to remove the misleading "mirrors `_spawn_retrain_runner`" claim.

## Why a one-line fix instead of the gh-400 mirror

Manual unblock run on 2026-05-05 13:09 UTC against the prod corpus:

```
Anchor for analysis: (lifetime, no prior succeeded run)
Pulled 675 decisions for analysis
Rolled up 25 distinct metrics
Mined 261 phrase findings
Wall clock: 530ms (13:09:46.396 → 13:09:46.924)
```

`(lifetime, no prior succeeded run)` proves no run had ever completed before today — every prior click stranded a row. Subsequent runs only mine the delta since the most recent `completed_at`, so 530ms on the worst-case lifetime corpus is the upper bound. A queue+worker mirror of gh-400 would be 4 PRs of mechanical work (CHECK-constraint migration, runner module, watch-loop wire-up, threshold gate update) for no observable win on a sub-second job.

## Test plan

- [x] `pytest -x -q tests/unit/web/test_text_analysis_api.py` — 15/15 pass
- [x] `pytest -x -q tests/unit/web/` — 307/307 pass
- [x] `ruff check` — clean
- [x] Manual unblock against prod confirms the script + schema are reachable and the run completes in <1s
- [ ] After merge: re-click "Update Text Pattern Analysis" on `/v2/review/stats`, watch `text_decision_analysis_runs` flip from `running` → `succeeded` without operator intervention

## Out-of-scope follow-up

#497 — no proactive alert on stalled `text_decision_analysis_runs` / `model_training_runs` / `v2_ingest_batches` rows. Same observability gap applies to all three; the bug above only got noticed because a reviewer flagged the spinner never resolving. Filed as `docs/known-issues/gh-497-stalled-analysis-runs-undetected.md` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeevnKW7C3dop4wsLFkhbW)_