### PR TITLE
feat(stats): Review Activity section with Latest/All-time toggle

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -127,6 +127,14 @@ To edit the action text or severity thresholds for a category, modify `CATEGORY_
 
 Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summarized "Top Reviewer Themes" panel (deferred) will read `reviewer_notes` — the two panels are complementary.
 
+## Review Activity panel
+
+`/v2/review/stats` **Summary tab** renders the "Review Activity" section — four cards that surface frequency-aggregated rankings of reviewer activity, not chronological feeds. Each card is a top-10 list of metrics or metric pairs sorted by event count DESC, with a "last seen" timestamp tiebreak. The cards are: Text Fact Corrections (grouped by `(original_metric_id, corrected_metric_id)` — value-only corrections render as `cm_X (value)`, metric-id changes render as `cm_X → cm_Y`), Text Fact Additions (grouped by `canonical_metric_id`, manual extractions only), Image Metric Additions (grouped by `confirmed_metric_id`, decision='add'), and Image Metric Corrections (grouped by `(detected_metric_id, confirmed_metric_id)`, decision='correct'). Backed by `db.get_top_text_corrections`, `get_top_text_additions`, `get_top_image_additions`, `get_top_image_corrections`, all in `src/infra/db.py`.
+
+A **[Latest 7 days | All-time]** toggle (button group `#review-activity-scope-toggle`) swaps between two scope panes per card; the inactive pane is hidden via `display:none`. Persisted under localStorage key `cmasb:stats:review_activity_scope`. Each card header carries two count badges (`.scope-latest` / `.scope-alltime`); the JS handler shows the matching one. Per-window totals come from a single `db.count_review_activity(window)` call — one DB roundtrip per scope returning all four type counts. Each card footer links to `/v2/review/stats/activity/<activity_type>` for the full event-level history.
+
+`GET /v2/review/stats/activity/<activity_type>` (`activity_type ∈ {"text-corrections", "text-additions", "image-additions", "image-corrections"}`) renders `activity_detail.html` — a chronological event-level table (limit=200) reusing the existing `db.get_recent_*` fetchers. Unknown types return 404. No pagination yet; if volume warrants it, add a `?page=N` query param.
+
 ## Conventions
 
 - API auth: `_check_api_key` before_request hook in the V2 API blueprint, configured via `FILINGS_API_KEY` env var. For individual routes on mixed blueprints (e.g. `image_crop` on `review_unified_bp`), use the `@require_api_key` per-view decorator from `src/web/middleware.py` — same Origin/Referer bypass, no blueprint-wide `before_request` install. Same-origin browser bypass uses scheme-independent host comparison for both `Origin` and `Referer` so HTTPS-terminating proxies (Render) don't mask same-origin GET AJAX (which omits `Origin` per the Fetch spec) as cross-origin and 401 it.
@@ -161,6 +169,7 @@ The unified review UI persists filter/sort/tab state client-side via localStorag
 | `cmasb:review:text_filter`       | review page   | `{status, metric, sort}` JSON       | `unified_review.html`    |
 | `cmasb:review:image_filter`      | review page   | `{status, sort}` JSON               | `unified_review.html`    |
 | `cmasb:patterns:reasons_scope`   | stats page    | `"run" \| "lifetime"`               | `unified_stats.html` (Patterns tab Why-Reviewers-Reject toggle — only durable Patterns preference; search and category filter are session-scoped) |
+| `cmasb:stats:review_activity_scope` | stats page | `"latest" \| "alltime"`             | `unified_stats.html` (Summary tab Review Activity Latest/All-time toggle; default `"latest"`) |
 
 **Pattern**: on page load, URL params win and are written to localStorage; if a param is absent and localStorage has a value, the page redirects once with the stored value applied. This pattern lets server routes stay stateless — do not add server-side session storage for view state. Do NOT rename `hideCompleted` → a `cmasb:` key; that would silently wipe existing users' saved preference.
 

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -12,7 +12,7 @@ import logging
 import os
 from contextlib import contextmanager
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import psycopg
 from psycopg.rows import dict_row
