### PR TITLE
fix(auth): remove stacked @require_admin from recommendation-decisions endpoints (gh-482)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -93,7 +93,7 @@ Each Suggested-actions card renders three buttons (Accept / Dismiss / Defer) plu
 - `POST /api/v2/extraction/recommendation-decisions` — upsert on `(metric_id, rule, decision_key, reviewer_id)`. Body: `{metric_id, rule, decision_key, decision, reviewer_id, reviewer_note?}`. `decision ∈ {accepted, dismissed, deferred}`. Returns the upserted row.
 - `DELETE /api/v2/extraction/recommendation-decisions/<uuid:decision_id>` — owner-scoped undo. Returns 404 when the row is missing OR exists but belongs to a different reviewer (so admins don't accidentally undo each other's decisions).
 
-Both endpoints are gated by `_require_reviewer_id` + `require_admin` (`src/web/middleware.py`). The admin gate reads a comma-separated allowlist from env var `ADMIN_USER_IDS` and returns HTTP 403 `{error: "admin_required"}` when missing or unmatched. **Transitional** — to be replaced by `src/auth/middleware.py::require(<permission>)` against `auth_users.role` once Stage A2 of the auth rollout lands (`docs/architecture/auth-rollout-implementation-plan.md`). Migration is one-line per call site.
+Both endpoints are gated by `_require_reviewer_id` + `@require(INGEST_RUN)` (`src/auth/middleware.py`). Only users with `admin` role hold the `ingest.run` permission.
 
 `decision_key` is the stable identifier across analysis reruns:
 - `exclusion_pattern` → the phrase (e.g. `"accounts receivable"`)

--- a/.env.template
+++ b/.env.template
@@ -37,13 +37,6 @@ FILINGS_API_KEY=
 # Set to 'true' to require API key authentication (always true in production)
 API_KEY_REQUIRED=false
 
-# Admin allowlist for /v2/review/stats Suggested-actions decisions
-# (POST/DELETE /api/v2/extraction/recommendation-decisions). Comma-separated
-# reviewer IDs. Empty (or unset) = endpoint returns 403 for everyone.
-# Transitional — replaced by auth_users.role lookup when Stage A2 of the auth
-# rollout lands (docs/architecture/auth-rollout-implementation-plan.md).
-ADMIN_USER_IDS=
-
 # OpenAI API Configuration
 # Get your API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-proj-your-key-here

--- a/docs/analysis/text-decision-analysis-spec-critique.md
+++ b/docs/analysis/text-decision-analysis-spec-critique.md
@@ -156,11 +156,7 @@ Spec Phase 1.2 proposes "reviewer and filing de-duplication controls" and Phase 
 proposes a `distinct_reviewer_count` field on phrase statistics. Phase 2.3 sets an
 acceptance criterion of "disagreement detection appears for all conflicting keys."
 
-The recommendation decision endpoints are gated by `require_admin`
-(`src/web/routes/api_unified.py`, the `_require_reviewer_id` + admin gate in
-`upsert_recommendation_decision`). The admin allowlist is configured via the
-`ADMIN_USER_IDS` environment variable (`.claude/rules/web.md`, Recommendation decisions
-section). In practice this has been a single-operator workflow. Reviewer normalization
+The recommendation decision endpoints are gated by `_require_reviewer_id` + `@require(INGEST_RUN)` (`src/web/routes/api_unified.py`). Only users with `admin` role hold the `ingest.run` permission. In practice this has been a single-operator workflow. Reviewer normalization
 that removes per-reviewer bias is a meaningful technique at ≥3 independent reviewers
 with diverging behavior. At 1-2 reviewers it reduces sample size without removing bias
 — the "bias" is the entire dataset.

--- a/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
+++ b/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
@@ -3,7 +3,7 @@ id: 482
 source: gh
 slug: stacked-require-admin-cleanup
 title: "auth: remove stacked @require_admin from retrain/analysis endpoints (PR-C1 cleanup)"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: S
@@ -11,7 +11,7 @@ touches:
   - src/web/routes/api_unified.py
   - src/web/middleware.py
 discovered: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 gh_issue: 482
 pr_refs:
   - 479
