### PR TITLE
feat(stats): Patterns-tab UX redesign Phase 2-4 — route wiring, template restructure, docs

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -64,13 +64,13 @@ The script writes findings to three tables — it does NOT mutate `v2_review_dec
 
 **Drill-down links**: phrase findings link to `/v2/review/<filing_id>` (no fact-anchor — that route does not currently accept a fact-selection query parameter). Reviewers click through to the filing-level review page and locate the fact manually. Adding a `?fact_id=` anchor would require a non-trivial change to `unified_review.html`'s text-tab JS state restore and is deferred.
 
-**View persistence**: the new "Text Patterns" tab (`#patterns-tab` → `#patterns-stats`) does not currently persist to localStorage. If you add a key for it, follow the `cmasb:` namespace convention documented under "View persistence (localStorage)" below.
+**View persistence**: the Patterns tab persists the Why-Reviewers-Reject run/lifetime toggle under `cmasb:patterns:reasons_scope` (see "View persistence (localStorage)" below). Search and category filter on the Patterns tab are session-scoped only — not stored.
 
 ### Recommendation rules
 
 The Patterns-tab expanded row also renders a **Suggested actions** callout above the per-decision-type phrase columns. Recommendations are computed at render time by `src/web/text_pattern_recommendations.py::compute_recommendations(summaries, findings)` from the same DB rows the table iterates — no schema change, no separate analysis pass. This keeps rule thresholds tweakable without rerunning the script.
 
-Three rules in v1; a metric may fire multiple. Output is sorted by severity DESC then rule name ASC. Each recommendation dict carries `rule`, `severity` (`high` / `medium`), `title`, `evidence`, `action`.
+Four rules; a metric may fire multiple of the first three. Output is sorted by severity DESC then rule name ASC. Each recommendation dict carries `rule`, `severity` (`high` / `medium`), `title`, `evidence`, `action`.
 
 **Card-level metadata fields** (orthogonal to rule type — present on every card):
 
@@ -82,8 +82,9 @@ Three rules in v1; a metric may fire multiple. Output is sorted by severity DESC
 | **`exclusion_pattern`** | A `text_decision_phrase_findings` row with `decision_type='reject'`, `source_field = 'segment_text'`, `phrase_ngram_size >= 2`, `pct_of_decisions >= 30` | high if `pct >= 50`, else medium |
 | **`keyword_overlap`** | A `top_correction_targets` entry with `count >= 5` | high if `count >= 10`, else medium |
 | **`fp_filter_gap`** | `rejection_categories['wrong_value'] / reject_count >= 0.5` AND `reject_count >= 5` | high if ratio `>= 0.7`, else medium |
+| **`cross_metric_exclusion`** | A phrase-grouping row with `decision_type='reject'`, `source_field in EXCL_SOURCE_FIELDS`, `phrase_ngram_size >= EXCL_NGRAM_MIN`, appearing across `metric_count >= 3` metrics. Computed by `compute_cross_metric_findings` in `src/web/text_pattern_recommendations.py`. Render-only — does NOT participate in `text_pattern_recommendation_decisions`. Per-metric `exclusion_pattern` cards for covered phrases render as a "(rolled into cross-metric)" chip instead of the full card. | high if `metric_count >= 5`, else medium |
 
-Constants live at the top of the helper module (`EXCL_PCT_LOW`, `EXCL_PCT_HIGH`, `EXCL_NGRAM_MIN`, `EXCL_SOURCE_FIELDS`, `OVERLAP_COUNT_LOW`, `OVERLAP_COUNT_HIGH`, `FP_REJECT_FLOOR`, `FP_PCT_LOW`, `FP_PCT_HIGH`). Adding a fourth rule is a Python edit only — append a `_rule_<name>(...)` helper and call it from `compute_recommendations`.
+Constants live at the top of the helper module (`EXCL_PCT_LOW`, `EXCL_PCT_HIGH`, `EXCL_NGRAM_MIN`, `EXCL_SOURCE_FIELDS`, `OVERLAP_COUNT_LOW`, `OVERLAP_COUNT_HIGH`, `FP_REJECT_FLOOR`, `FP_PCT_LOW`, `FP_PCT_HIGH`). Adding a fifth per-metric rule is a Python edit only — append a `_rule_<name>(...)` helper and call it from `compute_recommendations`.
 
 The helper handles `psycopg`'s `Decimal` return for `pct_of_decisions NUMERIC(5,2)` via `float()` coercion at the boundary. Empty inputs return `{}` — the existing `_stub_analytics_helpers` test fixtures rely on this no-op behavior.
 
