### PR TITLE
fix(llm): unpack classify_segment tuple in script call sites

### DIFF
--- a/docs/known-issues/gh-546-script-test-mocks-classify-segment-signature-drift.md
+++ b/docs/known-issues/gh-546-script-test-mocks-classify-segment-signature-drift.md
@@ -1,0 +1,34 @@
+---
+id: 546
+source: gh
+slug: script-test-mocks-classify-segment-signature-drift
+title: "Script test mocks drift from PresenceClassifierClient.classify_segment signature"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches: []
+discovered: 2026-05-07
+updated: 2026-05-07
+gh_issue: 546
+note: tighten or share script-side fake-client mocks so they cannot drift from inspect.signature(real_classify_segment)
+---
+
+### Problem
+
+PR #535 (gh-531 token threading) changed
+`PresenceClassifierClient.classify_segment` to return
+`tuple[list[SegmentClassification], dict[str, int]]`. Two scripts
+(`scripts/run_phase1_eval.py:666` and
+`scripts/calibrate_llm_thresholds.py:542`) kept the old
+list-iteration shape and crashed on first live run with
+`AttributeError: 'list' object has no attribute 'metric_id'`. The
+eval-runner test file did not exercise `evaluate_filing_direct` at all
+against the real classifier signature; the sweep-mode test mocked
+`classify_segment` with the old list-only return.
+
+### Next Steps
+
+- Tighten existing fake-client mocks across `tests/unit/scripts/` to assert their return shape matches `inspect.signature(real_callable).return_annotation` at construction time.
+- Or introduce a shared `FakePresenceClient` under a `tests/_fixtures/` (or similar) module that mirrors the real signature, used by every script test's `run_sweep` / `evaluate_filing_direct` path.
+- Backfill an integration test for `run_sweep` (sweep_corpus → assertions about `thresholds.yaml` contents, end-to-end through `classify_segment`).

