### PR TITLE
fix(llm): thread LLM token counts end-to-end (#531)

### DIFF
--- a/docs/known-issues/gh-531-llm-token-columns-always-zero.md
+++ b/docs/known-issues/gh-531-llm-token-columns-always-zero.md
@@ -11,6 +11,8 @@ touches: []
 discovered: 2026-05-06
 updated: 2026-05-07
 gh_issue: 531
+pr_refs:
+  - 535
 note: add token fields to StageResult.metadata in LLMPresenceClassifierStage and wire to AggregateMetrics
 ---
 

--- a/docs/known-issues/gh-531-llm-token-columns-always-zero.md
+++ b/docs/known-issues/gh-531-llm-token-columns-always-zero.md
@@ -3,13 +3,13 @@ id: 531
 source: gh
 slug: llm-token-columns-always-zero
 title: LLM classifier token columns always 0 in validator (token threading not implemented)
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches: []
 discovered: 2026-05-06
-updated: 2026-05-06
+updated: 2026-05-07
 gh_issue: 531
 note: add token fields to StageResult.metadata in LLMPresenceClassifierStage and wire to AggregateMetrics
 ---
@@ -22,8 +22,20 @@ show 0. `PresenceClassifierClient._call_api()` logs token usage via `logger.info
 only — no structured path threads them to `StageResult.metadata` or
 `LLMPresenceSignal`. The validator has no access to per-call token data.
 
-### Next Steps
+### Resolution
 
-- Add token fields to `StageResult.metadata` in `LLMPresenceClassifierStage` (sum across all `_call_api` calls)
-- Or add token fields to `LLMPresenceSignal` and aggregate in `MetricPresenceStage`
-- Wire the chosen source into `AggregateMetrics` in `compute_metrics`
+Threaded token counts end-to-end through five changes:
+
+1. `_call_model` now returns `(by_metric, token_counts)` — a tuple where
+   `token_counts = {input_tokens, output_tokens, cache_read, cache_create}`.
+2. `classify_segment` accumulates token dicts across the Haiku call and any Sonnet
+   fallback, and returns `(list[SegmentClassification], total_tokens)`.
+3. `LLMPresenceClassifierStage.process` unpacks the tuple in both loops and sums
+   tokens into four new `StageResult.metadata` keys: `total_input_tokens`,
+   `total_output_tokens`, `total_cache_read`, `total_cache_create`.
+4. `ValidationResult` gained a `stage_metadata: dict[str, dict[str, Any]]` field,
+   populated alongside `stage_timings` in `validate_filing`.
+5. `compute_metrics` sums the token fields from `stage_metadata["llm_presence_classifier"]`
+   across all filings and passes them into `AggregateMetrics`, computing
+   `llm_cache_hit_rate` and `llm_estimated_cost_usd` via a new public helper
+   `estimate_cost_usd_from_counts` in `presence_classifier_client.py`.

--- a/src/extraction_v2/stages/llm_presence_classifier.py
+++ b/src/extraction_v2/stages/llm_presence_classifier.py
@@ -126,6 +126,10 @@ class LLMPresenceClassifierStage:
         errors: list[str] = []
         keyword_count = 0
         paraphrase_count = 0
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cache_read = 0
+        total_cache_create = 0
 
         for seg_id, metric_ids in kw_seg_metrics.items():
             segment = segment_by_id.get(seg_id)
@@ -137,7 +141,10 @@ class LLMPresenceClassifierStage:
                 continue
             try:
                 sec_type = segment.section_type.value if segment.section_type else None
-                for sc in client.classify_segment(segment.text, scoreable, section_type=sec_type):
+                classifications, seg_tokens = client.classify_segment(
+                    segment.text, scoreable, section_type=sec_type
+                )
+                for sc in classifications:
                     signals.append(
                         LLMPresenceSignal(
                             segment_id=seg_id,
@@ -153,6 +160,10 @@ class LLMPresenceClassifierStage:
                         )
                     )
                 keyword_count += 1
+                total_input_tokens += seg_tokens.get("input_tokens", 0)
+                total_output_tokens += seg_tokens.get("output_tokens", 0)
+                total_cache_read += seg_tokens.get("cache_read", 0)
+                total_cache_create += seg_tokens.get("cache_create", 0)
             except Exception as exc:
                 logger.warning(
                     "LLMPresenceClassifierStage: classify failed segment=%s metrics=%s: %s",
@@ -179,9 +190,10 @@ class LLMPresenceClassifierStage:
                         continue
                     try:
                         sec_type = segment.section_type.value
-                        for sc in client.classify_segment(
+                        classifications, seg_tokens = client.classify_segment(
                             segment.text, enrolled_with_prompts, section_type=sec_type
-                        ):
+                        )
+                        for sc in classifications:
                             signals.append(
                                 LLMPresenceSignal(
                                     segment_id=segment.segment_id,
@@ -197,6 +209,10 @@ class LLMPresenceClassifierStage:
                                 )
                             )
                         paraphrase_count += 1
+                        total_input_tokens += seg_tokens.get("input_tokens", 0)
+                        total_output_tokens += seg_tokens.get("output_tokens", 0)
+                        total_cache_read += seg_tokens.get("cache_read", 0)
+                        total_cache_create += seg_tokens.get("cache_create", 0)
                     except Exception as exc:
                         logger.warning(
                             "LLMPresenceClassifierStage: paraphrase classify failed segment=%s: %s",
@@ -235,6 +251,10 @@ class LLMPresenceClassifierStage:
                 "paraphrase_segments": paraphrase_count,
                 "total_signals": len(signals),
                 "error_count": len(errors),
+                "total_input_tokens": total_input_tokens,
+                "total_output_tokens": total_output_tokens,
+                "total_cache_read": total_cache_read,
+                "total_cache_create": total_cache_create,
             },
         )
 

--- a/src/gold_standard/v2_validator.py
+++ b/src/gold_standard/v2_validator.py
@@ -45,6 +45,7 @@ from src.gold_standard.baseline import (
 from src.gold_standard.baseline import (
     ComparisonResult as BaselineComparisonResult,
 )
+from src.llm.presence_classifier_client import estimate_cost_usd_from_counts
 from src.shared.keyword_config import get_metric_tiers
 
 logger = logging.getLogger(__name__)
@@ -294,6 +295,11 @@ class ValidationResult:
     # Populated from v2_result.stage_results; empty if the pipeline failed.
     stage_timings: dict[str, int] = field(default_factory=dict)
     total_pipeline_ms: int = 0
+
+    # Per-stage metadata dicts (stage name → StageResult.metadata).
+    # Populated alongside stage_timings; used to thread LLM token counts to
+    # compute_metrics without adding per-metric fields to ValidationResult.
+    stage_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     # LLM classifier diagnostics (informational; populated when flag is on).
     # classifier_metadata_by_metric: metric_id → classifier_metadata dict from presences.
@@ -677,10 +683,11 @@ class V2GoldStandardValidator:
             all_v2_facts = v2_result.facts  # Includes low-confidence facts for FN tracing
             v2_context = v2_result.context  # type: ignore[assignment]
 
-            # Capture per-stage timings for Phase C observability.
+            # Capture per-stage timings and metadata for Phase C observability.
             result.stage_timings = {
                 sr.stage.value: sr.duration_ms for sr in v2_result.stage_results
             }
+            result.stage_metadata = {sr.stage.value: sr.metadata for sr in v2_result.stage_results}
             result.total_pipeline_ms = v2_result.total_duration_ms
 
             # Count chart facts and cross-source confirmation for Phase 3 gate.
@@ -1938,8 +1945,8 @@ class V2GoldStandardValidator:
         Run-level: total_input_tokens, total_output_tokens, cache_hit_rate, estimated_cost_usd.
 
         Skips the section when no classifier metadata was collected (flag off → no signals).
-        Run-level token columns always show 0 until a future PR threads token data from
-        PresenceClassifierClient through StageResult.metadata.
+        Run-level token columns are populated when ``enable_llm_presence_classifier``
+        is on; they show 0 when the flag is off or no API calls were made.
         """
         if not metrics.classifier_score_mean_by_metric:
             return
@@ -2130,6 +2137,23 @@ class V2GoldStandardValidator:
             if agreements
         }
 
+        # LLM token aggregation: sum token counts from stage metadata across all filings.
+        llm_stage_key = "llm_presence_classifier"
+        llm_total_input = sum(
+            r.stage_metadata.get(llm_stage_key, {}).get("total_input_tokens", 0) for r in results
+        )
+        llm_total_output = sum(
+            r.stage_metadata.get(llm_stage_key, {}).get("total_output_tokens", 0) for r in results
+        )
+        llm_total_cache_read = sum(
+            r.stage_metadata.get(llm_stage_key, {}).get("total_cache_read", 0) for r in results
+        )
+        llm_total_cache_create = sum(
+            r.stage_metadata.get(llm_stage_key, {}).get("total_cache_create", 0) for r in results
+        )
+        llm_cacheable = llm_total_cache_read + llm_total_cache_create + llm_total_input
+        llm_cache_hit_rate = llm_total_cache_read / llm_cacheable if llm_cacheable > 0 else 0.0
+
         return AggregateMetrics(
             precision=precision,
             recall=recall,
@@ -2156,6 +2180,15 @@ class V2GoldStandardValidator:
             classifier_score_mean_by_metric=classifier_score_mean_by_metric,
             classifier_score_p90_by_metric=classifier_score_p90_by_metric,
             classifier_agreement_by_metric=classifier_agreement_by_metric,
+            llm_total_input_tokens=llm_total_input,
+            llm_total_output_tokens=llm_total_output,
+            llm_cache_hit_rate=llm_cache_hit_rate,
+            llm_estimated_cost_usd=estimate_cost_usd_from_counts(
+                llm_total_input,
+                llm_total_output,
+                llm_total_cache_read,
+                llm_total_cache_create,
+            ),
         )
 
     def compute_metrics_at_threshold(

--- a/src/llm/presence_classifier_client.py
+++ b/src/llm/presence_classifier_client.py
@@ -371,6 +371,28 @@ def _estimate_cost_usd(usage: Any, model: str) -> float:
     ) / 1_000_000
 
 
+def estimate_cost_usd_from_counts(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read: int,
+    cache_create: int,
+    model: str = DEFAULT_HAIKU_MODEL,
+) -> float:
+    """Estimate cost from raw token counts rather than a Usage object.
+
+    Defaults to Haiku pricing — the dominant model in a corpus validation
+    run. For aggregate totals that mix Haiku + Sonnet calls the cost is an
+    underestimate; accurate for Haiku-only runs.
+    """
+    in_rate, out_rate = _PRICING_PER_MTOK.get(model, _DEFAULT_PRICING)
+    return (
+        input_tokens * in_rate
+        + cache_read * in_rate * _CACHE_READ_MULTIPLIER
+        + cache_create * in_rate * _CACHE_WRITE_MULTIPLIER
+        + output_tokens * out_rate
+    ) / 1_000_000
+
+
 def _extract_json_text(response: Any) -> str:
     """Pull the JSON-bearing text block out of an Anthropic Message response."""
     content = getattr(response, "content", None) or []
@@ -437,18 +459,20 @@ class PresenceClassifierClient:
         segment_text: str,
         metric_ids: list[str],
         section_type: str | None = None,  # noqa: ARG002 — caller-side filter
-    ) -> list[SegmentClassification]:
+    ) -> tuple[list[SegmentClassification], dict[str, int]]:
         """Score a segment against multiple metrics in a single batched call.
 
-        Returns one ``SegmentClassification`` per requested metric_id, in
-        the input order. Raises ``ValueError`` if any requested metric_id
-        has no prompt YAML loaded, or if the API response is missing a
-        metric we asked about. Raises whatever the Anthropic SDK raises
+        Returns ``(classifications, token_counts)`` where ``classifications``
+        has one ``SegmentClassification`` per requested metric_id (in input
+        order) and ``token_counts`` is the sum of tokens across the Haiku call
+        and any Sonnet fallback call.  Raises ``ValueError`` if any requested
+        metric_id has no prompt YAML loaded, or if the API response is missing
+        a metric we asked about.  Raises whatever the Anthropic SDK raises
         (rate limit, server errors) — callers wrap the call in their own
         retry policy.
         """
         if not metric_ids:
-            return []
+            return [], {}
         missing = [m for m in metric_ids if m not in self.config.prompts]
         if missing:
             raise ValueError(
@@ -457,7 +481,7 @@ class PresenceClassifierClient:
                 f"and re-load the config."
             )
 
-        haiku_scores = self._call_model(
+        haiku_scores, haiku_tokens = self._call_model(
             model=self.config.haiku_model,
             metric_ids=metric_ids,
             segment_text=segment_text,
@@ -474,8 +498,14 @@ class PresenceClassifierClient:
                 borderline.append(mid)
 
         sonnet_scores: dict[str, dict[str, Any]] = {}
+        sonnet_tokens: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read": 0,
+            "cache_create": 0,
+        }
         if borderline:
-            sonnet_scores = self._call_model(
+            sonnet_scores, sonnet_tokens = self._call_model(
                 model=self.config.sonnet_model,
                 metric_ids=borderline,
                 segment_text=segment_text,
@@ -504,7 +534,8 @@ class PresenceClassifierClient:
                     prompt_version=self.config.prompts[mid].prompt_version,
                 )
             )
-        return out
+        total_tokens = {k: haiku_tokens[k] + sonnet_tokens[k] for k in haiku_tokens}
+        return out, total_tokens
 
     # ----- internals -----
 
@@ -532,8 +563,8 @@ class PresenceClassifierClient:
         model: str,
         metric_ids: list[str],
         segment_text: str,
-    ) -> dict[str, dict[str, Any]]:
-        """Run one Anthropic call and return {metric_id: response_entry}.
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, int]]:
+        """Run one Anthropic call and return ({metric_id: response_entry}, token_counts).
 
         Validates that every requested metric appears in the response and
         logs token usage + cost + cache hit rate.
@@ -563,12 +594,24 @@ class PresenceClassifierClient:
         )
 
         # Telemetry — log even if parsing fails so we still see the cost.
+        token_counts: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read": 0,
+            "cache_create": 0,
+        }
         usage = getattr(response, "usage", None)
         if usage is not None:
             input_tokens = getattr(usage, "input_tokens", 0) or 0
             output_tokens = getattr(usage, "output_tokens", 0) or 0
             cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
             cache_create = getattr(usage, "cache_creation_input_tokens", 0) or 0
+            token_counts = {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read": cache_read,
+                "cache_create": cache_create,
+            }
             cacheable = cache_read + cache_create + input_tokens
             hit_rate = (cache_read / cacheable) if cacheable > 0 else 0.0
             logger.info(
@@ -605,4 +648,4 @@ class PresenceClassifierClient:
                 f"Classifier response missing metrics={missing_in_response} "
                 f"(model={model}); got={list(by_metric)}"
             )
-        return by_metric
+        return by_metric, token_counts

--- a/tests/extraction_v2/test_llm_presence_classifier.py
+++ b/tests/extraction_v2/test_llm_presence_classifier.py
@@ -90,7 +90,7 @@ def _make_client(
     client = MagicMock()
     client.config = config
     client.classify_segment = (
-        MagicMock(side_effect=classify_fn) if classify_fn else MagicMock(return_value=[])
+        MagicMock(side_effect=classify_fn) if classify_fn else MagicMock(return_value=([], {}))
     )
     return client
 
@@ -165,6 +165,63 @@ def test_stage_is_noop_when_api_key_missing() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Stage metadata — token fields
+# ---------------------------------------------------------------------------
+
+
+def test_stage_metadata_includes_token_fields_from_classify_calls() -> None:
+    """Token counts returned by classify_segment accumulate into StageResult.metadata."""
+    seg = _seg("X" * 80, section=SectionType.MDA, sid="seg-t")
+
+    def fake_classify(text, metric_ids, section_type=None):
+        return (
+            [_FakeSegmentClassification(metric_id=m, score=0.9, present=True) for m in metric_ids],
+            {"input_tokens": 150, "output_tokens": 40, "cache_read": 30, "cache_create": 10},
+        )
+
+    client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=fake_classify)
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg],
+        candidates=[_candidate("cm_net_revenue_retention", seg)],
+    )
+
+    result = stage.process(ctx)
+
+    assert result.metadata["total_input_tokens"] == 150
+    assert result.metadata["total_output_tokens"] == 40
+    assert result.metadata["total_cache_read"] == 30
+    assert result.metadata["total_cache_create"] == 10
+
+
+def test_stage_metadata_accumulates_across_multiple_segments() -> None:
+    """Tokens from multiple classify_segment calls are summed."""
+    seg1 = _seg("A" * 80, section=SectionType.MDA, sid="seg-1")
+    seg2 = _seg("B" * 80, section=SectionType.MDA, sid="seg-2")
+
+    def fake_classify(text, metric_ids, section_type=None):
+        return (
+            [_FakeSegmentClassification(metric_id=m, score=0.9, present=True) for m in metric_ids],
+            {"input_tokens": 100, "output_tokens": 20, "cache_read": 0, "cache_create": 0},
+        )
+
+    client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=fake_classify)
+    stage = LLMPresenceClassifierStage(client=client)
+    ctx = _make_context(
+        segments=[seg1, seg2],
+        candidates=[
+            _candidate("cm_net_revenue_retention", seg1),
+            _candidate("cm_net_revenue_retention", seg2),
+        ],
+    )
+
+    result = stage.process(ctx)
+
+    assert result.metadata["total_input_tokens"] == 200  # 2 × 100
+    assert result.metadata["total_output_tokens"] == 40  # 2 × 20
+
+
+# ---------------------------------------------------------------------------
 # Keyword path
 # ---------------------------------------------------------------------------
 
@@ -177,10 +234,13 @@ def test_keyword_path_scores_each_segment_with_its_keyword_metrics() -> None:
     )
 
     def fake_classify(text, metric_ids, section_type=None):
-        return [
-            _FakeSegmentClassification(metric_id=m, score=0.9, present=True, rationale="r")
-            for m in metric_ids
-        ]
+        return (
+            [
+                _FakeSegmentClassification(metric_id=m, score=0.9, present=True, rationale="r")
+                for m in metric_ids
+            ],
+            {},
+        )
 
     client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=fake_classify)
     stage = LLMPresenceClassifierStage(client=client)
@@ -238,7 +298,7 @@ def test_keyword_path_continues_after_classify_error() -> None:
     def flaky(text, metric_ids, section_type=None):
         if "Y" in text[:5]:
             raise RuntimeError("rate limit")
-        return [_FakeSegmentClassification("cm_net_revenue_retention", 0.5, True)]
+        return ([_FakeSegmentClassification("cm_net_revenue_retention", 0.5, True)], {})
 
     client = _make_client(prompts={"cm_net_revenue_retention"}, classify_fn=flaky)
     stage = LLMPresenceClassifierStage(client=client)
@@ -270,7 +330,7 @@ def test_paraphrase_path_scans_whitelisted_sections_without_keyword_hits() -> No
     )
 
     def fake_classify(text, metric_ids, section_type=None):
-        return [_FakeSegmentClassification(m, 0.8, True) for m in metric_ids]
+        return ([_FakeSegmentClassification(m, 0.8, True) for m in metric_ids], {})
 
     client = _make_client(
         prompts={"cm_net_revenue_retention"},
@@ -299,9 +359,10 @@ def test_paraphrase_path_skips_segments_outside_whitelist() -> None:
         prompts={"cm_net_revenue_retention"},
         enrolled=frozenset({"cm_net_revenue_retention"}),
         section_whitelist=frozenset({"mda", "business", "risk_factors"}),
-        classify_fn=lambda *a, **kw: [
-            _FakeSegmentClassification("cm_net_revenue_retention", 0.9, True)
-        ],
+        classify_fn=lambda *a, **kw: (
+            [_FakeSegmentClassification("cm_net_revenue_retention", 0.9, True)],
+            {},
+        ),
     )
     stage = LLMPresenceClassifierStage(client=client)
     ctx = _make_context(segments=[seg])
@@ -318,7 +379,7 @@ def test_paraphrase_path_skips_segments_already_in_keyword_pass() -> None:
 
     def fake_classify(text, metric_ids, section_type=None):
         call_log.append(tuple(sorted(metric_ids)))
-        return [_FakeSegmentClassification(m, 0.7, True) for m in metric_ids]
+        return ([_FakeSegmentClassification(m, 0.7, True) for m in metric_ids], {})
 
     client = _make_client(
         prompts={"cm_net_revenue_retention", "cm_revenue_concentration"},
@@ -484,7 +545,7 @@ def test_integration_single_mda_segment_full_path() -> None:
                 out.append(_FakeSegmentClassification(m, 0.82, True, "found"))
             else:
                 out.append(_FakeSegmentClassification(m, 0.10, False, "miss"))
-        return out
+        return out, {}
 
     client = _make_client(
         prompts={"cm_net_revenue_retention", "cm_gross_revenue_retention"},

--- a/tests/unit/llm/test_presence_classifier_client.py
+++ b/tests/unit/llm/test_presence_classifier_client.py
@@ -244,8 +244,63 @@ def _make_client(
 
 def test_classify_segment_empty_metric_ids_returns_empty(config_root: Path) -> None:
     client, fake = _make_client(config_root, responses=[])
-    assert client.classify_segment("some text", []) == []
+    classifications, tokens = client.classify_segment("some text", [])
+    assert classifications == []
+    assert tokens == {}
     assert fake.calls == []  # no API call
+
+
+def test_classify_segment_returns_token_counts_single_pass(config_root: Path) -> None:
+    """Haiku-only call returns token counts from the usage object."""
+    response = _fake_response(
+        [
+            {
+                "metric_id": "cm_net_revenue_retention",
+                "present": True,
+                "score": 0.9,
+                "rationale": "x",
+            }
+        ],
+        usage={"input_tokens": 200, "output_tokens": 30, "cache_read_input_tokens": 50},
+    )
+    client, _fake = _make_client(config_root, responses=[response])
+    _out, tokens = client.classify_segment("text", ["cm_net_revenue_retention"])
+    assert tokens["input_tokens"] == 200
+    assert tokens["output_tokens"] == 30
+    assert tokens["cache_read"] == 50
+    assert tokens["cache_create"] == 0
+
+
+def test_classify_segment_returns_token_counts_two_pass(config_root: Path) -> None:
+    """Haiku + Sonnet two-pass accumulates tokens from both calls."""
+    haiku = _fake_response(
+        [
+            {
+                "metric_id": "cm_net_revenue_retention",
+                "present": False,
+                "score": 0.55,  # inside [0.40, 0.70] band → Sonnet retry
+                "rationale": "borderline",
+            }
+        ],
+        usage={"input_tokens": 100, "output_tokens": 20},
+    )
+    sonnet = _fake_response(
+        [
+            {
+                "metric_id": "cm_net_revenue_retention",
+                "present": True,
+                "score": 0.80,
+                "rationale": "yes",
+            }
+        ],
+        usage={"input_tokens": 120, "output_tokens": 25, "cache_read_input_tokens": 80},
+    )
+    client, _fake = _make_client(config_root, responses=[haiku, sonnet])
+    _out, tokens = client.classify_segment("text", ["cm_net_revenue_retention"])
+    assert tokens["input_tokens"] == 100 + 120
+    assert tokens["output_tokens"] == 20 + 25
+    assert tokens["cache_read"] == 0 + 80
+    assert tokens["cache_create"] == 0
 
 
 def test_classify_segment_unknown_metric_raises(config_root: Path) -> None:
@@ -274,7 +329,7 @@ def test_classify_segment_happy_path_no_sonnet_fallback(config_root: Path) -> No
         ]
     )
     client, fake = _make_client(config_root, responses=[response])
-    out = client.classify_segment(
+    out, tokens = client.classify_segment(
         "Net Dollar Retention was 132%.",
         ["cm_net_revenue_retention", "cm_revenue_concentration"],
     )
@@ -319,7 +374,7 @@ def test_classify_segment_sonnet_fallback_replaces_borderline_only(config_root: 
         ]
     )
     client, fake = _make_client(config_root, responses=[haiku, sonnet])
-    out = client.classify_segment(
+    out, tokens = client.classify_segment(
         "ambiguous prose",
         ["cm_net_revenue_retention", "cm_revenue_concentration"],
     )
@@ -358,7 +413,7 @@ def test_classify_segment_present_uses_threshold(config_root: Path) -> None:
         ]
     )
     client, _fake = _make_client(config_root, responses=[haiku, sonnet])
-    out = client.classify_segment("text", ["cm_net_revenue_retention"])
+    out, _tokens = client.classify_segment("text", ["cm_net_revenue_retention"])
     assert out[0].score == 0.30
     assert out[0].present is False  # 0.30 < 0.62 threshold
 
@@ -376,7 +431,7 @@ def test_classify_segment_clamps_score_to_unit_interval(config_root: Path) -> No
         ]
     )
     client, _fake = _make_client(config_root, responses=[response])
-    out = client.classify_segment("text", ["cm_net_revenue_retention"])
+    out, _tokens = client.classify_segment("text", ["cm_net_revenue_retention"])
     assert out[0].score == 1.0
 
 
@@ -456,7 +511,7 @@ def test_classify_segment_returns_in_input_order(config_root: Path) -> None:
         ]
     )
     client, _fake = _make_client(config_root, responses=[response])
-    out = client.classify_segment(
+    out, _tokens = client.classify_segment(
         "text",
         ["cm_net_revenue_retention", "cm_revenue_concentration"],
     )


### PR DESCRIPTION
## Summary

- `_call_model` now returns `(by_metric, token_counts)` with input/output/cache_read/cache_create counts
- `classify_segment` accumulates tokens across Haiku and optional Sonnet fallback calls, returns `(classifications, total_tokens)`
- `LLMPresenceClassifierStage.process` unpacks tuples and writes 4 token fields to `StageResult.metadata`
- `ValidationResult` gains `stage_metadata: dict[str, dict[str, Any]]` populated in `validate_filing`
- `compute_metrics` sums token fields across all filings and passes them into `AggregateMetrics`, computing cache hit rate and estimated cost via new `estimate_cost_usd_from_counts()` helper

Closes #531

## Test plan

- [ ] `pytest tests/unit/llm/test_presence_classifier_client.py` — 2 new token tests: single-pass and two-pass accumulation
- [ ] `pytest tests/extraction_v2/test_llm_presence_classifier.py` — 2 new metadata tests: token fields present, accumulation across segments
- [ ] `pytest -x -q` — all 4796 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)