@@ -105,13 +106,26 @@ The recommendation helper (`compute_recommendations`) takes an optional third `d
 
 `pr_number` and `pr_url` columns on the table stay NULL through PR 1 (bookkeeping-only) — but bookkeeping-only **with a process backing it**. The manual procedure for translating an accepted decision into a config or FP-filter PR (reviewer criteria, weekly engineer cadence, per-rule edit guide, Tier-1 spot-check, gold-standard gating, aging policy) is in [`docs/operations/text-pattern-recommendations-runbook.md`](../../docs/operations/text-pattern-recommendations-runbook.md). They populate in PR 2 when an `exclusion_pattern` accept opens an auto-PR. Don't read them yet.
 
+### Category-level recommendations
+
+Run-scoped category rollup renders in the first collapsible panel above the per-metric rows on the Patterns tab. `CATEGORY_ACTIONS` in `src/web/text_decision_category_actions.py` maps each `rejection_category` enum value to a human-readable label, a concrete suggested action, and a target file path. `compute_category_rollup(summaries)` sums `rejection_categories` JSONB across all per-metric summary rows and returns rows ordered DESC by count, each with `{category, count, pct_of_rejects, label, action, target_file, severity}`.
+
+To edit the action text or severity thresholds for a category, modify `CATEGORY_ACTIONS` in `src/web/text_decision_category_actions.py` — no DB migration needed. New `rejection_category` values not in `CATEGORY_ACTIONS` get a fallback entry (`(20.0, 40.0)` severity thresholds, generic action text).
+
+**Decisions on category-level recommendation cards are NOT persisted.** Category cards are render-only and do not participate in the `text_pattern_recommendation_decisions` accept/dismiss/defer flow — categories are run-scoped aggregations without a stable per-card `decision_key`.
+
 ## Image-confirmation reviewer notes
 
 `v2_image_metric_confirmations` has a `reviewer_notes TEXT` column (nullable, Phase 4a). Free-text observation captured per-batch — one `#image-reviewer-notes` textarea on the image card, applied to every per-metric row submitted in the same POST. Validated at the API layer to ≤1000 chars; mirrors the text-side `v2_review_decisions.reviewer_notes` contract. JS clears the textarea after a successful submit. Bulk-reject and the "Reject all (no relevant metrics)" sentinel writes leave the column NULL — by design, no free-text capture for bulk actions. The deferred LLM "Top Reviewer Themes" panel (Phase 4b) will read this column for image-side themes.
 
-## Why Reviewers Reject — Summary panel
+## Why Reviewers Reject — Patterns panel
 
