### PR TITLE
fix(review): allow horizontal pan in image lightbox

### DIFF
--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -1654,7 +1654,7 @@ document.addEventListener('keydown', function(e) {
 
   modalEl.addEventListener('shown.bs.modal', function () {
     if (typeof Panzoom === 'undefined') return;  // CDN failed; image still visible at 1:1
-    pz = Panzoom(imgEl, { maxScale: 8, minScale: 1, contain: 'outside' });
+    pz = Panzoom(imgEl, { maxScale: 8, minScale: 1, contain: 'inside' });
     wrapEl.addEventListener('wheel', onWheel, { passive: false });
     imgEl.addEventListener('panzoomstart', onStart);
     imgEl.addEventListener('panzoomend', onEnd);


### PR DESCRIPTION
Switch panzoom contain mode from 'outside' to 'inside'. The 'outside'
mode requires the image to always cover the modal viewport, which is
unsatisfiable when a wide chart hits max-height: 100% first and ends up
narrower than the wrap — panzoom auto-translates the image right and
locks horizontal pan. 'inside' is the standard lightbox mode: image
stays fully visible at minScale=1 and pans freely on both axes when
zoomed in.