@@ -2751,6 +2751,127 @@ class DatabaseAdapter:
         """
         rows = self.query(sql, {"limit": limit})
         return [dict(r) for r in rows]
+
+    def get_top_text_corrections(self, window: Literal["7d", "all"], limit: int = 10) -> list[dict]:
+        """Top metric (original, corrected) pairs by reject volume.
+
+        Aggregates v2_review_decisions joined to v2_metric_facts so the
+        Review Activity card on /v2/review/stats can rank where text
+        extraction is most often corrected. Value-only corrections retain
+        original_metric_id == corrected_metric_id; the template renders those
+        as "cm_X (value)" rather than "cm_X -> cm_X".
+        """
+        where_window = "AND rd.created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        sql = f"""
+            SELECT
+                mf.canonical_metric_id   AS original_metric_id,
+                rd.assigned_metric_id    AS corrected_metric_id,
+                COUNT(*)                 AS count,
+                MAX(rd.created_at)       AS last_seen
+              FROM v2_review_decisions rd
+              JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
+             WHERE rd.decision = 'correct'
+               {where_window}
+             GROUP BY mf.canonical_metric_id, rd.assigned_metric_id
+             ORDER BY count DESC, last_seen DESC
+             LIMIT %(limit)s
+        """
+        rows = self.query(sql, {"limit": limit})
+        return [dict(r) for r in rows]
+
+    def get_top_text_additions(self, window: Literal["7d", "all"], limit: int = 10) -> list[dict]:
+        """Top manually-added text-fact metrics by addition volume."""
+        where_window = "AND mf.created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        sql = f"""
+            SELECT
+                mf.canonical_metric_id   AS metric_id,
+                COUNT(*)                 AS count,
+                MAX(mf.created_at)       AS last_seen
+              FROM v2_metric_facts mf
+             WHERE mf.extraction_method = 'manual'
+               {where_window}
+             GROUP BY mf.canonical_metric_id
+             ORDER BY count DESC, last_seen DESC
+             LIMIT %(limit)s
+        """
+        rows = self.query(sql, {"limit": limit})
+        return [dict(r) for r in rows]
+
+    def get_top_image_additions(self, window: Literal["7d", "all"], limit: int = 10) -> list[dict]:
+        """Top reviewer-added image metrics (decision='add') by add volume."""
+        where_window = "AND imc.created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        sql = f"""
+            SELECT
+                imc.confirmed_metric_id  AS metric_id,
+                COUNT(*)                 AS count,
+                MAX(imc.created_at)      AS last_seen
+              FROM v2_image_metric_confirmations imc
+             WHERE imc.decision = 'add'
+               {where_window}
+             GROUP BY imc.confirmed_metric_id
+             ORDER BY count DESC, last_seen DESC
+             LIMIT %(limit)s
+        """
+        rows = self.query(sql, {"limit": limit})
+        return [dict(r) for r in rows]
+
+    def get_top_image_corrections(
+        self, window: Literal["7d", "all"], limit: int = 10
+    ) -> list[dict]:
+        """Top image-metric (detected -> confirmed) correction pairs.
+
+        Image corrections always change the metric_id (no value-only case),
+        so detected_metric_id and confirmed_metric_id always differ.
+        """
+        where_window = "AND imc.created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        sql = f"""
+            SELECT
+                imc.detected_metric_id,
+                imc.confirmed_metric_id,
+                COUNT(*)                 AS count,
+                MAX(imc.created_at)      AS last_seen
+              FROM v2_image_metric_confirmations imc
+             WHERE imc.decision = 'correct'
+               {where_window}
+             GROUP BY imc.detected_metric_id, imc.confirmed_metric_id
+             ORDER BY count DESC, last_seen DESC
+             LIMIT %(limit)s
+        """
+        rows = self.query(sql, {"limit": limit})
+        return [dict(r) for r in rows]
+
+    def count_review_activity(self, window: Literal["7d", "all"]) -> dict[str, int]:
+        """Total counts for the four Review Activity card types in one roundtrip.
+
+        Returns {text_corrections, text_additions, image_additions,
+        image_corrections}. Drives the per-card header badges on the
+        Latest/All-time toggle.
+        """
+        where_text_decision = (
+            "AND created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        )
+        where_facts = "AND created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        where_imc = "AND created_at >= NOW() - INTERVAL '7 days'" if window == "7d" else ""
+        sql = f"""
+            SELECT
+                (SELECT COUNT(*) FROM v2_review_decisions
+                  WHERE decision = 'correct' {where_text_decision})       AS text_corrections,
+                (SELECT COUNT(*) FROM v2_metric_facts
+                  WHERE extraction_method = 'manual' {where_facts})       AS text_additions,
+                (SELECT COUNT(*) FROM v2_image_metric_confirmations
+                  WHERE decision = 'add' {where_imc})                     AS image_additions,
+                (SELECT COUNT(*) FROM v2_image_metric_confirmations
+                  WHERE decision = 'correct' {where_imc})                 AS image_corrections
+        """
+        rows = self.query(sql, {})
+        if not rows:
+            return {
+                "text_corrections": 0,
+                "text_additions": 0,
+                "image_additions": 0,
+                "image_corrections": 0,
+            }
+        return {k: int(v or 0) for k, v in dict(rows[0]).items()}
 
     def get_rejection_reason_rollup(self, side: str, since: datetime | None = None) -> list[dict]:
         """Aggregate rejected decisions by reason for the Summary tab.

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -225,10 +225,20 @@ def stats():
     since_ts = last_run.get("completed_at") if last_run else None
     image_decisions_since = db.count_image_decisions_since(since_ts)
 
-    recent_text_corrections = db.get_recent_text_corrections(limit=10)
-    recent_text_additions = db.get_recent_text_additions(limit=10)
-    recent_image_additions = db.get_recent_image_additions(limit=10)
-    recent_image_corrections = db.get_recent_image_corrections(limit=10)
+    # Review Activity section: frequency-aggregated rankings per card.
+    # Two scopes (Latest 7 days / All-time) rendered side-by-side; client toggle
+    # swaps via display:none. Per-card header badge reads from
+    # activity_counts_{latest,alltime}. See .claude/rules/web.md.
+    top_text_corrections_latest = db.get_top_text_corrections(window="7d", limit=10)
+    top_text_corrections_alltime = db.get_top_text_corrections(window="all", limit=10)
+    top_text_additions_latest = db.get_top_text_additions(window="7d", limit=10)
+    top_text_additions_alltime = db.get_top_text_additions(window="all", limit=10)
+    top_image_additions_latest = db.get_top_image_additions(window="7d", limit=10)
+    top_image_additions_alltime = db.get_top_image_additions(window="all", limit=10)
+    top_image_corrections_latest = db.get_top_image_corrections(window="7d", limit=10)
+    top_image_corrections_alltime = db.get_top_image_corrections(window="all", limit=10)
+    activity_counts_latest = db.count_review_activity(window="7d")
+    activity_counts_alltime = db.count_review_activity(window="all")
 
     # Phase 4c: rejection-reason rollup. "Why Reviewers Reject" panel groups
     # decisions by category for both sides. Lifetime totals (since=None) so
