### PR TITLE
feat(llm): PR3b — LLMPresenceClassifierStage shadow-mode wiring

### DIFF
--- a/src/extraction_v2/models.py
+++ b/src/extraction_v2/models.py
@@ -694,6 +694,30 @@ class MetricPresence:
     evidence_segment_ids: list[str] = field(default_factory=list)
     advisory_value_count: int = 0
     advisory_fact_ids: list[str] = field(default_factory=list)
+    # Shadow-mode LLM classifier output: {metric_id: {score, present, rationale, model,
+    # sonnet_fallback, prompt_version, source}}. None when classifier is off or produced
+    # no signal for this metric. Written to v2_text_metric_presence.classifier_metadata.
+    classifier_metadata: dict | None = field(default=None)
+
+
+@dataclass
+class LLMPresenceSignal:
+    """One LLM classifier output for a (segment, metric) pair.
+
+    Written by LLMPresenceClassifierStage into PipelineContext.llm_presence_signals.
+    Read by MetricPresenceStage to populate MetricPresence.classifier_metadata.
+    """
+
+    segment_id: str
+    section_type: str | None
+    metric_id: str
+    score: float
+    present: bool
+    rationale: str
+    model: str
+    sonnet_fallback: bool
+    prompt_version: str
+    source: str  # "keyword" — segment was in candidate shortlist; "paraphrase" — recall path
 
 
 @dataclass

--- a/src/extraction_v2/persistence.py
+++ b/src/extraction_v2/persistence.py
@@ -767,6 +767,7 @@ class V2PersistenceAdapter:
                 evidence_segment_ids,
                 advisory_value_count,
                 advisory_fact_ids,
+                classifier_metadata,
                 pipeline_version,
                 created_at,
                 updated_at
@@ -778,6 +779,7 @@ class V2PersistenceAdapter:
                 %(evidence_segment_ids)s,
                 %(advisory_value_count)s,
                 %(advisory_fact_ids)s,
+                %(classifier_metadata)s,
                 %(pipeline_version)s,
                 NOW(),
                 NOW()
@@ -788,6 +790,7 @@ class V2PersistenceAdapter:
                 evidence_segment_ids = EXCLUDED.evidence_segment_ids,
                 advisory_value_count = EXCLUDED.advisory_value_count,
                 advisory_fact_ids = EXCLUDED.advisory_fact_ids,
