### PR TITLE
feat(stats): Accepted card → image-distinct relevance total (legacy ∪ per-metric)

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -129,9 +129,17 @@ Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summa
 
 ## Images tab — decision-type breakdown
 
-`/v2/review/stats` **Images tab** opens with five mutually-exclusive cards keyed on `v2_image_metric_confirmations.decision`: Accepted / Corrected / Added / Rejected / Skipped. The total decision count is shown as a small subtitle in the section header. Backed by `db.get_image_decision_breakdown_v2()`, which returns one dict per call (single roundtrip). The Summary-tab Image Confirmations card still uses `db.get_image_decision_overall_v2()` (Relevant / Not Relevant rollup) — the two helpers are independent on purpose so the simpler Summary view is decoupled from the per-decision breakdown.
+`/v2/review/stats` **Images tab** opens with five cards backed by `db.get_image_decision_breakdown_v2()` (single roundtrip). The Summary-tab Image Confirmations card uses the independent `db.get_image_decision_overall_v2()` (Relevant / Not Relevant rollup) — the two helpers stay decoupled so the simpler Summary view is unaffected by changes to the per-decision breakdown.
 
-A warning banner above the cards surfaces `legacy_accepts_pending` — distinct images with a `v2_image_review_decisions.decision='accept'` row but no rows in `v2_image_metric_confirmations` yet. These are pre-per-metric-pivot reviews where the reviewer marked the image relevant without naming a metric; the banner disappears when the count hits zero (i.e., the legacy backfill is complete). The same anti-join lives inside `get_image_decision_breakdown_v2`.
+The **Accepted** card is image-distinct and unions both review flows: `accepted_images` counts distinct images with any positive reviewer signal — `v2_image_review_decisions.decision='relevant'` (legacy flow) UNIONed with `v2_image_metric_confirmations.decision IN ('accept','correct','add')` (per-metric flow). A small sub-line on the same card shows `accepted_images_per_metric` — the per-metric subset, which should grow as the legacy backlog drains.
+
+The other four cards (Corrected / Added / Rejected / Skipped) are per-metric **decision counts** on `v2_image_metric_confirmations`. Mixed-unit by design: the Accepted total measures reviewer effort across both flows (the headline "what has the reviewer marked relevant"), while the other cards remain decision-type drill-downs useful for keyword-detector recall diagnostics (e.g. a tiny `accepted_images_per_metric` relative to `added` says the keyword rules are missing the right metric on most charts).
+
+The total decision count is shown as a small subtitle in the section header — that aligns with the four right-hand cards, not the Accepted total.
+
+Returned dict keys: `total`, `accepted_images`, `accepted_images_per_metric`, `corrected`, `added`, `rejected`, `skipped`, `legacy_accepts_pending`. The pre-PR-528 `accepted` field (per-metric `accept` decision count) is intentionally not returned — the Decisions-by-Detection-Tier section below conveys that signal at tier granularity.
+
+A warning banner above the cards surfaces `legacy_accepts_pending` — distinct images with a `v2_image_review_decisions.decision='relevant'` row but no rows in `v2_image_metric_confirmations` yet. These are pre-per-metric-pivot reviews where the reviewer marked the image relevant without naming a metric; the banner disappears when the count hits zero (i.e., the legacy backfill is complete). The legacy table's CHECK constraint enforces `'relevant'` / `'not_relevant'`, not the new flow's `'accept'` / `'reject'` vocabulary — getting the filter wrong (PR #528's original landing) zeros the count silently. The same anti-join lives inside `get_image_decision_breakdown_v2`.
 
 ## Review Activity panel
 

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2431,32 +2431,51 @@ class DatabaseAdapter:
         }
 
     def get_image_decision_breakdown_v2(self) -> dict:
-        """Per-decision-type breakdown of image-metric confirmations.
+        """Decision-type breakdown of image review activity.
 
