### PR TITLE
fix(feature_flags): narrow except to re-raise programmer errors (gh-475)

### DIFF
--- a/docs/known-issues/gh-475-feature-flags-silent-context-error.md
+++ b/docs/known-issues/gh-475-feature-flags-silent-context-error.md
@@ -3,7 +3,7 @@ id: 475
 source: gh
 slug: feature-flags-silent-context-error
 title: "auth: feature_flags _read_flag_from_db silently swallows context errors, hides config bugs"
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: S
@@ -12,7 +12,7 @@ touches:
   - src/auth/csrf.py
   - src/auth/load_user.py
 discovered: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 gh_issue: 475
 pr_refs:
   - 472
@@ -30,3 +30,11 @@ The symptom-level fix shipped in #472 (wrap the boot-time check in `with app.app
 - Distinguish transient DB errors (connection, network) from programmer errors (`RuntimeError: Working outside of application context`, `ImportError`, attribute errors). Log the latter at `ERROR` or re-raise instead of swallowing as WARNING.
 - Consider a fail-closed mode for security-sensitive flags: if `is_enabled()` raises an unexpected exception type, raise rather than default to False, so misconfigurations surface loudly instead of silently.
 - Audit other `except Exception` blocks in the auth surface (`src/auth/csrf.py`, `src/auth/load_user.py`) for similar silent-fallback hazards.
+
+### Resolution
+
+Narrowed `except Exception` in `feature_flags.py::_read_flag_from_db` and `csrf.py::_read_enforcement_flag` to re-raise programmer errors (`RuntimeError`, `ImportError`, `AttributeError`, `NameError`) instead of silently defaulting to False. Transient DB errors (connection failures, missing table during initial deploy) continue to soft-fallback.
+
+Added `fail_closed: bool = False` keyword parameter to `is_enabled()` and `_read_flag_from_db()`. The boot-time call in `app.py` now passes `fail_closed=True` so any exception during startup flag reads fails loudly rather than silently not registering the auth blueprint.
+
+`load_user.py` broad catches (lines 64–70 and 161–166) were audited and left intentionally broad — both are per-request fail-open paths (never crash a request / never lock out a user due to a DB hiccup), distinct from the flag-read case.

--- a/docs/known-issues/gh-475-feature-flags-silent-context-error.md
+++ b/docs/known-issues/gh-475-feature-flags-silent-context-error.md
@@ -16,6 +16,7 @@ updated: 2026-05-05
 gh_issue: 475
 pr_refs:
   - 472
+  - 511
 note: broad except in feature_flags swallowed RuntimeError during Stage B activation; symptom fixed in #472, broader hazard remains
 ---
 

--- a/src/auth/csrf.py
+++ b/src/auth/csrf.py
@@ -90,9 +90,17 @@ def _read_enforcement_flag() -> bool:
         else:
             enabled = rows[0]["value"] == "true"
     except Exception as exc:
-        # Any DB error (connection failure, table not yet applied, etc.) —
-        # default off and warn rather than raising. This keeps the middleware
-        # safe to register before the DB is fully available.
+        # Programmer / configuration errors (wrong context, import failures, etc.)
+        # should propagate loudly rather than silently defaulting to off.
+        # Transient DB errors (connection failure, table not yet applied, etc.)
+        # default off so the middleware stays safe before the DB is fully available.
+        _programmer_errors = (RuntimeError, ImportError, AttributeError, NameError)
+        if isinstance(exc, _programmer_errors):
+            logger.error(
+                "csrf_protect: programmer error reading auth_enforcement_enabled flag (re-raising): %s",
+                exc,
+            )
+            raise
         logger.warning(
             "csrf_protect: failed to read auth_enforcement_enabled flag (defaulting to False): %s",
             exc,

--- a/src/auth/feature_flags.py
+++ b/src/auth/feature_flags.py
@@ -36,6 +36,15 @@ import time
 
 logger = logging.getLogger(__name__)
 
+# Exception types that signal a programmer / configuration error — these should
+# propagate rather than being silently swallowed and defaulting to False.
+_PROGRAMMER_ERRORS: tuple[type[Exception], ...] = (
+    RuntimeError,
+    ImportError,
+    AttributeError,
+    NameError,
+)
+
 # ---------------------------------------------------------------------------
 # Cache
 # ---------------------------------------------------------------------------
@@ -61,7 +70,7 @@ def _clear_cache_for_tests() -> None:
 # ---------------------------------------------------------------------------
 
 
-def is_enabled(flag_key: str) -> bool:
+def is_enabled(flag_key: str, *, fail_closed: bool = False) -> bool:
     """Return True iff ``flag_key`` is set to ``'true'`` and not expired.
 
     Caches each key's value for ``_FLAG_CACHE_TTL`` seconds so the hot path
@@ -69,6 +78,9 @@ def is_enabled(flag_key: str) -> bool:
 
     Args:
         flag_key: The ``feature_flags.key`` value to read.
+        fail_closed: If True, any exception (including transient DB errors) is
+            re-raised rather than defaulting to False. Use for boot-time flag
+            reads where silent failure is the wrong default.
 
     Returns:
         Boolean — ``True`` if the row exists, ``value == 'true'``, and
@@ -83,7 +95,7 @@ def is_enabled(flag_key: str) -> bool:
             return value
 
     # Cache miss or expired — re-read from DB.
-    enabled = _read_flag_from_db(flag_key)
+    enabled = _read_flag_from_db(flag_key, fail_closed=fail_closed)
 
     with _CACHE_LOCK:
         _FLAG_CACHE[flag_key] = (enabled, now)
@@ -96,7 +108,7 @@ def is_enabled(flag_key: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _read_flag_from_db(flag_key: str) -> bool:
+def _read_flag_from_db(flag_key: str, *, fail_closed: bool = False) -> bool:
     """Read *flag_key* from ``feature_flags`` and return the resolved bool.
 
     Returns ``False`` on any DB error (connection, missing table, etc.) so
@@ -121,6 +133,13 @@ def _read_flag_from_db(flag_key: str) -> bool:
             {"flag_key": flag_key},
         )
     except Exception as exc:
+        if fail_closed or isinstance(exc, _PROGRAMMER_ERRORS):
+            logger.error(
+                "feature_flags.is_enabled(%s): unexpected error (re-raising): %s",
+                flag_key,
+                exc,
+            )
+            raise
         logger.warning(
             "feature_flags.is_enabled(%s): DB read failed (defaulting to False): %s",
             flag_key,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -324,7 +324,7 @@ def create_app(
     from src.auth.feature_flags import is_enabled
 
     with app.app_context():
-        google_login_on = is_enabled("google_login_enabled")
+        google_login_on = is_enabled("google_login_enabled", fail_closed=True)
 
     if google_login_on:
         from src.web.routes.auth import auth_bp

--- a/tests/unit/auth/test_csrf.py
+++ b/tests/unit/auth/test_csrf.py
@@ -37,13 +37,20 @@ def reset_flag_cache():
 @pytest.fixture()
 def app():
     """Minimal Flask test app with CSRF middleware registered."""
-    return create_app(
-        config_name="testing",
-        config_override={
-            "DATABASE_URL": "postgresql://test:test@localhost/test",
-            "API_KEY_REQUIRED": False,
-        },
-    )
+    from unittest.mock import patch as _patch
+
+    # Patch is_enabled at the source so create_app() never calls get_db().
+    # Patching src.web.app.get_db here would poison any blueprint that imports
+    # get_db at module level (e.g. ingest.py line 55), permanently replacing
+    # its bound reference with the test MagicMock for the rest of the session.
+    with _patch("src.auth.feature_flags.is_enabled", return_value=False):
+        return create_app(
+            config_name="testing",
+            config_override={
+                "DATABASE_URL": "postgresql://test:test@localhost/test",
+                "API_KEY_REQUIRED": False,
+            },
+        )
 
 
 @pytest.fixture()
@@ -272,3 +279,24 @@ class TestFlagCache:
 
         # query() should have been called a second time.
         assert mock_db.query.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: programmer errors propagate rather than silently defaulting to off
+# ---------------------------------------------------------------------------
+
+
+class TestProgrammerErrorPropagates:
+    def test_runtime_error_propagates_from_flag_read(self, client):
+        """RuntimeError during flag read re-raises instead of defaulting to False."""
+        from unittest.mock import patch
+
+        def boom():
+            raise RuntimeError("Working outside of application context")
+
+        with patch("src.web.app.get_db", boom):
+            with pytest.raises(RuntimeError):
+                client.post(
+                    "/health",
+                    headers={"Origin": "https://evil.example.com"},
+                )

--- a/tests/unit/auth/test_feature_flags.py
+++ b/tests/unit/auth/test_feature_flags.py
@@ -72,7 +72,7 @@ class TestIsEnabled:
 
     def test_db_error_returns_false(self, monkeypatch):
         def boom():
-            raise RuntimeError("db down")
+            raise Exception("connection refused")
 
         monkeypatch.setattr("src.web.app.get_db", boom)
         assert feature_flags.is_enabled("some_flag") is False
@@ -111,3 +111,31 @@ class TestIsEnabled:
         feature_flags.is_enabled("flag_a")
         feature_flags.is_enabled("flag_b")
         assert fake.call_count == 2
+
+    def test_runtime_error_propagates(self, monkeypatch):
+        def boom():
+            raise RuntimeError("Working outside of application context")
+
+        monkeypatch.setattr("src.web.app.get_db", boom)
+        with pytest.raises(RuntimeError):
+            feature_flags.is_enabled("some_flag")
+
+    def test_import_error_propagates(self, monkeypatch):
+        def boom():
+            raise ImportError("module not found")
+
+        monkeypatch.setattr("src.web.app.get_db", boom)
+        with pytest.raises(ImportError):
+            feature_flags.is_enabled("some_flag")
+
+    def test_fail_closed_true_re_raises_db_error(self, monkeypatch):
+        def boom():
+            raise Exception("connection refused")
+
+        monkeypatch.setattr("src.web.app.get_db", boom)
+        with pytest.raises(Exception, match="connection refused"):
+            feature_flags.is_enabled("some_flag", fail_closed=True)
+
+    def test_fail_closed_true_successful_read_returns_value(self, patch_db):
+        patch_db([{"value": "true"}])
+        assert feature_flags.is_enabled("some_flag", fail_closed=True) is True

--- a/tests/unit/web/conftest.py
+++ b/tests/unit/web/conftest.py
@@ -1,0 +1,30 @@
+"""
+Unit-test conftest for tests/unit/web/.
+
+Stubs ``is_enabled`` so that ``create_app()`` calls inside unit tests never
+attempt a live DB round-trip to read the ``google_login_enabled`` flag.
+
+Background: ``create_app()`` calls ``is_enabled("google_login_enabled",
+fail_closed=True)`` at boot time.  With ``fail_closed=True``, any exception
+(including DB-unreachable errors in a test environment that lacks a real
+database) propagates instead of silently defaulting to False.  Unit tests don't
+run against a live database, so we stub the flag reader to return False for all
+keys, which preserves the pre-existing test contract (auth blueprint not
+registered during unit tests) without triggering a DB connection.
+
+Tests that need specific flag values can override via ``monkeypatch.setattr``
+in their own fixtures — a local patch always wins.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_is_enabled_for_create_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent boot-time DB flag reads in create_app() for all web unit tests."""
+    monkeypatch.setattr(
+        "src.auth.feature_flags.is_enabled",
+        lambda *args, **kwargs: False,
+    )


### PR DESCRIPTION
## Summary

- Narrows `except Exception` in `feature_flags._read_flag_from_db` and `csrf._read_enforcement_flag` to re-raise programmer errors (`RuntimeError`, `ImportError`, `AttributeError`, `NameError`) instead of silently defaulting to False
- Adds `fail_closed: bool = False` param to `is_enabled()`; boot-time call in `app.py` now uses `fail_closed=True` so startup misconfigurations surface loudly
- Audited `load_user.py` broad excepts — left intentionally broad (per-request fail-open, never crash a request)
- Adds `tests/unit/web/conftest.py` autouse stub to prevent live DB flag reads during web unit test setup
- Fixes `test_csrf.py` app fixture to patch `is_enabled` at source instead of `src.web.app.get_db`, preventing module-level import poisoning of `ingest.py.get_db` across the test session
- Resolves gh-475 fragment

## Test plan

- [ ] `pytest tests/unit/ -x -q` passes (4576 tests)
- [ ] `ruff check src/ tests/` clean
- [ ] `tests/unit/auth/test_feature_flags.py` — 13 tests including new propagation + fail_closed cases
- [ ] `tests/unit/auth/test_csrf.py` — 16 tests including `TestProgrammerErrorPropagates`
- [ ] `tests/unit/auth/test_csrf.py` followed by `tests/unit/web/test_ingest_unit.py` — no ordering-dependent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)