### PR TITLE
feat(review): reviewer attribution badges and cross-filing decisions pages

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -149,6 +149,18 @@ The banner's count and the trailing call-to-action both link to **`/v2/review/le
 
 **`images_legacy_pending` column.** `get_unified_filings_for_review`, `get_unified_filings_for_review_count`, and `get_next_filing_with_pending_work` all project `images_legacy_pending` (COUNT DISTINCT via EXISTS+NOT EXISTS in an `image_progress` CTE). The value is available on every row dict returned by `get_unified_filings_for_review`. `get_filing_pending_counts` also returns `images_legacy_pending` so `next_filing()` can apply the smart-default `tab=images&image_status=legacy_backfill` landing when a filing only has legacy backfill work. Note: legacy-backfill images have `images_pending=0` (they have been reviewed but never assigned a metric), so the normal `(facts_pending > 0 OR images_pending > 0)` pending filter in `get_next_filing_with_pending_work` MUST be REPLACED (not stacked) by `images_legacy_pending > 0` when `legacy_backfill_only=True`.
 
+## Cross-filing decision-type review pages
+
+`GET /v2/review/decisions/<decision_type>` (`decision_type ∈ {'accepted', 'corrected', 'added'}`) renders `unified_review.html` in cross-filing read-only mode. `?img_id=<X>` focuses a specific image; defaults to the first in the set. The page shows a thumbnail strip of all images matching the decision type across all filings, with the focused image's full per-metric decision rows (read-only — no Accept/Reject/Correct/Add/Skip controls). Reviewer attribution badges from `v2_image_metric_confirmations.reviewer_id` render on both the image-card header and individual decision rows.
+
+Mode is activated by passing `cross_filing_decisions_mode=decision_type` (a non-empty string) to `render_template`. `review_filing()` always passes `cross_filing_decisions_mode=None` explicitly so Jinja `StrictUndefined` does not trip on existing per-filing renders. Unknown `decision_type` values return 404.
+
+Template guards (`{% if not cross_filing_decisions_mode %}`) hide: the breadcrumb's per-filing link (replaced with "Metric Analytics → All X images (N)"), the tab bar, the "Next filing" / progress pill row, the bulk action bar, the image-level Skip/Reject-all/Next-Pending buttons, per-metric write controls (Accept/Reject/Correct/Skip/Undo), the Add-metric panel, notes textarea, and Submit buttons. The thumbnail `<a>` links to `decisions_review` with `?img_id=<X>` instead of `review_filing`.
+
+The stats page Accepted / Corrected / Added cards link to this route via a Bootstrap `stretched-link` anchor inside each `.card` (with `position: relative` on the card div).
+
+DB helper: `DatabaseAdapter.get_images_with_decision_type(decision_type)` — single SELECT reusing `_V2_IMAGE_CANDIDATE_SELECT` + `_V2_IMAGE_CONFIRMATION_ROLLUP_JOIN` shape. Ordered by `(filing_id ASC, img_id ASC)`. No pagination needed at current corpus size (~100 images).
+
 ## Legacy-backfill guided queue
 
 `/v2/review/legacy-backfill` and `/v2/review/legacy-backfill/next` are stateless 302 redirectors that walk the reviewer through every legacy-relevant image awaiting per-metric backfill, across whichever filings they live in. Both are click targets from the warning banner on the Images stats tab.

--- a/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
+++ b/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
@@ -1,0 +1,25 @@
+---
+id: 548
+source: gh
+slug: db-image-candidate-join-duplication
+title: "db.py: get_images_with_decision_type duplicates JOIN structure from get_image_review_candidate_v2"
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches:
+  - src/infra/db.py
+discovered: 2026-05-07
+updated: 2026-05-07
+gh_issue: 548
+note: two DB helpers share the same complex JOIN aliases with no shared helper; silent drift risk if primary method evolves
+---
+
+### Problem
+
+`get_images_with_decision_type` (added in the reviewer-badges / cross-filing decisions feature) duplicates the full `_V2_IMAGE_CANDIDATE_SELECT` JOIN structure (table aliases `v/f/c/d/imc_rollup/ic`) from `get_image_review_candidate_v2` with no shared abstraction. If the primary method gains new columns or renamed aliases, the cross-filing helper silently drifts and cross-filing pages show stale/missing data.
+
+### Next Steps
+
+- Evaluate whether a shared `_build_image_candidate_query` helper would reduce duplication without over-abstracting
+- At minimum, add a comment in both methods cross-referencing the other so maintainers know to update both

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2228,6 +2228,78 @@ class DatabaseAdapter:
         results[0]["is_stale_vs_decision"] = self._derive_is_stale_vs_decision(results[0])
         return results[0]
 