@@ -329,10 +339,16 @@ def stats():
         rejection_reason_labels=IMAGE_REJECTION_REASON_LABELS,
         last_training_run=last_run,
         image_decisions_since=image_decisions_since,
-        recent_text_corrections=recent_text_corrections,
-        recent_text_additions=recent_text_additions,
-        recent_image_additions=recent_image_additions,
-        recent_image_corrections=recent_image_corrections,
+        top_text_corrections_latest=top_text_corrections_latest,
+        top_text_corrections_alltime=top_text_corrections_alltime,
+        top_text_additions_latest=top_text_additions_latest,
+        top_text_additions_alltime=top_text_additions_alltime,
+        top_image_additions_latest=top_image_additions_latest,
+        top_image_additions_alltime=top_image_additions_alltime,
+        top_image_corrections_latest=top_image_corrections_latest,
+        top_image_corrections_alltime=top_image_corrections_alltime,
+        activity_counts_latest=activity_counts_latest,
+        activity_counts_alltime=activity_counts_alltime,
         threshold_total=threshold_total,
         threshold_positive=threshold_positive,
         retrain_running=retrain_running,
@@ -355,6 +371,43 @@ def stats():
         cross_metric_findings=cross_metric_findings,
         covered_phrases=covered_phrases,
         interpretations=interpretations,
+    )
+
+
+_ACTIVITY_DETAIL_TYPES: dict[str, dict[str, Any]] = {
+    "text-corrections": {
+        "label": "Text Fact Corrections",
+        "fetcher": "get_recent_text_corrections",
+    },
+    "text-additions": {
+        "label": "Text Fact Additions",
+        "fetcher": "get_recent_text_additions",
+    },
+    "image-additions": {
+        "label": "Image Metric Additions",
+        "fetcher": "get_recent_image_additions",
+    },
+    "image-corrections": {
+        "label": "Image Metric Corrections",
+        "fetcher": "get_recent_image_corrections",
+    },
+}
+
+
+@review_unified_bp.route("/stats/activity/<activity_type>")
+@require(PROTECTED_READ)
+def activity_detail(activity_type: str):
+    """Full event-level history for one Review Activity card type."""
+    spec = _ACTIVITY_DETAIL_TYPES.get(activity_type)
+    if spec is None:
+        abort(404)
+    db = get_db()
+    rows = getattr(db, spec["fetcher"])(limit=200)
+    return render_template(
+        "activity_detail.html",
+        activity_type=activity_type,
+        label=spec["label"],
+        rows=rows,
     )
 
 