+                classifier_metadata = EXCLUDED.classifier_metadata,
                 pipeline_version = EXCLUDED.pipeline_version,
                 updated_at = NOW()
             """,
@@ -800,6 +803,11 @@ class V2PersistenceAdapter:
                     "evidence_segment_ids": json.dumps(p.evidence_segment_ids),
                     "advisory_value_count": p.advisory_value_count,
                     "advisory_fact_ids": json.dumps(p.advisory_fact_ids),
+                    "classifier_metadata": (
+                        json.dumps(p.classifier_metadata)
+                        if p.classifier_metadata is not None
+                        else None
+                    ),
                     "pipeline_version": "2.0.0",
                 }
                 for p in presences

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -18,6 +18,8 @@ see ``_setup_stages``):
 5b.   Image Classify                 → Vision metric-classifier audit trail
                                        (gated by ENABLE_METRIC_CLASSIFY)
 6.    Metric Candidate Generation    → YAML taxonomy matching
+6.5.  LLM Presence Classifier        → per-(segment, metric) LLM scores; paraphrase-recall path
+                                       (gated by PRESENCE_CLASSIFIER_ENABLED / presence_classifier_enabled flag)
 7.    Value Binding                  → structural link required
 7.5.  False Positive Filter          → 13 rule-based suppression rules
 8.    Period Inference               → from header_path or context
@@ -71,6 +73,7 @@ from src.extraction_v2.stages.false_positive_filter import FalsePositiveFilterSt
 from src.extraction_v2.stages.image_classify import ImageClassifyStage
 from src.extraction_v2.stages.image_triage import ImageTriageStage
 from src.extraction_v2.stages.ingestion import IngestionStage
+from src.extraction_v2.stages.llm_presence_classifier import LLMPresenceClassifierStage
 from src.extraction_v2.stages.metric_presence import MetricPresenceStage
 from src.extraction_v2.stages.ocr_extraction import OCRExtractionStage
 from src.extraction_v2.stages.period_inference import PeriodInferenceStage
@@ -104,6 +107,7 @@ class PipelineStage(str, Enum):
     CHART_FACT_BRIDGE = "chart_fact_bridge"
     IMAGE_CLASSIFY = "image_classify"
     CANDIDATE_GENERATION = "candidate_generation"
+    LLM_PRESENCE_CLASSIFIER = "llm_presence_classifier"
     VALUE_BINDING = "value_binding"
     FALSE_POSITIVE_FILTER = "false_positive_filter"
     PERIOD_INFERENCE = "period_inference"
@@ -122,6 +126,9 @@ class PipelineConfig:
     enable_section_classification: bool = True
     enable_image_extraction: bool = True
     enable_chart_extraction: bool = True
+    enable_llm_presence_classifier: bool = (
+        False  # Shadow mode; enabled via PRESENCE_CLASSIFIER_ENABLED env or DB flag
+    )
 
     # Quality thresholds
     min_confidence_auto_accept: float = 0.90  # Auto-accept above this
@@ -422,6 +429,9 @@ class PipelineContext:
     presences: list[MetricPresence] = field(
         default_factory=list
     )  # Populated by MetricPresenceStage (final stage)
+    llm_presence_signals: list[Any] = field(
+        default_factory=list
+    )  # list[SegmentClassification] written by LLMPresenceClassifierStage; read by MetricPresenceStage
 
     # Diagnostics (only populated when config.retain_context=True)
     _pre_filter_bound_values: list[BoundValue] = field(default_factory=list)  # Before FP filter
@@ -501,6 +511,17 @@ class V2Pipeline:
             self.config.enable_image_keyword_prescan = True
         if _env_truthy("ENABLE_METRIC_CLASSIFY"):
             self.config.enable_metric_classify = True
+        if _env_truthy("PRESENCE_CLASSIFIER_ENABLED"):
+            self.config.enable_llm_presence_classifier = True
+        else:
+            # Fall back to DB feature flag when env var is absent.
+            try:
+                from src.auth.feature_flags import is_enabled as _ff_is_enabled
+
+                if _ff_is_enabled("presence_classifier_enabled"):
+                    self.config.enable_llm_presence_classifier = True
+            except Exception:
+                pass  # DB unavailable at pipeline-init time; stay off
         if os.environ.get("VISION_CLASSIFY_PROVIDER"):
             self.config.vision_classify_provider = os.environ["VISION_CLASSIFY_PROVIDER"]
         if os.environ.get("VISION_CLASSIFY_MODEL"):
@@ -597,6 +618,12 @@ class V2Pipeline:
 
         # Stage 6: Metric Candidate Generation
         self._stages.append((PipelineStage.CANDIDATE_GENERATION, CandidateGenerationStage()))
+
+        # Stage 6.5: LLM Presence Classifier (shadow mode — no-op when flag is off)
+        if self.config.enable_llm_presence_classifier:
+            self._stages.append(
+                (PipelineStage.LLM_PRESENCE_CLASSIFIER, LLMPresenceClassifierStage())
+            )
 
         # Stage 7: Value Binding
         self._stages.append((PipelineStage.VALUE_BINDING, ValueBindingStage()))

--- a/src/extraction_v2/stages/llm_presence_classifier.py
+++ b/src/extraction_v2/stages/llm_presence_classifier.py
@@ -1,0 +1,264 @@
+"""
+Stage 6.5: LLM Presence Classifier (shadow mode).
+
+Runs per-(segment, metric) LLM scoring via PresenceClassifierClient after
+candidate_generation, before value_binding. Two scoring paths:
+
+  keyword path  — segments that produced at least one MetricCandidate are
+                  scored against their keyword-matched metric_ids.
+
+  paraphrase path (Part E) — segments in whitelisted sections (MD&A,
+                  Business, Risk Factors) that had NO keyword hit are
+                  scored against the enrolled-metric set from
+                  recall_augmentation.yaml, without requiring a keyword hit.
+                  This is the mechanism for +5pt Tier-1 recall lift.
+
+Shadow-mode invariant: this stage only writes to
+``context.llm_presence_signals``. It never modifies ``context.candidates``,
+``context.facts``, or ``context.presences``. MetricPresenceStage reads the
+signals to populate ``MetricPresence.classifier_metadata`` but keyword/fact
+evidence remains the authoritative presence signal. No new presence records
+are created from LLM-only findings in shadow mode.
+
+Gated by ``context.config.enable_llm_presence_classifier`` (defaults False).
+When False the stage is a no-op and returns immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from src.extraction_v2.models import LLMPresenceSignal
+
+if TYPE_CHECKING:
+    from src.extraction_v2.pipeline import PipelineContext, StageResult
+
+logger = logging.getLogger(__name__)
+
+# Minimum segment text length to bother classifying.
+_MIN_SEGMENT_CHARS = 50
+
+
+class LLMPresenceClassifierStage:
+    """Stage 6.5 — LLM presence classifier in shadow mode.
+
+    Accepts an optional pre-built ``client`` for dependency injection in
+    tests. When ``None``, constructs ``PresenceClassifierClient`` lazily from
+    the default config on first ``process()`` call.
+    """
+
+    def __init__(self, client: Any | None = None) -> None:
+        self._client = client
+        self._initialized_client: Any | None = None
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        if self._initialized_client is None:
+            from src.llm.presence_classifier_client import PresenceClassifierClient
+
+            self._initialized_client = PresenceClassifierClient()
+        return self._initialized_client
+
+    def process(self, context: PipelineContext) -> StageResult:
+        from src.extraction_v2.pipeline import PipelineStage, StageResult
+
+        start = datetime.now(UTC)
+
+        if not context.config.enable_llm_presence_classifier:
+            return StageResult(
+                stage=PipelineStage.LLM_PRESENCE_CLASSIFIER,
+                success=True,
+                duration_ms=0,
+                items_processed=0,
+                items_output=0,
+            )
+
+        try:
+            client = self._get_client()
+        except Exception as exc:
+            logger.warning("LLMPresenceClassifierStage: client init failed: %s", exc)
+            return StageResult(
+                stage=PipelineStage.LLM_PRESENCE_CLASSIFIER,
+                success=True,
+                duration_ms=0,
+                items_processed=0,
+                items_output=0,
+                warnings=[f"client init failed: {exc}"],
+            )
+
+        if not client.config.api_key:
+            logger.warning("LLMPresenceClassifierStage: ANTHROPIC_API_KEY not set; skipping")
+            return StageResult(
+                stage=PipelineStage.LLM_PRESENCE_CLASSIFIER,
+                success=True,
+                duration_ms=0,
+                items_processed=0,
+                items_output=0,
+                warnings=["ANTHROPIC_API_KEY not set"],
+            )
+
+        recall_cfg = client.config.recall_augmentation
+        enrolled: frozenset[str] = recall_cfg.enrolled_metrics if recall_cfg else frozenset()
+        section_whitelist: frozenset[str] = (
+            recall_cfg.section_whitelist if recall_cfg else frozenset()
+        )
+
+        # Build segment lookup.
+        segment_by_id = {s.segment_id: s for s in context.segments}
+
+        # --- Keyword path ---
+        # Group candidates by segment_id → set of metric_ids that fired.
+        kw_seg_metrics: dict[str, set[str]] = defaultdict(set)
+        for cand in context.candidates:
+            seg_id = cand.source_locator.segment_id if cand.source_locator else None
+            if seg_id:
+                kw_seg_metrics[seg_id].add(cand.metric_id)
+
+        signals: list[LLMPresenceSignal] = []
+        errors: list[str] = []
+        keyword_count = 0
+        paraphrase_count = 0
+
+        for seg_id, metric_ids in kw_seg_metrics.items():
+            segment = segment_by_id.get(seg_id)
+            if not segment or not segment.text or len(segment.text.strip()) < _MIN_SEGMENT_CHARS:
+                continue
+            # Only classify metrics that have a loaded prompt YAML.
+            scoreable = [m for m in metric_ids if m in client.config.prompts]
+            if not scoreable:
+                continue
+            try:
+                sec_type = segment.section_type.value if segment.section_type else None
+                for sc in client.classify_segment(segment.text, scoreable, section_type=sec_type):
+                    signals.append(
+                        LLMPresenceSignal(
+                            segment_id=seg_id,
+                            section_type=sec_type,
+                            metric_id=sc.metric_id,
+                            score=sc.score,
+                            present=sc.present,
+                            rationale=sc.rationale,
+                            model=sc.model,
+                            sonnet_fallback=sc.sonnet_fallback,
+                            prompt_version=sc.prompt_version,
+                            source="keyword",
+                        )
+                    )
+                keyword_count += 1
+            except Exception as exc:
+                logger.warning(
+                    "LLMPresenceClassifierStage: classify failed segment=%s metrics=%s: %s",
+                    seg_id,
+                    scoreable,
+                    exc,
+                )
+                errors.append(f"segment {seg_id}: {exc}")
+
+        # --- Paraphrase-recall path (Part E) ---
+        # Score whitelisted-section segments that had NO keyword hit, against
+        # the full enrolled-metric set. This is the source of recall lift.
+        if enrolled and section_whitelist:
+            enrolled_with_prompts = [m for m in sorted(enrolled) if m in client.config.prompts]
+            if enrolled_with_prompts:
+                for segment in context.segments:
+                    if segment.segment_id in kw_seg_metrics:
+                        continue  # Already scored in keyword path
+                    if not segment.section_type:
+                        continue
+                    if segment.section_type.value not in section_whitelist:
+                        continue
+                    if not segment.text or len(segment.text.strip()) < _MIN_SEGMENT_CHARS:
+                        continue
+                    try:
+                        sec_type = segment.section_type.value
+                        for sc in client.classify_segment(
+                            segment.text, enrolled_with_prompts, section_type=sec_type
+                        ):
+                            signals.append(
+                                LLMPresenceSignal(
+                                    segment_id=segment.segment_id,
+                                    section_type=sec_type,
+                                    metric_id=sc.metric_id,
+                                    score=sc.score,
+                                    present=sc.present,
+                                    rationale=sc.rationale,
+                                    model=sc.model,
+                                    sonnet_fallback=sc.sonnet_fallback,
+                                    prompt_version=sc.prompt_version,
+                                    source="paraphrase",
+                                )
+                            )
+                        paraphrase_count += 1
+                    except Exception as exc:
+                        logger.warning(
+                            "LLMPresenceClassifierStage: paraphrase classify failed segment=%s: %s",
+                            segment.segment_id,
+                            exc,
+                        )
+                        errors.append(f"paraphrase segment {segment.segment_id}: {exc}")
+
+        context.llm_presence_signals = signals  # type: ignore[assignment]
+
+        # Log disagreements: paraphrase-recall found a metric that keywords missed.
+        if signals:
+            _log_disagreements(signals, kw_seg_metrics, context.filing_id)
+
+        duration_ms = int((datetime.now(UTC) - start).total_seconds() * 1000)
+        logger.info(
+            "LLMPresenceClassifierStage: filing_id=%s keyword_segs=%d "
+            "paraphrase_segs=%d signals=%d errors=%d duration_ms=%d",
+            context.filing_id,
+            keyword_count,
+            paraphrase_count,
+            len(signals),
+            len(errors),
+            duration_ms,
+        )
+
+        return StageResult(
+            stage=PipelineStage.LLM_PRESENCE_CLASSIFIER,
+            success=True,
+            duration_ms=duration_ms,
+            items_processed=keyword_count + paraphrase_count,
+            items_output=len(signals),
+            errors=errors,
+            metadata={
+                "keyword_segments": keyword_count,
+                "paraphrase_segments": paraphrase_count,
+                "total_signals": len(signals),
+                "error_count": len(errors),
+            },
+        )
+
+
+def _log_disagreements(
+    signals: list[LLMPresenceSignal],
+    kw_seg_metrics: dict[str, set[str]],
+    filing_id: int,
+) -> None:
+    """Log (metric, segment) pairs where LLM found presence but keywords didn't."""
+    # Keyword-confirmed: (seg_id, metric_id) pairs where keyword fired.
+    kw_pairs: set[tuple[str, str]] = set()
+    for seg_id, metrics in kw_seg_metrics.items():
+        for m in metrics:
+            kw_pairs.add((seg_id, m))
+
+    llm_only = [
+        s
+        for s in signals
+        if s.present and s.source == "paraphrase" and (s.segment_id, s.metric_id) not in kw_pairs
+    ]
+    if llm_only:
+        by_metric: dict[str, int] = defaultdict(int)
+        for s in llm_only:
+            by_metric[s.metric_id] += 1
+        logger.info(
+            "LLMPresenceClassifierStage: filing_id=%s llm_only_present=%d by_metric=%s",
+            filing_id,
+            len(llm_only),
+            dict(sorted(by_metric.items())),
+        )