+    def get_images_with_decision_type(self, decision_type: str) -> list[dict]:
+        """Return all images matching a cross-filing decision-type set.
+
+        decision_type must be one of 'accepted', 'corrected', 'added'.
+
+        'accepted' unions legacy v2_image_review_decisions.decision='relevant'
+        with per-metric decisions IN ('accept','correct','add') — mirrors the
+        definition used by get_image_decision_breakdown_v2().
+
+        Ordered by (filing_id, img_id) for stable cross-filing navigation.
+        """
+        if decision_type == "accepted":
+            filter_clause = """
+                AND (
+                    EXISTS (
+                        SELECT 1 FROM v2_image_review_decisions ird
+                        WHERE ird.img_id = v.img_id AND ird.decision = 'relevant'
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM v2_image_metric_confirmations imc
+                        WHERE imc.img_id = v.img_id
+                          AND imc.decision IN ('accept', 'correct', 'add')
+                    )
+                )
+            """
+        elif decision_type == "corrected":
+            filter_clause = """
+                AND EXISTS (
+                    SELECT 1 FROM v2_image_metric_confirmations imc
+                    WHERE imc.img_id = v.img_id AND imc.decision = 'correct'
+                )
+            """
+        elif decision_type == "added":
+            filter_clause = """
+                AND EXISTS (
+                    SELECT 1 FROM v2_image_metric_confirmations imc
+                    WHERE imc.img_id = v.img_id AND imc.decision = 'add'
+                )
+            """
+        else:
+            raise ValueError(f"Unknown decision_type: {decision_type!r}")
+
+        sql = f"""
+            SELECT {self._V2_IMAGE_CANDIDATE_SELECT},
+                f.accession_number, c.company_name, c.cik, c.ticker,
+                ic.classification_id,
+                ic.predicted_metrics,
+                ic.confidence AS classification_confidence
+            FROM v2_image_assets v
+            JOIN filings f ON v.filing_id = f.filing_id
+            JOIN companies c ON f.company_id = c.company_id
+            LEFT JOIN v2_image_review_decisions d ON d.img_id = v.img_id
+            LEFT JOIN LATERAL (
+                SELECT classification_id, predicted_metrics, confidence
+                FROM v2_image_classifications
+                WHERE img_id = v.img_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) ic ON true
+            {self._V2_IMAGE_CONFIRMATION_ROLLUP_JOIN}
+            WHERE v.classification NOT IN ('decorative', 'logo', 'signature')
+              AND v.filename IS NOT NULL
+              AND v.filename != ''
+              {filter_clause}
+            ORDER BY v.filing_id ASC, v.img_id ASC
+        """
+        results = self.query(sql)
+        for row in results:
+            row["image_review_state"] = self._derive_image_review_state(row)
+            row["is_stale_vs_decision"] = self._derive_is_stale_vs_decision(row)
+        return results
+
     def get_legacy_backfill_queue(self) -> list[dict]:
         """Ordered cross-filing list of legacy-relevant images awaiting backfill.
 

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -461,6 +461,116 @@ def _legacy_backfill_done_response() -> Response:
     return redirect(url_for("review_unified.stats") + "#images-stats")
 
 
+_VALID_DECISION_TYPES = ("accepted", "corrected", "added")
+
+
+@review_unified_bp.route("/decisions/<decision_type>")
+@require(PROTECTED_READ)
+def decisions_review(decision_type: str):
+    """Cross-filing read-only view of all images carrying a given decision type.
+
+    decision_type ∈ ('accepted', 'corrected', 'added'). Anything else 404s.
+    Optional ?img_id=<X> focuses a specific image (defaults to first in set).
+    """
+    if decision_type not in _VALID_DECISION_TYPES:
+        abort(404)
+
+    db = get_db()
+    images = db.get_images_with_decision_type(decision_type)
+
+    # Pick focused image: ?img_id param if valid, else first in list
+    requested_img_id = request.args.get("img_id", type=str)
+    current_image = None
+    if requested_img_id:
+        for img in images:
+            if str(img["img_id"]) == requested_img_id:
+                current_image = img
+                break
+    if current_image is None and images:
+        current_image = images[0]
+
+    current_image_confirmations: list = []
+    if current_image:
+        current_image_confirmations = db.get_image_metric_confirmations(current_image["img_id"])
+
+    # Build a minimal filing context from the focused image so the template
+    # filing-header chrome (company name, accession, SEC link) still resolves.
+    filing: dict = {}
+    sec_filing_url: str | None = None
+    if current_image:
+        filing = {
+            "filing_id": current_image["filing_id"],
+            "company_name": current_image.get("company_name", ""),
+            "ticker": current_image.get("ticker"),
+            "accession_number": current_image.get("accession_number", ""),
+            "form_type": None,
+        }
+        try:
+            sec_filing_url = resolve_sec_filing_url(
+                {
+                    "cik": current_image.get("cik", ""),
+                    "accession_number": current_image.get("accession_number", ""),
+                }
+            )
+        except Exception:
+            sec_filing_url = None
+
+    label_map = {
+        "accepted": "All accepted images",
+        "corrected": "All images with corrections",
+        "added": "All images with added metrics",
+    }
+    cross_filing_label = f"{label_map[decision_type]} ({len(images)})"
+
+    return render_template(
+        "unified_review.html",
+        filing=filing,
+        document_type=None,
+        active_tab="images",
+        # Text-tab stubs (tab hidden in cross-filing mode; stubs prevent StrictUndefined)
+        facts=[],
+        current_fact=None,
+        existing_decision=None,
+        available_metrics=[],
+        all_metrics=[],
+        current_filters={"status": "all", "metric": "all", "sort": "confidence_desc"},
+        total_facts=0,
+        total_facts_unfiltered=0,
+        pending_count=0,
+        accepted_count=0,
+        rejected_count=0,
+        review_statuses=V2_REVIEW_STATUSES,
+        sort_options=V2_SORT_OPTIONS,
+        rejection_categories=CATEGORY_ACTIONS,
+        page=1,
+        per_page=25,
+        total_pages=1,
+        sec_filing_url=sec_filing_url,
+        image_ocr_segments=[],
+        # Image tab
+        image_candidates=images,
+        all_image_candidates=images,
+        current_image=current_image,
+        current_image_confirmations=current_image_confirmations,
+        image_pending=0,
+        image_reviewed=len(images),
+        image_skipped=0,
+        image_auto_rejected=0,
+        image_auto_reject_candidates=0,
+        image_filters={"status": "all", "sort": "relevance"},
+        chart_types=[],
+        rejection_reasons=[],
+        image_decisions=IMAGE_DECISIONS,
+        review_statuses_images=IMAGE_REVIEW_FILTER_STATUSES,
+        next_filing_url=url_for("review_unified.filing_list"),
+        # Cross-filing mode flag
+        cross_filing_decisions_mode=decision_type,
+        cross_filing_decisions_label=cross_filing_label,
+        legacy_backfill_mode=False,
+        legacy_backfill_progress={},
+    )
+
+
 @review_unified_bp.route("/legacy-backfill")
 @require(PROTECTED_READ)
 def legacy_backfill_entry():
@@ -876,6 +986,7 @@ def review_filing(filing_id: int):
             # Legacy-backfill guided queue (cross-filing)
             legacy_backfill_mode=legacy_backfill_mode,
             legacy_backfill_progress=legacy_backfill_progress,
+            cross_filing_decisions_mode=None,
         )
 
     except Exception as e:

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -436,6 +436,7 @@
                 confirmed_metric_id: c.confirmed_metric_id,
                 decision: 'add',
                 rejection_reason: null,
+                reviewer_id: c.reviewer_id || null,
             };
             if (cid) state.confirmationIds[key] = cid;
         } else if (c.detected_metric_id) {
@@ -444,6 +445,7 @@
                 confirmed_metric_id: c.confirmed_metric_id || null,
                 decision: c.decision,
                 rejection_reason: c.rejection_reason || null,
+                reviewer_id: c.reviewer_id || null,
             };
             if (cid) state.confirmationIds[c.detected_metric_id] = cid;
         }
@@ -482,6 +484,7 @@
               <button type="button" class="btn btn-outline-secondary btn-sm btn-remove-added">Remove</button>
             </div>
             <div class="metric-state-indicator small mt-1 text-muted">Will be submitted as 'add'</div>
+            ${d.reviewer_id ? `<span class="row-reviewer-tag text-muted small ms-2">[${escapeHtml(d.reviewer_id)}]</span>` : ''}
         `;
         list.appendChild(li);
         li.querySelector('.btn-remove-added').addEventListener('click', () => {
@@ -834,6 +837,17 @@
         }
         const undoBtn = row.querySelector('.btn-undo-metric');
         if (undoBtn) undoBtn.style.display = '';
+        let reviewerTag = row.querySelector('.row-reviewer-tag');
+        if (d.reviewer_id) {
+            if (!reviewerTag) {
+                reviewerTag = document.createElement('span');
+                reviewerTag.className = 'row-reviewer-tag text-muted small ms-2';
+                if (indicator) indicator.after(reviewerTag);
+            }
+            reviewerTag.textContent = `[${d.reviewer_id}]`;
+        } else if (reviewerTag) {
+            reviewerTag.remove();
+        }
     }
 
     function clearRowState(row) {

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -153,8 +153,13 @@
 {%- endif -%}
 <nav aria-label="breadcrumb" class="mb-2">
   <ol class="breadcrumb">
+    {% if cross_filing_decisions_mode|default(false) %}
+    <li class="breadcrumb-item"><a href="{{ url_for('review_unified.stats') }}#images-stats">Metric Analytics</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ cross_filing_decisions_label|default('') }}</li>
+    {% else %}
     <li class="breadcrumb-item"><a href="{{ url_for('review_unified.filing_list', **breadcrumb_kwargs) }}">Review Filings</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ filing.company_name }}</li>
+    {% endif %}
   </ol>
 </nav>
 
@@ -164,7 +169,14 @@
     <div class="col-12">
       <div class="d-flex justify-content-between align-items-center">
         <div>
+          {% if cross_filing_decisions_mode|default(false) %}
+          <h4 class="mb-0">
+            <span class="badge bg-secondary me-2" style="font-size:0.55em;vertical-align:middle;">{{ cross_filing_decisions_label|default('') }}</span>
+            {{ filing.company_name }}{% if filing.ticker %} <small class="text-muted" style="font-size: 0.65em;">{{ filing.ticker }}</small>{% endif %}
+          </h4>
+          {% else %}
           <h4 class="mb-0">{{ filing.company_name }}{% if filing.ticker %} <small class="text-muted" style="font-size: 0.65em;">{{ filing.ticker }}</small>{% endif %}</h4>
+          {% endif %}
           <small class="text-muted">
             {{ filing.accession_number }}
             {% if filing.form_type %}&middot; {{ filing.form_type }}{% endif %}
@@ -175,6 +187,8 @@
             {% endif %}
           </small>
         </div>
+        {% if not cross_filing_decisions_mode|default(false) %}
+        {# Hidden in cross-filing mode: no per-filing progress or next-filing nav #}
         <div class="text-end review-pill-row">
           <span class="badge bg-primary">{{ total_facts_unfiltered }} facts</span>
           <span class="badge bg-warning text-dark">{{ pending_count }} pending</span>
@@ -193,11 +207,13 @@
             Next filing <span class="kbd ms-1">F</span>
           </a>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>
 
-  {# Tab Bar #}
+  {# Tab Bar — hidden in cross-filing mode (text tab is meaningless cross-filing) #}
+  {% if not cross_filing_decisions_mode|default(false) %}
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <a class="nav-link {% if active_tab == 'text' %}active{% endif %}"
@@ -212,6 +228,7 @@
       </a>
     </li>
   </ul>
+  {% endif %}
 
   {# Tab-specific filter bar (sticky with header + tabs) #}
   {% if active_tab == 'text' %}
@@ -761,6 +778,8 @@
   <div class="row image-review-layout">
     {# Left Column: Thumbnail Sidebar #}
     <div class="col-auto image-thumbnail-sidebar">
+      {% if not cross_filing_decisions_mode|default(false) %}
+      {# Hidden in cross-filing mode: no bulk write actions in read-only view #}
       <div id="bulk-action-bar" class="mb-2 d-none">
         <div class="d-flex flex-wrap align-items-center gap-2 p-2 bg-light border rounded">
           <span id="bulk-selected-count" class="small fw-bold">0 selected</span>
@@ -770,6 +789,7 @@
           <button type="button" class="btn btn-sm btn-link text-secondary p-0" id="btn-bulk-clear">Clear</button>
         </div>
       </div>
+      {% endif %}
       <div class="card">
         <div class="card-header py-2">
           <h6 class="mb-0">Images ({{ image_candidates|length }})</h6>
@@ -778,7 +798,7 @@
           <div class="list-group list-group-flush">
             {% for candidate in image_candidates %}
             {% set is_current = current_image and candidate.img_id == current_image.img_id %}
-            <a href="{{ url_for('review_unified.review_filing', filing_id=filing.filing_id, img_id=candidate.img_id, image_status=image_filters.status, image_sort=image_filters.sort if image_filters.sort and image_filters.sort != 'relevance' else None, tab='images') }}"
+            <a href="{% if cross_filing_decisions_mode|default(false) %}{{ url_for('review_unified.decisions_review', decision_type=cross_filing_decisions_mode) }}?img_id={{ candidate.img_id }}{% else %}{{ url_for('review_unified.review_filing', filing_id=filing.filing_id, img_id=candidate.img_id, image_status=image_filters.status, image_sort=image_filters.sort if image_filters.sort and image_filters.sort != 'relevance' else None, tab='images') }}{% endif %}"
                class="list-group-item list-group-item-action thumbnail-item {{ 'active' if is_current else '' }} {{ 'reviewed' if candidate.image_review_state in ('relevant', 'no_relevant') else '' }}"
                data-img-id="{{ candidate.img_id }}"
                data-image-review-state="{{ candidate.image_review_state or 'pending' }}"
@@ -892,6 +912,17 @@
               {% if current_image.auto_reject_candidate %}
               <span class="badge bg-secondary ms-1" title="Auto-reject candidate: tier-3 image, likely no relevant metrics. Review to confirm or override.">Auto-reject candidate</span>
               {% endif %}
+              {# Reviewer attribution badge — driven by data already on the page.
+                 Hidden when no per-metric confirmations exist for this image. #}
+              {% set imc_reviewers = (current_image_confirmations or [])
+                                     |map(attribute='reviewer_id')
+                                     |reject('none')|unique|list %}
+              {% if imc_reviewers %}
+              <span class="badge bg-info ms-1" title="Reviewers who recorded per-metric decisions on this image">
+                {{ 'Reviewer' if imc_reviewers|length == 1 else 'Reviewers' }}:
+                {{ imc_reviewers|join(', ') }}
+              </span>
+              {% endif %}
             </div>
           </div>
 
@@ -950,6 +981,8 @@
             </div>
           </div>
           {% else %}
+          {% if not cross_filing_decisions_mode|default(false) %}
+          {# Hidden in cross-filing mode: no per-filing pending queue or write actions #}
           <div class="d-flex justify-content-between align-items-center mb-3">
             <div class="d-flex gap-2">
               <button type="button" id="btn-skip" class="btn btn-outline-secondary">
@@ -965,6 +998,7 @@
               Next Pending &rarr;
             </a>
           </div>
+          {% endif %}
           {% endif %}
 
           {# Detected Metrics card — chart-presence pivot (#86 PR 3b, sql/47).
@@ -1021,6 +1055,8 @@
                       <span class="metric-label fw-semibold">{{ metric.metric_id }}</span>
                       <span class="metric-score text-muted small ms-2">{{ '%.2f'|format(metric.score) }}</span>
                     </div>
+                    {% if not cross_filing_decisions_mode|default(false) %}
+                    {# Hidden in cross-filing mode: read-only view, no per-metric write actions #}
                     <div class="btn-group btn-group-sm metric-actions" role="group">
                       <button type="button" class="btn btn-outline-success btn-accept-metric"
                               data-action="accept">
@@ -1043,6 +1079,7 @@
                             data-action="undo" style="display: none;">
                       Undo
                     </button>
+                    {% endif %}
                   </div>
                   <div class="reject-expansion mt-2" style="display: none;">
                     <label class="form-label small mb-1">Reason</label>
@@ -1068,6 +1105,8 @@
                 </li>
                 {% endfor %}
               </ul>
+              {% if not cross_filing_decisions_mode|default(false) %}
+              {# Hidden in cross-filing mode: no write actions in read-only view #}
               <div class="mt-3 border-top pt-3">
                 <button type="button" class="btn btn-outline-secondary btn-sm"
                         id="btn-add-missed-detected-metric">
@@ -1110,6 +1149,7 @@
                   Submit and mark image complete <span class="kbd ms-1">M</span>
                 </button>
               </div>
+              {% endif %}
             </div>
           </div>
           {% endif %}
@@ -1289,6 +1329,7 @@ window.TEXT_PENDING = {{ pending_count|tojson }};
 // returns a /legacy-backfill/next URL, and short-circuits the empty-queue
 // cross-tab cascade to flow through the same route (which 302s to stats).
 window.LEGACY_BACKFILL_MODE = {{ (legacy_backfill_mode|default(false))|tojson }};
+window.CROSS_FILING_DECISIONS_MODE = {{ (cross_filing_decisions_mode|default(false))|tojson }};
 let reviewStartTime = Date.now();
 
 function filterParams() {

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -903,29 +903,35 @@
        Summary-tab Image Confirmations card so the two surfaces stay consistent. #}
     <div class="row mb-4 g-2">
       <div class="col">
-        <div class="card border-success h-100">
+        <div class="card border-success h-100" style="position: relative;">
           <div class="card-body p-3">
             <h6 class="card-subtitle mb-1 text-muted small">Accepted</h6>
             <h3 class="mb-0 text-success">{{ breakdown.accepted_images or 0 }}</h3>
             <small class="d-block text-muted mt-1">
               {{ breakdown.accepted_images_per_metric or 0 }} with specific metrics
             </small>
+            <a href="{{ url_for('review_unified.decisions_review', decision_type='accepted') }}"
+               class="stretched-link text-decoration-none" aria-label="Browse accepted images"></a>
           </div>
         </div>
       </div>
       <div class="col">
-        <div class="card border-info h-100">
+        <div class="card border-info h-100" style="position: relative;">
           <div class="card-body p-3">
             <h6 class="card-subtitle mb-1 text-muted small">Corrected</h6>
             <h3 class="mb-0 text-info">{{ breakdown.corrected or 0 }}</h3>
+            <a href="{{ url_for('review_unified.decisions_review', decision_type='corrected') }}"
+               class="stretched-link text-decoration-none" aria-label="Browse corrected images"></a>
           </div>
         </div>
       </div>
       <div class="col">
-        <div class="card border-primary h-100">
+        <div class="card border-primary h-100" style="position: relative;">
           <div class="card-body p-3">
             <h6 class="card-subtitle mb-1 text-muted small">Added</h6>
             <h3 class="mb-0 text-primary">{{ breakdown.added or 0 }}</h3>
+            <a href="{{ url_for('review_unified.decisions_review', decision_type='added') }}"
+               class="stretched-link text-decoration-none" aria-label="Browse added images"></a>
           </div>
         </div>
       </div>

--- a/tests/unit/web/test_decisions_review.py
+++ b/tests/unit/web/test_decisions_review.py
@@ -1,0 +1,202 @@
+"""Tests for the cross-filing decisions_review route."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.web.app import create_app
+
+
+@pytest.fixture
+def app():
+    app = create_app("testing")
+    app.config["TESTING"] = True
+    app.config["DATABASE_URL"] = "postgresql://test"
+    app.config["_db_pool"] = None
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def mock_db():
+    with (
+        patch("src.web.routes.review_unified.get_db") as mock_get_db,
+        patch("src.web.routes._metrics.get_db") as mock_metrics_get_db,
+    ):
+        mock = MagicMock()
+        mock_get_db.return_value = mock
+        mock_metrics_get_db.return_value = mock
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def mock_render():
+    with patch("src.web.routes.review_unified.render_template") as mock:
+        mock.return_value = "mocked template"
+        yield mock
+
+
+def _make_image(img_id="img-1", filing_id=1, company_name="Acme Corp"):
+    return {
+        "img_id": img_id,
+        "filing_id": filing_id,
+        "filename": "chart.png",
+        "image_src": "chart.png",
+        "image_url": "/images/cache/123/chart.png",
+        "image_src_url": "https://www.sec.gov/chart.png",
+        "image_width": 400,
+        "image_height": 300,
+        "preceding_text": "Revenue chart",
+        "detected_keywords": [],
+        "classification": "chart",
+        "cohort_confidence": 0.8,
+        "predicted_relevance": None,
+        "review_status": "reviewed",
+        "section_type": None,
+        "is_decorative": False,
+        "auto_reject_candidate": False,
+        "detection_tier": "tier_1_cohort",
+        "detected_metrics": [{"metric_id": "cm_revenue_by_cohort", "score": 0.9}],
+        "created_at": None,
+        "image_decision_id": None,
+        "decision": None,
+        "legacy_decision": False,
+        "chart_type": None,
+        "rejection_reason": None,
+        "decision_notes": None,
+        "review_time_seconds": None,
+        "decided_against_hash": None,
+        "current_ocr_text": None,
+        "current_chart_data_json": None,
+        "positive_count": 1,
+        "detected_decided_count": 1,
+        "total_confirmation_count": 1,
+        "has_add": False,
+        "accession_number": "0001234567-23-000001",
+        "company_name": company_name,
+        "cik": "123456",
+        "ticker": "ACM",
+        "classification_id": None,
+        "predicted_metrics": None,
+        "classification_confidence": None,
+        "image_review_state": "relevant",
+        "is_stale_vs_decision": False,
+    }
+
+
+def test_decisions_review_accepted_renders_200(client, mock_db, mock_render):
+    """GET /v2/review/decisions/accepted renders 200."""
+    img = _make_image()
+    mock_db.get_images_with_decision_type.return_value = [img]
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    response = client.get("/v2/review/decisions/accepted")
+    assert response.status_code == 200
+
+    mock_db.get_images_with_decision_type.assert_called_once_with("accepted")
+    _, kwargs = mock_render.call_args
+    assert kwargs["cross_filing_decisions_mode"] == "accepted"
+    assert kwargs["image_candidates"] == [img]
+    assert kwargs["current_image"] == img
+
+
+def test_decisions_review_corrected_renders_200(client, mock_db, mock_render):
+    """GET /v2/review/decisions/corrected renders 200."""
+    mock_db.get_images_with_decision_type.return_value = []
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    response = client.get("/v2/review/decisions/corrected")
+    assert response.status_code == 200
+
+    mock_db.get_images_with_decision_type.assert_called_once_with("corrected")
+
+
+def test_decisions_review_added_renders_200(client, mock_db, mock_render):
+    """GET /v2/review/decisions/added renders 200."""
+    mock_db.get_images_with_decision_type.return_value = []
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    response = client.get("/v2/review/decisions/added")
+    assert response.status_code == 200
+
+
+def test_decisions_review_unknown_type_returns_404(client, mock_db):
+    """Unknown decision_type returns 404."""
+    response = client.get("/v2/review/decisions/rejected")
+    assert response.status_code == 404
+
+
+def test_decisions_review_skipped_returns_404(client, mock_db):
+    """'skipped' is not a valid decision_type — returns 404."""
+    response = client.get("/v2/review/decisions/skipped")
+    assert response.status_code == 404
+
+
+def test_decisions_review_img_id_focuses_requested_image(client, mock_db, mock_render):
+    """?img_id=<X> focuses the requested image when present in the set."""
+    img1 = _make_image("img-1", filing_id=1)
+    img2 = _make_image("img-2", filing_id=2, company_name="Beta Corp")
+    mock_db.get_images_with_decision_type.return_value = [img1, img2]
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    response = client.get("/v2/review/decisions/accepted?img_id=img-2")
+    assert response.status_code == 200
+
+    _, kwargs = mock_render.call_args
+    assert kwargs["current_image"]["img_id"] == "img-2"
+
+
+def test_decisions_review_img_id_defaults_to_first(client, mock_db, mock_render):
+    """Without ?img_id, the first image in the set is focused."""
+    img1 = _make_image("img-1", filing_id=1)
+    img2 = _make_image("img-2", filing_id=2)
+    mock_db.get_images_with_decision_type.return_value = [img1, img2]
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    client.get("/v2/review/decisions/accepted")
+    _, kwargs = mock_render.call_args
+    assert kwargs["current_image"]["img_id"] == "img-1"
+
+
+def test_decisions_review_empty_set_no_current_image(client, mock_db, mock_render):
+    """Empty image set renders without current_image (e.g. corrected=0)."""
+    mock_db.get_images_with_decision_type.return_value = []
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    response = client.get("/v2/review/decisions/corrected")
+    assert response.status_code == 200
+
+    _, kwargs = mock_render.call_args
+    assert kwargs["current_image"] is None
+    assert kwargs["cross_filing_decisions_mode"] == "corrected"
+
+
+def test_decisions_review_passes_text_tab_stubs(client, mock_db, mock_render):
+    """Route passes all text-tab stubs to prevent Jinja StrictUndefined errors."""
+    mock_db.get_images_with_decision_type.return_value = []
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    client.get("/v2/review/decisions/added")
+    _, kwargs = mock_render.call_args
+
+    assert kwargs["facts"] == []
+    assert kwargs["current_fact"] is None
+    assert kwargs["total_facts"] == 0
+    assert kwargs["pending_count"] == 0
+    assert kwargs["image_ocr_segments"] == []
+
+
+def test_decisions_review_label_includes_count(client, mock_db, mock_render):
+    """cross_filing_decisions_label includes the image count."""
+    img = _make_image()
+    mock_db.get_images_with_decision_type.return_value = [img]
+    mock_db.get_image_metric_confirmations.return_value = []
+
+    client.get("/v2/review/decisions/accepted")
+    _, kwargs = mock_render.call_args
+    assert "(1)" in kwargs["cross_filing_decisions_label"]
+    assert "accepted" in kwargs["cross_filing_decisions_label"].lower()

