### PR TITLE
feat(stats): config_snapshot_hash + freshness badge on recommendation cards

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -72,6 +72,10 @@ The Patterns-tab expanded row also renders a **Suggested actions** callout above
 
 Three rules in v1; a metric may fire multiple. Output is sorted by severity DESC then rule name ASC. Each recommendation dict carries `rule`, `severity` (`high` / `medium`), `title`, `evidence`, `action`.
 
+**Card-level metadata fields** (orthogonal to rule type — present on every card):
+
+- `config_drift: bool` — `True` when `config_snapshot_hash` stored on the analysis run row differs from the current `compute_config_hash()` value at render time. Signals that `config/metric_keywords.yaml` or `false_positive_filter.py` has changed since the run was captured; the template renders a "Config changed since this analysis" badge. `False` when the hashes match OR when `config_snapshot_hash` is `NULL` (legacy runs from before the hash feature — legacy cards are never false-flagged). Computed in `compute_recommendations(config_snapshot_hash=...)` and set on every rec dict in the same loop as `decision`.
+
 | Rule | Trigger | Severity bands |
 |---|---|---|
 | **`exclusion_pattern`** | A `text_decision_phrase_findings` row with `decision_type='reject'`, `source_field IN ('rejection_reason', 'segment_text')`, `phrase_ngram_size >= 2`, `pct_of_decisions >= 30` | high if `pct >= 50`, else medium |

--- a/docs/operations/text-pattern-recommendations-runbook.md
+++ b/docs/operations/text-pattern-recommendations-runbook.md
@@ -29,7 +29,7 @@ Process accepted decisions **weekly**, after the gold-standard pre-commit gate h
 
 For each accepted row, the procedure is:
 
-1. **Re-read the evidence on the stats page.** Each phrase finding includes up to 5 `{fact_id, filing_id}` examples. Open at least 2 in the review UI and confirm the suggestion still describes them after any keyword changes that have landed since the analysis run — the recommendation is stateless and a recent merge may have already addressed it.
+1. **Re-read the evidence on the stats page.** Each phrase finding includes up to 5 `{fact_id, filing_id}` examples. Open at least 2 in the review UI and confirm the suggestion still describes them after any keyword changes that have landed since the analysis run — the recommendation is stateless and a recent merge may have already addressed it. If the card shows the "Config changed since this analysis" badge, treat it as a re-verify even if the decision_key has not been touched — the keyword or FP-filter rules have moved since the analysis run was captured.
 2. **`EnterWorktree`** before any edits (CLAUDE.md project rule for any 3+ file or config change; a PreToolUse guard refuses `git checkout` in the primary tree).
 3. **Apply the smallest possible edit.** See "Per-rule edit guide" below. Do not refactor adjacent rules in the same PR.
 4. **Run gold-standard validation locally** before committing:

--- a/scripts/analyze_text_decision_patterns.py
+++ b/scripts/analyze_text_decision_patterns.py
@@ -55,6 +55,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import psycopg
 from psycopg.rows import dict_row
 
+from src.extraction_v2.config_hash import compute_config_hash
 from src.infra.logging_config import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -478,6 +479,21 @@ def _orchestrate(args: argparse.Namespace) -> None:
 
     with psycopg.connect(args.database_url, autocommit=False) as conn:
         run_id = _ensure_run_row(conn, run_id=args.run_id, triggered_by=args.triggered_by or "cli")
+
+        # Capture the config hash at run-start so the stats page can flag
+        # cards as stale when the keyword/FP-filter config changes after the run.
+        config_snapshot_hash = compute_config_hash()
+        with conn.cursor() as _cur:
+            _cur.execute(
+                """
+                UPDATE text_decision_analysis_runs
+                   SET config_snapshot_hash = %(hash)s
+                 WHERE id = %(run_id)s
+                """,
+                {"hash": config_snapshot_hash, "run_id": run_id},
+            )
+        conn.commit()
+        logger.info("Config snapshot hash: %s", config_snapshot_hash[:12])
 
         anchor = _resolve_anchor(conn)
         logger.info("Anchor for analysis: %s", anchor or "(lifetime, no prior succeeded run)")