-`/v2/review/stats` Summary tab renders a categorical rollup of rejected decisions (lifetime totals, both sides). `db.get_rejection_reason_rollup(side, since=None)` reads `v2_review_decisions.rejection_category` for `side='text'` and `v2_image_metric_confirmations.rejection_reason` for `side='image'`. Returns `[{reason, count, percent}]` ordered DESC. Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summarized "Top Reviewer Themes" panel (deferred) will read `reviewer_notes` rather than the categorical rollup — the two panels are complementary.
+`/v2/review/stats` **Patterns tab** renders the "Why Reviewers Reject" panel (moved from the Summary tab in PR #518). The panel has a **[This run | Lifetime]** toggle persisted under localStorage key `cmasb:patterns:reasons_scope` (`"run"` | `"lifetime"`).
+
+- **This run**: text side uses `compute_category_rollup(text_metric_summary)` (the same data as Panel 1). Image side continues to use the lifetime rollup (`db.get_rejection_reason_rollup('image', since=None)`) — there is no per-run image breakdown.
+- **Lifetime**: both sides use `db.get_rejection_reason_rollup(side, since=None)`. `side='text'` reads `v2_review_decisions.rejection_category`; `side='image'` reads `v2_image_metric_confirmations.rejection_reason`. Returns `[{reason, count, percent}]` ordered DESC.
+
+Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summarized "Top Reviewer Themes" panel (deferred) will read `reviewer_notes` — the two panels are complementary.
 
 ## Conventions
 
@@ -143,9 +157,10 @@ The unified review UI persists filter/sort/tab state client-side via localStorag
 | `cmasb:filings:doc_type`    | filings list  | `"ipo" \| "earnings" \| "investor_day"` | `unified_filing_list.html` |
 | `cmasb:filings:per_page`    | filings list  | integer string                      | `unified_filing_list.html` |
 | `cmasb:filings:reviewers`   | filings list  | `string[]` JSON                     | `unified_filing_list.html` |
-| `cmasb:review:tab`          | review page   | `"text" \| "images"`                | `unified_review.html`    |
-| `cmasb:review:text_filter`  | review page   | `{status, metric, sort}` JSON       | `unified_review.html`    |
-| `cmasb:review:image_filter` | review page   | `{status, sort}` JSON               | `unified_review.html`    |
+| `cmasb:review:tab`               | review page   | `"text" \| "images"`                | `unified_review.html`    |
+| `cmasb:review:text_filter`       | review page   | `{status, metric, sort}` JSON       | `unified_review.html`    |
+| `cmasb:review:image_filter`      | review page   | `{status, sort}` JSON               | `unified_review.html`    |
+| `cmasb:patterns:reasons_scope`   | stats page    | `"run" \| "lifetime"`               | `unified_stats.html` (Patterns tab Why-Reviewers-Reject toggle — only durable Patterns preference; search and category filter are session-scoped) |
 
 **Pattern**: on page load, URL params win and are written to localStorage; if a param is absent and localStorage has a value, the page redirects once with the stored value applied. This pattern lets server routes stay stateless — do not add server-side session storage for view state. Do NOT rename `hideCompleted` → a `cmasb:` key; that would silently wipe existing users' saved preference.
 

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -279,7 +279,12 @@ def stats():
         text_metric_summary = []
         text_phrase_findings = []
 
-    from src.web.text_pattern_recommendations import compute_recommendations
+    from src.web.text_decision_category_actions import compute_category_rollup
+    from src.web.text_pattern_recommendations import (
+        compute_cross_metric_findings,
+        compute_recommendations,
+        interpret_finding_row,
+    )
 
     text_recommendation_decisions = db.get_recommendation_decisions(
         [s["metric_id"] for s in text_metric_summary] or None
@@ -297,6 +302,20 @@ def stats():
     )
     all_recommendations = [r for recs in text_recommendations.values() for r in recs]
     archived_count = sum(1 for r in all_recommendations if r.get("is_stale"))
+
+    category_rollup = compute_category_rollup(text_metric_summary)
+    cross_metric_findings = compute_cross_metric_findings(text_phrase_findings)
+    covered_phrases = {
+        (f["phrase"], f["source_field"])
+        for f in cross_metric_findings
+        if f.get("cross_metric_exclusion")
+    }
+    interpretations = {
+        (f["metric_id"], f["phrase"], f["source_field"], f["decision_type"]): interpret_finding_row(
+            f
+        )
+        for f in text_phrase_findings
+    }
 
     return render_template(
         "unified_stats.html",
@@ -332,6 +351,10 @@ def stats():
         text_recommendations=text_recommendations,
         archived_count=archived_count,
         analytics_health=analytics_health,
+        category_rollup=category_rollup,
+        cross_metric_findings=cross_metric_findings,
+        covered_phrases=covered_phrases,
+        interpretations=interpretations,
     )
 
 

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -482,74 +482,6 @@
       </div>
     </div>
 
-    {# Phase 4c: "Why Reviewers Reject" — categorical rejection-reason rollup
-       across all decisions ever recorded (lifetime totals, not since-anchor).
-       Bootstrap progress bars used for the simple bar-chart effect (no chart
-       library; same approach as the existing Confidence Band Distribution). #}
-    <div class="row mb-4">
-      <div class="col-12">
-        <h4 class="mb-3">Why Reviewers Reject</h4>
-      </div>
-
-      {# Text-fact rejection categories #}
-      <div class="col-lg-6 mb-3">
-        <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Text Facts <span class="badge bg-secondary ms-1">{{ text_rejection_rollup|length }}</span></h6>
-          </div>
-          <div class="card-body">
-            {% if text_rejection_rollup %}
-              {% set max_text_pct = (text_rejection_rollup|map(attribute='percent')|max) or 100 %}
-              {% for r in text_rejection_rollup %}
-              <div class="mb-2">
-                <div class="d-flex justify-content-between small">
-                  <span>{{ r.reason|replace('_', ' ')|title }}</span>
-                  <span class="text-muted">{{ r.count }} ({{ r.percent }}%)</span>
-                </div>
-                <div class="progress" style="height: 8px;">
-                  <div class="progress-bar bg-danger" role="progressbar"
-                       style="width: {{ ((r.percent / max_text_pct) * 100)|round(1) }}%"
-                       aria-valuenow="{{ r.percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                </div>
-              </div>
-              {% endfor %}
-            {% else %}
-            <p class="text-muted small mb-0">No text-fact rejections yet.</p>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-
-      {# Image-metric rejection reasons #}
-      <div class="col-lg-6 mb-3">
-        <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Image Metrics <span class="badge bg-secondary ms-1">{{ image_rejection_rollup|length }}</span></h6>
-          </div>
-          <div class="card-body">
-            {% if image_rejection_rollup %}
-              {% set max_img_pct = (image_rejection_rollup|map(attribute='percent')|max) or 100 %}
-              {% for r in image_rejection_rollup %}
-              <div class="mb-2">
-                <div class="d-flex justify-content-between small">
-                  <span>{{ rejection_reason_labels.get(r.reason, r.reason|replace('_', ' ')|title) }}</span>
-                  <span class="text-muted">{{ r.count }} ({{ r.percent }}%)</span>
-                </div>
-                <div class="progress" style="height: 8px;">
-                  <div class="progress-bar bg-danger" role="progressbar"
-                       style="width: {{ ((r.percent / max_img_pct) * 100)|round(1) }}%"
-                       aria-valuenow="{{ r.percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-                </div>
-              </div>
-              {% endfor %}
-            {% else %}
-            <p class="text-muted small mb-0">No image-metric rejections yet.</p>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </div>
-
   </div> {# end summary-stats tab pane #}
 
   {# =====================================================================
@@ -1047,6 +979,272 @@
       </div>
     </div>
 
+    {# ---- Search + category filter bar (session-scoped; not localStorage) ---- #}
+    <div class="row mb-3" id="patterns-filter-bar">
+      <div class="col-md-5 mb-2">
+        <input type="text" class="form-control form-control-sm"
+               id="patterns-search-input"
+               placeholder="Search phrases or metric IDs…"
+               autocomplete="off">
+      </div>
+      <div class="col-md-4 mb-2">
+        <select class="form-select form-select-sm" id="patterns-category-filter" multiple size="1">
+          {% set all_cats = [] %}
+          {% for s in text_metric_summary %}
+            {% for cat in (s.rejection_categories or {}).keys() %}
+              {% if cat not in all_cats %}
+                {% set _ = all_cats.append(cat) %}
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+          {% for cat in all_cats | sort %}
+          <option value="{{ cat }}">{{ cat|replace('_',' ')|title }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-3 mb-2">
+        <button type="button" class="btn btn-sm btn-outline-secondary"
+                id="patterns-filter-clear">Clear filters</button>
+      </div>
+    </div>
+
+    {# ---- Panel 1: Category rollup (this run) ---- #}
+    <div class="row mb-3">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center"
+               data-bs-toggle="collapse" data-bs-target="#patterns-category-body"
+               style="cursor:pointer;" aria-expanded="true">
+            <h6 class="mb-0">
+              Category rollup (this run)
+              <span class="badge bg-secondary ms-1">{{ category_rollup|length }}</span>
+            </h6>
+            <span class="small text-muted">collapse ▾</span>
+          </div>
+          <div class="collapse show" id="patterns-category-body">
+            <div class="card-body">
+              {% if category_rollup %}
+              <div class="row g-2">
+                {% for c in category_rollup %}
+                <div class="col-md-6 col-lg-4">
+                  <div class="card h-100 border-{{ 'danger' if c.severity == 'high' else ('warning' if c.severity == 'medium' else 'secondary') }}">
+                    <div class="card-body py-2 px-3">
+                      <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                          {% if c.severity %}
+                          <span class="badge bg-{{ 'danger' if c.severity == 'high' else 'warning text-dark' }} me-1">{{ c.severity }}</span>
+                          {% endif %}
+                          <strong class="small">{{ c.label }}</strong>
+                        </div>
+                        <span class="badge bg-secondary ms-1">{{ c.count }} ({{ c.pct_of_rejects }}%)</span>
+                      </div>
+                      <div class="small text-muted mt-1">{{ c.action }}</div>
+                      {% if c.target_file %}
+                      <code class="small text-secondary d-block mt-1">{{ c.target_file }}</code>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+                {% endfor %}
+              </div>
+              {% else %}
+              <p class="text-muted small mb-0">No rejection-category data for this run.</p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {# ---- Panel 2: Cross-metric phrases ---- #}
+    {% set cross_excl_list = cross_metric_findings | selectattr("cross_metric_exclusion") | list %}
+    <div class="row mb-3">
+      <div class="col-12">
+        <div class="card" id="patterns-cross-metric">
+          <div class="card-header d-flex justify-content-between align-items-center"
+               data-bs-toggle="collapse" data-bs-target="#patterns-cross-body"
+               style="cursor:pointer;" aria-expanded="true">
+            <h6 class="mb-0">
+              Cross-metric phrases
+              <span class="badge bg-secondary ms-1">{{ cross_metric_findings|length }}</span>
+              {% if cross_excl_list %}
+              <span class="badge bg-warning text-dark ms-1">
+                {{ cross_excl_list|length }} exclusion {{ 'candidate' if cross_excl_list|length == 1 else 'candidates' }}
+              </span>
+              {% endif %}
+            </h6>
+            <span class="small text-muted">collapse ▾</span>
+          </div>
+          <div class="collapse show" id="patterns-cross-body">
+            {% if cross_metric_findings %}
+            <div class="table-responsive">
+              <table class="table table-sm mb-0 small">
+                <thead class="table-light">
+                  <tr>
+                    <th>Phrase</th>
+                    <th>Type</th>
+                    <th class="text-end">Occurrences</th>
+                    <th class="text-end">Metrics</th>
+                    <th>Participating metrics</th>
+                    <th>Cross-metric rec.</th>
+                  </tr>
+                </thead>
+                <tbody>
+                {% for f in cross_metric_findings %}
+                <tr class="patterns-cross-row" data-phrase="{{ f.phrase }}">
+                  <td><code>{{ f.phrase }}</code></td>
+                  <td>
+                    <span class="badge bg-{{ 'danger' if f.decision_type == 'reject' else ('info' if f.decision_type == 'correct' else 'success') }}">
+                      {{ f.decision_type }}
+                    </span>
+                  </td>
+                  <td class="text-end">{{ f.total_occurrence }}</td>
+                  <td class="text-end">{{ f.metric_count }}</td>
+                  <td>
+                    {% for m in f.metrics %}
+                    <a href="#patterns-metric-anchor-{{ m|replace('_', '-') }}"
+                       class="text-decoration-none small me-1"><code>{{ m }}</code></a>
+                    {% endfor %}
+                  </td>
+                  <td>
+                    {% if f.cross_metric_exclusion %}
+                    <span class="badge bg-{{ 'danger' if f.severity == 'high' else 'warning text-dark' }}">
+                      exclusion · {{ f.severity }}
+                    </span>
+                    {% else %}
+                    <span class="text-muted">—</span>
+                    {% endif %}
+                  </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body">
+              <p class="text-muted small mb-0">No phrase appears across 3+ metrics in this run.</p>
+            </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {# ---- Panel 3: Why Reviewers Reject (moved from Summary tab) ----
+       Toggle: "this run" uses category_rollup; "lifetime" uses text_rejection_rollup.
+       Toggle state persisted in localStorage key cmasb:patterns:reasons_scope. #}
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Why Reviewers Reject</h6>
+            <div class="btn-group btn-group-sm" role="group" id="patterns-reasons-scope-toggle">
+              <button type="button" class="btn btn-outline-secondary active"
+                      id="patterns-scope-run" data-scope="run">This run</button>
+              <button type="button" class="btn btn-outline-secondary"
+                      id="patterns-scope-lifetime" data-scope="lifetime">Lifetime</button>
+            </div>
+          </div>
+          <div class="card-body">
+            {# "This run" pane — text uses category_rollup; images use lifetime (no per-run breakdown) #}
+            <div id="patterns-reasons-run">
+              <div class="row">
+                <div class="col-lg-6 mb-3">
+                  <h6 class="small fw-semibold mb-2">Text Facts (this run)</h6>
+                  {% if category_rollup %}
+                    {% set run_cat_max = (category_rollup|map(attribute='pct_of_rejects')|max) or 100 %}
+                    {% for c in category_rollup %}
+                    <div class="mb-2">
+                      <div class="d-flex justify-content-between small">
+                        <span>{{ c.label }}</span>
+                        <span class="text-muted">{{ c.count }} ({{ c.pct_of_rejects }}%)</span>
+                      </div>
+                      <div class="progress" style="height: 8px;">
+                        <div class="progress-bar bg-danger" role="progressbar"
+                             style="width: {{ ((c.pct_of_rejects / run_cat_max) * 100)|round(1) }}%"
+                             aria-valuenow="{{ c.pct_of_rejects }}" aria-valuemin="0" aria-valuemax="100"></div>
+                      </div>
+                    </div>
+                    {% endfor %}
+                  {% else %}
+                  <p class="text-muted small mb-0">No rejection data for this run.</p>
+                  {% endif %}
+                </div>
+                <div class="col-lg-6 mb-3">
+                  <h6 class="small fw-semibold mb-2">Image Metrics (lifetime)</h6>
+                  {% if image_rejection_rollup %}
+                    {% set run_img_max = (image_rejection_rollup|map(attribute='percent')|max) or 100 %}
+                    {% for r in image_rejection_rollup %}
+                    <div class="mb-2">
+                      <div class="d-flex justify-content-between small">
+                        <span>{{ rejection_reason_labels.get(r.reason, r.reason|replace('_', ' ')|title) }}</span>
+                        <span class="text-muted">{{ r.count }} ({{ r.percent }}%)</span>
+                      </div>
+                      <div class="progress" style="height: 8px;">
+                        <div class="progress-bar bg-danger" role="progressbar"
+                             style="width: {{ ((r.percent / run_img_max) * 100)|round(1) }}%"
+                             aria-valuenow="{{ r.percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                      </div>
+                    </div>
+                    {% endfor %}
+                  {% else %}
+                  <p class="text-muted small mb-0">No image-metric rejections yet.</p>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+            {# "Lifetime" pane — text uses text_rejection_rollup (full corpus) #}
+            <div id="patterns-reasons-lifetime" style="display:none;">
+              <div class="row">
+                <div class="col-lg-6 mb-3">
+                  <h6 class="small fw-semibold mb-2">Text Facts (lifetime)</h6>
+                  {% if text_rejection_rollup %}
+                    {% set lt_txt_max = (text_rejection_rollup|map(attribute='percent')|max) or 100 %}
+                    {% for r in text_rejection_rollup %}
+                    <div class="mb-2">
+                      <div class="d-flex justify-content-between small">
+                        <span>{{ r.reason|replace('_', ' ')|title }}</span>
+                        <span class="text-muted">{{ r.count }} ({{ r.percent }}%)</span>
+                      </div>
+                      <div class="progress" style="height: 8px;">
+                        <div class="progress-bar bg-danger" role="progressbar"
+                             style="width: {{ ((r.percent / lt_txt_max) * 100)|round(1) }}%"
+                             aria-valuenow="{{ r.percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                      </div>
+                    </div>
+                    {% endfor %}
+                  {% else %}
+                  <p class="text-muted small mb-0">No text-fact rejections yet.</p>
+                  {% endif %}
+                </div>
+                <div class="col-lg-6 mb-3">
+                  <h6 class="small fw-semibold mb-2">Image Metrics (lifetime)</h6>
+                  {% if image_rejection_rollup %}
+                    {% set lt_img_max = (image_rejection_rollup|map(attribute='percent')|max) or 100 %}
+                    {% for r in image_rejection_rollup %}
+                    <div class="mb-2">
+                      <div class="d-flex justify-content-between small">
+                        <span>{{ rejection_reason_labels.get(r.reason, r.reason|replace('_', ' ')|title) }}</span>
+                        <span class="text-muted">{{ r.count }} ({{ r.percent }}%)</span>
+                      </div>
+                      <div class="progress" style="height: 8px;">
+                        <div class="progress-bar bg-danger" role="progressbar"
+                             style="width: {{ ((r.percent / lt_img_max) * 100)|round(1) }}%"
+                             aria-valuenow="{{ r.percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+                      </div>
+                    </div>
+                    {% endfor %}
+                  {% else %}
+                  <p class="text-muted small mb-0">No image-metric rejections yet.</p>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     {# Per-metric rollup. Sorted by reject volume DESC server-side. Each row
        expands to show the phrase findings + (for corrections) the top
        canonical→assigned target metrics for that group. #}
@@ -1087,7 +1285,10 @@
               </thead>
               <tbody>
               {% for s in text_metric_summary %}
-                <tr data-bs-toggle="collapse" data-bs-target="#patterns-row-{{ loop.index }}"
+                <tr id="patterns-metric-anchor-{{ s.metric_id|replace('_', '-') }}"
+                    data-bs-toggle="collapse" data-bs-target="#patterns-row-{{ loop.index }}"
+                    data-metric-id="{{ s.metric_id }}"
+                    data-dominant-category="{{ (s.rejection_categories or {}) | dictsort(by='value', reverse=True) | first | first if (s.rejection_categories or {}) else '' }}"
                     aria-expanded="false" style="cursor:pointer;">
                   <td><code class="small">{{ s.metric_id }}</code></td>
                   <td class="text-end">{{ s.total_decisions }}</td>
@@ -1124,6 +1325,13 @@
                         <span class="badge bg-secondary ms-1">{{ active_recs|length }}</span>
                       </strong>
                       {% for r in active_recs %}
+                      {% if r.rule == 'exclusion_pattern' and (r.decision_key, 'segment_text') in covered_phrases %}
+                      <div class="small text-muted mb-2 fst-italic ps-2 border-start border-secondary">
+                        <code>{{ r.decision_key }}</code>
+                        <span class="badge bg-secondary ms-1">rolled into cross-metric</span>
+                        <a href="#patterns-cross-metric" class="ms-1 small text-decoration-none">↑ see cross-metric panel</a>
+                      </div>
+                      {% else %}
                       {# rec-card: data attributes drive the JS click handlers
                          in static/js/analytics.js. Decision state, when set,
                          dims the card and swaps the action buttons for an
@@ -1177,6 +1385,7 @@
                           </div>
                         {% endif %}
                       </div>
+                      {% endif %}
                       {% endfor %}
                     </div>
                     {% endif %}
@@ -1259,6 +1468,13 @@
                                   {% endfor %}
                                 </span>
                                 {% endif %}
+                                {% set interp = interpretations.get((s.metric_id, f.phrase, source_field, decision_type), {}) %}
+                                {% if interp %}
+                                <div class="small text-secondary mt-1">
+                                  <em>{{ interp.interpretation }}</em>
+                                  — {{ interp.suggested_action }}
+                                </div>
+                                {% endif %}
                               </li>
                               {% endfor %}
                             </ul>
@@ -1307,4 +1523,129 @@
 
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/analytics.js') }}"></script>
+<script>
+(function () {
+  'use strict';
+
+  // -------------------------------------------------------------------
+  // Why-Reviewers-Reject toggle — persisted in localStorage
+  // Key: cmasb:patterns:reasons_scope  ("run" | "lifetime")
+  // -------------------------------------------------------------------
+  var LS_SCOPE_KEY = 'cmasb:patterns:reasons_scope';
+
+  function applyReasonsScope(scope) {
+    var patternsTab = document.getElementById('patterns-stats');
+    if (!patternsTab) return;
+    var runPane = patternsTab.querySelector('#patterns-reasons-run');
+    var ltPane  = patternsTab.querySelector('#patterns-reasons-lifetime');
+    var btnRun  = patternsTab.querySelector('#patterns-scope-run');
+    var btnLt   = patternsTab.querySelector('#patterns-scope-lifetime');
+    if (!runPane || !ltPane) return;
+    if (scope === 'lifetime') {
+      runPane.style.display = 'none';
+      ltPane.style.display  = '';
+      if (btnRun) btnRun.classList.remove('active');
+      if (btnLt)  btnLt.classList.add('active');
+    } else {
+      runPane.style.display = '';
+      ltPane.style.display  = 'none';
+      if (btnRun) btnRun.classList.add('active');
+      if (btnLt)  btnLt.classList.remove('active');
+    }
+  }
+
+  // Restore saved scope on load.
+  var savedScope = localStorage.getItem(LS_SCOPE_KEY) || 'run';
+  applyReasonsScope(savedScope);
+
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest('#patterns-stats #patterns-reasons-scope-toggle [data-scope]');
+    if (!btn) return;
+    var scope = btn.getAttribute('data-scope');
+    localStorage.setItem(LS_SCOPE_KEY, scope);
+    applyReasonsScope(scope);
+  });
+
+  // -------------------------------------------------------------------
+  // Search — session-scoped (not persisted)
+  // Filters cross-metric rows (.patterns-cross-row) by phrase text
+  // and per-metric summary rows by metric_id.
+  // -------------------------------------------------------------------
+  var searchInput = document.getElementById('patterns-search-input');
+  if (searchInput) {
+    searchInput.addEventListener('input', function () {
+      applyPatternFilters();
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Category multi-select filter — session-scoped (not persisted)
+  // Dims per-metric rows whose dominant category isn't selected.
+  // -------------------------------------------------------------------
+  var catFilter = document.getElementById('patterns-category-filter');
+  if (catFilter) {
+    catFilter.addEventListener('change', function () {
+      applyPatternFilters();
+    });
+  }
+
+  // Clear button resets both filters.
+  var clearBtn = document.getElementById('patterns-filter-clear');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', function () {
+      if (searchInput) searchInput.value = '';
+      if (catFilter) {
+        for (var i = 0; i < catFilter.options.length; i++) {
+          catFilter.options[i].selected = false;
+        }
+      }
+      applyPatternFilters();
+    });
+  }
+
+  function applyPatternFilters() {
+    var patternsTab = document.getElementById('patterns-stats');
+    if (!patternsTab) return;
+
+    var query = searchInput ? searchInput.value.trim().toLowerCase() : '';
+
+    var selectedCats = [];
+    if (catFilter) {
+      for (var i = 0; i < catFilter.options.length; i++) {
+        if (catFilter.options[i].selected) {
+          selectedCats.push(catFilter.options[i].value);
+        }
+      }
+    }
+
+    // Filter cross-metric rows.
+    patternsTab.querySelectorAll('.patterns-cross-row').forEach(function (row) {
+      var phrase = (row.getAttribute('data-phrase') || '').toLowerCase();
+      var visible = !query || phrase.indexOf(query) !== -1;
+      row.style.display = visible ? '' : 'none';
+    });
+
+    // Filter per-metric summary rows (and their collapse targets).
+    patternsTab.querySelectorAll('tr[data-metric-id]').forEach(function (row) {
+      var metricId = (row.getAttribute('data-metric-id') || '').toLowerCase();
+      var domCat   = row.getAttribute('data-dominant-category') || '';
+
+      var matchSearch = !query || metricId.indexOf(query) !== -1;
+      var matchCat    = selectedCats.length === 0 || selectedCats.indexOf(domCat) !== -1;
+
+      var visible = matchSearch && matchCat;
+      row.style.opacity = visible ? '1' : '0.25';
+
+      // Also collapse/hide the detail row when not visible.
+      var collapseId = row.getAttribute('data-bs-target');
+      if (collapseId) {
+        var detail = patternsTab.querySelector(collapseId);
+        if (detail && !visible) {
+          detail.classList.remove('show');
+        }
+      }
+    });
+  }
+})();
+</script>
 {% endblock %}

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -585,3 +585,283 @@ def test_patterns_tab_archived_section(client, mock_db):
     # Count rec-decide-btn occurrences: should be 0 for the stale card.
     # (The active deferred card also has no decide buttons — it shows Undo.)
     assert "rec-undo-btn" in body  # active decided card has Undo
+
+
+# ---------------------------------------------------------------------------
+# Phase 2-4 (gh-515): new panels, interpretation column, Why-Reviewers-Reject
+# ---------------------------------------------------------------------------
+
+
+def _zero_image_data():
+    return {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }, {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+
+
+def test_patterns_tab_category_rollup_panel(client, mock_db):
+    """Category rollup panel renders with per-category counts from the run."""
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    overall, progress = _zero_image_data()
+    mock_db.get_image_decision_overall_v2.return_value = overall
+    mock_db.get_image_review_progress_v2.return_value = progress
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 50,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+        "config_snapshot_hash": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_total_customers",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 40,
+            "correct_count": 5,
+            "rejection_categories": {"part_of_date": 30, "wrong_metric": 10},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = []
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Category rollup panel exists.
+    assert "Category rollup (this run)" in body
+    # Category data renders — "Part Of Date" (label from CATEGORY_ACTIONS).
+    assert "Part of date" in body
+    # Severity badge present for dominant category.
+    assert "high" in body or "medium" in body
+
+
+def test_patterns_tab_cross_metric_panel_and_why_reject_toggle(client, mock_db):
+    """Cross-metric panel renders with exclusion badge and Why-Reviewers-Reject
+    toggle renders on the Patterns tab (not the Summary tab).
+    """
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    overall, progress = _zero_image_data()
+    mock_db.get_image_decision_overall_v2.return_value = overall
+    mock_db.get_image_review_progress_v2.return_value = progress
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 90,
+        "num_metrics_analyzed": 3,
+        "triggered_by": "RGM",
+        "error": None,
+        "config_snapshot_hash": None,
+    }
+
+    # Three metrics each have "shared phrase" in segment_text rejects — fires
+    # cross_metric_exclusion (metric_count >= 3, ngram >= 2, source=segment_text).
+    def shared_finding(metric_id):
+        return {
+            "metric_id": metric_id,
+            "decision_type": "reject",
+            "phrase": "shared phrase",
+            "phrase_ngram_size": 2,
+            "source_field": "segment_text",
+            "occurrence_count": 10,
+            "pct_of_decisions": 35.0,
+            "examples": [],
+        }
+
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": m,
+            "total_decisions": 30,
+            "accept_count": 5,
+            "reject_count": 20,
+            "correct_count": 5,
+            "rejection_categories": {"wrong_metric": 20},
+            "top_correction_targets": [],
+        }
+        for m in ["cm_metric_a", "cm_metric_b", "cm_metric_c"]
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        shared_finding(m) for m in ["cm_metric_a", "cm_metric_b", "cm_metric_c"]
+    ]
+    mock_db.get_rejection_reason_rollup.return_value = [
+        {"reason": "wrong_metric", "count": 60, "percent": 100.0}
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Cross-metric panel renders.
+    assert "Cross-metric phrases" in body
+    assert "shared phrase" in body
+    # Cross-metric exclusion badge.
+    assert "exclusion" in body
+
+    # Why-Reviewers-Reject is now on the Patterns tab, with a run/lifetime toggle.
+    assert "Why Reviewers Reject" in body
+    assert "This run" in body
+    assert "Lifetime" in body
+    assert "cmasb:patterns:reasons_scope" in body
+
+    # Old Summary-tab h4 heading is gone — it now renders as h6 in Patterns tab.
+    assert '<h4 class="mb-3">Why Reviewers Reject</h4>' not in body
+
+
+def test_patterns_tab_interpretation_column_renders(client, mock_db):
+    """Interpretation/Action column renders for phrase rows in per-metric tables."""
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    overall, progress = _zero_image_data()
+    mock_db.get_image_decision_overall_v2.return_value = overall
+    mock_db.get_image_review_progress_v2.return_value = progress
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+        "config_snapshot_hash": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "segment_text",
+            "occurrence_count": 14,
+            "pct_of_decisions": 35.0,
+            "examples": [],
+        }
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Interpretation column renders — the phrase row should show interpretation text.
+    # interpret_finding_row returns "Phrase appears in extracted text of rejected facts"
+    # for reject + segment_text + ngram >= 2.
+    assert "Phrase appears in extracted text of rejected facts" in body
+    assert "YAML exclusion" in body
+
+
+def test_patterns_tab_covered_phrases_chip(client, mock_db):
+    """When a phrase fires cross_metric_exclusion, the per-metric exclusion_pattern
+    rec card renders as a '(rolled into cross-metric)' chip instead of the full card.
+    """
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    overall, progress = _zero_image_data()
+    mock_db.get_image_decision_overall_v2.return_value = overall
+    mock_db.get_image_review_progress_v2.return_value = progress
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 90,
+        "num_metrics_analyzed": 3,
+        "triggered_by": "RGM",
+        "error": None,
+        "config_snapshot_hash": None,
+    }
+    # Three metrics fire the exclusion_pattern rule for "multi metric phrase"
+    # → cross_metric_exclusion fires (metric_count=3).
+    findings = [
+        {
+            "metric_id": m,
+            "decision_type": "reject",
+            "phrase": "multi metric phrase",
+            "phrase_ngram_size": 3,
+            "source_field": "segment_text",
+            "occurrence_count": 15,
+            "pct_of_decisions": 50.0,
+            "examples": [],
+        }
+        for m in ["cm_metric_x", "cm_metric_y", "cm_metric_z"]
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = findings
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": m,
+            "total_decisions": 30,
+            "accept_count": 5,
+            "reject_count": 20,
+            "correct_count": 5,
+            "rejection_categories": {},
+            "top_correction_targets": [],
+        }
+        for m in ["cm_metric_x", "cm_metric_y", "cm_metric_z"]
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # The phrase fires cross_metric_exclusion (metric_count=3, ngram=3, reject, segment_text).
+    # Per-metric exclusion_pattern recs for this phrase render as the chip.
+    assert "rolled into cross-metric" in body
+    # The chip links back to the cross-metric panel.
+    assert "patterns-cross-metric" in body
+    # The full rec-decide-btn is NOT rendered for covered phrases
+    # (it would be present for other undecided recs, so count check is not needed —
+    # just verify the chip text is present).
+    assert "multi metric phrase" in body


### PR DESCRIPTION
## Summary

- **Route (Phase 2)** — `stats()` now computes `category_rollup`, `cross_metric_findings`, `covered_phrases` (exclusion-firing only), and `interpretations` and passes them to the template.
- **Template (Phase 3)** — Three new collapsible panels on the Patterns tab: Category rollup, Cross-metric phrases, and Why Reviewers Reject (relocated from Summary tab with run/lifetime toggle). Per-metric phrase rows gain an Interpretation/Action column; `exclusion_pattern` cards where the phrase fires `cross_metric_exclusion` render as a "(rolled into cross-metric)" chip. Search and category filter bar added (session-scoped).
- **Tests + Docs (Phase 4)** — 4 new unit tests; `.claude/rules/web.md` updated with `cross_metric_exclusion` rule, renamed Why-Reviewers-Reject section, new Category-level recommendations subsection, and `cmasb:patterns:reasons_scope` localStorage entry.

## Test plan

- [ ] `pytest -x -q tests/unit/web/test_review_unified_stats.py` — all 11 tests green (7 pre-existing + 4 new)
- [ ] Category rollup panel renders `part_of_date` card with canonical action + target file
- [ ] Cross-metric phrase panel surfaces shared phrases; same phrase does NOT appear as a per-metric `exclusion_pattern` card
- [ ] Why-Reviewers-Reject toggle flips run↔lifetime and survives reload (`cmasb:patterns:reasons_scope`)
- [ ] Per-metric phrase tables show Interpretation/Action column
- [ ] Summary tab no longer contains a Why-Reviewers-Reject panel
- [ ] Other tabs unaffected by Patterns search/filter

## Prerequisites

PRs: #501, #502, #503, #509, #513, #517 (Phase 1 helpers).

Closes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)