### PR TITLE
feat: surface user-added metrics in image review card

### DIFF
--- a/src/web/static/css/review.css
+++ b/src/web/static/css/review.css
@@ -1723,3 +1723,17 @@
     display: flex;
     gap: 0.5rem;
 }
+
+/* =============================================================================
+   Detected metrics card — user-added rows
+   ============================================================================= */
+#detected-metrics-list .added-metric-row {
+    background-color: #cff4fc;
+    border-left: 3px solid #0dcaf0;
+}
+
+#detected-metrics-list .added-metric-row .metric-label::before {
+    content: "+ ";
+    color: #087990;
+    font-weight: 600;
+}

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -949,6 +949,7 @@
                 and current_image.review_status in ('pending', 'reviewed') %}
           {% set active_metrics = current_image.predicted_metrics if current_image.predicted_metrics else (current_image.detected_metrics or []) %}
           {% set metrics_source = 'vision' if current_image.predicted_metrics else 'keywords' %}
+          {% set added_metrics_count = (current_image_confirmations or [])|selectattr('decision','equalto','add')|list|length %}
           <div class="card detected-metrics-card mt-3"
                id="detected-metrics-card"
                data-img-id="{{ current_image.img_id }}"
@@ -957,10 +958,21 @@
                data-classification-id="{{ current_image.classification_id or '' }}"
                data-confirmations='{{ (current_image_confirmations or [])|tojson }}'>
             <div class="card-header py-2 d-flex justify-content-between align-items-center">
-              <h6 class="mb-0">{% if metrics_source == 'vision' %}Predicted metrics (Vision){% else %}Detected metrics (Keywords){% endif %}</h6>
-              <span class="badge bg-secondary">
-                {{ active_metrics|length }} detected
-              </span>
+              <h6 class="mb-0">
+                {% if added_metrics_count > 0 %}Metrics (detected + user-added)
+                {% elif metrics_source == 'vision' %}Predicted metrics (Vision)
+                {% else %}Detected metrics (Keywords){% endif %}
+              </h6>
+              <div class="d-flex gap-1">
+                <span class="badge bg-secondary">
+                  {{ active_metrics|length }} detected
+                </span>
+                {% if added_metrics_count > 0 %}
+                <span class="badge bg-info">
+                  {{ added_metrics_count }} added
+                </span>
+                {% endif %}
+              </div>
             </div>
             <div class="card-body">
               <p class="small text-muted mb-2">

--- a/tests/ui/review_image_metric_confirmations.spec.js
+++ b/tests/ui/review_image_metric_confirmations.spec.js
@@ -104,6 +104,23 @@ test.describe('Detected Metrics card — rendering', () => {
     await expect(acceptedRow).toHaveClass(/decided-accept/);
     await expect(acceptedRow.locator('.metric-state-indicator')).toContainText('Accepted');
   });
+
+  test('pre-seeded add confirmation renders an added-metric-row on load', async ({ page }) => {
+    await page.goto('/images-tab-detected-with-added');
+    const addedRow = page.locator(
+      '#detected-metrics-list .added-metric-row[data-added-metric="cm_lifetime_value_per_customer"]',
+    );
+    await expect(addedRow).toBeVisible();
+    await expect(addedRow).toContainText('cm_lifetime_value_per_customer');
+  });
+
+  test('header shows "M added" badge and inclusive title when an add confirmation exists', async ({ page }) => {
+    await page.goto('/images-tab-detected-with-added');
+    const header = page.locator('#detected-metrics-card .card-header');
+    await expect(header).toContainText('4 detected');
+    await expect(header).toContainText('1 added');
+    await expect(header).toContainText('Metrics (detected + user-added)');
+  });
 });
 
 // =========================================================================

--- a/tests/ui/test_server.py
+++ b/tests/ui/test_server.py
@@ -570,6 +570,34 @@ def review_images_tab_vision():
     )
 
 
+@app.route("/images-tab-detected-with-added")
+def review_images_tab_detected_with_added():
+    """Images tab with detected_metrics + a prior 'add' confirmation — verifies user-added metrics are visible on reopen."""
+    preseeded = [
+        {
+            "confirmation_id": "c-add-1",
+            "img_id": MOCK_IMAGE_CANDIDATE_WITH_DETECTED["img_id"],
+            "detected_metric_id": None,
+            "confirmed_metric_id": "cm_lifetime_value_per_customer",
+            "decision": "add",
+            "rejection_reason": None,
+            "reviewer_id": "test_reviewer",
+            "created_at": "2026-04-23T00:00:00+00:00",
+            "updated_at": "2026-04-23T00:00:00+00:00",
+        },
+    ]
+    return render_template(
+        "unified_review.html",
+        **_shared_template_vars(
+            active_tab="images",
+            current_image=MOCK_IMAGE_CANDIDATE_WITH_DETECTED,
+            image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+            all_image_candidates=[MOCK_IMAGE_CANDIDATE_WITH_DETECTED],
+            current_image_confirmations=preseeded,
+        ),
+    )
+
+
 # ---- Cross-filing auto-advance routes ----
 
 MOCK_FACT_LAST_PENDING = {


### PR DESCRIPTION
When a reviewer adds a metric to an image and later returns to it, the
card now relabels to "Metrics (detected + user-added)", shows a second
"M added" badge alongside the existing detected count, and visually
accents added rows with a left border, light-cyan background, and a
"+ " prefix on the metric label. The added rows were already being
appended by the JS on init — they were just visually indistinguishable
from detected rows and not reflected in the card title/badge, which
made it look like reviewer additions hadn't stuck.