@@ -27,3 +27,7 @@ PR-C1 (#479) added `@require(INGEST_RUN)` to four admin-style endpoints in `src/
 - After Stage-C enforcement has been live for at least one soak window, remove `@require_admin` from the four endpoints above.
 - Confirm no other call sites still use `require_admin`; remove the import where it's the only consumer.
 - If `ADMIN_USER_IDS` env var is no longer read anywhere, delete `require_admin` from `src/web/middleware.py` entirely.
+
+### Resolution
+
+The fragment over-counted the footprint: only two endpoints still had `@require_admin` stacked at the time of cleanup (`/extraction/recommendation-decisions` POST and DELETE); the other two (`/models/image-classifier/retrain`, `/extraction/analyze-text-decisions`) had already been cleaned before this fragment was filed. Stage-C enforcement (`auth_enforcement_enabled=true`) was confirmed live in production on 2026-05-05 before proceeding. Removed: both `@require_admin` decorator lines, the `require_admin` function from `src/web/middleware.py`, `import os` (its sole consumer), and `ADMIN_USER_IDS` from `.env.template`. Tests migrated from `ADMIN_USER_IDS` monkeypatching to `@require(INGEST_RUN)` permission-gate tests.

--- a/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
+++ b/docs/known-issues/gh-482-stacked-require-admin-cleanup.md
@@ -15,6 +15,7 @@ updated: 2026-05-05
 gh_issue: 482
 pr_refs:
   - 479
+  - 514
 note: four admin endpoints carry both @require_admin and @require(INGEST_RUN); remove the legacy decorator once Stage-C enforcement has soaked
 ---
 

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -4,9 +4,6 @@ Shared Flask middleware for the review application.
 Provides reusable before_request/after_request hooks for:
 - API key authentication (non-browser callers via ``Authorization: ApiKey``
   or ``X-API-Key`` header — same-origin browser bypass removed in PR-C1)
-- Admin gate (transitional — will be replaced by role lookup against
-  auth_users when Stage A2 of the auth rollout lands; see
-  docs/architecture/auth-rollout-implementation-plan.md)
 - Request timing
 - Audit log insertion
 
@@ -22,7 +19,6 @@ that need per-endpoint API-key checks can still use ``require_api_key``.
 import functools
 import hmac
 import logging
-import os
 import time
 from collections.abc import Callable
 from typing import Any
@@ -108,48 +104,6 @@ def require_api_key(view: Callable) -> Callable:
         rejection = _verify_api_key()
         if rejection is not None:
             return rejection
-        return view(*args, **kwargs)
-
-    return wrapper
-
-
-def require_admin(view: Callable) -> Callable:
-    """Gate a view to admin reviewers only.
-
-    Reads the comma-separated allowlist from env var ``ADMIN_USER_IDS``
-    and matches against ``reviewer_id`` from the JSON body, query string,
-    or ``X-Reviewer-Id`` header (in that order, mirroring the per-metric
-    image-confirmation contract). Returns HTTP 403 ``{error:
-    "admin_required"}`` when the env var is unset/empty or the reviewer
-    isn't on the list.
-
-    **Transitional.** This is a stop-gap admin gate until Stage A2 of
-    the auth rollout lands (`src/auth/middleware.py::require(<permission>)`,
-    role lookup against ``auth_users``). Migration is mechanical — swap
-    ``@require_admin`` for ``@require('<permission>')`` on each call site.
-    See ``docs/architecture/auth-rollout-implementation-plan.md``.
-    """
-
-    @functools.wraps(view)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        data = request.get_json(silent=True) or {}
-        reviewer = (
-            data.get("reviewer_id")
-            or request.args.get("reviewer_id")
-            or request.headers.get("X-Reviewer-Id")
-            or ""
-        ).strip()
-
-        admins_csv = os.environ.get("ADMIN_USER_IDS", "")
-        admins = frozenset(e.strip() for e in admins_csv.split(",") if e.strip())
-
-        if not admins or reviewer not in admins:
-            logger.warning(
-                "Admin-only endpoint blocked: reviewer=%r path=%s",
-                reviewer or "<missing>",
-                request.path,
-            )
-            return jsonify({"error": "admin_required"}), 403
         return view(*args, **kwargs)
 
     return wrapper

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -30,7 +30,6 @@ from src.web.app import get_db
 from src.web.middleware import (
     insert_audit_log_entry,
     register_timing,
-    require_admin,
 )
 
 api_unified_bp = Blueprint("api_unified", __name__, url_prefix="/api/v2")
@@ -1601,7 +1600,6 @@ def _serialize_recommendation_decision(row: dict) -> dict:
 
 
 @api_unified_bp.route("/extraction/recommendation-decisions", methods=["POST"])
-@require_admin
 @require(INGEST_RUN)
 def upsert_recommendation_decision():
     """Record an admin's Accept/Dismiss/Defer click on a Suggested-actions row.
@@ -1615,7 +1613,7 @@ def upsert_recommendation_decision():
           "rule": "exclusion_pattern" | "keyword_overlap" | "fp_filter_gap",
           "decision_key": str,
           "decision": "accepted" | "dismissed" | "deferred",
-          "reviewer_id": str,        # required by _require_reviewer_id + require_admin
+          "reviewer_id": str,        # required by _require_reviewer_id
           "reviewer_note": str?      # optional, <= 1000 chars
         }
 
@@ -1663,7 +1661,6 @@ def upsert_recommendation_decision():
 
 
 @api_unified_bp.route("/extraction/recommendation-decisions/<uuid:decision_id>", methods=["DELETE"])
-@require_admin
 @require(INGEST_RUN)
 def delete_recommendation_decision(decision_id):
     """Undo a recommendation decision. Reviewer-scoped — admins can't undo

--- a/tests/unit/web/test_recommendation_decisions_api.py
+++ b/tests/unit/web/test_recommendation_decisions_api.py
@@ -1,13 +1,13 @@
 """Unit tests for the recommendation-decisions endpoints.
 
 Covers:
-  - POST /api/v2/extraction/recommendation-decisions — admin gate, reviewer gate,
+  - POST /api/v2/extraction/recommendation-decisions — permission gate, reviewer gate,
     field validation, upsert wiring, change-of-mind path.
   - DELETE /api/v2/extraction/recommendation-decisions/<uuid> — owner scope
-    (reviewer A can't undo reviewer B's decision via 404), admin gate.
+    (reviewer A can't undo reviewer B's decision via 404), permission gate.
 
-The admin gate is the new transitional `require_admin` decorator on
-`src.web.middleware`; tests set ADMIN_USER_IDS via monkeypatch.
+The permission gate is @require(INGEST_RUN) from src.auth.middleware; tests
+patch src.auth.feature_flags.is_enabled to control enforcement.
 """
 
 from __future__ import annotations
@@ -17,13 +17,15 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from flask import g
 
+from src.auth.sessions import SessionUser
 from src.web.app import create_app
 
 
 @pytest.fixture
 def app(monkeypatch):
-    monkeypatch.setenv("ADMIN_USER_IDS", "RGM,admin@example.com")
+    monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key, **kwargs: False)
     app = create_app("testing")
     app.config["TESTING"] = True
     app.config["DATABASE_URL"] = "postgresql://test"
