### PR TITLE
docs(known-issues): close gh-481 (PR #519 shipped) and legacy-053 (obsolete)

### DIFF
--- a/docs/known-issues/gh-481-route-enforcement-integration-test.md
+++ b/docs/known-issues/gh-481-route-enforcement-integration-test.md
@@ -3,18 +3,19 @@ id: 481
 source: gh
 slug: route-enforcement-integration-test
 title: "auth: add tests/integration/auth/test_route_enforcement.py (deferred from PR-C1)"
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: M
 touches:
   - tests/integration/auth/test_route_enforcement.py
 discovered: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-07
 gh_issue: 481
 pr_refs:
   - 479
-note: per-route-module integration suite for the flag-on enforcement contract; unit tests cover the decorator in isolation but not the wiring on every route
+  - 519
+note: Integration suite shipped in PR #519 (`315e68a8`, "test(auth): integration suite for @require flag-on enforcement (gh-481)"); `tests/integration/auth/test_route_enforcement.py` exists on main. Fragment was stale — pr_refs never updated past the deferral PR.
 ---
 
 ### Problem

--- a/docs/known-issues/legacy-053-chart-call-limit-10-truncates-ocr-on-high-chart-filings.md
+++ b/docs/known-issues/legacy-053-chart-call-limit-10-truncates-ocr-on-high-chart-filings.md
@@ -3,16 +3,16 @@ autonomy: skip
 discovered: '2026-04-21'
 estimated: M
 id: 53
-note: Count cap superseded by dollar budget in PR #131; residual concern is presence-coverage truncation on non-Tier-1 charts post-pivot
+note: Original count cap superseded by dollar budget in PR #131 (2026-04-22). Residual presence-truncation concern declared obsolete (2026-05-07) — non-Tier-1 chart presence signals are not load-bearing post-#86 pivot, and Tier-1 charts bypass the budget entirely. Closing without measurement.
 pr_refs:
   - 131
 severity: low
 slug: chart-call-limit-10-truncates-ocr-on-high-chart-filings
 source: legacy
-status: open
+status: resolved
 title: Chart OCR dollar budget may truncate non-Tier-1 presence signals on high-chart filings
 touches: []
-updated: '2026-04-28'
+updated: '2026-05-07'
 ---
 
 ### Original problem (2026-04-21)


### PR DESCRIPTION
- gh-481 → resolved. tests/integration/auth/test_route_enforcement.py
  shipped in PR #519 (315e68a8); fragment pr_refs only listed the
  deferral PR (#479), so the auto-closer never linked them.
- legacy-053 → resolved. Original count cap superseded by dollar
  budget in PR #131. Residual non-Tier-1 chart presence-truncation
  concern declared obsolete — non-Tier-1 chart presence signals are
  not load-bearing post-#86 pivot, and Tier-1 charts bypass the
  budget entirely.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