--- a/sql/202605051420_add_config_snapshot_hash_to_text_decision_runs.sql
+++ b/sql/202605051420_add_config_snapshot_hash_to_text_decision_runs.sql
@@ -1,0 +1,15 @@
+-- Migration 202605051420: add config snapshot hash to text decision runs
+--
+-- Adds config_snapshot_hash TEXT to text_decision_analysis_runs so the
+-- stats page can display a freshness badge when the keyword/FP-filter
+-- config has changed since the run was captured. NULL for legacy rows
+-- (pre-this-migration runs) — the render layer treats NULL as no drift.
+--
+-- Idempotency: ALTER TABLE ... ADD COLUMN IF NOT EXISTS is safe to re-run.
+
+BEGIN;
+
+ALTER TABLE text_decision_analysis_runs
+    ADD COLUMN IF NOT EXISTS config_snapshot_hash TEXT;
+
+COMMIT;

--- a/src/extraction_v2/config_hash.py
+++ b/src/extraction_v2/config_hash.py
@@ -1,0 +1,40 @@
+"""Compute a stable hash of the extraction config files.
+
+Used to detect when config/metric_keywords.yaml or the FP-filter rules
+have changed since an analysis run was captured, so the stats page can
+show a freshness badge on stale recommendation cards.
+
+The hash is SHA-256 of the concatenated byte contents of the two input
+files, joined by a NUL byte separator. Order is fixed:
+  1. config/metric_keywords.yaml
+  2. src/extraction_v2/stages/false_positive_filter.py
+
+File reads happen inside compute_config_hash() on every call — NOT at
+import time — so tests can monkeypatch Path.read_bytes and gunicorn does
+not freeze the hash at boot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# Project root is two levels above this file:
+# src/extraction_v2/config_hash.py → src/extraction_v2 → src → project root.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_KEYWORDS_PATH = _PROJECT_ROOT / "config" / "metric_keywords.yaml"
+_FP_FILTER_PATH = _PROJECT_ROOT / "src" / "extraction_v2" / "stages" / "false_positive_filter.py"
+
+
+def compute_config_hash() -> str:
+    """Return SHA-256 hex of the two extraction-config files.
+
+    Reads the files fresh on every call so changes after the process
+    starts are reflected. Raises FileNotFoundError if either file is
+    missing (intentional — the caller should know the config is broken).
+    """
+    keywords_bytes = _KEYWORDS_PATH.read_bytes()
+    fp_filter_bytes = _FP_FILTER_PATH.read_bytes()
+    digest = hashlib.sha256(keywords_bytes + b"\x00" + fp_filter_bytes)
+    return digest.hexdigest()

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -284,8 +284,16 @@ def stats():
     text_recommendation_decisions = db.get_recommendation_decisions(
         [s["metric_id"] for s in text_metric_summary] or None
     )
+    # Pass the stored config hash so compute_recommendations can detect drift.
+    # None when no run exists or the run predates the config_snapshot_hash column.
+    stored_config_hash: str | None = (
+        last_text_analysis_run.get("config_snapshot_hash") if last_text_analysis_run else None
+    )
     text_recommendations = compute_recommendations(
-        text_metric_summary, text_phrase_findings, text_recommendation_decisions
+        text_metric_summary,
+        text_phrase_findings,
+        text_recommendation_decisions,
+        config_snapshot_hash=stored_config_hash,
     )
 
     return render_template(

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1132,6 +1132,11 @@
                             {{ r.severity }}
                           </span>
                           <strong>{{ r.title }}</strong>
+                          {% if r.config_drift %}
+                          <span class="badge bg-info text-dark ms-1"
+                                title="The keyword/FP-filter config has changed since this analysis was captured. Re-verify this recommendation against the current config before acting — see the Engineer cadence Step 1 in the text-pattern-recommendations runbook."
+                                style="cursor:help;">Config changed since this analysis &middot; re-verify</span>
+                          {% endif %}
                         </div>
                         <div class="text-muted small">{{ r.evidence }}</div>
                         <div class="small"><em>{{ r.action }}</em></div>

--- a/src/web/text_pattern_recommendations.py
+++ b/src/web/text_pattern_recommendations.py
@@ -17,8 +17,11 @@ only knobs.
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # --- Rule thresholds ---------------------------------------------------------
 # Single source of truth so a tweak is one edit + one PR. Documented in
@@ -50,6 +53,7 @@ def compute_recommendations(
     summaries: list[dict[str, Any]],
     findings: list[dict[str, Any]],
     decisions: list[dict[str, Any]] | None = None,
+    config_snapshot_hash: str | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Map metric_id -> list of recommendation dicts.
 
@@ -66,6 +70,7 @@ def compute_recommendations(
           "evidence": str,
           "action": str,
           "decision": dict | None,  # populated when `decisions` arg matches
+          "config_drift": bool,    # True when config changed since this run
         }
 
     When ``decisions`` is provided (a list of recommendation-decision rows
@@ -75,9 +80,28 @@ def compute_recommendations(
     most-recent one (by ``updated_at``) wins. Skipping/omitting the arg
     leaves ``decision`` as ``None`` on every rec, preserving the prior
     contract.
+
+    ``config_snapshot_hash`` is the hash stored on the analysis run row. When
+    it differs from the current hash (computed at call time from the live
+    config files), ``config_drift`` is set to ``True`` on every card so the
+    template can render a freshness badge. When ``config_snapshot_hash`` is
+    ``None`` (legacy runs from before this feature), ``config_drift`` is
+    ``False`` — legacy cards are never false-flagged.
     """
     if not summaries and not findings:
         return {}