--- a/src/extraction_v2/stages/metric_presence.py
+++ b/src/extraction_v2/stages/metric_presence.py
@@ -30,6 +30,22 @@ Design invariants (must hold; downstream PRs depend on them):
 - ``advisory_value_count`` is the count of contributing facts (not unique
   values). Rough disclosure-depth signal for downstream UI.
 
+LLM presence-classifier integration (shadow mode, PR3b):
+
+- Reads ``context.llm_presence_signals`` (written by
+  ``LLMPresenceClassifierStage`` when ``presence_classifier_enabled`` is on).
+- For metrics already in the keyword-confirmed accumulator: signals are
+  attached as ``classifier_metadata`` only. ``score`` and ``detected_at_stage``
+  are unchanged — keyword path remains authoritative.
+- For metrics with at least one ``source="paraphrase"`` and ``present=True``
+  signal AND no facts/definitions: a new presence record is created with
+  ``detected_at_stage='llm_presence_classifier'``. This is the +5pt recall
+  lift mechanism, kept distinguishable so the keyword-only baseline can be
+  re-derived in SQL via ``WHERE detected_at_stage <> 'llm_presence_classifier'``.
+- Keyword-pass LLM signals on metrics with no facts/definitions are
+  discarded — they would create records that the keyword path itself
+  rejected.
+
 The stage never mutates ``context.facts`` / ``context.definitions`` — it
 only reads them and writes ``context.presences``.
 """
@@ -37,10 +53,11 @@ only reads them and writes ``context.presences``.
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from src.extraction_v2.models import MetricPresence
+from src.extraction_v2.models import LLMPresenceSignal, MetricPresence
 
 if TYPE_CHECKING:
     from src.extraction_v2.pipeline import PipelineContext, StageResult
@@ -104,6 +121,42 @@ class MetricPresenceStage:
             if definition.methodology_segment_id:
                 acc.segment_ids.add(definition.methodology_segment_id)
 
+        # Source 3 (shadow mode): LLM presence-classifier signals.
+        # Group by metric_id. Two cases:
+        #   (a) metric already has a keyword-confirmed accumulator entry
+        #       → attach signals; do NOT touch score / first_stage.
+        #   (b) metric has only paraphrase-positive signals (LLM found a
+        #       presence keywords missed) → create a new accumulator entry
+        #       with first_stage='llm_presence_classifier' so the record
+        #       is filterable from keyword-only baseline queries.
+        # Keyword-pass signals on metrics with no facts/definitions are
+        # discarded (no record created) — keyword path is authoritative for
+        # what the keyword pipeline produced.
+        llm_signals: list[LLMPresenceSignal] = list(
+            getattr(context, "llm_presence_signals", []) or []
+        )
+        llm_by_metric: dict[str, list[LLMPresenceSignal]] = defaultdict(list)
+        for sig in llm_signals:
+            llm_by_metric[sig.metric_id].append(sig)
+
+        paraphrase_only_count = 0
+        for metric_id, sigs in llm_by_metric.items():
+            existing = accumulator.get(metric_id)
+            if existing is not None:
+                existing.llm_signals.extend(sigs)
+                continue
+            paraphrase_present = [s for s in sigs if s.source == "paraphrase" and s.present]
+            if not paraphrase_present:
+                continue
+            acc = _Accumulator(first_stage=PipelineStage.LLM_PRESENCE_CLASSIFIER.value)
+            acc.score = max(s.score for s in paraphrase_present)
+            for s in paraphrase_present:
+                if s.segment_id:
+                    acc.segment_ids.add(s.segment_id)
+            acc.llm_signals.extend(sigs)
+            accumulator[metric_id] = acc
+            paraphrase_only_count += 1
+
         context.presences = [
             MetricPresence(
                 canonical_metric_id=metric_id,
@@ -112,16 +165,22 @@ class MetricPresenceStage:
                 evidence_segment_ids=sorted(acc.segment_ids),
                 advisory_value_count=acc.advisory_value_count,
                 advisory_fact_ids=list(acc.fact_ids),
+                classifier_metadata=_build_classifier_metadata(acc.llm_signals)
+                if acc.llm_signals
+                else None,
             )
             for metric_id, acc in sorted(accumulator.items())
         ]
 
         duration_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
         logger.info(
-            "MetricPresenceStage: doc_id=%s metrics_present=%s fact_contributors=%s",
+            "MetricPresenceStage: doc_id=%s metrics_present=%s fact_contributors=%s "
+            "paraphrase_only_presences=%d llm_signals=%d",
             context.filing_id,
             len(context.presences),
             sum(p.advisory_value_count for p in context.presences),
+            paraphrase_only_count,
+            len(llm_signals),
         )
 
         return StageResult(
@@ -136,6 +195,8 @@ class MetricPresenceStage:
                 "definition_only_presences": sum(
                     1 for p in context.presences if p.advisory_value_count == 0
                 ),
+                "paraphrase_only_presences": paraphrase_only_count,
+                "llm_signals_seen": len(llm_signals),
             },
         )
 
@@ -143,7 +204,14 @@ class MetricPresenceStage:
 class _Accumulator:
     """Mutable per-metric aggregator used only within ``MetricPresenceStage``."""
 
-    __slots__ = ("score", "first_stage", "segment_ids", "fact_ids", "advisory_value_count")
+    __slots__ = (
+        "score",
+        "first_stage",
+        "segment_ids",
+        "fact_ids",
+        "advisory_value_count",
+        "llm_signals",
+    )
 
     def __init__(self, first_stage: str) -> None:
         self.score: float = 0.0
@@ -151,3 +219,30 @@ class _Accumulator:
         self.segment_ids: set[str] = set()
         self.fact_ids: list[str] = []
         self.advisory_value_count: int = 0
+        self.llm_signals: list[LLMPresenceSignal] = []
+
+
+def _build_classifier_metadata(signals: list[LLMPresenceSignal]) -> dict:
+    """Serialize LLM signals for v2_text_metric_presence.classifier_metadata.
+
+    Output: ``{"signals": [<per-signal dict>, ...]}``. Per-signal dict carries
+    segment_id, source ("keyword"/"paraphrase"), score, present, model,
+    sonnet_fallback, prompt_version, rationale. ``rationale`` is truncated to
+    240 chars to keep JSONB row size bounded.
+    """
+    return {
+        "signals": [
+            {
+                "segment_id": s.segment_id,
+                "section_type": s.section_type,
+                "source": s.source,
+                "score": s.score,
+                "present": s.present,
+                "model": s.model,
+                "sonnet_fallback": s.sonnet_fallback,
+                "prompt_version": s.prompt_version,
+                "rationale": (s.rationale or "")[:240],
+            }
+            for s in signals
+        ],
+    }

--- a/tests/extraction_v2/test_llm_presence_classifier.py
+++ b/tests/extraction_v2/test_llm_presence_classifier.py
@@ -1,0 +1,508 @@
+"""Unit + small integration tests for LLMPresenceClassifierStage.
+
+The Anthropic SDK is mocked end-to-end via a fake ``PresenceClassifierClient``
+implementation — these tests never make a network call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.extraction_v2.models import (
+    LLMPresenceSignal,
+    MetricCandidate,
+    MetricPresence,
+    SectionType,
+    Segment,
+    SegmentType,
+    SourceLocator,
+    SourceType,
+)
+from src.extraction_v2.pipeline import (
+    PipelineConfig,
+    PipelineContext,
+    PipelineStage,
+)
+from src.extraction_v2.stages.llm_presence_classifier import LLMPresenceClassifierStage
+from src.extraction_v2.stages.metric_presence import MetricPresenceStage
+
+# ---------------------------------------------------------------------------
+# Fakes / fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRecallCfg:
+    enrolled_metrics: frozenset[str] = field(default_factory=frozenset)
+    section_whitelist: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass
+class _FakeClassifierConfig:
+    api_key: str | None = "test-key"
+    recall_augmentation: _FakeRecallCfg | None = None
+    prompts: dict[str, object] = field(default_factory=dict)
+
+
+class _FakeSegmentClassification:
+    """Mirrors src.llm.presence_classifier_client.SegmentClassification fields."""
+
+    def __init__(
+        self,
+        metric_id: str,
+        score: float,
+        present: bool,
+        rationale: str = "",
+        model: str = "claude-haiku-4-5-20251001",
+        sonnet_fallback: bool = False,
+        prompt_version: str = "0.1.0-template",
+    ) -> None:
+        self.metric_id = metric_id
+        self.score = score
+        self.present = present
+        self.rationale = rationale
+        self.model = model
+        self.sonnet_fallback = sonnet_fallback
+        self.prompt_version = prompt_version
+
+
+def _make_client(
+    *,
+    api_key: str | None = "test-key",
+    enrolled: frozenset[str] | None = None,
+    section_whitelist: frozenset[str] | None = None,
+    prompts: set[str] | None = None,
+    classify_fn=None,
+) -> MagicMock:
+    """Build a fake PresenceClassifierClient suitable for stage injection."""
+    config = _FakeClassifierConfig(
+        api_key=api_key,
+        recall_augmentation=_FakeRecallCfg(
+            enrolled_metrics=enrolled or frozenset(),
+            section_whitelist=section_whitelist or frozenset(),
+        ),
+        prompts={m: object() for m in (prompts or set())},
+    )
+    client = MagicMock()
+    client.config = config
+    client.classify_segment = (
+        MagicMock(side_effect=classify_fn) if classify_fn else MagicMock(return_value=[])
+    )
+    return client
+
+
+def _make_context(
+    *,
+    enable: bool = True,
+    segments: list[Segment] | None = None,
+    candidates: list[MetricCandidate] | None = None,
+) -> PipelineContext:
+    cfg = PipelineConfig(enable_llm_presence_classifier=enable)
+    ctx = PipelineContext(
+        html_path=Path("/dev/null"),
+        filing_id=42,
+        config=cfg,
+    )
+    if segments:
+        ctx.segments = list(segments)
+    if candidates:
+        ctx.candidates = list(candidates)
+    return ctx
+
+
+def _seg(text: str, *, section: SectionType = SectionType.MDA, sid: str | None = None) -> Segment:
+    return Segment(
+        segment_id=sid or f"seg-{abs(hash(text)) % 10_000}",
+        text=text,
+        segment_type=SegmentType.PARAGRAPH,
+        section_type=section,
+    )
+
+
+def _candidate(metric_id: str, segment: Segment) -> MetricCandidate:
+    return MetricCandidate(
+        metric_id=metric_id,
+        match_text=metric_id.replace("cm_", ""),
+        source_locator=SourceLocator(segment_id=segment.segment_id),
+        source_type=SourceType.TEXT,
+        section_type=segment.section_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage gating
+# ---------------------------------------------------------------------------
+
+
+def test_stage_is_noop_when_flag_disabled() -> None:
+    client = _make_client()
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(enable=False, segments=[_seg("Net revenue retention was 120%.")])
+
+    result = stage.process(ctx)
+
+    assert result.success is True
+    assert result.items_output == 0
+    assert ctx.llm_presence_signals == []
+    client.classify_segment.assert_not_called()
+
+
+def test_stage_is_noop_when_api_key_missing() -> None:
+    client = _make_client(api_key=None)
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(segments=[_seg("Net revenue retention was 120%.")])
+
+    result = stage.process(ctx)
+
+    assert result.success is True
+    assert "ANTHROPIC_API_KEY not set" in (result.warnings or [])
+    assert ctx.llm_presence_signals == []
+    client.classify_segment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Keyword path
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_path_scores_each_segment_with_its_keyword_metrics() -> None:
+    seg = _seg(
+        "Our net revenue retention rate was 120% for fiscal year 2024." * 2,
+        section=SectionType.MDA,
+        sid="seg-1",
+    )
+
+    def fake_classify(text, metric_ids, section_type=None):
+        return [
+            _FakeSegmentClassification(metric_id=m, score=0.9, present=True, rationale="r")
+            for m in metric_ids
+        ]
+
+    client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=fake_classify)
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg],
+        candidates=[_candidate("cm_net_revenue_retention", seg)],
+    )
+
+    result = stage.process(ctx)
+
+    assert result.success is True
+    assert len(ctx.llm_presence_signals) == 1
+    sig = ctx.llm_presence_signals[0]
+    assert sig.metric_id == "cm_net_revenue_retention"
+    assert sig.source == "keyword"
+    assert sig.segment_id == "seg-1"
+    assert sig.score == pytest.approx(0.9)
+    client.classify_segment.assert_called_once()
+
+
+def test_keyword_path_skips_metrics_without_loaded_prompts() -> None:
+    seg = _seg("X" * 80, section=SectionType.MDA, sid="seg-1")
+    client = _make_client(prompts={"cm_net_revenue_retention"})
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg],
+        candidates=[_candidate("cm_no_prompt_metric", seg)],
+    )
+
+    stage.process(ctx)
+
+    assert ctx.llm_presence_signals == []
+    client.classify_segment.assert_not_called()
+
+
+def test_keyword_path_skips_short_segments() -> None:
+    seg = _seg("short", section=SectionType.MDA, sid="seg-1")
+    client = _make_client(prompts={"cm_net_revenue_retention"})
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg],
+        candidates=[_candidate("cm_net_revenue_retention", seg)],
+    )
+
+    stage.process(ctx)
+
+    assert ctx.llm_presence_signals == []
+    client.classify_segment.assert_not_called()
+
+
+def test_keyword_path_continues_after_classify_error() -> None:
+    seg_ok = _seg("X" * 80, section=SectionType.MDA, sid="seg-ok")
+    seg_bad = _seg("Y" * 80, section=SectionType.MDA, sid="seg-bad")
+
+    def flaky(text, metric_ids, section_type=None):
+        if "Y" in text[:5]:
+            raise RuntimeError("rate limit")
+        return [_FakeSegmentClassification("cm_net_revenue_retention", 0.5, True)]
+
+    client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=flaky)
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg_ok, seg_bad],
+        candidates=[
+            _candidate("cm_net_revenue_retention", seg_ok),
+            _candidate("cm_net_revenue_retention", seg_bad),
+        ],
+    )
+
+    result = stage.process(ctx)
+
+    assert len(ctx.llm_presence_signals) == 1
+    assert result.errors  # one error logged
+    assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Paraphrase path (Part E)
+# ---------------------------------------------------------------------------
+
+
+def test_paraphrase_path_scans_whitelisted_sections_without_keyword_hits() -> None:
+    seg = _seg(
+        "We had strong customer retention this period." * 3,
+        section=SectionType.MDA,
+        sid="seg-mda",
+    )
+
+    def fake_classify(text, metric_ids, section_type=None):
+        return [_FakeSegmentClassification(m, 0.8, True) for m in metric_ids]
+
+    client = _make_client(
+        prompts={"cm_net_revenue_retention"},
+        enrolled=frozenset({"cm_net_revenue_retention"}),
+        section_whitelist=frozenset({"mda"}),
+        classify_fn=fake_classify,
+    )
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(segments=[seg])  # no candidates → pure paraphrase path
+
+    stage.process(ctx)
+
+    assert len(ctx.llm_presence_signals) == 1
+    sig = ctx.llm_presence_signals[0]
+    assert sig.source == "paraphrase"
+    assert sig.metric_id == "cm_net_revenue_retention"
+
+
+def test_paraphrase_path_skips_segments_outside_whitelist() -> None:
+    seg = _seg(
+        "Some boilerplate disclosure text..." * 3,
+        section=SectionType.UNKNOWN,
+        sid="seg-other",
+    )
+    client = _make_client(
+        prompts={"cm_net_revenue_retention"},
+        enrolled=frozenset({"cm_net_revenue_retention"}),
+        section_whitelist=frozenset({"mda", "business", "risk_factors"}),
+        classify_fn=lambda *a, **kw: [
+            _FakeSegmentClassification("cm_net_revenue_retention", 0.9, True)
+        ],
+    )
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(segments=[seg])
+
+    stage.process(ctx)
+
+    assert ctx.llm_presence_signals == []
+    client.classify_segment.assert_not_called()
+
+
+def test_paraphrase_path_skips_segments_already_in_keyword_pass() -> None:
+    seg = _seg("X" * 80, section=SectionType.MDA, sid="seg-shared")
+    call_log: list[tuple[str, ...]] = []
+
+    def fake_classify(text, metric_ids, section_type=None):
+        call_log.append(tuple(sorted(metric_ids)))
+        return [_FakeSegmentClassification(m, 0.7, True) for m in metric_ids]
+
+    client = _make_client(
+        prompts={"cm_net_revenue_retention", "cm_revenue_concentration"},
+        enrolled=frozenset({"cm_revenue_concentration"}),
+        section_whitelist=frozenset({"mda"}),
+        classify_fn=fake_classify,
+    )
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg],
+        candidates=[_candidate("cm_net_revenue_retention", seg)],
+    )
+
+    stage.process(ctx)
+
+    assert len(call_log) == 1  # only keyword pass; no paraphrase pass on same segment
+    assert all(s.source == "keyword" for s in ctx.llm_presence_signals)
+
+
+# ---------------------------------------------------------------------------
+# Integration with MetricPresenceStage (shadow mode)
+# ---------------------------------------------------------------------------
+
+
+def _run_metric_presence_with_signals(
+    *,
+    facts_metric: str | None,
+    signals: list[LLMPresenceSignal],
+) -> list[MetricPresence]:
+    cfg = PipelineConfig()
+    ctx = PipelineContext(html_path=Path("/dev/null"), filing_id=1, config=cfg)
+    if facts_metric:
+        from src.extraction_v2.models import MetricFact
+
+        fact = MetricFact(
+            fact_id="f1",
+            canonical_metric_id=facts_metric,
+            confidence=0.85,
+            source_locator=SourceLocator(segment_id="seg-1"),
+        )
+        ctx.facts = [fact]
+    ctx.llm_presence_signals = list(signals)  # type: ignore[assignment]
+    MetricPresenceStage().process(ctx)
+    return list(ctx.presences)
+
+
+def test_metric_presence_attaches_classifier_metadata_to_keyword_records() -> None:
+    sig = LLMPresenceSignal(
+        segment_id="seg-1",
+        section_type="mda",
+        metric_id="cm_net_revenue_retention",
+        score=0.9,
+        present=True,
+        rationale="found NRR",
+        model="haiku",
+        sonnet_fallback=False,
+        prompt_version="v1",
+        source="keyword",
+    )
+
+    out = _run_metric_presence_with_signals(
+        facts_metric="cm_net_revenue_retention",
+        signals=[sig],
+    )
+
+    assert len(out) == 1
+    rec = out[0]
+    assert rec.canonical_metric_id == "cm_net_revenue_retention"
+    assert rec.detected_at_stage == PipelineStage.FACT_CONSTRUCTION.value
+    assert rec.score == pytest.approx(0.85)  # fact confidence — UNCHANGED by LLM
+    assert rec.classifier_metadata is not None
+    assert len(rec.classifier_metadata["signals"]) == 1
+    assert rec.classifier_metadata["signals"][0]["source"] == "keyword"
+
+
+def test_metric_presence_creates_record_for_paraphrase_only_signal() -> None:
+    sig = LLMPresenceSignal(
+        segment_id="seg-2",
+        section_type="mda",
+        metric_id="cm_revenue_concentration",
+        score=0.78,
+        present=True,
+        rationale="paraphrase match",
+        model="haiku",
+        sonnet_fallback=False,
+        prompt_version="v1",
+        source="paraphrase",
+    )
+
+    out = _run_metric_presence_with_signals(facts_metric=None, signals=[sig])
+
+    assert len(out) == 1
+    rec = out[0]
+    assert rec.canonical_metric_id == "cm_revenue_concentration"
+    assert rec.detected_at_stage == PipelineStage.LLM_PRESENCE_CLASSIFIER.value
+    assert rec.score == pytest.approx(0.78)
+    assert rec.advisory_value_count == 0
+    assert rec.advisory_fact_ids == []
+    assert "seg-2" in rec.evidence_segment_ids
+    assert rec.classifier_metadata is not None
+    assert rec.classifier_metadata["signals"][0]["source"] == "paraphrase"
+
+
+def test_metric_presence_skips_paraphrase_negative_signals() -> None:
+    sig = LLMPresenceSignal(
+        segment_id="seg-2",
+        section_type="mda",
+        metric_id="cm_revenue_concentration",
+        score=0.20,
+        present=False,  # below threshold
+        rationale="not present",
+        model="haiku",
+        sonnet_fallback=False,
+        prompt_version="v1",
+        source="paraphrase",
+    )
+
+    out = _run_metric_presence_with_signals(facts_metric=None, signals=[sig])
+
+    assert out == []  # no record created from negative-only paraphrase signals
+
+
+def test_metric_presence_discards_keyword_signals_without_facts() -> None:
+    """LLM keyword-pass signals on metrics with no facts/definitions are discarded.
+    The keyword path itself produced no facts; LLM signals do not promote them."""
+    sig = LLMPresenceSignal(
+        segment_id="seg-3",
+        section_type="mda",
+        metric_id="cm_lifetime_value_per_customer",
+        score=0.95,
+        present=True,
+        rationale="strong",
+        model="haiku",
+        sonnet_fallback=False,
+        prompt_version="v1",
+        source="keyword",
+    )
+
+    out = _run_metric_presence_with_signals(facts_metric=None, signals=[sig])
+
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Small integration test: stage + MetricPresenceStage on a single MD&A segment
+# ---------------------------------------------------------------------------
+
+
+def test_integration_single_mda_segment_full_path() -> None:
+    """A single MD&A segment, no keyword candidates, paraphrase-recall finds NRR."""
+    seg = _seg(
+        "We measure customer health by tracking how much existing customers spend "
+        "year over year, including upsells and excluding churn." * 2,
+        section=SectionType.MDA,
+        sid="seg-mda-only",
+    )
+
+    def fake_classify(text, metric_ids, section_type=None):
+        # Paraphrase finds NRR present, gross retention absent.
+        out = []
+        for m in metric_ids:
+            if m == "cm_net_revenue_retention":
+                out.append(_FakeSegmentClassification(m, 0.82, True, "found"))
+            else:
+                out.append(_FakeSegmentClassification(m, 0.10, False, "miss"))
+        return out
+
+    client = _make_client(
+        prompts={"cm_net_revenue_retention", "cm_gross_revenue_retention"},
+        enrolled=frozenset({"cm_net_revenue_retention", "cm_gross_revenue_retention"}),
+        section_whitelist=frozenset({"mda"}),
+        classify_fn=fake_classify,
+    )
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(segments=[seg])
+
+    stage.process(ctx)
+    MetricPresenceStage().process(ctx)
+
+    presences_by_metric = {p.canonical_metric_id: p for p in ctx.presences}
+    assert "cm_net_revenue_retention" in presences_by_metric
+    assert "cm_gross_revenue_retention" not in presences_by_metric  # below threshold
+
+    nrr = presences_by_metric["cm_net_revenue_retention"]
+    assert nrr.detected_at_stage == PipelineStage.LLM_PRESENCE_CLASSIFIER.value
+    assert nrr.score == pytest.approx(0.82)
+    assert nrr.classifier_metadata is not None


