### PR TITLE
feat(stats): per-decision-type breakdown + legacy-accepts banner on Images tab

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -127,6 +127,12 @@ To edit the action text or severity thresholds for a category, modify `CATEGORY_
 
 Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summarized "Top Reviewer Themes" panel (deferred) will read `reviewer_notes` — the two panels are complementary.
 
+## Images tab — decision-type breakdown
+
+`/v2/review/stats` **Images tab** opens with five mutually-exclusive cards keyed on `v2_image_metric_confirmations.decision`: Accepted / Corrected / Added / Rejected / Skipped. The total decision count is shown as a small subtitle in the section header. Backed by `db.get_image_decision_breakdown_v2()`, which returns one dict per call (single roundtrip). The Summary-tab Image Confirmations card still uses `db.get_image_decision_overall_v2()` (Relevant / Not Relevant rollup) — the two helpers are independent on purpose so the simpler Summary view is decoupled from the per-decision breakdown.
+
+A warning banner above the cards surfaces `legacy_accepts_pending` — distinct images with a `v2_image_review_decisions.decision='accept'` row but no rows in `v2_image_metric_confirmations` yet. These are pre-per-metric-pivot reviews where the reviewer marked the image relevant without naming a metric; the banner disappears when the count hits zero (i.e., the legacy backfill is complete). The same anti-join lives inside `get_image_decision_breakdown_v2`.
+
 ## Review Activity panel
 
 `/v2/review/stats` **Summary tab** renders the "Review Activity" section — four cards that surface frequency-aggregated rankings of reviewer activity, not chronological feeds. Each card is a top-10 list of metrics or metric pairs sorted by event count DESC, with a "last seen" timestamp tiebreak. The cards are: Text Fact Corrections (grouped by `(original_metric_id, corrected_metric_id)` — value-only corrections render as `cm_X (value)`, metric-id changes render as `cm_X → cm_Y`), Text Fact Additions (grouped by `canonical_metric_id`, manual extractions only), Image Metric Additions (grouped by `confirmed_metric_id`, decision='add'), and Image Metric Corrections (grouped by `(detected_metric_id, confirmed_metric_id)`, decision='correct'). Backed by `db.get_top_text_corrections`, `get_top_text_additions`, `get_top_image_additions`, `get_top_image_corrections`, all in `src/infra/db.py`.

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2430,6 +2430,60 @@ class DatabaseAdapter:
             "review_pct": round(reviewed / total * 100, 1) if total > 0 else 0.0,
         }
 
+    def get_image_decision_breakdown_v2(self) -> dict:
+        """Per-decision-type breakdown of image-metric confirmations.
+
+        Returns mutually-exclusive counts for each decision value the
+        per-metric flow records (accept / correct / add / reject / skip)
+        plus the lifetime total. Drives the five summary cards on the
+        Images tab of /v2/review/stats.
+
+        Also returns ``legacy_accepts_pending``: count of distinct images
+        accepted under the pre-per-metric flow (rows in
+        ``v2_image_review_decisions`` with decision='accept') that have
+        no rows in ``v2_image_metric_confirmations`` yet — i.e., the
+        reviewer's "relevant" intent never got a metric assigned. Powers
+        the backfill banner and goes to zero once the legacy review set
+        is migrated.
+        """
+        sql = """
+            WITH breakdown AS (
+                SELECT
+                    COUNT(*)                                            AS total,
+                    COUNT(*) FILTER (WHERE decision = 'accept')         AS accepted,
+                    COUNT(*) FILTER (WHERE decision = 'correct')        AS corrected,
+                    COUNT(*) FILTER (WHERE decision = 'add')            AS added,
+                    COUNT(*) FILTER (WHERE decision = 'reject')         AS rejected,
+                    COUNT(*) FILTER (WHERE decision = 'skip')           AS skipped
+                  FROM v2_image_metric_confirmations
+            ),
+            legacy AS (
+                SELECT COUNT(DISTINCT ird.img_id) AS legacy_accepts_pending
+                  FROM v2_image_review_decisions ird
+                 WHERE ird.decision = 'accept'
+                   AND NOT EXISTS (
+                       SELECT 1
+                         FROM v2_image_metric_confirmations imc
+                        WHERE imc.img_id = ird.img_id
+                   )
+            )
+            SELECT b.total, b.accepted, b.corrected, b.added, b.rejected, b.skipped,
+                   l.legacy_accepts_pending
+              FROM breakdown b CROSS JOIN legacy l
+        """
+        rows = self.query(sql)
+        if not rows:
+            return {
+                "total": 0,
+                "accepted": 0,
+                "corrected": 0,
+                "added": 0,
+                "rejected": 0,
+                "skipped": 0,
+                "legacy_accepts_pending": 0,
+            }
+        return {k: int(v or 0) for k, v in dict(rows[0]).items()}
+
     def get_image_decision_overall_v2(self) -> dict:
         """Aggregate totals over all v2_image_metric_confirmations rows.
 

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -211,7 +211,11 @@ def stats():
 
     db = get_db()
     text_data = db.get_v2_review_stats()
+    # image_overall (Relevant / Not Relevant rollup) still feeds the side-by-side
+    # Summary-tab card. The Images tab now consumes image_breakdown for a
+    # per-decision-type view + legacy-accepts banner.
     image_overall = db.get_image_decision_overall_v2()
+    image_breakdown = db.get_image_decision_breakdown_v2()
     image_progress = db.get_image_review_progress_v2()
     image_tier = db.get_image_decisions_by_tier_v2()
     image_rejections = db.get_image_rejection_reasons_by_tier_v2()
@@ -333,6 +337,7 @@ def stats():
         totals=text_data["totals"],
         confidence_bands=text_data["confidence_bands"],
         image_overall=image_overall,
+        image_breakdown=image_breakdown,
         image_progress=image_progress,
         image_tier=image_tier,
         image_rejections=image_rejections,

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -840,6 +840,7 @@
   <div class="tab-pane fade" id="images-stats" role="tabpanel" aria-labelledby="images-tab">
 
     {% set overall_stats = image_overall %}
+    {% set breakdown = image_breakdown or {} %}
     {% set progress = image_progress %}
     {% set tier_stats = image_tier %}
     {% set rejection_stats = image_rejections %}
@@ -861,35 +862,78 @@
     </div>
     {% else %}
 
-    {# Summary Cards #}
-    <div class="row mb-4">
-      <div class="col-md-4">
-        <div class="card">
-          <div class="card-body">
-            <h6 class="card-subtitle mb-2 text-muted">Total Decisions</h6>
-            <h2 class="mb-0">{{ overall_stats.total_decisions }}</h2>
+    {# Per-decision-type breakdown header. Total is shown as a small subtitle
+       above five mutually-exclusive cards (accept / correct / add / reject /
+       skip). The legacy-accepts banner above the cards tracks pre-per-metric
+       reviews awaiting metric assignment — disappears when count == 0. #}
+    <div class="row mb-3">
+      <div class="col-12 d-flex justify-content-between align-items-end">
+        <div>
+          <h5 class="mb-1">Decisions by Type</h5>
+          <p class="text-muted small mb-0">
+            Total Decisions: <strong>{{ breakdown.total or overall_stats.total_decisions }}</strong>
+            &middot; lifetime per-metric confirmations across all images
+          </p>
+        </div>
+      </div>
+    </div>
+
+    {% if breakdown.legacy_accepts_pending and breakdown.legacy_accepts_pending > 0 %}
+    <div class="row mb-3">
+      <div class="col-12">
+        <div class="alert alert-warning py-2 px-3 mb-0 small" role="alert">
+          <strong>{{ breakdown.legacy_accepts_pending }}</strong>
+          image{{ '' if breakdown.legacy_accepts_pending == 1 else 's' }}
+          accepted under the legacy flow
+          {{ 'is' if breakdown.legacy_accepts_pending == 1 else 'are' }}
+          awaiting per-metric backfill — the reviewer marked the image relevant
+          but never assigned a specific metric. Backfill is being addressed in a
+          separate task.
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
+    {# Five mutually-exclusive decision-type cards. Same color language as the
+       Summary-tab Image Confirmations card so the two surfaces stay consistent. #}
+    <div class="row mb-4 g-2">
+      <div class="col">
+        <div class="card border-success h-100">
+          <div class="card-body p-3">
+            <h6 class="card-subtitle mb-1 text-muted small">Accepted</h6>
+            <h3 class="mb-0 text-success">{{ breakdown.accepted or 0 }}</h3>
           </div>
         </div>
       </div>
-      <div class="col-md-4">
-        <div class="card border-success">
-          <div class="card-body">
-            <h6 class="card-subtitle mb-2 text-muted">Relevant</h6>
-            <h2 class="mb-0 text-success">
-              {{ overall_stats.relevant_count }}
-              <small class="fs-6 text-muted">({{ overall_stats.relevant_pct|round(1) }}%)</small>
-            </h2>
+      <div class="col">
+        <div class="card border-info h-100">
+          <div class="card-body p-3">
+            <h6 class="card-subtitle mb-1 text-muted small">Corrected</h6>
+            <h3 class="mb-0 text-info">{{ breakdown.corrected or 0 }}</h3>
           </div>
         </div>
       </div>
-      <div class="col-md-4">
-        <div class="card border-danger">
-          <div class="card-body">
-            <h6 class="card-subtitle mb-2 text-muted">Not Relevant</h6>
-            <h2 class="mb-0 text-danger">
-              {{ overall_stats.not_relevant_count }}
-              <small class="fs-6 text-muted">({{ overall_stats.not_relevant_pct|round(1) }}%)</small>
-            </h2>
+      <div class="col">
+        <div class="card border-primary h-100">
+          <div class="card-body p-3">
+            <h6 class="card-subtitle mb-1 text-muted small">Added</h6>
+            <h3 class="mb-0 text-primary">{{ breakdown.added or 0 }}</h3>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card border-danger h-100">
+          <div class="card-body p-3">
+            <h6 class="card-subtitle mb-1 text-muted small">Rejected</h6>
+            <h3 class="mb-0 text-danger">{{ breakdown.rejected or 0 }}</h3>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card border-secondary h-100">
+          <div class="card-body p-3">
+            <h6 class="card-subtitle mb-1 text-muted small">Skipped</h6>
+            <h3 class="mb-0 text-secondary">{{ breakdown.skipped or 0 }}</h3>
           </div>
         </div>
       </div>

--- a/tests/unit/infra/test_db_analytics.py
+++ b/tests/unit/infra/test_db_analytics.py
@@ -310,3 +310,66 @@ class TestCountReviewActivity:
         db.count_review_activity(window="all")
         sql, _ = db.query.call_args[0]
         assert "INTERVAL" not in sql
+
+
+class TestGetImageDecisionBreakdownV2:
+    def test_filters_per_decision_type(self, db):
+        db.query.return_value = []
+        db.get_image_decision_breakdown_v2()
+        sql = db.query.call_args.args[0]
+        for clause in (
+            "FILTER (WHERE decision = 'accept')",
+            "FILTER (WHERE decision = 'correct')",
+            "FILTER (WHERE decision = 'add')",
+            "FILTER (WHERE decision = 'reject')",
+            "FILTER (WHERE decision = 'skip')",
+        ):
+            assert clause in sql
+
+    def test_legacy_accepts_subquery_filters_orphaned_legacy_rows(self, db):
+        """Legacy accepts only count when no per-metric confirmation row exists."""
+        db.query.return_value = []
+        db.get_image_decision_breakdown_v2()
+        sql = db.query.call_args.args[0]
+        assert "v2_image_review_decisions" in sql
+        assert "ird.decision = 'accept'" in sql
+        # Anti-join: image must NOT have any per-metric confirmation row.
+        assert "NOT EXISTS" in sql
+        assert "v2_image_metric_confirmations imc" in sql
+
+    def test_returns_zeros_when_no_rows(self, db):
+        db.query.return_value = []
+        result = db.get_image_decision_breakdown_v2()
+        assert result == {
+            "total": 0,
+            "accepted": 0,
+            "corrected": 0,
+            "added": 0,
+            "rejected": 0,
+            "skipped": 0,
+            "legacy_accepts_pending": 0,
+        }
+
+    def test_coerces_to_ints(self, db):
+        db.query.return_value = [
+            {
+                "total": 100,
+                "accepted": 40,
+                "corrected": 5,
+                "added": 25,
+                "rejected": 28,
+                "skipped": 2,
+                "legacy_accepts_pending": 137,
+            }
+        ]
+        result = db.get_image_decision_breakdown_v2()
+        assert result == {
+            "total": 100,
+            "accepted": 40,
+            "corrected": 5,
+            "added": 25,
+            "rejected": 28,
+            "skipped": 2,
+            "legacy_accepts_pending": 137,
+        }
+        assert all(isinstance(v, int) for v in result.values())

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -84,6 +84,18 @@ def _stub_analytics_helpers(mock_db) -> None:
         "image_additions": 0,
         "image_corrections": 0,
     }
+    # Images-tab per-decision-type breakdown + legacy-accepts banner. Empty by
+    # default so the breakdown cards render with zeros and the banner stays
+    # hidden; tests that exercise the populated state override explicitly.
+    mock_db.get_image_decision_breakdown_v2.return_value = {
+        "total": 0,
+        "accepted": 0,
+        "corrected": 0,
+        "added": 0,
+        "rejected": 0,
+        "skipped": 0,
+        "legacy_accepts_pending": 0,
+    }
     # Phase 3: stats() now calls db.query() directly to check whether a retrain
     # is currently running. Default to "none running" so button gating depends
     # only on the threshold counters.
@@ -941,3 +953,99 @@ def test_activity_detail_image_corrections_empty(client, mock_db):
     body = resp.get_data(as_text=True)
     assert "All Image Metric Corrections" in body
     assert "No activity recorded yet" in body
+
+
+# ---------------------------------------------------------------------------
+# Images-tab per-decision-type breakdown + legacy-accepts banner
+# ---------------------------------------------------------------------------
+
+
+def test_images_tab_renders_decision_breakdown_cards(client, mock_db):
+    """Five mutually-exclusive cards render with per-decision-type counts."""
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 100,
+        "relevant_count": 70,
+        "not_relevant_count": 30,
+        "relevant_pct": 70.0,
+        "not_relevant_pct": 30.0,
+    }
+    mock_db.get_image_decision_breakdown_v2.return_value = {
+        "total": 100,
+        "accepted": 40,
+        "corrected": 5,
+        "added": 25,
+        "rejected": 28,
+        "skipped": 2,
+        "legacy_accepts_pending": 0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 120,
+        "pending_count": 20,
+        "reviewed_count": 100,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 83.3,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # New section heading + total subtitle.
+    assert "Decisions by Type" in body
+    assert "Total Decisions:" in body
+
+    # All five card labels appear.
+    for label in ("Accepted", "Corrected", "Added", "Rejected", "Skipped"):
+        assert f">{label}<" in body, f"missing card label: {label}"
+
+    # Each card's count renders. Use unique values so we can pin them.
+    for value in ("40", "25", "28"):
+        assert value in body
+
+    # Banner does NOT render when legacy_accepts_pending == 0.
+    assert "awaiting per-metric backfill" not in body
+
+
+def test_images_tab_renders_legacy_accepts_banner(client, mock_db):
+    """Banner renders with the count when legacy_accepts_pending > 0."""
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 50,
+        "relevant_count": 30,
+        "not_relevant_count": 20,
+        "relevant_pct": 60.0,
+        "not_relevant_pct": 40.0,
+    }
+    mock_db.get_image_decision_breakdown_v2.return_value = {
+        "total": 50,
+        "accepted": 20,
+        "corrected": 0,
+        "added": 10,
+        "rejected": 20,
+        "skipped": 0,
+        "legacy_accepts_pending": 137,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 60,
+        "pending_count": 10,
+        "reviewed_count": 50,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 83.3,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    assert "137" in body
+    assert "awaiting per-metric backfill" in body
+    assert "alert-warning" in body


### PR DESCRIPTION
Replaces the three top cards on the Images tab (Total / Relevant / Not Relevant)
with five mutually-exclusive cards keyed on v2_image_metric_confirmations.decision
(Accepted / Corrected / Added / Rejected / Skipped). Total moves to a small
subtitle in the section header. Surfaces add-decisions — a leading indicator of
keyword-detector recall gaps — that were previously rolled up into "Relevant"
with no way to break them out.

Adds a warning banner above the cards counting images accepted under the
legacy (pre-per-metric) flow that don't yet have a per-metric confirmation
row. Goes to zero once the legacy review set is backfilled.

DB: new get_image_decision_breakdown_v2() returns
{accepted, corrected, added, rejected, skipped, total, legacy_accepts_pending}
in one query. The Summary-tab Image Confirmations card still uses the
existing get_image_decision_overall_v2() (Relevant / Not Relevant) — the two
helpers stay independent.
Tests: 4 new unit tests for the DB method (decision-type filters, legacy-accept
anti-join, zero-state, int coercion), 2 new route tests for the rendering
(card labels + banner visibility).
Docs: .claude/rules/web.md gets a new "Images tab — decision-type breakdown"
section.

4733 unit tests pass.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
