### PR TITLE
feat(review-images): add U shortcut to undo image decision; surface X on Reject-all

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -270,14 +270,14 @@ The unified review page (`unified_review.html`) binds shortcuts on both tabs. Cr
 | Key        | Action                                      |
 |------------|---------------------------------------------|
 | `S`        | Skip image                                  |
-| `U`        | Undo skip                                   |
+| `U`        | Undo previous image-level decision — dispatches by current `review_status`: fires `reopenImage()` when `#btn-reopen-image` is rendered (`review_status='reviewed'`), else `undoSkip()` when `#btn-undo` is rendered (`review_status='skipped'`). The two states are mutually exclusive on a single image, so the dispatch is unambiguous. No-op on pending images (neither button rendered). |
 | `←` / `→`  | Previous / next image                       |
 | `N` / `P`  | Next / previous image (alias)               |
 | `?` / `H`  | Toggle help overlay                         |
 | `F`        | Next filing                                 |
 | `X`        | Reject all (no relevant metrics) — fires regardless of row focus, triggers `#btn-reject-all-metrics` click |
 | `Shift+R`  | Reject all (deprecated alias for `X`, kept for muscle memory) |
-| `Shift+U`  | Re-open a fully-reviewed image (only effective when `#btn-reopen-image` is rendered) |
+| `Shift+U`  | Deprecated alias for `U` — same dispatch logic; kept for muscle memory |
 | `Shift+A`  | Open "Add metric the classifier missed" panel and focus the metric search input (`#add-missed-detected-input`); plain `A` is per-row accept so a chord is required |
 | `M`        | Submit decisions and mark image complete — triggers `#btn-submit-and-finalize` click |
 

--- a/src/web/static/js/review_images_v2.js
+++ b/src/web/static/js/review_images_v2.js
@@ -86,12 +86,28 @@
             return;
         }
 
-        // Shift+U — re-open a fully-reviewed image. The button is only
-        // rendered when review_status == 'reviewed' (template branch); when
-        // it's absent, this is a no-op.
-        if (event.shiftKey && (event.key === 'U' || event.key === 'u')) {
-            event.preventDefault();
-            reopenImage();
+        // U / Shift+U — undo previous decision on this image. Dispatches based
+        // on which undo button the template rendered: '#btn-reopen-image' for
+        // review_status == 'reviewed', '#btn-undo' for review_status ==
+        // 'skipped'. The two states are mutually exclusive on a single image,
+        // so plain U is unambiguous. Shift+U is a deprecated alias kept for
+        // muscle memory (matches the X / Shift+R precedent above).
+        const isUndoChord =
+            (event.shiftKey && (event.key === 'U' || event.key === 'u')) ||
+            (!event.shiftKey && (event.key === 'u' || event.key === 'U'));
+        if (isUndoChord) {
+            if (document.getElementById('btn-reopen-image')) {
+                event.preventDefault();
+                reopenImage();
+                return;
+            }
+            if (document.getElementById('btn-undo')) {
+                event.preventDefault();
+                undoSkip();
+                return;
+            }
+            // Neither button rendered — no-op (fall through; nothing else
+            // below catches plain or chord U).
             return;
         }
 
@@ -140,10 +156,6 @@
                 // preventDefault+stopPropagation) when a row is focused.
                 event.preventDefault();
                 submitSkip();
-                break;
-            case 'u':
-                event.preventDefault();
-                undoSkip();
                 break;
             case 'arrowleft':
                 event.preventDefault();

--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -976,7 +976,7 @@
               <button type="button" id="btn-reopen-image" class="btn btn-outline-secondary"
                       data-img-id="{{ current_image.img_id }}"
                       title="Return this image to the pending queue. Prior decisions are preserved.">
-                Re-open for review
+                Re-open for review <span class="kbd ms-1">U</span>
               </button>
             </div>
           </div>
@@ -990,7 +990,7 @@
               </button>
               <button type="button" id="btn-reject-all-metrics" class="btn btn-outline-danger"
                       title="Mark every unreviewed detected metric as 'not present' on this chart and move to the next image.">
-                Reject all (no relevant metrics)
+                Reject all (no relevant metrics) <span class="kbd ms-1">X</span>
               </button>
             </div>
             <a href="{{ url_for('review_unified.review_filing', filing_id=filing.filing_id, tab='images', image_status=image_filters.status) }}"
@@ -1246,11 +1246,11 @@
         <div class="hints-content">
           <kbd>S</kbd> Skip
           <span class="mx-1">|</span>
-          <kbd>U</kbd> Undo
+          <kbd>U</kbd> Undo / Re-open
           <span class="mx-1">|</span>
           <kbd>&larr;&rarr;</kbd> / <kbd>N</kbd>/<kbd>P</kbd> Navigate
           <span class="mx-1">|</span>
-          <kbd>Shift+R</kbd> Reject all
+          <kbd>X</kbd> Reject all
           <span class="mx-1">|</span>
           <kbd>F</kbd> Next filing
           <span class="mx-1">|</span>


### PR DESCRIPTION
Plain U on the image-review page now dispatches to whichever undo path applies
on the current image (reopen for review_status='reviewed', unskip for
'skipped' — the two states are mutually exclusive). Speeds up the legacy-
backfill workflow at /v2/review/legacy-backfill where every legacy image
needs a reopen-then-decide cycle to capture the per-metric ML training signal.
Shift+U kept as deprecated alias (matches the existing X / Shift+R precedent).

The 'Reject all (no relevant metrics)' button gains an inline kbd chip
showing X (the existing primary binding) so the shortcut is discoverable
without hovering for the tooltip. Help-overlay bar updated to drop the
deprecated Shift+R hint and show U as 'Undo / Re-open'.
