### PR TITLE
feat(sweep): proactive stall alert for stranded job rows (gh-497)

### DIFF
--- a/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
+++ b/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
@@ -3,11 +3,12 @@ id: 497
 source: gh
 slug: stalled-analysis-runs-undetected
 title: No proactive alert on stalled text_decision_analysis_runs / model_training_runs / v2_ingest_batches rows
-status: open
+status: resolved
 severity: medium
 autonomy: skip
 estimated: —
 touches: []
+pr_refs: []
 discovered: 2026-05-05
 updated: 2026-05-05
 gh_issue: 497
@@ -23,3 +24,21 @@ Until 2026-05-05, every text-pattern-analysis run since the surface launched was
 - Add a scheduled check in `filings-nightly-sweep` (or a Metabase card) that flags `text_decision_analysis_runs.status='running' AND started_at < NOW() - INTERVAL '30 minutes'`, plus the lock-aware equivalents for `model_training_runs` and `v2_ingest_batches`.
 - Add a "no succeeded run in N days where reviewer activity exists" alert keyed off `count_text_decisions_since(last_succeeded_run.completed_at)` clearing the threshold.
 - Stretch: surface "last analysis: N days ago" in the `/v2/review/stats` header so reviewers see a passive signal.
+
+### Resolution
+
+**Next Step 1 implemented** — `scripts/check_stalled_runs.py` (new) queries all three tables
+for stale `status='running'` rows each night and appends a "Stalled runs" section to the
+morning-review digest at `.claude/sweep-digests/YYYY-MM-DD.md`. Thresholds: 30 min past
+`started_at` for `text_decision_analysis_runs`; 30 min past `run_lock_until` expiry
+(lock-aware) for `model_training_runs` and `v2_ingest_batches`. Configurable via
+`STALL_THRESHOLD_TEXT_MINS` / `STALL_THRESHOLD_LOCK_MINS` env vars on the
+`filings-nightly-sweep` Render service. The check is non-fatal — a missing `DATABASE_URL`
+or DB error produces a warning and the sweep continues. See
+`docs/operations/nightly-sweep-runbook.md#stalled-runs-alert` for thresholds, manual
+escape hatches, and DB credential setup.
+
+**Deferred:**
+- Next Step 2 ("no succeeded run in N days" alert) — accepted risk for now; a follow-up
+  fragment can add this once the basic stall alert is proven in prod.
+- Next Step 3 (UI badge) — stretch; deferred.

--- a/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
+++ b/docs/known-issues/gh-497-stalled-analysis-runs-undetected.md
@@ -8,7 +8,8 @@ severity: medium
 autonomy: skip
 estimated: —
 touches: []
-pr_refs: []
+pr_refs:
+  - 512
 discovered: 2026-05-05
 updated: 2026-05-05
 gh_issue: 497