-        Returns mutually-exclusive counts for each decision value the
-        per-metric flow records (accept / correct / add / reject / skip)
-        plus the lifetime total. Drives the five summary cards on the
-        Images tab of /v2/review/stats.
+        Drives the five summary cards on the Images tab of
+        ``/v2/review/stats``.
 
-        Also returns ``legacy_accepts_pending``: count of distinct images
-        accepted under the pre-per-metric flow (rows in
-        ``v2_image_review_decisions`` with decision='relevant' — the
-        legacy table's CHECK constraint enforces 'relevant' / 'not_relevant',
-        not the new flow's 'accept' / 'reject' vocabulary) that have no
-        rows in ``v2_image_metric_confirmations`` yet — i.e., the
-        reviewer's "relevant" intent never got a metric assigned. Powers
-        the backfill banner and goes to zero once the legacy review set
-        is migrated.
+        The Accepted card is **image-distinct** and unions both review
+        flows: ``accepted_images`` counts distinct images with any
+        positive reviewer signal — ``v2_image_review_decisions.decision='relevant'``
+        (legacy flow) UNIONed with
+        ``v2_image_metric_confirmations.decision IN ('accept','correct','add')``
+        (per-metric flow). ``accepted_images_per_metric`` is the
+        per-metric subset of that — distinct images with at least one
+        accept/correct/add row — surfaced as a sub-line on the same
+        card so reviewers can see the "modern pipeline" number grow as
+        the legacy backlog drains.
+
+        The other four cards are per-metric **decision counts** on
+        ``v2_image_metric_confirmations``: ``corrected``, ``added``,
+        ``rejected``, ``skipped``. Mixed-unit by design — the Accepted
+        total measures reviewer effort across both flows; the other
+        cards remain decision-type drill-downs useful for keyword-
+        detector recall diagnostics (e.g. a tiny ``accepted_images_per_metric``
+        relative to ``added`` says the keyword rules are missing the
+        right metric on most charts).
+
+        Also returns ``legacy_accepts_pending``: count of distinct
+        legacy ``'relevant'`` rows that have NO row in
+        ``v2_image_metric_confirmations`` at all — i.e., the reviewer
+        marked the image relevant but never assigned a specific metric.
+        Powers the backfill banner and goes to zero once the legacy
+        review set is migrated. Note the legacy table's CHECK
+        constraint enforces ``'relevant'`` / ``'not_relevant'``, not
+        the new flow's ``'accept'`` / ``'reject'`` vocabulary.
         """
         sql = """
             WITH breakdown AS (
                 SELECT
                     COUNT(*)                                            AS total,
-                    COUNT(*) FILTER (WHERE decision = 'accept')         AS accepted,
                     COUNT(*) FILTER (WHERE decision = 'correct')        AS corrected,
                     COUNT(*) FILTER (WHERE decision = 'add')            AS added,
                     COUNT(*) FILTER (WHERE decision = 'reject')         AS rejected,
-                    COUNT(*) FILTER (WHERE decision = 'skip')           AS skipped
+                    COUNT(*) FILTER (WHERE decision = 'skip')           AS skipped,
+                    COUNT(DISTINCT img_id) FILTER (
+                        WHERE decision IN ('accept', 'correct', 'add')
+                    )                                                    AS accepted_images_per_metric
                   FROM v2_image_metric_confirmations
             ),
             legacy AS (
@@ -2468,16 +2487,30 @@ class DatabaseAdapter:
                          FROM v2_image_metric_confirmations imc
                         WHERE imc.img_id = ird.img_id
                    )
+            ),
+            relevant_images AS (
+                SELECT COUNT(*) AS accepted_images FROM (
+                    SELECT img_id
+                      FROM v2_image_metric_confirmations
+                     WHERE decision IN ('accept', 'correct', 'add')
+                    UNION
+                    SELECT img_id
+                      FROM v2_image_review_decisions
+                     WHERE decision = 'relevant'
+                ) AS u
             )