### PR DESCRIPTION
PR3b = Parts D + E + F of the metric-id redesign per
docs/plans-temp/metric-id-redesign-plan.md, gated entirely behind the
default-off PRESENCE_CLASSIFIER_ENABLED env / presence_classifier_enabled
DB feature flag.

- New stage src/extraction_v2/stages/llm_presence_classifier.py wired
  after candidate_generation. Two scoring paths:
    * keyword: scores keyword-shortlisted segments against their matched
      metrics
    * paraphrase (Part E): scans whitelisted-section segments
      (mda/business/risk_factors) without requiring a keyword hit, scoring
      against the recall_augmentation enrolled set — the +5pt recall lift
      mechanism
- MetricPresenceStage consumes context.llm_presence_signals and:
    * attaches LLM output to existing keyword-confirmed records as
      classifier_metadata (score / detected_at_stage UNCHANGED)
    * creates new presence records from paraphrase-positive signals with
      detected_at_stage='llm_presence_classifier' so the keyword-only
      baseline remains derivable via SQL filter
    * discards keyword-pass LLM signals on metrics with no facts/defs
    * skips negative paraphrase signals
- _persist_presence_in_tx writes the classifier_metadata JSONB column
  added in PR #524's migration (insert + ON CONFLICT update).

Tier-1 zero-tolerance gate: stage is registered only when the flag is
on, so default behavior is no-op. Validator confirmed exit=0
"no regression" — see metric_presence stage at 0ms in per-stage timing.

14 new tests (SDK mocked end-to-end) cover keyword/paraphrase paths,
flag gating, error handling, and MetricPresenceStage shadow-mode
semantics. Full unit suite remains green (4,776 tests).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
