### PR TITLE
fix(stats): legacy-accepts banner — match 'relevant' vocabulary on legacy table

### DIFF
--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2440,8 +2440,10 @@ class DatabaseAdapter:
 
         Also returns ``legacy_accepts_pending``: count of distinct images
         accepted under the pre-per-metric flow (rows in
-        ``v2_image_review_decisions`` with decision='accept') that have
-        no rows in ``v2_image_metric_confirmations`` yet — i.e., the
+        ``v2_image_review_decisions`` with decision='relevant' — the
+        legacy table's CHECK constraint enforces 'relevant' / 'not_relevant',
+        not the new flow's 'accept' / 'reject' vocabulary) that have no
+        rows in ``v2_image_metric_confirmations`` yet — i.e., the
         reviewer's "relevant" intent never got a metric assigned. Powers
         the backfill banner and goes to zero once the legacy review set
         is migrated.
@@ -2460,7 +2462,7 @@ class DatabaseAdapter:
             legacy AS (
                 SELECT COUNT(DISTINCT ird.img_id) AS legacy_accepts_pending
                   FROM v2_image_review_decisions ird
-                 WHERE ird.decision = 'accept'
+                 WHERE ird.decision = 'relevant'
                    AND NOT EXISTS (
                        SELECT 1
                          FROM v2_image_metric_confirmations imc

--- a/tests/unit/infra/test_db_analytics.py
+++ b/tests/unit/infra/test_db_analytics.py
@@ -332,7 +332,7 @@ class TestGetImageDecisionBreakdownV2:
         db.get_image_decision_breakdown_v2()
         sql = db.query.call_args.args[0]
         assert "v2_image_review_decisions" in sql
-        assert "ird.decision = 'accept'" in sql
+        assert "ird.decision = 'relevant'" in sql
         # Anti-join: image must NOT have any per-metric confirmation row.
         assert "NOT EXISTS" in sql
         assert "v2_image_metric_confirmations imc" in sql


### PR DESCRIPTION
PR #528's get_image_decision_breakdown_v2 filtered v2_image_review_decisions
on decision='accept', but that table's CHECK constraint enforces
('relevant', 'not_relevant') — so the banner's count was structurally
forced to zero and never rendered. Switch the filter to 'relevant'.

Live diagnostic against prod after the fix: 48 legacy-relevant images
without per-metric confirmation rows. 4733 unit tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