-            SELECT b.total, b.accepted, b.corrected, b.added, b.rejected, b.skipped,
+            SELECT b.total, b.corrected, b.added, b.rejected, b.skipped,
+                   b.accepted_images_per_metric,
+                   r.accepted_images,
                    l.legacy_accepts_pending
-              FROM breakdown b CROSS JOIN legacy l
+              FROM breakdown b CROSS JOIN legacy l CROSS JOIN relevant_images r
         """
         rows = self.query(sql)
         if not rows:
             return {
                 "total": 0,
-                "accepted": 0,
+                "accepted_images": 0,
+                "accepted_images_per_metric": 0,
                 "corrected": 0,
                 "added": 0,
                 "rejected": 0,

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -901,7 +901,10 @@
         <div class="card border-success h-100">
           <div class="card-body p-3">
             <h6 class="card-subtitle mb-1 text-muted small">Accepted</h6>
-            <h3 class="mb-0 text-success">{{ breakdown.accepted or 0 }}</h3>
+            <h3 class="mb-0 text-success">{{ breakdown.accepted_images or 0 }}</h3>
+            <small class="d-block text-muted mt-1">
+              {{ breakdown.accepted_images_per_metric or 0 }} with specific metrics
+            </small>
           </div>
         </div>
       </div>

--- a/tests/unit/infra/test_db_analytics.py
+++ b/tests/unit/infra/test_db_analytics.py
@@ -318,7 +318,6 @@ class TestGetImageDecisionBreakdownV2:
         db.get_image_decision_breakdown_v2()
         sql = db.query.call_args.args[0]
         for clause in (
-            "FILTER (WHERE decision = 'accept')",
             "FILTER (WHERE decision = 'correct')",
             "FILTER (WHERE decision = 'add')",
             "FILTER (WHERE decision = 'reject')",
@@ -337,12 +336,35 @@ class TestGetImageDecisionBreakdownV2:
         assert "NOT EXISTS" in sql
         assert "v2_image_metric_confirmations imc" in sql
 
+    def test_accepted_images_unions_legacy_and_per_metric_sources(self, db):
+        """Accepted card is image-distinct across both review flows.
+
+        Asserts the SQL builds the union of (per-metric accept/correct/add)
+        and (legacy 'relevant') and exposes both the union total
+        (accepted_images) and the per-metric subset
+        (accepted_images_per_metric).
+        """
+        db.query.return_value = []
+        db.get_image_decision_breakdown_v2()
+        sql = db.query.call_args.args[0]
+        # Per-metric subset: distinct images with any positive per-metric row.
+        assert (
+            "COUNT(DISTINCT img_id) FILTER (\n                        WHERE decision IN ('accept', 'correct', 'add')\n                    )"
+            in sql
+        )
+        # Union of legacy 'relevant' and per-metric positive — drives the
+        # image-distinct headline.
+        assert "UNION" in sql
+        assert "accepted_images" in sql
+        assert "accepted_images_per_metric" in sql
+
     def test_returns_zeros_when_no_rows(self, db):
         db.query.return_value = []
         result = db.get_image_decision_breakdown_v2()
         assert result == {
             "total": 0,
-            "accepted": 0,
+            "accepted_images": 0,
+            "accepted_images_per_metric": 0,
             "corrected": 0,
             "added": 0,
             "rejected": 0,
@@ -354,22 +376,24 @@ class TestGetImageDecisionBreakdownV2:
         db.query.return_value = [
             {
                 "total": 100,
-                "accepted": 40,
+                "accepted_images": 79,
+                "accepted_images_per_metric": 31,
                 "corrected": 5,
                 "added": 25,
                 "rejected": 28,
                 "skipped": 2,
-                "legacy_accepts_pending": 137,
+                "legacy_accepts_pending": 48,
             }
         ]
         result = db.get_image_decision_breakdown_v2()
         assert result == {
             "total": 100,
-            "accepted": 40,
+            "accepted_images": 79,
+            "accepted_images_per_metric": 31,
             "corrected": 5,
             "added": 25,
             "rejected": 28,
             "skipped": 2,
-            "legacy_accepts_pending": 137,
+            "legacy_accepts_pending": 48,
         }
         assert all(isinstance(v, int) for v in result.values())

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -89,7 +89,8 @@ def _stub_analytics_helpers(mock_db) -> None:
     # hidden; tests that exercise the populated state override explicitly.
     mock_db.get_image_decision_breakdown_v2.return_value = {
         "total": 0,
-        "accepted": 0,
+        "accepted_images": 0,
+        "accepted_images_per_metric": 0,
         "corrected": 0,
         "added": 0,
         "rejected": 0,
@@ -973,7 +974,8 @@ def test_images_tab_renders_decision_breakdown_cards(client, mock_db):
     }
     mock_db.get_image_decision_breakdown_v2.return_value = {
         "total": 100,
-        "accepted": 40,
+        "accepted_images": 79,
+        "accepted_images_per_metric": 31,
         "corrected": 5,
         "added": 25,
         "rejected": 28,
@@ -1003,9 +1005,14 @@ def test_images_tab_renders_decision_breakdown_cards(client, mock_db):
     for label in ("Accepted", "Corrected", "Added", "Rejected", "Skipped"):
         assert f">{label}<" in body, f"missing card label: {label}"
 
-    # Each card's count renders. Use unique values so we can pin them.
-    for value in ("40", "25", "28"):
+    # Accepted card is image-distinct (79). The other three cards retain
+    # decision-level counts (5 corrected, 25 added, 28 rejected). Use unique
+    # values so we can pin them.
+    for value in ("79", "25", "28"):
         assert value in body
+
+    # Sub-line on the Accepted card surfaces the per-metric subset.
+    assert "31 with specific metrics" in body
 
     # Banner does NOT render when legacy_accepts_pending == 0.
     assert "awaiting per-metric backfill" not in body
@@ -1024,7 +1031,8 @@ def test_images_tab_renders_legacy_accepts_banner(client, mock_db):
     }
     mock_db.get_image_decision_breakdown_v2.return_value = {
         "total": 50,
-        "accepted": 20,
+        "accepted_images": 30,
+        "accepted_images_per_metric": 15,
         "corrected": 0,
         "added": 10,
         "rejected": 20,


### PR DESCRIPTION
The Images-tab "Accepted" card was counting v2_image_metric_confirmations rows
where decision='accept' — i.e. per-metric decisions where the keyword detector
proposed a metric AND the reviewer agreed. In prod that reads 3, while the
reviewer has actually marked 79 distinct images as relevant (48 legacy
'relevant'-only, 16 in both flows, 15 new-flow-only). The card systematically
undercounts reviewer effort because keyword rules rarely propose the right
metric on charts; reviewer-identified-relevant signals flow through 'add'
instead, plus 48 legacy 'relevant' decisions never got per-metric data.

Reframe the Accepted card as image-distinct, unioning both flows:
- accepted_images: COUNT(DISTINCT img_id) over legacy 'relevant' UNIONed with
  per-metric accept/correct/add (= 79 today)
- accepted_images_per_metric: per-metric subset, surfaced as a sub-line on the
  same card so reviewers see the "modern pipeline" number grow as the legacy
  backlog drains (= 31 today)

The other four cards (Corrected/Added/Rejected/Skipped) remain per-metric
decision counts — useful as keyword-detector recall diagnostics. The mixed-unit
visual is principled and called out in .claude/rules/web.md.

Drop the now-unused 'accepted' (decision count) field from the dict — the
Decisions-by-Detection-Tier section below conveys that signal at tier
granularity. 4734 unit tests pass; live SQL on prod confirms 79/31/48.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
