### PR TITLE
feat(stats): Image Add Patterns panel on Patterns tab

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -129,6 +129,24 @@ The same `CATEGORY_ACTIONS` dict also drives the Reject-form dropdown in `unifie
 
 Rendered as Bootstrap progress-bar rows (no chart library). The future LLM-summarized "Top Reviewer Themes" panel (deferred) will read `reviewer_notes` — the two panels are complementary.
 
+## Image Add Patterns — Patterns panel
+
+`/v2/review/stats` **Patterns tab** renders a collapsible "Image Add Patterns" panel (below the Why-Reviewers-Reject panel, above the per-metric rollup). Gated on `{% if image_add_findings %}` — empty in dev/test where zero Add decisions exist; visible in prod where the substrate is non-empty.
+
+**Purpose**: surfaces the most common 2–4 word n-gram phrases from `v2_image_assets.nearby_text` for images where a reviewer chose `decision='add'`, grouped by `confirmed_metric_id`. These are labelled `(image, correct-metric-id)` signals where the keyword detector missed — the panel prompts the operator to add the top phrases to `config/metric_keywords.yaml` under the metric's `patterns` list.
+
+**Data flow** (render-time, no schema, no background script):
+
+1. `db.get_image_add_substrate()` — single SELECT joining `v2_image_metric_confirmations` (WHERE `decision='add'`) to `v2_image_assets`, filtering `nearby_text IS NOT NULL AND length(nearby_text) >= 20`. Returns `{confirmed_metric_id, img_id, filing_id, nearby_text}` per row.
+2. `src/web/image_pattern_recommendations.compute_image_add_findings(rows)` — pure function; no DB calls. Tokenizes `nearby_text`, strips stopwords + per-metric keyword tokens, counts n-grams per metric, applies `IMG_MIN_OCCURRENCES=2` and `IMG_MIN_PCT=10.0` thresholds, returns top 5 phrases per metric ranked by add_count DESC. Each finding dict includes `"min_occurrences": int` so the template can display the threshold without an extra context kwarg.
+3. `stats()` passes `image_add_findings` to `unified_stats.html`.
+
+**Tunables** (constants at top of `src/web/image_pattern_recommendations.py`): `IMG_MIN_OCCURRENCES`, `IMG_MIN_PCT`, `IMG_TOP_N_PER_METRIC`, `IMG_NGRAM_SIZES`, `IMG_MAX_SAMPLE_IMAGES`. Tighten `IMG_MIN_PCT` upward if findings contain boilerplate noise. No schema, migration, or test churn — a one-line change + server restart.
+
+**No persistence**: read-only panel. No Accept/Dismiss/Defer buttons; no `image_pattern_recommendation_decisions` table. The text-side recommendation-decisions plumbing is reusable later if volume warrants persisting per-recommendation state.
+
+**Sample-image links** drill through to `/v2/review/<filing_id>?img_id=<uuid>&tab=images` — the `review_filing` route reads both as query params.
+
 ## Images tab — decision-type breakdown
 
 `/v2/review/stats` **Images tab** opens with five cards backed by `db.get_image_decision_breakdown_v2()` (single roundtrip). The Summary-tab Image Confirmations card uses the independent `db.get_image_decision_overall_v2()` (Relevant / Not Relevant rollup) — the two helpers stay decoupled so the simpler Summary view is unaffected by changes to the per-decision breakdown.

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2982,6 +2982,30 @@ class DatabaseAdapter:
         rows = self.query(sql, {"limit": limit})
         return [dict(r) for r in rows]
 
+    def get_image_add_substrate(self) -> list[dict]:
+        """Per-Add row substrate for image-pattern mining.
+
+        Returns one row per decision='add' confirmation with nearby_text
+        populated (length >= 20 chars). Ordered by metric then created_at DESC
+        for stable sample-image selection. Used by
+        `src/web/image_pattern_recommendations.compute_image_add_findings`.
+        """
+        sql = """
+            SELECT
+                imc.confirmed_metric_id,
+                imc.img_id,
+                ia.filing_id,
+                ia.nearby_text
+              FROM v2_image_metric_confirmations imc
+              JOIN v2_image_assets ia ON ia.img_id = imc.img_id
+             WHERE imc.decision = 'add'
+               AND ia.nearby_text IS NOT NULL
+               AND length(ia.nearby_text) >= 20
+             ORDER BY imc.confirmed_metric_id, imc.created_at DESC
+        """
+        rows = self.query(sql)
+        return [dict(r) for r in rows]
+
     def get_recent_image_corrections(self, limit: int = 10) -> list[dict]:
         """Most recent image-metric corrections (decision='correct').
 

--- a/src/web/image_pattern_recommendations.py
+++ b/src/web/image_pattern_recommendations.py
@@ -1,0 +1,169 @@
+"""Mine image Add-decision nearby_text for keyword-detector recall gaps.
+
+Stateless render-time helper called from `review_unified.stats()`. Takes
+the list of rows returned by `db.get_image_add_substrate()` and returns
+per-metric n-gram findings that point the operator at phrases to add to
+`config/metric_keywords.yaml`.
+
+Mirrors the structure of `src/web/text_pattern_recommendations.py` so a
+maintainer working on both surfaces sees parallel code. Constants use the
+`IMG_` prefix to avoid confusion with the text-side constants.
+
+Pure function — no DB calls. Unit-testable without mocks.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter, defaultdict
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# --- Constants ---------------------------------------------------------------
+# Tighten IMG_MIN_PCT upward if findings contain boilerplate noise.
+
+IMG_MIN_OCCURRENCES: int = 2
+IMG_MIN_PCT: float = 10.0
+IMG_TOP_N_PER_METRIC: int = 5
+IMG_NGRAM_SIZES: tuple[int, ...] = (2, 3, 4)
+IMG_MAX_SAMPLE_IMAGES: int = 3
+
+# Copied from scripts/analyze_text_decision_patterns.py — scripts/ is not on
+# the src import path so the list is duplicated here rather than imported.
+_IMG_STOPWORDS: frozenset[str] = frozenset(
+    """
+    a an and any as at be been being but by can could did do does each
+    either few for from had has have having he her here him his how i if
+    in into is it its just may me might more most must my no nor not now
+    of off on only or our out over per s shall she should so some such
+    t than that the their them then there these they this those through
+    to too under until up upon us used we were what when where whether
+    which while who whom why will with within without would you your
+    company customer customers data financial fiscal include including
+    information measure metric metrics period periods quarter quarters
+    revenue revenues number percent total
+    """.split()
+)
+
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9_]+")
+
+
+def _tokenize(text: str | None, extra_stopwords: set[str] | None = None) -> list[str]:
+    if not text:
+        return []
+    tokens = _TOKEN_RE.findall(text.lower())
+    blocked = _IMG_STOPWORDS | (extra_stopwords or set())
+    return [t for t in tokens if len(t) >= 3 and t not in blocked]
+
+
+def _ngrams(tokens: list[str], n: int) -> list[str]:
+    if len(tokens) < n:
+        return []
+    return [" ".join(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+
+
+def _load_metric_keyword_tokens() -> dict[str, set[str]]:
+    """Per-metric token blocklist derived from config/metric_keywords.yaml."""
+    try:
+        from src.shared.keyword_config import get_metric_keywords
+
+        keywords = get_metric_keywords()
+    except Exception:  # noqa: BLE001
+        return {}
+
+    out: dict[str, set[str]] = {}
+    for metric_id, patterns in keywords.items():
+        toks: set[str] = set()
+        for pat in patterns or []:
+            for t in _TOKEN_RE.findall((pat or "").lower()):
+                if len(t) >= 3:
+                    toks.add(t)
+        out[metric_id] = toks
+    return out
+
+
+def compute_image_add_findings(
+    rows: list[dict[str, Any]],
+    *,
+    min_occurrences: int = IMG_MIN_OCCURRENCES,
+    min_pct: float = IMG_MIN_PCT,
+    top_n_per_metric: int = IMG_TOP_N_PER_METRIC,
+    ngram_sizes: tuple[int, ...] = IMG_NGRAM_SIZES,
+) -> list[dict[str, Any]]:
+    """Mine nearby_text n-grams per metric for Add decisions.
+
+    Returns one dict per metric ranked by add_count DESC::
+
+        {
+            "metric_id": str,
+            "add_count": int,
+            "image_count": int,
+            "min_occurrences": int,
+            "top_phrases": [
+                {"phrase": str, "count": int, "pct_of_adds": float}, ...
+            ],
+            "sample_images": [{"img_id": str, "filing_id": int}, ...],
+        }
+
+    Empty input returns []. Rows without nearby_text contribute to
+    add_count / image_count / sample_images but not to phrase mining.
+    """
+    if not rows:
+        return []
+
+    metric_keyword_tokens = _load_metric_keyword_tokens()
+
+    # Group by metric.
+    by_metric: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_metric[row["confirmed_metric_id"]].append(row)
+
+    findings: list[dict[str, Any]] = []
+
+    for metric_id, metric_rows in by_metric.items():
+        add_count = len(metric_rows)
+        image_count = len({r["img_id"] for r in metric_rows})
+
+        # Collect sample images (distinct img_id, stable order via first seen).
+        seen_imgs: set[str] = set()
+        sample_images: list[dict[str, Any]] = []
+        for r in metric_rows:
+            img_id = r["img_id"]
+            if img_id not in seen_imgs:
+                seen_imgs.add(img_id)
+                sample_images.append({"img_id": img_id, "filing_id": r["filing_id"]})
+            if len(sample_images) >= IMG_MAX_SAMPLE_IMAGES:
+                break
+
+        # Mine n-grams from nearby_text.
+        extra_stop = metric_keyword_tokens.get(metric_id, set())
+        phrase_counter: Counter[str] = Counter()
+        for r in metric_rows:
+            tokens = _tokenize(r.get("nearby_text"), extra_stop)
+            for n in ngram_sizes:
+                phrase_counter.update(_ngrams(tokens, n))
+
+        top_phrases: list[dict[str, Any]] = []
+        for phrase, count in phrase_counter.most_common():
+            pct = 100.0 * count / add_count
+            if count < min_occurrences or pct < min_pct:
+                continue
+            top_phrases.append({"phrase": phrase, "count": count, "pct_of_adds": pct})
+            if len(top_phrases) >= top_n_per_metric:
+                break
+
+        findings.append(
+            {
+                "metric_id": metric_id,
+                "add_count": add_count,
+                "image_count": image_count,
+                "min_occurrences": min_occurrences,
+                "top_phrases": top_phrases,
+                "sample_images": sample_images,
+            }
+        )
+
+    findings.sort(key=lambda f: f["add_count"], reverse=True)
+    return findings

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -298,12 +298,16 @@ def stats():
         text_metric_summary = []
         text_phrase_findings = []
 
+    from src.web.image_pattern_recommendations import compute_image_add_findings
     from src.web.text_decision_category_actions import compute_category_rollup
     from src.web.text_pattern_recommendations import (
         compute_cross_metric_findings,
         compute_recommendations,
         interpret_finding_row,
     )
+
+    image_add_substrate = db.get_image_add_substrate()
+    image_add_findings = compute_image_add_findings(image_add_substrate)
 
     text_recommendation_decisions = db.get_recommendation_decisions(
         [s["metric_id"] for s in text_metric_summary] or None
@@ -381,6 +385,7 @@ def stats():
         cross_metric_findings=cross_metric_findings,
         covered_phrases=covered_phrases,
         interpretations=interpretations,
+        image_add_findings=image_add_findings,
     )
 
 

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1107,6 +1107,71 @@
      ===================================================================== #}
   <div class="tab-pane fade" id="patterns-stats" role="tabpanel" aria-labelledby="patterns-tab">
 
+    {# Image Add Patterns panel — render-time n-gram mining over nearby_text
+       for Add decisions. Independent of the text analysis run — visible
+       whenever there are Add decisions, regardless of whether text analysis
+       has been run. Gated on non-empty findings so dev/test environments
+       (zero Add rows) skip the panel entirely. #}
+    {% if image_add_findings %}
+    <div class="row mb-3">
+      <div class="col-12">
+        <details class="card">
+          <summary class="card-header bg-info-subtle" style="cursor:pointer;">
+            <strong>Image Add Patterns</strong> — phrases reviewers see when
+            adding metrics the keyword rules missed.
+            <span class="badge bg-secondary ms-1">{{ image_add_findings|length }} metric{{ '' if image_add_findings|length == 1 else 's' }}</span>
+          </summary>
+          <div class="card-body">
+            <p class="text-muted small mb-3">
+              Reviewer added a metric to an image that the keyword rules didn't
+              detect. The phrases below are common 2–4 word patterns from the
+              text surrounding those images. Consider adding them to
+              <code>config/metric_keywords.yaml</code> under the metric's
+              <code>patterns</code> list to close the recall gap.
+            </p>
+            {% for f in image_add_findings %}
+            <div class="border-top py-2">
+              <div class="d-flex justify-content-between align-items-baseline">
+                <code>{{ f.metric_id }}</code>
+                <span class="text-muted small">
+                  {{ f.add_count }} add{{ '' if f.add_count == 1 else 's' }} across {{ f.image_count }} image{{ '' if f.image_count == 1 else 's' }}
+                </span>
+              </div>
+              {% if f.top_phrases %}
+              <ul class="list-unstyled mb-1 mt-1 small">
+                {% for p in f.top_phrases %}
+                <li>
+                  <code>{{ p.phrase }}</code>
+                  <span class="text-muted">— {{ p.count }} ({{ p.pct_of_adds|round(0)|int }}%)</span>
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <p class="text-muted small mb-0">
+                No multi-word phrases above threshold ({{ f.min_occurrences }} occurrences).
+                Inspect sample images directly.
+              </p>
+              {% endif %}
+              <details>
+                <summary class="small text-muted" style="cursor:pointer;">Sample images ({{ f.sample_images|length }})</summary>
+                <ul class="small mt-1">
+                  {% for s in f.sample_images %}
+                  <li>
+                    <a href="{{ url_for('review_unified.review_filing', filing_id=s.filing_id, img_id=s.img_id, tab='images') }}">
+                      filing {{ s.filing_id }} / img {{ s.img_id[:8] }}
+                    </a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </details>
+            </div>
+            {% endfor %}
+          </div>
+        </details>
+      </div>
+    </div>
+    {% endif %}
+
     {% if not last_text_analysis_run %}
     <div class="row">
       <div class="col-12">

--- a/tests/unit/infra/test_db_image_patterns.py
+++ b/tests/unit/infra/test_db_image_patterns.py
@@ -1,0 +1,67 @@
+"""Unit tests for DatabaseAdapter.get_image_add_substrate.
+
+SQL-shape tests only — verifies that the query filters decision='add',
+joins v2_image_assets, and applies the nearby_text length floor. We mock
+`DatabaseAdapter.query` and inspect the SQL string passed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.infra.db import DatabaseAdapter
+
+
+def _make_db() -> DatabaseAdapter:
+    adapter = DatabaseAdapter.__new__(DatabaseAdapter)
+    adapter.query = MagicMock(return_value=[])  # type: ignore[method-assign]
+    return adapter
+
+
+class TestGetImageAddSubstrate:
+    def test_filters_decision_add(self):
+        db = _make_db()
+        db.get_image_add_substrate()
+        sql: str = db.query.call_args[0][0]
+        assert "decision = 'add'" in sql
+
+    def test_joins_v2_image_assets(self):
+        db = _make_db()
+        db.get_image_add_substrate()
+        sql: str = db.query.call_args[0][0]
+        assert "v2_image_assets" in sql
+
+    def test_applies_nearby_text_length_floor(self):
+        db = _make_db()
+        db.get_image_add_substrate()
+        sql: str = db.query.call_args[0][0]
+        assert "nearby_text" in sql
+        assert "length" in sql.lower()
+
+    def test_selects_required_columns(self):
+        db = _make_db()
+        db.get_image_add_substrate()
+        sql: str = db.query.call_args[0][0]
+        assert "confirmed_metric_id" in sql
+        assert "img_id" in sql
+        assert "filing_id" in sql
+
+    def test_returns_list_of_dicts(self):
+        db = _make_db()
+        db.query.return_value = [
+            {
+                "confirmed_metric_id": "cm_x",
+                "img_id": "uuid-1",
+                "filing_id": 42,
+                "nearby_text": "purchase transactions volume",
+            }
+        ]
+        result = db.get_image_add_substrate()
+        assert isinstance(result, list)
+        assert result[0]["confirmed_metric_id"] == "cm_x"
+        assert result[0]["filing_id"] == 42
+
+    def test_empty_rows_returns_empty_list(self):
+        db = _make_db()
+        db.query.return_value = []
+        assert db.get_image_add_substrate() == []

--- a/tests/unit/web/test_image_pattern_recommendations.py
+++ b/tests/unit/web/test_image_pattern_recommendations.py
@@ -1,0 +1,179 @@
+"""Unit tests for src/web/image_pattern_recommendations.py.
+
+All tests are pure Python — no DB or Flask context needed.
+"""
+
+from __future__ import annotations
+
+from src.web.image_pattern_recommendations import compute_image_add_findings
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    metric_id: str,
+    img_id: str,
+    filing_id: int,
+    nearby_text: str | None = "purchase transactions volume quarterly growth",
+) -> dict:
+    return {
+        "confirmed_metric_id": metric_id,
+        "img_id": img_id,
+        "filing_id": filing_id,
+        "nearby_text": nearby_text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Empty-input contract
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_list():
+    assert compute_image_add_findings([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Single-metric basic structure
+# ---------------------------------------------------------------------------
+
+
+def test_single_metric_returns_one_finding():
+    rows = [
+        _row("cm_active_customers_total", "img-1", 1, "active customers monthly growth"),
+        _row("cm_active_customers_total", "img-2", 2, "active customers monthly growth"),
+    ]
+    findings = compute_image_add_findings(rows)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f["metric_id"] == "cm_active_customers_total"
+    assert f["add_count"] == 2
+    assert f["image_count"] == 2
+
+
+def test_finding_contains_min_occurrences():
+    rows = [_row("cm_x", "img-1", 1), _row("cm_x", "img-2", 2)]
+    findings = compute_image_add_findings(rows)
+    assert findings[0]["min_occurrences"] == 2  # default constant echoed
+
+
+def test_add_count_counts_rows_not_distinct_images():
+    """Same img_id appearing twice (two different reviewers) → add_count 2."""
+    rows = [
+        _row("cm_x", "img-1", 1),
+        _row("cm_x", "img-1", 1),  # duplicate img_id
+    ]
+    findings = compute_image_add_findings(rows)
+    assert findings[0]["add_count"] == 2
+    assert findings[0]["image_count"] == 1  # one distinct image
+
+
+# ---------------------------------------------------------------------------
+# N-gram threshold
+# ---------------------------------------------------------------------------
+
+
+def test_phrase_below_min_occurrences_excluded():
+    """A phrase appearing only once (below min_occurrences=2) is excluded."""
+    rows = [
+        _row("cm_x", "img-1", 1, "unique phrase only here"),
+        _row("cm_x", "img-2", 2, "completely different text about orders"),
+    ]
+    findings = compute_image_add_findings(rows, min_occurrences=2)
+    # "unique phrase" appears in 1 row → excluded
+    phrases = [p["phrase"] for p in findings[0]["top_phrases"]]
+    assert "unique phrase" not in phrases
+
+
+def test_phrase_meeting_threshold_included():
+    """A bigram appearing in all rows (100%) is included."""
+    rows = [
+        _row("cm_x", "img-1", 1, "purchase transactions quarterly"),
+        _row("cm_x", "img-2", 2, "purchase transactions quarterly"),
+        _row("cm_x", "img-3", 3, "purchase transactions quarterly"),
+    ]
+    findings = compute_image_add_findings(rows)
+    phrases = [p["phrase"] for p in findings[0]["top_phrases"]]
+    assert "purchase transactions" in phrases
+
+
+def test_pct_threshold_filters_rare_phrases():
+    """A phrase appearing in 1/10 rows (10%) is at the edge; below 10% excluded."""
+    rows = [_row("cm_x", f"img-{i}", i, "purchase transactions growth") for i in range(10)]
+    # Replace one row's text so "purchase transactions" still appears in 9/10 (90%)
+    # but introduce a phrase appearing in only 1 row → below 10% threshold on min_pct>10
+    rows[9] = _row("cm_x", "img-9", 9, "rare phrase zebra")
+    findings = compute_image_add_findings(rows, min_pct=15.0)
+    phrases = [p["phrase"] for p in findings[0]["top_phrases"]]
+    assert "rare phrase" not in phrases
+
+
+# ---------------------------------------------------------------------------
+# Stopword suppression
+# ---------------------------------------------------------------------------
+
+
+def test_stopwords_suppressed():
+    """Common stopwords don't appear as phrase tokens."""
+    rows = [
+        _row("cm_x", "img-1", 1, "for the period ended quarterly revenue"),
+        _row("cm_x", "img-2", 2, "for the period ended quarterly revenue"),
+    ]
+    findings = compute_image_add_findings(rows)
+    all_phrase_text = " ".join(p["phrase"] for p in findings[0]["top_phrases"])
+    # "for", "the" are stopwords — should not appear as tokens
+    assert " for " not in f" {all_phrase_text} "
+    assert " the " not in f" {all_phrase_text} "
+
+
+# ---------------------------------------------------------------------------
+# Sample-image cap
+# ---------------------------------------------------------------------------
+
+
+def test_sample_images_capped():
+    """sample_images is capped at IMG_MAX_SAMPLE_IMAGES (default 3)."""
+    rows = [_row("cm_x", f"img-{i}", i) for i in range(10)]
+    findings = compute_image_add_findings(rows)
+    assert len(findings[0]["sample_images"]) <= 3
+
+
+def test_sample_images_distinct_img_ids():
+    """sample_images contains distinct img_ids."""
+    rows = [_row("cm_x", "img-1", 1)] * 5  # same img_id repeated
+    findings = compute_image_add_findings(rows)
+    img_ids = [s["img_id"] for s in findings[0]["sample_images"]]
+    assert len(img_ids) == len(set(img_ids))
+
+
+# ---------------------------------------------------------------------------
+# Multi-metric ordering
+# ---------------------------------------------------------------------------
+
+
+def test_findings_sorted_by_add_count_desc():
+    """Metrics with more adds appear first."""
+    rows = [_row("cm_low", f"img-low-{i}", i) for i in range(2)] + [
+        _row("cm_high", f"img-high-{i}", i) for i in range(5)
+    ]
+    findings = compute_image_add_findings(rows)
+    assert findings[0]["metric_id"] == "cm_high"
+    assert findings[1]["metric_id"] == "cm_low"
+
+
+# ---------------------------------------------------------------------------
+# Rows without nearby_text
+# ---------------------------------------------------------------------------
+
+
+def test_rows_without_nearby_text_contribute_to_count_not_phrases():
+    """Rows with None nearby_text count toward add_count but not phrase mining."""
+    rows = [
+        _row("cm_x", "img-1", 1, None),
+        _row("cm_x", "img-2", 2, None),
+    ]
+    findings = compute_image_add_findings(rows)
+    assert findings[0]["add_count"] == 2
+    assert findings[0]["top_phrases"] == []

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -1164,7 +1164,8 @@ def test_legacy_accepts_banner_count_is_linked_to_backfill_queue(client, mock_db
         "reviewed_count": 48,
         "skipped_count": 0,
         "auto_rejected_count": 0,
-        "review_pct": 100.0,    }
+        "review_pct": 100.0,
+    }
     mock_db.get_image_decisions_by_tier_v2.return_value = []
     mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
 
@@ -1182,6 +1183,8 @@ def test_legacy_accepts_banner_count_is_linked_to_backfill_queue(client, mock_db
     assert re.search(r"<a[^>]+legacy-backfill[^>]*>[^<]*<strong>48</strong>", body), (
         "48 must be wrapped in <strong> inside the legacy-backfill anchor"
     )
+
+
 def test_patterns_tab_image_add_panel_renders(client, mock_db):
     """Image Add Patterns panel renders when substrate rows produce findings.
 
@@ -1248,4 +1251,3 @@ def test_patterns_tab_image_add_panel_renders(client, mock_db):
     assert "quarterly growth" in body
     # Sample image link resolves to the review page.
     assert "/v2/review/101" in body
-

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -115,6 +115,9 @@ def _stub_analytics_helpers(mock_db) -> None:
     # so recs render with their action buttons; tests that exercise the
     # decided-state path stub a non-empty list explicitly.
     mock_db.get_recommendation_decisions.return_value = []
+    # Image Add Patterns substrate. Default empty so the panel is hidden;
+    # tests that exercise the populated panel override explicitly.
+    mock_db.get_image_add_substrate.return_value = []
 
 
 def test_stats_renders_empty(client, mock_db):
@@ -1161,8 +1164,7 @@ def test_legacy_accepts_banner_count_is_linked_to_backfill_queue(client, mock_db
         "reviewed_count": 48,
         "skipped_count": 0,
         "auto_rejected_count": 0,
-        "review_pct": 100.0,
-    }
+        "review_pct": 100.0,    }
     mock_db.get_image_decisions_by_tier_v2.return_value = []
     mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
 
@@ -1180,3 +1182,70 @@ def test_legacy_accepts_banner_count_is_linked_to_backfill_queue(client, mock_db
     assert re.search(r"<a[^>]+legacy-backfill[^>]*>[^<]*<strong>48</strong>", body), (
         "48 must be wrapped in <strong> inside the legacy-backfill anchor"
     )
+def test_patterns_tab_image_add_panel_renders(client, mock_db):
+    """Image Add Patterns panel renders when substrate rows produce findings.
+
+    The panel is gated on non-empty image_add_findings; this test verifies
+    the full wire-up: substrate → compute_image_add_findings → template.
+    """
+    _stub_analytics_helpers(mock_db)
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+    # Three Add rows for the same metric. Use text with tokens not suppressed
+    # by cm_purchase_transactions_overall's own keyword config. "volume" IS
+    # suppressed (pattern \border\s+volume\b → token "volume" extracted by
+    # _TOKEN_RE), so "quarterly growth" is the first surfaced bigram.
+    img_a = "aaaaaaaa-0000-0000-0000-000000000001"
+    img_b = "bbbbbbbb-0000-0000-0000-000000000002"
+    img_c = "cccccccc-0000-0000-0000-000000000003"
+    mock_db.get_image_add_substrate.return_value = [
+        {
+            "confirmed_metric_id": "cm_purchase_transactions_overall",
+            "img_id": img_a,
+            "filing_id": 101,
+            "nearby_text": "volume quarterly growth trend analysis chart",
+        },
+        {
+            "confirmed_metric_id": "cm_purchase_transactions_overall",
+            "img_id": img_b,
+            "filing_id": 102,
+            "nearby_text": "volume quarterly growth trend analysis chart",
+        },
+        {
+            "confirmed_metric_id": "cm_purchase_transactions_overall",
+            "img_id": img_c,
+            "filing_id": 103,
+            "nearby_text": "volume quarterly growth trend analysis chart",
+        },
+    ]
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Panel heading renders.
+    assert "Image Add Patterns" in body
+    # Metric id renders.
+    assert "cm_purchase_transactions_overall" in body
+    # A repeated phrase surfaced ("quarterly growth" appears 3/3).
+    assert "quarterly growth" in body
+    # Sample image link resolves to the review page.
+    assert "/v2/review/101" in body
+


### PR DESCRIPTION
## Summary

- Adds a new **Image Add Patterns** panel to the Patterns tab on `/v2/review/stats` that surfaces n-gram phrases from `v2_image_assets.nearby_text` for images with `decision='add'` confirmations
- Mining is per-metric: shows `add_count`, distinct `image_count`, top recurring phrases (with % frequency), and sample image links to the review page
- Panel is gated on `{% if image_add_findings %}` so it renders only when data exists; positioned before the text-analysis-run conditional so it's visible regardless of text pipeline state

## Test plan

- [x] 12 new unit tests for `compute_image_add_findings()` (empty input, structure, bigram threshold, pct threshold, stopword suppression, sample image cap/dedup, multi-metric ordering, null nearby_text)
- [x] 6 new SQL-shape tests for `get_image_add_substrate()` (decision filter, join, length floor, required columns)
- [x] 1 new smoke test `test_patterns_tab_image_add_panel_renders` in stats test suite
- [x] All 4756 unit tests pass; pre-push hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)