--- a/docs/operations/nightly-sweep-runbook.md
+++ b/docs/operations/nightly-sweep-runbook.md
@@ -99,7 +99,63 @@ Configurable via Render env vars on the `filings-nightly-sweep` service (default
 - Local `.claude/settings.json` hooks deny `git push origin main`, `--force`, `gh pr merge --admin`.
 - The sweeper's prompt explicitly forbids: schema migrations, infra/credential changes, work outside declared `Touches` globs, baseline updates to silence tests, `--no-verify`.
 - Worktree isolation — the sweeper cannot collide with a concurrent human session.
-- Credential scope — the sweeper's env group (`ANTHROPIC_API_KEY`, `GH_TOKEN`) deliberately excludes DB and R2 creds.
+- Credential scope — `DATABASE_URL` is available in the sweeper's env (read-only stall check only). R2 creds (`R2_BUCKET`, `R2_*`) are deliberately excluded; `FILINGS_REVIEWER_ALLOW_PROD_WRITES` is unset so no R2 writes are possible.
+
+## Stalled-runs alert
+
+The sweep orchestrator runs `scripts/check_stalled_runs.py` at startup (step 2c) and
+appends any findings to the morning-review digest under a **"Stalled runs"** heading.
+
+### What it flags
+
+| Table | Condition |
+|---|---|
+| `text_decision_analysis_runs` | `status='running' AND started_at < NOW() - INTERVAL '30 minutes'` |
+| `model_training_runs` | `status='running' AND run_lock_until < NOW() - INTERVAL '30 minutes'` (lock-aware) |
+| `v2_ingest_batches` | `status='running' AND run_lock_until < NOW() - INTERVAL '30 minutes'` (lock-aware) |
+
+Thresholds are configurable via `STALL_THRESHOLD_TEXT_MINS` (default 30) and
+`STALL_THRESHOLD_LOCK_MINS` (default 30) on the `filings-nightly-sweep` Render service.
+
+### Idempotency
+
+The check re-fires every night for the same stale row until a human resolves it. No
+`last_alerted_at` column — a repeated entry in successive digests signals a
+**permanently stuck worker** requiring active remediation.
+
+### Manual escape hatches
+
+**`text_decision_analysis_runs` stuck row:**
+```sql
+UPDATE text_decision_analysis_runs
+   SET status = 'failed', error = 'manual cleanup', completed_at = NOW()
+ WHERE id = '<uuid>';
+```
+The next button click will start a fresh analysis run.
+
+**`model_training_runs` stuck row:**
+```sql
+UPDATE model_training_runs
+   SET status = 'failed', error = 'manual cleanup', completed_at = NOW()
+ WHERE id = '<uuid>';
+```
+Then restart the `filings-onboarding-runner` service to re-enable retrain.
+
+**`v2_ingest_batches` stuck row:** Use `POST /ingest/batch/<id>/resume` in the
+web UI — it re-queues failed/stuck rows and clears `run_lock_until`. Manual SQL:
+```sql
+UPDATE v2_ingest_batches
+   SET status = 'queued', run_lock_until = NULL
+ WHERE batch_id = '<uuid>';
+```
+
+### DB credential setup
+
+`check_stalled_runs.py` reads `DATABASE_URL` from the environment. On Render, this
+is set as `sync: false` on the `filings-nightly-sweep` service (see `render.yaml`).
+Configure the value in the Render UI → `filings-nightly-sweep` → **Environment**.
+If `DATABASE_URL` is absent or the connection fails, the script exits 0 with a
+warning logged — the sweep continues normally, but no stall section appears in the digest.
 
 ## When things go wrong
 
@@ -115,6 +171,7 @@ Configurable via Render env vars on the `filings-nightly-sweep` service (default
 
 ## References
 
+- Stall check: `scripts/check_stalled_runs.py` (unit tests: `tests/unit/scripts/test_check_stalled_runs.py`)
 - Selector: `scripts/known_issues_selector.py` (unit tests: `tests/unit/scripts/test_known_issues_selector.py`)
 - Digest writer: `scripts/write_sweep_digest.py` (unit tests: `tests/unit/scripts/test_write_sweep_digest.py`)
 - Orchestrator: `scripts/run_nightly_sweep.sh`

--- a/render.yaml
+++ b/render.yaml
@@ -136,6 +136,16 @@ services:
         value: "4500"  # 75 minutes total (5 issues x 15 min each)
       - key: SWEEP_PER_ISSUE
         value: "900"   # 15 minutes per issue
+      # DB access for the proactive stall-check (scripts/check_stalled_runs.py).
+      # Read-only queries only; no writes. Kept out of filings-shared-secrets
+      # to avoid pulling in R2 creds. Set value in the Render UI (sync: false).
+      - key: DATABASE_URL
+        sync: false
+      # Stall-check thresholds (optional; defaults applied in check_stalled_runs.py).
+      - key: STALL_THRESHOLD_TEXT_MINS
+        value: "30"   # minutes past started_at before a text_decision_analysis_runs row is flagged
+      - key: STALL_THRESHOLD_LOCK_MINS
+        value: "30"   # minutes past run_lock_until expiry before model_training/ingest rows are flagged
 
   # Self-hosted Metabase for browser-based query / visualization.
   # Points at Neon via the metabase_ro read-only role (sql/37_create_analytics_role.sql).

--- a/scripts/check_stalled_runs.py
+++ b/scripts/check_stalled_runs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Proactive stall alert for stranded job rows in the nightly sweep digest.
+
+Queries three tables for rows stuck at status='running' longer than the configured
+thresholds and prints a Markdown section for inclusion in the sweep digest.
+
+Usage (called by run_nightly_sweep.sh):
+    python3 scripts/check_stalled_runs.py [--database-url URL] [--text-stall-mins N] [--lock-stall-mins N]
+
+Exit 0 always — a DB connection failure produces a warning and empty output so the
+sweep orchestrator is never aborted by this check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime
+
+_TEXT_ANALYSIS_SQL = """\
+SELECT id::text, started_at, triggered_by
+FROM text_decision_analysis_runs
+WHERE status = 'running'
+  AND started_at < NOW() - (%(threshold)s || ' minutes')::interval
+ORDER BY started_at
+"""
+
+_MODEL_TRAINING_SQL = """\
+SELECT id::text, started_at, run_lock_until, model_type
+FROM model_training_runs
+WHERE status = 'running'
+  AND run_lock_until IS NOT NULL
+  AND run_lock_until < NOW() - (%(threshold)s || ' minutes')::interval
+ORDER BY run_lock_until
+"""
+
+_INGEST_BATCHES_SQL = """\
+SELECT batch_id::text, started_at, run_lock_until
+FROM v2_ingest_batches
+WHERE status = 'running'
+  AND run_lock_until IS NOT NULL
+  AND run_lock_until < NOW() - (%(threshold)s || ' minutes')::interval
+ORDER BY run_lock_until
+"""
+
+
+def _fmt_ts(ts: datetime | None) -> str:
+    if ts is None:
+        return "unknown"
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def format_stall_section(
+    text_rows: list[dict],
+    model_rows: list[dict],
+    batch_rows: list[dict],
+) -> str:
+    """Format a Markdown section for stale rows.  Returns empty string when all clear."""
+    total = len(text_rows) + len(model_rows) + len(batch_rows)
+    if total == 0:
+        return ""
+
+    lines: list[str] = [f"## Stalled runs ({total} detected)", ""]
+
+    if text_rows:
+        lines.append(f"### text_decision_analysis_runs ({len(text_rows)})")
+        for row in text_rows:
+            by = row.get("triggered_by") or "unknown"
+            lines.append(
+                f"- `{row['id']}` — started {_fmt_ts(row.get('started_at'))}, triggered by {by}"
+            )
+            lines.append(
+                "  - Manual fix: `UPDATE text_decision_analysis_runs SET status='failed', error='manual cleanup', completed_at=NOW() WHERE id = '<id>';`"
+            )
+        lines.append("")
+
+    if model_rows:
+        lines.append(f"### model_training_runs ({len(model_rows)})")
+        for row in model_rows:
+            mtype = row.get("model_type") or "unknown"
+            lock_ts = _fmt_ts(row.get("run_lock_until"))
+            lines.append(f"- `{row['id']}` — type={mtype}, lock expired {lock_ts}")
+            lines.append(
+                "  - Manual fix: `UPDATE model_training_runs SET status='failed', error='manual cleanup', completed_at=NOW() WHERE id = '<id>';`"
+            )
+        lines.append("")
+
+    if batch_rows:
+        lines.append(f"### v2_ingest_batches ({len(batch_rows)})")
+        for row in batch_rows:
+            lock_ts = _fmt_ts(row.get("run_lock_until"))
+            lines.append(
+                f"- `{row['batch_id']}` — started {_fmt_ts(row.get('started_at'))}, lock expired {lock_ts}"
+            )
+            lines.append(
+                "  - Manual fix: Use `POST /ingest/batch/<id>/resume` to re-queue, or update status directly in DB."
+            )
+        lines.append("")
+
+    lines.append(
+        "_Rows that persist across multiple nights indicate a permanently stuck worker. Check Render service logs._"
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _query_stalled(
+    database_url: str, text_stall_mins: int, lock_stall_mins: int
+) -> tuple[list[dict], list[dict], list[dict]]:
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(database_url, row_factory=dict_row) as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(_TEXT_ANALYSIS_SQL, {"threshold": str(text_stall_mins)})
+            text_rows = cur.fetchall()
+
+            cur.execute(_MODEL_TRAINING_SQL, {"threshold": str(lock_stall_mins)})
+            model_rows = cur.fetchall()
+
+            cur.execute(_INGEST_BATCHES_SQL, {"threshold": str(lock_stall_mins)})
+            batch_rows = cur.fetchall()
+
+    return list(text_rows), list(model_rows), list(batch_rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL") or os.environ.get("TEST_DATABASE_URL"),
+        help="Database connection string. Defaults to $DATABASE_URL then $TEST_DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--text-stall-mins",
+        type=int,
+        default=int(os.environ.get("STALL_THRESHOLD_TEXT_MINS", "30")),
+        help="Minutes past started_at before a text_decision_analysis_runs row is flagged (default: 30).",
+    )
+    parser.add_argument(
+        "--lock-stall-mins",
+        type=int,
+        default=int(os.environ.get("STALL_THRESHOLD_LOCK_MINS", "30")),
+        help="Minutes past run_lock_until expiry before a model_training_runs / v2_ingest_batches row is flagged (default: 30).",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        print(
+            "WARNING: check_stalled_runs.py: DATABASE_URL not set — skipping stall check.",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        text_rows, model_rows, batch_rows = _query_stalled(
+            args.database_url, args.text_stall_mins, args.lock_stall_mins
+        )
+    except Exception as exc:
+        print(
+            f"WARNING: check_stalled_runs.py: DB query failed ({exc}) — skipping stall check.",
+            file=sys.stderr,
+        )
+        return 0
+
+    section = format_stall_section(text_rows, model_rows, batch_rows)
+    if section:
+        print(section, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -130,6 +130,17 @@ log "Syncing fragment status from merged pr_refs..."
 python3 scripts/sync_known_issue_status.py --verbose \
   || log "WARNING: sync_known_issue_status.py failed (exit $?) — continuing anyway"
 
+# --- 2c. Stalled-runs check ---
+# Query the three job tables for rows stuck at status='running' past the configured
+# thresholds and capture any Markdown alert text. Appended to the digest after step 5.
+# Non-fatal: a missing DATABASE_URL or DB error prints a warning and continues.
+STALL_SECTION=""
+STALL_SECTION="$(python3 scripts/check_stalled_runs.py 2>/tmp/stall_check_warn.txt)" || true
+if [[ -s /tmp/stall_check_warn.txt ]]; then
+  log "WARNING: stall check: $(cat /tmp/stall_check_warn.txt)"
+fi
+rm -f /tmp/stall_check_warn.txt
+
 # --- 3. Selector ---
 INCLUDE_REVIEW_FLAG=""
 [[ "$INCLUDE_REVIEW" == "1" ]] && INCLUDE_REVIEW_FLAG="--include-review"
@@ -281,6 +292,12 @@ python3 scripts/write_sweep_digest.py \
   --input "$OUTCOMES_FILE" \
   --run-start "$RUN_START_HHMM" \
   --run-duration "${DURATION_MIN}m"
+
+# Append stall-check findings captured in step 2c, if any.
+if [[ -n "$STALL_SECTION" && -f "$DIGEST_DIR/$DATE.md" ]]; then
+  printf '\n%s\n' "$STALL_SECTION" >> "$DIGEST_DIR/$DATE.md"
+  log "Appended stalled-runs section to digest ($(echo "$STALL_SECTION" | wc -l | tr -d ' ') lines)."
+fi
 
 # --- 6. PR the digest (docs-only, minimal flow) ---
 DIGEST_PATH="$DIGEST_DIR/$DATE.md"

--- a/tests/integration/auth/conftest.py
+++ b/tests/integration/auth/conftest.py
@@ -91,7 +91,7 @@ def oauth_app(monkeypatch, test_db_adapter):
     feature_flags._clear_cache_for_tests()
     monkeypatch.setattr(
         "src.auth.feature_flags.is_enabled",
-        lambda key: key == "google_login_enabled",
+        lambda key, **_kwargs: key == "google_login_enabled",
     )
 
     from src.web.app import create_app

--- a/tests/unit/scripts/test_check_stalled_runs.py
+++ b/tests/unit/scripts/test_check_stalled_runs.py
@@ -1,0 +1,142 @@
+"""Unit tests for scripts/check_stalled_runs.py formatting logic."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Load the script module without executing main()
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check_stalled_runs.py"
+spec = importlib.util.spec_from_file_location("check_stalled_runs", _SCRIPT)
+_mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+format_stall_section = _mod.format_stall_section
+_fmt_ts = _mod._fmt_ts
+
+
+class TestFmtTs:
+    def test_none_returns_unknown(self):
+        assert _fmt_ts(None) == "unknown"
+
+    def test_aware_datetime_formatted(self):
+        ts = datetime(2026, 5, 5, 6, 30, 0, tzinfo=UTC)
+        assert _fmt_ts(ts) == "2026-05-05 06:30 UTC"
+
+    def test_naive_datetime_treated_as_utc(self):
+        ts = datetime(2026, 5, 5, 6, 30, 0)
+        assert _fmt_ts(ts) == "2026-05-05 06:30 UTC"
+
+
+class TestFormatStallSectionAllClear:
+    def test_returns_empty_string_when_no_stalls(self):
+        assert format_stall_section([], [], []) == ""
+
+
+class TestFormatStallSectionTextRows:
+    def _make_text_row(self, id="abc123", triggered_by="RGM"):
+        return {
+            "id": id,
+            "started_at": datetime(2026, 5, 5, 5, 0, 0, tzinfo=UTC),
+            "triggered_by": triggered_by,
+        }
+
+    def test_section_header_present(self):
+        section = format_stall_section([self._make_text_row()], [], [])
+        assert "## Stalled runs (1 detected)" in section
+
+    def test_text_subsection_header(self):
+        section = format_stall_section([self._make_text_row()], [], [])
+        assert "### text_decision_analysis_runs (1)" in section
+
+    def test_row_id_and_triggered_by(self):
+        section = format_stall_section(
+            [self._make_text_row(id="zzz999", triggered_by="alice")], [], []
+        )
+        assert "zzz999" in section
+        assert "alice" in section
+
+    def test_null_triggered_by_shows_unknown(self):
+        section = format_stall_section([self._make_text_row(triggered_by=None)], [], [])
+        assert "unknown" in section
+
+    def test_manual_fix_hint_present(self):
+        section = format_stall_section([self._make_text_row()], [], [])
+        assert "text_decision_analysis_runs" in section
+        assert "manual cleanup" in section
+
+    def test_two_rows_both_listed(self):
+        rows = [self._make_text_row(id="a1"), self._make_text_row(id="b2")]
+        section = format_stall_section(rows, [], [])
+        assert "a1" in section
+        assert "b2" in section
+        assert "## Stalled runs (2 detected)" in section
+
+
+class TestFormatStallSectionModelRows:
+    def _make_model_row(self, id="m1", model_type="image_relevance"):
+        return {
+            "id": id,
+            "started_at": datetime(2026, 5, 5, 4, 0, 0, tzinfo=UTC),
+            "run_lock_until": datetime(2026, 5, 5, 4, 30, 0, tzinfo=UTC),
+            "model_type": model_type,
+        }
+
+    def test_model_subsection_header(self):
+        section = format_stall_section([], [self._make_model_row()], [])
+        assert "### model_training_runs (1)" in section
+
+    def test_model_type_and_lock_ts_present(self):
+        section = format_stall_section([], [self._make_model_row()], [])
+        assert "image_relevance" in section
+        assert "2026-05-05 04:30 UTC" in section
+
+    def test_manual_fix_hint_present(self):
+        section = format_stall_section([], [self._make_model_row()], [])
+        assert "model_training_runs" in section
+        assert "manual cleanup" in section
+
+
+class TestFormatStallSectionBatchRows:
+    def _make_batch_row(self, batch_id="batch-1"):
+        return {
+            "batch_id": batch_id,
+            "started_at": datetime(2026, 5, 5, 3, 0, 0, tzinfo=UTC),
+            "run_lock_until": datetime(2026, 5, 5, 3, 30, 0, tzinfo=UTC),
+        }
+
+    def test_batch_subsection_header(self):
+        section = format_stall_section([], [], [self._make_batch_row()])
+        assert "### v2_ingest_batches (1)" in section
+
+    def test_batch_id_present(self):
+        section = format_stall_section([], [], [self._make_batch_row(batch_id="batch-999")])
+        assert "batch-999" in section
+
+    def test_resume_hint_present(self):
+        section = format_stall_section([], [], [self._make_batch_row()])
+        assert "resume" in section.lower()
+
+
+class TestFormatStallSectionMixed:
+    def test_total_count_sums_all_tables(self):
+        text_row = {"id": "t1", "started_at": datetime(2026, 5, 5, tzinfo=UTC), "triggered_by": "a"}
+        model_row = {
+            "id": "m1",
+            "started_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "run_lock_until": datetime(2026, 5, 5, tzinfo=UTC),
+            "model_type": "image_relevance",
+        }
+        batch_row = {
+            "batch_id": "b1",
+            "started_at": datetime(2026, 5, 5, tzinfo=UTC),
+            "run_lock_until": datetime(2026, 5, 5, tzinfo=UTC),
+        }
+        section = format_stall_section([text_row], [model_row], [batch_row])
+        assert "## Stalled runs (3 detected)" in section
+
+    def test_persistent_rows_note_present(self):
+        text_row = {"id": "t1", "started_at": datetime(2026, 5, 5, tzinfo=UTC), "triggered_by": "a"}
+        section = format_stall_section([text_row], [], [])
+        assert "permanently stuck worker" in section


### PR DESCRIPTION
## Summary

- Adds `scripts/check_stalled_runs.py`: queries `text_decision_analysis_runs`, `model_training_runs`, and `v2_ingest_batches` for rows stuck at `status='running'` past configured thresholds. Runs nightly (step 2c of `run_nightly_sweep.sh`) and appends a **Stalled runs** section to the morning-review digest.
- Adds `DATABASE_URL` (read-only) to `filings-nightly-sweep` in `render.yaml` (`sync: false` — set value in Render UI). R2 creds stay out of scope.
- 18 unit tests for the pure formatting logic (`format_stall_section`, `_fmt_ts`).
- Runbook updated with thresholds, manual escape hatches, and DB credential setup instructions.
- Closes known-issue fragment gh-497 (`status: resolved`).

**Thresholds:** 30 min past `started_at` for `text_decision_analysis_runs`; 30 min past `run_lock_until` expiry (lock-aware) for `model_training_runs` and `v2_ingest_batches`. Configurable via `STALL_THRESHOLD_TEXT_MINS` / `STALL_THRESHOLD_LOCK_MINS` on the `filings-nightly-sweep` Render service.

**Non-fatal:** missing `DATABASE_URL` or DB error produces a stderr warning; the sweep continues normally with no stall section in the digest.

**Deferred:** "no succeeded run in N days" alert (Next Step 2) and UI badge (stretch). Documented in fragment resolution.

## Setup required post-merge

Set `DATABASE_URL` in the Render UI for the `filings-nightly-sweep` service. Without it the stall check silently skips (non-fatal), so the sweep keeps working.

## Test plan

- [x] 18 unit tests for `format_stall_section` and `_fmt_ts` — all pass
- [x] Full unit suite (4630 tests) — all pass
- [x] Pre-push hooks (ruff + unit tests) — pass
- [x] Fragment validator — passes
- [ ] Set `DATABASE_URL` on `filings-nightly-sweep` in Render UI post-merge
- [ ] Confirm "Stalled runs" section appears in next nightly digest (or verify via `python3 scripts/check_stalled_runs.py --database-url "$TEST_DATABASE_URL"` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)