--- a/src/web/templates/activity_detail.html
+++ b/src/web/templates/activity_detail.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block title %}All {{ label }} - {{ super() }}{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+  <div class="col-12 d-flex justify-content-between align-items-center">
+    <div>
+      <h1>All {{ label }}</h1>
+      <p class="text-muted mb-0">Showing up to 200 most recent events.</p>
+    </div>
+    <a href="{{ url_for('review_unified.stats') }}" class="btn btn-outline-secondary">
+      &larr; Back to Stats
+    </a>
+  </div>
+</div>
+
+{% if not rows %}
+<div class="alert alert-info">No activity recorded yet.</div>
+{% else %}
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h6 class="mb-0">{{ label }}</h6>
+    <span class="badge bg-secondary">{{ rows|length }} shown</span>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-sm table-hover mb-0 small">
+      <thead class="table-light">
+        <tr>
+          <th>When</th>
+          <th>Company</th>
+          {% if activity_type == 'text-corrections' %}
+          <th>Original &rarr; Corrected</th>
+          <th>Reviewer</th>
+          {% elif activity_type == 'text-additions' %}
+          <th>Metric</th>
+          <th>Value</th>
+          {% elif activity_type == 'image-additions' %}
+          <th>Added Metric</th>
+          <th>Reviewer</th>
+          {% elif activity_type == 'image-corrections' %}
+          <th>Detected &rarr; Confirmed</th>
+          <th>Reviewer</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in rows %}
+        <tr>
+          <td class="text-nowrap text-muted">{{ r.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>
+            {% if activity_type in ('image-additions', 'image-corrections') %}
+            <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}?tab=images">
+              {{ r.company_name }}
+            </a>
+            {% else %}
+            <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}">
+              {{ r.company_name }}
+            </a>
+            {% endif %}
+          </td>
+          {% if activity_type == 'text-corrections' %}
+          <td class="font-monospace small">
+            {{ r.original_metric_id }}
+            {% if r.corrected_metric_id and r.corrected_metric_id != r.original_metric_id %}
+            &rarr; {{ r.corrected_metric_id }}
+            {% else %}
+            <span class="text-muted">(value)</span>
+            {% endif %}
+          </td>
+          <td>{{ r.reviewer_id or '—' }}</td>
+          {% elif activity_type == 'text-additions' %}
+          <td class="font-monospace small">{{ r.canonical_metric_id }}</td>
+          <td>{{ r.value_raw }}{% if r.unit %} <span class="text-muted">{{ r.unit }}</span>{% endif %}</td>
+          {% elif activity_type == 'image-additions' %}
+          <td class="font-monospace small">{{ r.confirmed_metric_id }}</td>
+          <td>{{ r.reviewer_id or '—' }}</td>
+          {% elif activity_type == 'image-corrections' %}
+          <td class="font-monospace small">
+            {{ r.detected_metric_id }} &rarr; {{ r.confirmed_metric_id }}
+          </td>
+          <td>{{ r.reviewer_id or '—' }}</td>
+          {% endif %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -280,16 +280,16 @@
                 <div class="text-muted small">Total Decisions</div>
               </div>
               <div class="col-4 mb-3">
+                <div class="fs-4 fw-bold text-warning">{{ image_progress.pending_count or 0 }}</div>
+                <div class="text-muted small">Pending Images</div>
+              </div>
+              <div class="col-4 mb-3">
                 <div class="fs-4 fw-bold text-success">{{ img.relevant_count or 0 }}</div>
                 <div class="text-muted small">Relevant</div>
               </div>
-              <div class="col-4 mb-3">
+              <div class="col-4">
                 <div class="fs-4 fw-bold text-danger">{{ img.not_relevant_count or 0 }}</div>
                 <div class="text-muted small">Not Relevant</div>
-              </div>
-              <div class="col-4">
-                <div class="fs-4 fw-bold text-warning">{{ image_progress.pending_count or 0 }}</div>
-                <div class="text-muted small">Pending Images</div>
               </div>
               <div class="col-4">
                 <div class="fs-4 fw-bold text-info">{{ image_progress.reviewed_count or 0 }}</div>
@@ -311,173 +311,278 @@
       </div>
     </div>
 
-    {# Recent Activity panels — 4 small tables of most recent reviewer activity.
-       Each row links to its source filing's review page. #}
+    {# Review Activity — frequency-aggregated rankings per card with
+       Latest (7d) / All-time scope toggle. Each card holds two table panes;
+       the inactive pane is hidden via display:none. JS handler in the
+       <script> block at the bottom; localStorage key cmasb:stats:review_activity_scope. #}
     <div class="row mb-4">
-      <div class="col-12">
-        <h4 class="mb-3">Recent Activity</h4>
+      <div class="col-12 d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Review Activity</h4>
+        <div class="btn-group btn-group-sm" role="group" id="review-activity-scope-toggle">
+          <button type="button" class="btn btn-outline-secondary active"
+                  data-scope="latest">Latest 7 days</button>
+          <button type="button" class="btn btn-outline-secondary"
+                  data-scope="alltime">All-time</button>
+        </div>
       </div>
 
       {# Text fact corrections #}
       <div class="col-lg-6 mb-3">
         <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Text Fact Corrections <span class="badge bg-secondary ms-1">{{ recent_text_corrections|length }}</span></h6>
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Text Fact Corrections</h6>
+            <span>
+              <span class="badge bg-secondary scope-latest">{{ activity_counts_latest.text_corrections }}</span>
+              <span class="badge bg-secondary scope-alltime" style="display:none;">{{ activity_counts_alltime.text_corrections }}</span>
+            </span>
           </div>
-          {% if recent_text_corrections %}
-          <div class="table-responsive">
-            <table class="table table-sm table-hover mb-0 small">
-              <thead class="table-light">
-                <tr>
-                  <th>When</th>
-                  <th>Company</th>
-                  <th>Original &rarr; Corrected</th>
-                  <th>Reviewer</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for r in recent_text_corrections %}
-                <tr>
-                  <td class="text-nowrap text-muted">{{ r.created_at.strftime('%m-%d %H:%M') }}</td>
-                  <td>
-                    <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}">
-                      {{ r.company_name }}
-                    </a>
-                  </td>
-                  <td class="font-monospace small">
-                    {{ r.original_metric_id }}
-                    {% if r.corrected_metric_id and r.corrected_metric_id != r.original_metric_id %}
-                    &rarr; {{ r.corrected_metric_id }}
-                    {% endif %}
-                  </td>
-                  <td>{{ r.reviewer_id or '—' }}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+          <div class="scope-latest">
+            {% if top_text_corrections_latest %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Original &rarr; Corrected</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_text_corrections_latest %}
+                  <tr>
+                    <td class="font-monospace small">
+                      {% if r.corrected_metric_id and r.corrected_metric_id != r.original_metric_id %}
+                      {{ r.original_metric_id }} &rarr; {{ r.corrected_metric_id }}
+                      {% else %}
+                      {{ r.original_metric_id }} <span class="text-muted">(value)</span>
+                      {% endif %}
+                    </td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No corrections in the last 7 days.</div>
+            {% endif %}
           </div>
-          {% else %}
-          <div class="card-body text-muted small">No corrections yet.</div>
-          {% endif %}
+          <div class="scope-alltime" style="display:none;">
+            {% if top_text_corrections_alltime %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Original &rarr; Corrected</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_text_corrections_alltime %}
+                  <tr>
+                    <td class="font-monospace small">
+                      {% if r.corrected_metric_id and r.corrected_metric_id != r.original_metric_id %}
+                      {{ r.original_metric_id }} &rarr; {{ r.corrected_metric_id }}
+                      {% else %}
+                      {{ r.original_metric_id }} <span class="text-muted">(value)</span>
+                      {% endif %}
+                    </td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No corrections yet.</div>
+            {% endif %}
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <a class="small" href="{{ url_for('review_unified.activity_detail', activity_type='text-corrections') }}">
+              See all activity &rarr;
+            </a>
+          </div>
         </div>
       </div>
 
-      {# Text fact additions (manually-entered missed metrics) #}
+      {# Text fact additions #}
       <div class="col-lg-6 mb-3">
         <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Text Fact Additions <span class="badge bg-secondary ms-1">{{ recent_text_additions|length }}</span></h6>
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Text Fact Additions</h6>
+            <span>
+              <span class="badge bg-secondary scope-latest">{{ activity_counts_latest.text_additions }}</span>
+              <span class="badge bg-secondary scope-alltime" style="display:none;">{{ activity_counts_alltime.text_additions }}</span>
+            </span>
           </div>
-          {% if recent_text_additions %}
-          <div class="table-responsive">
-            <table class="table table-sm table-hover mb-0 small">
-              <thead class="table-light">
-                <tr>
-                  <th>When</th>
-                  <th>Company</th>
-                  <th>Metric</th>
-                  <th>Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for r in recent_text_additions %}
-                <tr>
-                  <td class="text-nowrap text-muted">{{ r.created_at.strftime('%m-%d %H:%M') }}</td>
-                  <td>
-                    <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}">
-                      {{ r.company_name }}
-                    </a>
-                  </td>
-                  <td class="font-monospace small">{{ r.canonical_metric_id }}</td>
-                  <td>{{ r.value_raw }}{% if r.unit %} <span class="text-muted">{{ r.unit }}</span>{% endif %}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+          <div class="scope-latest">
+            {% if top_text_additions_latest %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Metric</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_text_additions_latest %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No manual additions in the last 7 days.</div>
+            {% endif %}
           </div>
-          {% else %}
-          <div class="card-body text-muted small">No manual additions yet.</div>
-          {% endif %}
+          <div class="scope-alltime" style="display:none;">
+            {% if top_text_additions_alltime %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Metric</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_text_additions_alltime %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No manual additions yet.</div>
+            {% endif %}
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <a class="small" href="{{ url_for('review_unified.activity_detail', activity_type='text-additions') }}">
+              See all activity &rarr;
+            </a>
+          </div>
         </div>
       </div>
 
       {# Image metric additions #}
       <div class="col-lg-6 mb-3">
         <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Image Metric Additions <span class="badge bg-secondary ms-1">{{ recent_image_additions|length }}</span></h6>
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Image Metric Additions</h6>
+            <span>
+              <span class="badge bg-secondary scope-latest">{{ activity_counts_latest.image_additions }}</span>
+              <span class="badge bg-secondary scope-alltime" style="display:none;">{{ activity_counts_alltime.image_additions }}</span>
+            </span>
           </div>
-          {% if recent_image_additions %}
-          <div class="table-responsive">
-            <table class="table table-sm table-hover mb-0 small">
-              <thead class="table-light">
-                <tr>
-                  <th>When</th>
-                  <th>Company</th>
-                  <th>Added Metric</th>
-                  <th>Reviewer</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for r in recent_image_additions %}
-                <tr>
-                  <td class="text-nowrap text-muted">{{ r.created_at.strftime('%m-%d %H:%M') }}</td>
-                  <td>
-                    <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}?tab=images">
-                      {{ r.company_name }}
-                    </a>
-                  </td>
-                  <td class="font-monospace small">{{ r.confirmed_metric_id }}</td>
-                  <td>{{ r.reviewer_id or '—' }}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+          <div class="scope-latest">
+            {% if top_image_additions_latest %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Added Metric</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_image_additions_latest %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No image additions in the last 7 days.</div>
+            {% endif %}
           </div>
-          {% else %}
-          <div class="card-body text-muted small">No image additions yet.</div>
-          {% endif %}
+          <div class="scope-alltime" style="display:none;">
+            {% if top_image_additions_alltime %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Added Metric</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_image_additions_alltime %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No image additions yet.</div>
+            {% endif %}
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <a class="small" href="{{ url_for('review_unified.activity_detail', activity_type='image-additions') }}">
+              See all activity &rarr;
+            </a>
+          </div>
         </div>
       </div>
 
       {# Image metric corrections #}
       <div class="col-lg-6 mb-3">
         <div class="card h-100">
-          <div class="card-header">
-            <h6 class="mb-0">Image Metric Corrections <span class="badge bg-secondary ms-1">{{ recent_image_corrections|length }}</span></h6>
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Image Metric Corrections</h6>
+            <span>
+              <span class="badge bg-secondary scope-latest">{{ activity_counts_latest.image_corrections }}</span>
+              <span class="badge bg-secondary scope-alltime" style="display:none;">{{ activity_counts_alltime.image_corrections }}</span>
+            </span>
           </div>
-          {% if recent_image_corrections %}
-          <div class="table-responsive">
-            <table class="table table-sm table-hover mb-0 small">
-              <thead class="table-light">
-                <tr>
-                  <th>When</th>
-                  <th>Company</th>
-                  <th>Detected &rarr; Confirmed</th>
-                  <th>Reviewer</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for r in recent_image_corrections %}
-                <tr>
-                  <td class="text-nowrap text-muted">{{ r.created_at.strftime('%m-%d %H:%M') }}</td>
-                  <td>
-                    <a href="{{ url_for('review_unified.review_filing', filing_id=r.filing_id) }}?tab=images">
-                      {{ r.company_name }}
-                    </a>
-                  </td>
-                  <td class="font-monospace small">
-                    {{ r.detected_metric_id }} &rarr; {{ r.confirmed_metric_id }}
-                  </td>
-                  <td>{{ r.reviewer_id or '—' }}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+          <div class="scope-latest">
+            {% if top_image_corrections_latest %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Detected &rarr; Confirmed</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_image_corrections_latest %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.detected_metric_id }} &rarr; {{ r.confirmed_metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No image corrections in the last 7 days.</div>
+            {% endif %}
           </div>
-          {% else %}
-          <div class="card-body text-muted small">No image corrections yet.</div>
-          {% endif %}
+          <div class="scope-alltime" style="display:none;">
+            {% if top_image_corrections_alltime %}
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0 small">
+                <thead class="table-light">
+                  <tr><th>Detected &rarr; Confirmed</th><th class="text-end">Count</th><th class="text-nowrap">Last seen</th></tr>
+                </thead>
+                <tbody>
+                  {% for r in top_image_corrections_alltime %}
+                  <tr>
+                    <td class="font-monospace small">{{ r.detected_metric_id }} &rarr; {{ r.confirmed_metric_id }}</td>
+                    <td class="text-end">{{ r.count }}</td>
+                    <td class="text-nowrap text-muted">{{ r.last_seen.strftime('%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="card-body text-muted small">No image corrections yet.</div>
+            {% endif %}
+          </div>
+          <div class="card-footer bg-transparent text-center">
+            <a class="small" href="{{ url_for('review_unified.activity_detail', activity_type='image-corrections') }}">
+              See all activity &rarr;
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -1564,6 +1669,46 @@
     var scope = btn.getAttribute('data-scope');
     localStorage.setItem(LS_SCOPE_KEY, scope);
     applyReasonsScope(scope);
+  });
+
+  // -------------------------------------------------------------------
+  // Review Activity toggle — persisted in localStorage
+  // Key: cmasb:stats:review_activity_scope  ("latest" | "alltime")
+  // Toggles .scope-latest / .scope-alltime panes inside the Review
+  // Activity section on the Summary tab.
+  // -------------------------------------------------------------------
+  var LS_REVIEW_ACTIVITY_KEY = 'cmasb:stats:review_activity_scope';
+
+  function applyReviewActivityScope(scope) {
+    var toggle = document.getElementById('review-activity-scope-toggle');
+    if (!toggle) return;
+    var section = toggle.closest('.row');
+    if (!section) return;
+    var showLatest = scope !== 'alltime';
+    section.querySelectorAll('.scope-latest').forEach(function (el) {
+      el.style.display = showLatest ? '' : 'none';
+    });
+    section.querySelectorAll('.scope-alltime').forEach(function (el) {
+      el.style.display = showLatest ? 'none' : '';
+    });
+    toggle.querySelectorAll('[data-scope]').forEach(function (btn) {
+      if (btn.getAttribute('data-scope') === (showLatest ? 'latest' : 'alltime')) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
+  }
+
+  var savedActivityScope = localStorage.getItem(LS_REVIEW_ACTIVITY_KEY) || 'latest';
+  applyReviewActivityScope(savedActivityScope);
+
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest('#review-activity-scope-toggle [data-scope]');
+    if (!btn) return;
+    var scope = btn.getAttribute('data-scope');
+    localStorage.setItem(LS_REVIEW_ACTIVITY_KEY, scope);
+    applyReviewActivityScope(scope);
   });
 
   // -------------------------------------------------------------------

--- a/tests/unit/infra/test_db_analytics.py
+++ b/tests/unit/infra/test_db_analytics.py
@@ -187,3 +187,126 @@ class TestRecentImageCorrections:
         sql, _ = db.query.call_args[0]
         assert "imc.detected_metric_id" in sql
         assert "imc.confirmed_metric_id" in sql
+
+
+# ---------------------------------------------------------------------------
+# Review Activity aggregations: get_top_* + count_review_activity
+# ---------------------------------------------------------------------------
+
+
+class TestGetTopTextCorrections:
+    def test_groups_by_pair_and_filters_correct(self, db):
+        db.query.return_value = []
+        db.get_top_text_corrections(window="all", limit=10)
+        sql, params = db.query.call_args[0]
+        assert "rd.decision = 'correct'" in sql
+        assert "GROUP BY mf.canonical_metric_id, rd.assigned_metric_id" in sql
+        assert "ORDER BY count DESC, last_seen DESC" in sql
+        assert params == {"limit": 10}
+
+    def test_window_7d_adds_interval_filter(self, db):
+        db.query.return_value = []
+        db.get_top_text_corrections(window="7d")
+        sql, _ = db.query.call_args[0]
+        assert "rd.created_at >= NOW() - INTERVAL '7 days'" in sql
+
+    def test_window_all_omits_interval_filter(self, db):
+        db.query.return_value = []
+        db.get_top_text_corrections(window="all")
+        sql, _ = db.query.call_args[0]
+        assert "INTERVAL" not in sql
+
+    def test_returns_dict_list_with_aliases(self, db):
+        ts = datetime(2026, 5, 1, tzinfo=UTC)
+        db.query.return_value = [
+            {
+                "original_metric_id": "cm_a",
+                "corrected_metric_id": "cm_b",
+                "count": 5,
+                "last_seen": ts,
+            }
+        ]
+        rows = db.get_top_text_corrections(window="all")
+        assert rows == [
+            {
+                "original_metric_id": "cm_a",
+                "corrected_metric_id": "cm_b",
+                "count": 5,
+                "last_seen": ts,
+            }
+        ]
+
+
+class TestGetTopTextAdditions:
+    def test_groups_by_metric_filters_manual(self, db):
+        db.query.return_value = []
+        db.get_top_text_additions(window="all")
+        sql, _ = db.query.call_args[0]
+        assert "mf.extraction_method = 'manual'" in sql
+        assert "GROUP BY mf.canonical_metric_id" in sql
+
+    def test_window_7d_filter(self, db):
+        db.query.return_value = []
+        db.get_top_text_additions(window="7d")
+        sql, _ = db.query.call_args[0]
+        assert "mf.created_at >= NOW() - INTERVAL '7 days'" in sql
+
+
+class TestGetTopImageAdditions:
+    def test_groups_by_confirmed_metric_filters_add(self, db):
+        db.query.return_value = []
+        db.get_top_image_additions(window="all")
+        sql, _ = db.query.call_args[0]
+        assert "imc.decision = 'add'" in sql
+        assert "GROUP BY imc.confirmed_metric_id" in sql
+
+
+class TestGetTopImageCorrections:
+    def test_groups_by_detected_confirmed_pair(self, db):
+        db.query.return_value = []
+        db.get_top_image_corrections(window="all")
+        sql, _ = db.query.call_args[0]
+        assert "imc.decision = 'correct'" in sql
+        assert "GROUP BY imc.detected_metric_id, imc.confirmed_metric_id" in sql
+
+
+class TestCountReviewActivity:
+    def test_returns_zeros_when_db_returns_no_row(self, db):
+        db.query.return_value = []
+        result = db.count_review_activity(window="all")
+        assert result == {
+            "text_corrections": 0,
+            "text_additions": 0,
+            "image_additions": 0,
+            "image_corrections": 0,
+        }
+
+    def test_returns_int_dict(self, db):
+        db.query.return_value = [
+            {
+                "text_corrections": 4,
+                "text_additions": 7,
+                "image_additions": 12,
+                "image_corrections": 0,
+            }
+        ]
+        result = db.count_review_activity(window="all")
+        assert result == {
+            "text_corrections": 4,
+            "text_additions": 7,
+            "image_additions": 12,
+            "image_corrections": 0,
+        }
+
+    def test_window_7d_appends_filter_to_each_subquery(self, db):
+        db.query.return_value = []
+        db.count_review_activity(window="7d")
+        sql, _ = db.query.call_args[0]
+        # Three distinct subqueries each gate on the 7-day window.
+        assert sql.count("INTERVAL '7 days'") >= 3
+
+    def test_window_all_omits_filter(self, db):
+        db.query.return_value = []
+        db.count_review_activity(window="all")
+        sql, _ = db.query.call_args[0]
+        assert "INTERVAL" not in sql

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -72,10 +72,18 @@ def _stub_analytics_helpers(mock_db) -> None:
         "negative": 0,
     }
     mock_db.count_text_decisions_since.return_value = 0
-    mock_db.get_recent_text_corrections.return_value = []
-    mock_db.get_recent_text_additions.return_value = []
-    mock_db.get_recent_image_additions.return_value = []
-    mock_db.get_recent_image_corrections.return_value = []
+    # Review Activity section: 4 frequency-aggregated cards x 2 scopes
+    # (Latest 7d, All-time) plus per-window count totals for the badges.
+    mock_db.get_top_text_corrections.return_value = []
+    mock_db.get_top_text_additions.return_value = []
+    mock_db.get_top_image_additions.return_value = []
+    mock_db.get_top_image_corrections.return_value = []
+    mock_db.count_review_activity.return_value = {
+        "text_corrections": 0,
+        "text_additions": 0,
+        "image_additions": 0,
+        "image_corrections": 0,
+    }
     # Phase 3: stats() now calls db.query() directly to check whether a retrain
     # is currently running. Default to "none running" so button gating depends
     # only on the threshold counters.
@@ -123,7 +131,7 @@ def test_stats_renders_empty(client, mock_db):
     assert "Metric Analytics" in body
     # Summary tab is now the default landing — sanity-check it rendered.
     assert "Image Relevance Classifier" in body
-    assert "Recent Activity" in body
+    assert "Review Activity" in body
     assert 'id="summary-stats"' in body
     # Update Image Classifier button — Phase 3 button, disabled below threshold.
     assert "Update Image Classifier" in body
@@ -187,8 +195,10 @@ def test_stats_renders_with_data(client, mock_db):
     assert "Tier 3 All" in body
 
 
-def test_stats_summary_renders_recent_activity(client, mock_db):
-    """Recent-activity rows render with the expected company / metric / reviewer cells."""
+def test_stats_summary_renders_review_activity(client, mock_db):
+    """Review Activity cards render frequency-aggregated rows with the
+    Latest/All-time toggle, count badges, and pair / value-only metric labels.
+    """
     from datetime import datetime
 
     mock_db.get_v2_review_stats.return_value = _empty_text_data()
@@ -229,51 +239,67 @@ def test_stats_summary_renders_recent_activity(client, mock_db):
         "negative": 41,
     }
     mock_db.count_text_decisions_since.return_value = 12
-    mock_db.get_recent_text_corrections.return_value = [
+
+    # Aggregated rows for the Review Activity cards. Same fixture for both
+    # scopes — the mock returns these regardless of window arg.
+    mock_db.get_top_text_corrections.return_value = [
         {
-            "created_at": ts,
-            "reviewer_id": "RGM",
-            "corrected_metric_id": "cm_total_customers",
-            "corrected_value": None,
-            "reviewer_notes": None,
-            "fact_id": "fact-1",
             "original_metric_id": "cm_arpu",
-            "original_value_raw": "100",
-            "filing_id": 42,
-            "company_name": "Acme",
-            "cik": "0001",
+            "corrected_metric_id": "cm_total_customers",
+            "count": 4,
+            "last_seen": ts,
         },
-    ]
-    mock_db.get_recent_text_additions.return_value = []
-    mock_db.get_recent_image_additions.return_value = [
         {
-            "created_at": ts,
-            "confirmation_id": "conf-1",
-            "img_id": "img-1",
-            "confirmed_metric_id": "cm_net_revenue_retention",
-            "reviewer_id": "RGM",
-            "filing_id": 42,
-            "company_name": "Acme",
-            "cik": "0001",
+            # Value-only correction: same metric, no -> arrow.
+            "original_metric_id": "cm_revenue_concentration",
+            "corrected_metric_id": "cm_revenue_concentration",
+            "count": 3,
+            "last_seen": ts,
         },
     ]
-    mock_db.get_recent_image_corrections.return_value = []
+    mock_db.get_top_text_additions.return_value = []
+    mock_db.get_top_image_additions.return_value = [
+        {
+            "metric_id": "cm_net_revenue_retention",
+            "count": 7,
+            "last_seen": ts,
+        },
+    ]
+    mock_db.get_top_image_corrections.return_value = []
+    mock_db.count_review_activity.return_value = {
+        "text_corrections": 7,
+        "text_additions": 0,
+        "image_additions": 7,
+        "image_corrections": 0,
+    }
+
     # Text-decision pattern analysis helpers (no run yet → empty Patterns tab).
     mock_db.get_last_text_analysis_run.return_value = None
     mock_db.is_text_analysis_running.return_value = (False, None)
     mock_db.get_text_decision_metric_summary.return_value = []
     mock_db.get_text_decision_phrase_findings.return_value = []
     mock_db.get_recommendation_decisions.return_value = []
+    mock_db.get_rejection_reason_rollup.return_value = []
+    mock_db.query.return_value = []
 
     resp = client.get("/v2/review/stats")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    assert "2026-05-01 14:30 UTC" in body
+    assert "2026-05-01 14:30 UTC" in body  # last training run timestamp
     assert "(by RGM)" in body
-    assert "47" in body  # total decisions since
+    # Aggregated metric pairs and singles render.
     assert "cm_arpu" in body and "cm_total_customers" in body
     assert "cm_net_revenue_retention" in body
-    assert "Acme" in body
+    # Value-only correction renders as the metric + "(value)" qualifier rather
+    # than "cm_X -> cm_X".
+    assert "cm_revenue_concentration" in body
+    assert "(value)" in body
+    # Toggle and persistence wiring.
+    assert 'id="review-activity-scope-toggle"' in body
+    assert "cmasb:stats:review_activity_scope" in body
+    # See-all link is present for each card type.
+    assert "/v2/review/stats/activity/text-corrections" in body
+    assert "/v2/review/stats/activity/image-additions" in body
 
 
 def test_patterns_tab_renders_recommendation_alert(client, mock_db):
@@ -865,3 +891,53 @@ def test_patterns_tab_covered_phrases_chip(client, mock_db):
     # (it would be present for other undecided recs, so count check is not needed —
     # just verify the chip text is present).
     assert "multi metric phrase" in body
+
+
+# ---------------------------------------------------------------------------
+# Activity-detail click-through page (/v2/review/stats/activity/<type>)
+# ---------------------------------------------------------------------------
+
+
+def test_activity_detail_unknown_type_returns_404(client, mock_db):
+    resp = client.get("/v2/review/stats/activity/bogus-type")
+    assert resp.status_code == 404
+
+
+def test_activity_detail_text_corrections_renders(client, mock_db):
+    from datetime import datetime
+
+    ts = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    mock_db.get_recent_text_corrections.return_value = [
+        {
+            "created_at": ts,
+            "reviewer_id": "RGM",
+            "corrected_metric_id": "cm_total_customers",
+            "corrected_value": None,
+            "reviewer_notes": None,
+            "fact_id": "fact-1",
+            "original_metric_id": "cm_arpu",
+            "original_value_raw": "100",
+            "filing_id": 42,
+            "company_name": "Acme",
+            "cik": "0001",
+        },
+    ]
+
+    resp = client.get("/v2/review/stats/activity/text-corrections")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "All Text Fact Corrections" in body
+    assert "Acme" in body
+    assert "cm_arpu" in body and "cm_total_customers" in body
+    # Limit was bumped to 200 for this page.
+    mock_db.get_recent_text_corrections.assert_called_once_with(limit=200)
+
+
+def test_activity_detail_image_corrections_empty(client, mock_db):
+    mock_db.get_recent_image_corrections.return_value = []
+
+    resp = client.get("/v2/review/stats/activity/image-corrections")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "All Image Metric Corrections" in body
+    assert "No activity recorded yet" in body


### PR DESCRIPTION
Replaces the Recent Activity feed on /v2/review/stats with frequency-aggregated
rankings keyed on metric (or original→corrected pair where applicable). Each of
the four cards renders top 10 by event count with a last-seen timestamp; a
button-group toggle swaps between a 7-day window and all-time, persisted under
localStorage key cmasb:stats:review_activity_scope. Per-card "See all activity"
links open the full event-level history at /v2/review/stats/activity/<type>.

Also swaps two cells in the Image Confirmations summary card so its color
pattern is parallel to the Text Facts card (Total → Pending → Relevant on the
top row, Not Relevant → Reviewed → Skipped on the bottom).

DB: 5 new methods on DatabaseAdapter (4 get_top_* aggregations + count_review_activity).
Route: stats() updated; new activity_detail handler with 404-on-unknown type.
Templates: Review Activity block rewritten in unified_stats.html; new
activity_detail.html for the see-all page.
Tests: 11 new unit tests for the aggregation methods, 3 for activity_detail,
existing stats-route test rewritten for the new shape; 4755 unit tests pass.
Docs: .claude/rules/web.md gets the new localStorage key and a Review Activity
panel section.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