+
+    # Compute config_drift: compare stored hash against current live hash.
+    # NULL stored hash (legacy run) → False so legacy cards are not flagged.
+    config_drift: bool = False
+    if config_snapshot_hash is not None:
+        try:
+            from src.extraction_v2.config_hash import compute_config_hash
+
+            current_hash = compute_config_hash()
+            config_drift = current_hash != config_snapshot_hash
+        except Exception:  # noqa: BLE001
+            logger.warning("Could not compute config hash for drift check", exc_info=True)
 
     # Group findings by metric_id once so each rule's helper can scan
     # locally without re-iterating the full list.
@@ -104,6 +128,7 @@ def compute_recommendations(
         if recs:
             for r in recs:
                 r["decision"] = decision_index.get((metric_id, r["rule"], r["decision_key"]))
+                r["config_drift"] = config_drift
             recs.sort(key=lambda r: (_SEVERITY_RANK[r["severity"]], r["rule"]))
             out[metric_id] = recs
     return out

--- a/tests/integration/test_analyze_text_decision_patterns.py
+++ b/tests/integration/test_analyze_text_decision_patterns.py
@@ -363,3 +363,46 @@ def test_exception_path_flips_status_to_failed(clean_db, cli):
     )
     assert run["error"] is not None
     assert "simulated" in run["error"]