--- a/scripts/calibrate_llm_thresholds.py
+++ b/scripts/calibrate_llm_thresholds.py
@@ -539,12 +539,17 @@ def run_sweep(
             continue
         for text in texts:
             try:
-                for sc in client.classify_segment(text, enrolled_with_prompts):
-                    key = (url, sc.metric_id)
-                    if sc.score > scores.get(key, -1.0):
-                        scores[key] = sc.score
+                # ``classify_segment`` returns ``(classifications, token_counts)``
+                # since the gh-531 token-threading fix (PR #535). Sweep mode
+                # discards the token totals.
+                classifications, _tokens = client.classify_segment(text, enrolled_with_prompts)
             except Exception as exc:
                 logger.warning("sweep: classify_segment failed url=%s: %s", url, exc)
+                continue
+            for sc in classifications:
+                key = (url, sc.metric_id)
+                if sc.score > scores.get(key, -1.0):
+                    scores[key] = sc.score
 
     calibration_run_id = str(uuid.uuid4())
     calibrated_at = datetime.now(UTC).isoformat()

--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -663,7 +663,11 @@ def evaluate_filing_direct(
 
     for text, section_type in texts:
         try:
-            results = client.classify_segment(text, metric_ids)
+            # ``classify_segment`` returns ``(classifications, token_counts)``
+            # since the gh-531 token-threading fix (PR #535). Token totals
+            # are discarded here — see follow-up fragment for surfacing them
+            # in summary.tokens.
+            results, _tokens = client.classify_segment(text, metric_ids)
         except ValueError as exc:  # parse / shape errors — hard fail per criterion #1
             errors.append(
                 {

--- a/tests/unit/scripts/test_calibrate_llm_thresholds.py
+++ b/tests/unit/scripts/test_calibrate_llm_thresholds.py
@@ -412,8 +412,14 @@ class _FakePresenceClient:
         self.config = SimpleNamespace(prompts={m: True for m in enrolled})
         self._scores = scores_map  # (text, metric_id) -> float
 
-    def classify_segment(self, text: str, metric_ids: list[str]) -> list[_FakeSC]:
-        return [_FakeSC(m, self._scores.get((text, m), 0.0)) for m in metric_ids]
+    def classify_segment(
+        self, text: str, metric_ids: list[str]
+    ) -> tuple[list[_FakeSC], dict[str, int]]:
+        # Match the real ``PresenceClassifierClient.classify_segment``
+        # signature (gh-531 / PR #535): ``(classifications, token_counts)``.
+        classifications = [_FakeSC(m, self._scores.get((text, m), 0.0)) for m in metric_ids]
+        tokens = {"input_tokens": 0, "output_tokens": 0, "cache_read": 0, "cache_create": 0}
+        return classifications, tokens
 
 
 def _make_fake_client_cls(scores_map: dict, enrolled: list[str]) -> type:

--- a/tests/unit/scripts/test_run_phase1_eval.py
+++ b/tests/unit/scripts/test_run_phase1_eval.py
@@ -337,3 +337,99 @@ def test_stratified_sample_deterministic(cli):
     assert s1 == s2
     s3 = cli._stratified_disagreement_sample(rows, sample_size=30, seed=99)
     assert s1 != s3
+
+
+# ---------------------------------------------------------------------------
+# evaluate_filing_direct — regression coverage for classify_segment signature
+# ---------------------------------------------------------------------------
+# This test exists because the original PR landed without exercising
+# evaluate_filing_direct against the real classify_segment signature
+# (gh-531 / PR #535 changed it to return ``(list, dict)``); the script
+# crashed on first live run. The fake here mirrors the real shape — if
+# classify_segment's signature drifts again, this test will catch it
+# rather than the next operator paying for the API call.
+
+
+class _FakeClassification:
+    """Minimal SegmentClassification stand-in for evaluate_filing_direct."""
+
+    def __init__(self, metric_id: str, score: float, present: bool) -> None:
+        self.metric_id = metric_id
+        self.score = score
+        self.present = present
+        self.model = "claude-haiku-4-5-20251001"
+        self.sonnet_fallback = False
+        self.prompt_version = "0.1.0-test"
+        self.rationale = ""
+
+
+class _FakeClassifierClient:
+    """Mirror the real PresenceClassifierClient.classify_segment signature.
+
+    Returns ``(classifications, token_counts)`` so the script's call site is
+    exercised the same way the real client behaves.
+    """
+
+    def __init__(self, scores_per_metric: dict[str, float]) -> None:
+        self._scores = scores_per_metric
+
+    def classify_segment(
+        self, text: str, metric_ids: list[str]
+    ) -> tuple[list[_FakeClassification], dict[str, int]]:
+        score_for = self._scores.get
+        classifications = [
+            _FakeClassification(m, score_for(m, 0.0), present=score_for(m, 0.0) >= 0.5)
+            for m in metric_ids
+        ]
+        tokens = {"input_tokens": 10, "output_tokens": 5, "cache_read": 0, "cache_create": 0}
+        return classifications, tokens
+
+
+def test_evaluate_filing_direct_unpacks_classify_segment_tuple(cli):
+    """Regression: evaluate_filing_direct iterates the classifications list,
+    not the (list, dict) tuple. Crashed live in pre-fix code with
+    ``AttributeError: 'list' object has no attribute 'metric_id'``.
+    """
+    filing = cli.FilingSelection(
+        corpus="gold",
+        filing_url="https://example.com/f1.htm",
+        filing_id=None,
+        issuer_key="alpha",
+        company="Alpha Inc",
+    )
+    client = _FakeClassifierClient(
+        {"cm_net_revenue_retention": 0.92, "cm_revenue_concentration": 0.10}
+    )
+    aggregates, errors = cli.evaluate_filing_direct(
+        filing,
+        ["cm_net_revenue_retention", "cm_revenue_concentration"],
+        client,
+        gold_quotes=["NRR was 132% reflecting expansion."],
+    )
+    assert errors == []
+    assert aggregates["cm_net_revenue_retention"].score == 0.92
+    assert aggregates["cm_net_revenue_retention"].present is True
+    assert aggregates["cm_revenue_concentration"].score == 0.10
+    assert aggregates["cm_revenue_concentration"].present is False
+
+
+def test_evaluate_filing_direct_classify_segment_signature_matches_real_client():
+    """Drift guard: if PresenceClassifierClient.classify_segment ever
+    changes its return type, this assertion fails before the next live
+    eval run does. The eval runner depends on the tuple-returning shape
+    introduced by PR #535 (gh-531).
+    """
+    import inspect
+
+    from src.llm.presence_classifier_client import PresenceClassifierClient
+
+    sig = inspect.signature(PresenceClassifierClient.classify_segment)
+    return_anno = sig.return_annotation
+    # Stringify so this works whether the annotation is evaluated lazily
+    # (PEP 563) or as a real type. The eval runner unpacks a 2-tuple.
+    return_str = str(return_anno).replace(" ", "")
+    assert "tuple[" in return_str, (
+        f"PresenceClassifierClient.classify_segment must return a tuple "
+        f"(scripts/run_phase1_eval.py and scripts/calibrate_llm_thresholds.py "
+        f"unpack it). Got: {return_anno!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'list' object has no attribute 'metric_id'` thrown by `python3 scripts/run_phase1_eval.py` on first live run after PR #539 merged.

PR #535 (gh-531 token threading) changed `PresenceClassifierClient.classify_segment` from returning `list[SegmentClassification]` to returning `tuple[list[SegmentClassification], dict[str, int]]`. The in-pipeline stage at `src/extraction_v2/stages/llm_presence_classifier.py:144,193` was updated, but two script call sites kept the old shape:

- `scripts/run_phase1_eval.py:666` (`evaluate_filing_direct`) — surfaced live by the user during the smoke eval after one billed Haiku call (~$0.01 spent before the crash).
- `scripts/calibrate_llm_thresholds.py:542` (`run_sweep`) — same bug; been broken since PR #535 merged.

## Why CI didn't catch this

- `tests/unit/scripts/test_run_phase1_eval.py` does not exercise `evaluate_filing_direct` at all — only `--dry-run` end-to-end and pure smoke-criteria computation. The "classify-direct path is exercised in unit tests" claim in that file's docstring was aspirational.
- `tests/unit/scripts/test_calibrate_llm_thresholds.py:415` mocks `classify_segment` with the **old** list-only return shape, so the mock and the real signature drifted apart silently.

## Fixes

| File | Change |
|---|---|
| `scripts/run_phase1_eval.py` | Unpack tuple: `results, _tokens = client.classify_segment(...)`. Token totals discarded for now (surfacing them in `summary.tokens` is a separate enhancement). |
| `scripts/calibrate_llm_thresholds.py` | Unpack tuple: `classifications, _tokens = client.classify_segment(...)`. Sweep mode discards tokens. |
| `tests/unit/scripts/test_calibrate_llm_thresholds.py` | `_FakePresenceClient.classify_segment` now returns the tuple shape, mirroring the real signature. |
| `tests/unit/scripts/test_run_phase1_eval.py` | Two new tests: a regression test for `evaluate_filing_direct` (with a fake classifier that returns the tuple), and a signature-drift guard that asserts `inspect.signature(...).return_annotation` contains `"tuple["`. |

The drift guard is the structural defense: if `classify_segment`'s return type is ever changed again, the unit suite fails before the next operator pays for an API call.

## Out-of-scope follow-up

Filed as **gh-546**: a more thorough integration-style coverage of the orchestration paths (`run_sweep`, `evaluate_filing_direct`) against the real `classify_segment` signature would catch any future drift faster. Either tighten existing fake-client mocks with an `inspect.signature` assertion at construction time, or introduce a shared `FakePresenceClient` test fixture that mirrors the real signature.

## Test plan

- [x] `pytest -x -q` (unit suite): **4808 passed**
- [x] `ruff check`: clean
- [x] New regression test crashes against the buggy code (verified by reverting the fix locally) and passes against the fixed code
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright), Docker Build & Smoke
- [ ] Manual: re-run `python3 scripts/run_phase1_eval.py --gold-only` after merge — should now proceed past the previous crash point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
