### PR TITLE
fix(stats): coerce UUID to string before slicing in unified_stats template

### DIFF
--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -1164,7 +1164,7 @@
                   {% for s in f.sample_images %}
                   <li>
                     <a href="{{ url_for('review_unified.review_filing', filing_id=s.filing_id, img_id=s.img_id, tab='images') }}">
-                      filing {{ s.filing_id }} / img {{ s.img_id[:8] }}
+                      filing {{ s.filing_id }} / img {{ (s.img_id|string)[:8] }}
                     </a>
                   </li>
                   {% endfor %}


### PR DESCRIPTION
Image-additions phrase findings panel was 500'ing on production with
`TypeError: 'UUID' object is not subscriptable` because the template at
unified_stats.html:1167 sliced `s.img_id[:8]` directly on the row dict
returned from psycopg, which yields uuid.UUID instances. Slicing requires
a string, so `(s.img_id|string)[:8]` makes the conversion explicit.

The bug only triggered when `f.sample_images` had at least one row, which
is why dev/test (sparse Image Add substrate) didn't surface it before
prod traffic hit it.