+
+
+@pytest.mark.skipif(
+    not __import__("os").getenv("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set",
+)
+def test_run_writes_config_snapshot_hash(clean_db, cli):
+    """_orchestrate writes config_snapshot_hash to the run row at run-start.
+
+    Asserts:
+    - The run row has a non-null config_snapshot_hash after a successful run.
+    - The stored hash matches compute_config_hash() called at assertion time
+      (the config files have not changed between the analysis run and the
+      assertion, so the hashes must be equal).
+    """
+    _truncate_analysis_tables(clean_db)
+    _seed_corpus(clean_db)
+
+    db_url = __import__("os").environ["TEST_DATABASE_URL"]
+    args = Namespace(
+        database_url=db_url,
+        run_id=None,
+        triggered_by="test",
+        max_decisions=None,
+    )
+    cli._orchestrate(args)
+
+    runs = _query_runs(clean_db)
+    assert len(runs) == 1, "Expected exactly one run row"
+    run = runs[0]
+    assert run["status"] == "succeeded"
+
+    stored_hash = run.get("config_snapshot_hash")
+    assert stored_hash is not None, "config_snapshot_hash must be non-null after a successful run"
+
+    # The config files have not changed, so the live hash must match the
+    # stored hash captured at run-start.
+    from src.extraction_v2.config_hash import compute_config_hash
+
+    assert stored_hash == compute_config_hash(), (
+        "Stored config_snapshot_hash does not match current compute_config_hash() — "
+        "either the hash was not written correctly or config files changed mid-test"
+    )

--- a/tests/unit/extraction_v2/test_config_hash.py
+++ b/tests/unit/extraction_v2/test_config_hash.py
@@ -1,0 +1,204 @@
+"""Unit tests for src/extraction_v2/config_hash.py.
+
+Verifies:
+- Return type is a 64-char hex SHA-256 string.
+- Determinism: same file contents → same hash.
+- Sensitivity: different file bytes → different hash.
+- Call-time reads: Path.read_bytes is invoked on every call (not cached at import).
+- FileNotFoundError propagation when a file is missing.
+
+Patching strategy: monkeypatch ``pathlib.Path.read_bytes`` at the class level,
+routing by ``self.name`` to return per-file fake bytes. This is necessary because
+``PosixPath`` instance attributes are read-only (C-level slots).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+_FAKE_KEYWORDS_BYTES = b"cm_net_revenue_retention:\n  - retained\n"
+_FAKE_FP_FILTER_BYTES = b"def _rule_wrong_value(segment):\n    pass\n"
+
+
+def _make_router(keywords: bytes, fp_filter: bytes):
+    """Return a Path.read_bytes replacement that dispatches by filename."""
+
+    def _read_bytes(self):  # noqa: ANN001
+        if self.name == "metric_keywords.yaml":
+            return keywords
+        if self.name == "false_positive_filter.py":
+            return fp_filter
+        raise FileNotFoundError(f"Unexpected path in test: {self}")
+
+    return _read_bytes
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReturnType:
+    def test_returns_64_char_hex_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, _FAKE_FP_FILTER_BYTES),
+        )
+        result = ch.compute_config_hash()
+        assert isinstance(result, str)
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_hash_matches_manual_sha256(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, _FAKE_FP_FILTER_BYTES),
+        )
+        expected = hashlib.sha256(
+            _FAKE_KEYWORDS_BYTES + b"\x00" + _FAKE_FP_FILTER_BYTES
+        ).hexdigest()
+        assert ch.compute_config_hash() == expected
+
+
+class TestDeterminism:
+    def test_same_bytes_same_hash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, _FAKE_FP_FILTER_BYTES),
+        )
+        h1 = ch.compute_config_hash()
+        h2 = ch.compute_config_hash()
+        assert h1 == h2
+
+
+class TestSensitivity:
+    def test_different_keywords_bytes_yields_different_hash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, _FAKE_FP_FILTER_BYTES),
+        )
+        h1 = ch.compute_config_hash()
+
+        # Swap in different keywords bytes for the second call.
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(b"different_keyword_content: true", _FAKE_FP_FILTER_BYTES),
+        )
+        h2 = ch.compute_config_hash()
+        assert h1 != h2
+
+    def test_different_fp_filter_bytes_yields_different_hash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, _FAKE_FP_FILTER_BYTES),
+        )
+        h1 = ch.compute_config_hash()
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "read_bytes",
+            _make_router(_FAKE_KEYWORDS_BYTES, b"def rule_changed(): return True"),
+        )
+        h2 = ch.compute_config_hash()
+        assert h1 != h2
+
+
+class TestCallTimeReads:
+    def test_read_bytes_called_on_every_invocation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """read_bytes must be invoked fresh on each compute_config_hash() call.
+
+        Two calls → 4 total read_bytes invocations (2 files × 2 calls).
+        We count by filename to isolate keywords vs fp_filter reads.
+        """
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        keywords_calls = 0
+        fp_filter_calls = 0
+
+        def counting_router(self):  # noqa: ANN001
+            nonlocal keywords_calls, fp_filter_calls
+            if self.name == "metric_keywords.yaml":
+                keywords_calls += 1
+                return _FAKE_KEYWORDS_BYTES
+            if self.name == "false_positive_filter.py":
+                fp_filter_calls += 1
+                return _FAKE_FP_FILTER_BYTES
+            raise FileNotFoundError(f"Unexpected path in test: {self}")
+
+        monkeypatch.setattr(pathlib.Path, "read_bytes", counting_router)
+
+        ch.compute_config_hash()
+        ch.compute_config_hash()
+
+        assert keywords_calls == 2, (
+            f"Expected 2 reads of keywords file (one per call), got {keywords_calls}"
+        )
+        assert fp_filter_calls == 2, (
+            f"Expected 2 reads of fp_filter file (one per call), got {fp_filter_calls}"
+        )
+
+
+class TestFileNotFound:
+    def test_raises_when_keywords_file_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        def raise_for_keywords(self):  # noqa: ANN001
+            if self.name == "metric_keywords.yaml":
+                raise FileNotFoundError("metric_keywords.yaml not found")
+            return _FAKE_FP_FILTER_BYTES
+
+        monkeypatch.setattr(pathlib.Path, "read_bytes", raise_for_keywords)
+
+        with pytest.raises(FileNotFoundError):
+            ch.compute_config_hash()
+
+    def test_raises_when_fp_filter_file_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import pathlib
+
+        from src.extraction_v2 import config_hash as ch
+
+        def raise_for_fp(self):  # noqa: ANN001
+            if self.name == "false_positive_filter.py":
+                raise FileNotFoundError("false_positive_filter.py not found")
+            return _FAKE_KEYWORDS_BYTES
+
+        monkeypatch.setattr(pathlib.Path, "read_bytes", raise_for_fp)
+
+        with pytest.raises(FileNotFoundError):
+            ch.compute_config_hash()

--- a/tests/unit/web/test_text_pattern_recommendations.py
+++ b/tests/unit/web/test_text_pattern_recommendations.py
@@ -378,3 +378,84 @@ class TestDecisionMerging:
         rec = [r for r in out["cm_x"] if r["rule"] == "exclusion_pattern"][0]
         assert rec["decision"]["id"] == "d-fresh"
         assert rec["decision"]["reviewer_id"] == "RGM"
+
+
+# ---------------------------------------------------------------------------
+# config_drift flag — set when stored hash differs from live hash
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDriftFlag:
+    """config_drift is a card-level metadata field; it fires on any rule type.
+
+    compute_recommendations imports compute_config_hash lazily inside the
+    function body, so we patch it at the source module
+    (``src.extraction_v2.config_hash.compute_config_hash``) to intercept
+    the call regardless of where the import lands.
+    """
+
+    _STORED_HASH = "a" * 64  # stable fake stored hash
+
+    def test_drift_true_when_stored_hash_differs(self) -> None:
+        """Stored hash != live hash → config_drift True on every card."""
+        from unittest.mock import patch
+
+        live_hash = "b" * 64  # differs from _STORED_HASH ("a" * 64)
+
+        with patch(
+            "src.extraction_v2.config_hash.compute_config_hash",
+            return_value=live_hash,
+        ):
+            out = compute_recommendations(
+                [_summary()],
+                [_finding()],
+                config_snapshot_hash=self._STORED_HASH,
+            )
+
+        assert "cm_x" in out
+        for rec in out["cm_x"]:
+            assert rec["config_drift"] is True, (
+                f"Expected config_drift=True on rule {rec['rule']!r} when hash differs"
+            )
+
+    def test_drift_false_when_stored_hash_matches(self) -> None:
+        """Stored hash == live hash → config_drift False on every card."""
+        from unittest.mock import patch
+
+        matching_hash = self._STORED_HASH  # same as stored
+
+        with patch(
+            "src.extraction_v2.config_hash.compute_config_hash",
+            return_value=matching_hash,
+        ):
+            out = compute_recommendations(
+                [_summary()],
+                [_finding()],
+                config_snapshot_hash=self._STORED_HASH,
+            )
+
+        assert "cm_x" in out
+        for rec in out["cm_x"]:
+            assert rec["config_drift"] is False, (
+                f"Expected config_drift=False on rule {rec['rule']!r} when hash matches"
+            )
+
+    def test_drift_false_when_stored_hash_is_none(self) -> None:
+        """Stored hash is None (legacy run) → config_drift False; legacy cards not flagged."""
+        from unittest.mock import patch
+
+        with patch(
+            "src.extraction_v2.config_hash.compute_config_hash",
+            return_value="b" * 64,
+        ):
+            out = compute_recommendations(
+                [_summary()],
+                [_finding()],
+                config_snapshot_hash=None,
+            )
+
+        assert "cm_x" in out
+        for rec in out["cm_x"]:
+            assert rec["config_drift"] is False, (
+                f"Expected config_drift=False on rule {rec['rule']!r} for legacy None hash"
+            )


### PR DESCRIPTION
## Summary

- New migration `sql/202605051420_add_config_snapshot_hash_to_text_decision_runs.sql` adds `config_snapshot_hash TEXT` (NULL-allowed for legacy rows) to `text_decision_analysis_runs`.
- New util `src/extraction_v2/config_hash.py` computes SHA-256 of `config/metric_keywords.yaml` + `src/extraction_v2/stages/false_positive_filter.py` byte contents joined by NUL. **Reads files at call time, not import time** — gunicorn doesn't freeze the hash at boot, and tests can monkeypatch `Path.read_bytes`.
- `scripts/analyze_text_decision_patterns.py` writes the hash on every run start.
- `src/web/text_pattern_recommendations.py` attaches a per-card `config_drift: bool`. `true` when stored hash differs from current; `false` when stored hash is NULL (legacy rows — no false-flagging).
- `src/web/templates/unified_stats.html` renders a "Config changed since this analysis · re-verify" badge inline with the existing severity badges when `config_drift` is true.
- Runbook + `.claude/rules/web.md` updated.

## Why

Step 1 of `docs/operations/text-pattern-recommendations-runbook.md` was doing manual config-drift detection ("Re-read the evidence on the stats page... a recent merge may have already addressed it"). The hash + render-time comparison automates the check before reviewers waste time on already-fixed recommendations.

Plan: `~/.claude/plans/read-the-file-located-parallel-crane.md` (PR 1 of 4). Wave 1 sibling PRs (#TBD: PR 3 link CLI, PR 4 drop free-text mining) ship in parallel; Wave 2 PR 2 (stale archival) is sequenced after this PR.

## Scope

11 files: 1 new migration, 1 new util, 1 new test file, 4 source-file edits, 2 test-file edits, 2 doc edits.

## Tier-1 spot check

N/A — extraction logic untouched. `python3 -m src.gold_standard.v2_validator --fail-on-regression` ran clean ("no regression").

## Test plan

- [x] `pytest -x -q tests/unit/extraction_v2/test_config_hash.py tests/unit/web/test_text_pattern_recommendations.py` — 44/44 passed locally
- [ ] CI: Lint, Unit Tests, Integration Tests, Vulnerability Scan, UI E2E (Playwright), Docker Build & Smoke
- [ ] After merge: edit a comment in `config/metric_keywords.yaml`, reload `/v2/review/stats` without re-running analysis. Every active recommendation card from the latest succeeded run should show the freshness badge. Re-running analysis clears the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)