--- a/tests/unit/web/test_url_for_resolves.py
+++ b/tests/unit/web/test_url_for_resolves.py
@@ -19,6 +19,7 @@ from src.web.app import create_app  # noqa: I001
 _ENDPOINTS: list[tuple[str, dict]] = [
     ("review_unified.filing_list", {}),
     ("review_unified.review_filing", {"filing_id": 1}),
+    ("review_unified.decisions_review", {"decision_type": "accepted"}),
     ("review_unified.stats", {}),
     ("review_unified.image_crop", {"img_id": "00000000-0000-0000-0000-000000000000"}),
     ("review_unified.next_filing", {}),


### PR DESCRIPTION
## Summary

- Adds reviewer attribution badge on the image header (distinct `reviewer_id`s from `v2_image_metric_confirmations`) and per-row `[reviewer]` JS tags on decided metric rows
- New `/v2/review/decisions/<type>` route (`accepted`/`corrected`/`added`) renders a read-only cross-filing thumbnail strip — clicking a stat card on the Images tab navigates there
- Stats page Accepted/Corrected/Added cards are now clickable via Bootstrap `stretched-link`
- New `get_images_with_decision_type` DB helper with UNION-based accepted filter and EXISTS filters for corrected/added
- 9 Jinja guards in `unified_review.html` for cross-filing mode (breadcrumb, heading, write controls hidden); `window.CROSS_FILING_DECISIONS_MODE` JS constant

## Test plan

- [ ] `uv run pytest tests/unit/ -x -q` — 4798 passed
- [ ] Lint: `ruff check src/ tests/` — all checks passed
- [ ] `test_decisions_review.py` — 10 new tests covering accepted/corrected/added 200, unknown 404, img_id focus, empty set, text-tab stubs, label count
- [ ] `test_url_for_resolves.py` — `decisions_review` endpoint registered and resolvable
- [ ] Manual: click Accepted card on `/v2/review/stats` Images tab → navigates to `/v2/review/decisions/accepted`
- [ ] Manual: reviewer badge appears on images with per-metric confirmations

## Notes

- Filed #548 (low severity): `get_images_with_decision_type` duplicates JOIN structure from `get_image_review_candidate_v2`; deferred as acceptable coupling given plan's no-abstraction discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)