@@ -85,7 +87,7 @@ class TestPostGates:
         body = {k: v for k, v in _VALID_BODY.items() if k != "reviewer_id"}
         resp = client.post(_POST, json=body)
         assert resp.status_code == 403
-        assert resp.get_json()["error"] in {"admin_required", "reviewer_name_required"}
+        assert resp.get_json()["error"] == "reviewer_name_required"
         mock_db.upsert_recommendation_decision.assert_not_called()
 
     def test_blocklisted_reviewer_returns_403(self, client, mock_db):
@@ -93,19 +95,29 @@ class TestPostGates:
         assert resp.status_code == 403
         mock_db.upsert_recommendation_decision.assert_not_called()
 
-    def test_non_admin_returns_403(self, client, mock_db, monkeypatch):
-        monkeypatch.setenv("ADMIN_USER_IDS", "OTHER_ADMIN")
-        resp = client.post(_POST, json=_VALID_BODY)
+    def test_reviewer_role_returns_403(self, app, mock_db, monkeypatch):
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key, **kwargs: True)
+        reviewer_user = SessionUser(
+            id="00000000-0000-0000-0000-000000000002",
+            email="reviewer@example.com",
+            display_name="Reviewer",
+            role="reviewer",
+            account_status="active",
+        )
+
+        @app.before_request
+        def inject_reviewer():
+            g.user = reviewer_user
+
+        resp = app.test_client().post(_POST, json=_VALID_BODY)
         assert resp.status_code == 403
-        body = resp.get_json()
-        assert body["error"] == "admin_required"
         mock_db.upsert_recommendation_decision.assert_not_called()
 
-    def test_missing_admin_env_returns_403(self, client, mock_db, monkeypatch):
-        monkeypatch.delenv("ADMIN_USER_IDS", raising=False)
-        resp = client.post(_POST, json=_VALID_BODY)
-        assert resp.status_code == 403
-        assert resp.get_json()["error"] == "admin_required"
+    def test_unauthenticated_returns_401(self, app, mock_db, monkeypatch):
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key, **kwargs: True)
+        resp = app.test_client().post(_POST, json=_VALID_BODY)
+        assert resp.status_code == 401
+        mock_db.upsert_recommendation_decision.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -205,9 +217,21 @@ class TestDelete:
         assert resp.status_code == 404
         assert resp.get_json()["error"] == "not_found_or_not_owner"
 
-    def test_non_admin_returns_403(self, client, mock_db, monkeypatch):
-        monkeypatch.setenv("ADMIN_USER_IDS", "OTHER_ADMIN")
-        resp = client.delete(_delete_url(str(uuid.uuid4())), json={"reviewer_id": "RGM"})
+    def test_non_ingest_role_returns_403(self, app, mock_db, monkeypatch):
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key, **kwargs: True)
+        reviewer_user = SessionUser(
+            id="00000000-0000-0000-0000-000000000002",
+            email="reviewer@example.com",
+            display_name="Reviewer",
+            role="reviewer",
+            account_status="active",
+        )
+
+        @app.before_request
+        def inject_reviewer():
+            g.user = reviewer_user
+
+        resp = app.test_client().delete(_delete_url(str(uuid.uuid4())), json={"reviewer_id": "RGM"})
         assert resp.status_code == 403
         mock_db.delete_recommendation_decision.assert_not_called()
 


### PR DESCRIPTION
Stage-C enforcement is live. Removes the legacy require_admin decorator from
POST/DELETE /api/v2/extraction/recommendation-decisions, deletes the function
from src/web/middleware.py, drops import os (sole consumer), removes
ADMIN_USER_IDS from .env.template, and migrates tests from env-var
monkeypatching to @require(INGEST_RUN) permission-gate pattern. Closes gh-482.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
