### PR TITLE
fix(auth): three A8 follow-ups in auth_readiness_report.py (gh-484)

### DIFF
--- a/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
+++ b/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
@@ -3,7 +3,7 @@ id: 484
 source: gh
 slug: auth-readiness-report-a8-followups
 title: "auth: three A8 follow-ups in auth_readiness_report.py"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: S
@@ -27,3 +27,9 @@ Three minor issues in `scripts/auth_readiness_report.py` were surfaced during th
 - Add a `--target-env` flag that reads env vars from a deploy config (or document the limitation and tell operators to run `--check` from inside the production container).
 - Replace the inline dev-bypass predicate with `from src.auth.dev_bypass import is_dev_bypass_enabled` and a single call.
 - Add a unit test that seeds 2-3 `auth_users` and 1-2 `auth_legacy_aliases`, runs `--json`, and asserts the output shape matches the expected schema.
+
+### Resolution
+
+- Issue 1: Added stderr warning in `--check` mode when `APP_ENV != 'production'`; updated `--check` help text and `docs/operations/auth-stage-b-runbook.md` with operator guidance to run from inside the prod container.
+- Issue 2: Replaced inline bypass predicate in `evaluate_dev_bypass_guard()` with a call to `is_dev_bypass_enabled()` imported from `src.auth.dev_bypass`. JSON output shape unchanged.
+- Issue 3: Added `test_populated_json_shape` integration test seeding 3 users + 2 aliases and asserting all six top-level JSON keys and sub-field sets. Tests live at `tests/integration/auth/test_readiness_report.py` (the fragment cited a non-existent unit-test path — integration path is correct per `.claude/rules/scripts.md`).

--- a/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
+++ b/docs/known-issues/gh-484-auth-readiness-report-a8-followups.md
@@ -15,6 +15,7 @@ updated: 2026-05-04
 gh_issue: 484
 pr_refs:
   - 479
+  - 518
 note: dev-bypass guard checks local env not prod, dev-bypass predicate duplicated instead of imported, JSON serialization only tested with empty data
 ---
 

--- a/docs/operations/auth-stage-b-runbook.md
+++ b/docs/operations/auth-stage-b-runbook.md
@@ -64,6 +64,12 @@ python3 scripts/auth_readiness_report.py --check
 # expect: exit 0 (silent on success)
 ```
 
+> **Run from inside the production container.** `--check` reads `APP_ENV` and
+> `AUTH_DEV_BYPASS` from whichever environment executes the script. Running it
+> locally will show a `WARNING:` on stderr; the result may not reflect prod env vars.
+> Use the Render shell (`filings-reviewer → Shell`) or set the vars explicitly:
+> `APP_ENV=production AUTH_DEV_BYPASS="" python3 scripts/auth_readiness_report.py --check`
+
 If `--check` exits 1, read the `NOT READY:` lines on stderr and resolve before proceeding.
 
 ```bash

--- a/scripts/auth_readiness_report.py
+++ b/scripts/auth_readiness_report.py
@@ -58,6 +58,7 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from src.auth.dev_bypass import is_dev_bypass_enabled  # noqa: E402
 from src.infra.db import DatabaseAdapter  # noqa: E402
 
 VALID_ROLES = {"admin", "reviewer", "viewer"}
@@ -189,15 +190,13 @@ def fetch_flags(db: DatabaseAdapter) -> list[dict]:
 
 
 def evaluate_dev_bypass_guard() -> dict:
-    """Mirror the predicate in src/auth/dev_bypass.py::verify_dev_bypass_safe.
+    """Uses `is_dev_bypass_enabled()` from `src.auth.dev_bypass`.
 
     PASS unless BOTH APP_ENV=production AND AUTH_DEV_BYPASS=1.
     """
     app_env = os.environ.get("APP_ENV")
-    bypass = os.environ.get("AUTH_DEV_BYPASS", "").strip()
     is_prod = app_env == "production"
-    is_bypass = bypass == "1"
-    fail = is_prod and is_bypass
+    fail = is_prod and is_dev_bypass_enabled()
     return {
         "status": "FAIL" if fail else "PASS",
         "app_env": app_env,
@@ -390,7 +389,11 @@ def build_parser() -> argparse.ArgumentParser:
     group.add_argument(
         "--check",
         action="store_true",
-        help="Silent on success. Exit 0 if Stage-B-ready, 1 if not, 2 on script error.",
+        help=(
+            "Silent on success. Exit 0 if Stage-B-ready, 1 if not, 2 on script error. "
+            "NOTE: reads env vars from the running environment — use inside the prod container "
+            "for authoritative results."
+        ),
     )
     return parser
 
@@ -412,6 +415,13 @@ def main() -> int:
         return 2
 
     if args.check:
+        if os.environ.get("APP_ENV") != "production":
+            print(
+                "WARNING: --check is reading env vars from the local environment. "
+                "Run from inside the production container (where APP_ENV=production) "
+                "or set APP_ENV and AUTH_DEV_BYPASS to match prod before trusting this result.",
+                file=sys.stderr,
+            )
         ready, reasons = evaluate_readiness(report)
         if ready:
             return 0

--- a/tests/integration/auth/test_readiness_report.py
+++ b/tests/integration/auth/test_readiness_report.py
@@ -136,6 +136,48 @@ def test_empty_db_json_shape(auth_db, cli):
     assert payload["dev_bypass_guard"]["status"] == "PASS"
 
 
+def test_populated_json_shape(auth_db, cli, users_cli, aliases_cli):
+    """--json output shape is correct with seeded data (populated case)."""
+    for u in users_cli.SEED_USERS:
+        users_cli.upsert_user(auth_db, u["email"], u["role"], u["display_name"], verbose=False)
+    for a in aliases_cli.SEED_ALIASES:
+        aliases_cli.upsert_alias(
+            auth_db, a["legacy_reviewer_string"], a["target_email"], verbose=False
+        )
+
+    report = cli.build_report(auth_db)
+    payload = json.loads(cli._format_json(report))
+
+    assert set(payload.keys()) == {
+        "allowlisted",
+        "users",
+        "active_sessions",
+        "legacy_aliases",
+        "flags",
+        "dev_bypass_guard",
+    }
+    assert len(payload["allowlisted"]) == 3
+    assert all(
+        {"normalized_email", "intended_role", "status", "created_at"} <= set(r)
+        for r in payload["allowlisted"]
+    )
+    assert len(payload["users"]) == 3
+    assert all(
+        {"normalized_email", "display_name", "first_login_at", "last_login_at", "account_status"}
+        <= set(r)
+        for r in payload["users"]
+    )
+    assert payload["active_sessions"] == 0
+    assert len(payload["legacy_aliases"]) == 2
+    assert all(
+        {"legacy_reviewer_string", "target_email", "active", "created_at"} <= set(r)
+        for r in payload["legacy_aliases"]
+    )
+    assert payload["flags"] == []
+    assert set(payload["dev_bypass_guard"].keys()) == {"status", "app_env", "auth_dev_bypass"}
+    assert payload["dev_bypass_guard"]["status"] == "PASS"
+
+
 def test_post_seed_check_passes(auth_db, cli, users_cli, aliases_cli):
     """Run the seed scripts (their main paths), then evaluate readiness."""
     # Seed users via the script's default code path.
@@ -319,7 +361,7 @@ def test_main_check_returns_zero_when_ready(auth_db, cli, users_cli, monkeypatch
     captured = capsys.readouterr()
     assert rc == 0, f"unexpected NOT READY output: {captured.err}"
     assert captured.out == ""
-    assert captured.err == ""
+    assert not any("NOT READY" in line for line in captured.err.splitlines())
 
 
 def test_main_check_returns_one_on_empty_db(auth_db, cli, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- **Issue 1 (`--check` env-var locality):** Added stderr `WARNING:` when `--check` is run outside a production container (`APP_ENV != 'production'`). Also updated `--check` help text and `docs/operations/auth-stage-b-runbook.md` to tell operators to run from inside the prod container or set the env vars explicitly.
- **Issue 2 (predicate duplication):** Replaced the inline bypass predicate in `evaluate_dev_bypass_guard()` with a call to `is_dev_bypass_enabled()` imported from `src.auth.dev_bypass`. JSON output shape unchanged.
- **Issue 3 (populated-case JSON test):** Added `test_populated_json_shape` integration test seeding 3 users + 2 aliases, running `build_report` + `_format_json`, and asserting all six top-level JSON keys and per-section field sets. Also relaxed `test_main_check_returns_zero_when_ready`'s stderr assertion to allow the new warning line.

Closes gh-484. Fragment cited `tests/unit/auth/test_readiness_report.py` (non-existent); correct path is `tests/integration/auth/test_readiness_report.py` per `.claude/rules/scripts.md`.

## Test plan

- [ ] `pytest -x -q --tb=short tests/integration/auth/test_readiness_report.py` passes (CI Integration Tests)
- [ ] Unit Tests check green (4651 passing locally)
- [ ] Lint passes
- [ ] `scripts/auth_readiness_report.py --help` shows updated `--check` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)