### PR TITLE
feat(eval): implement --path pipeline (Path A) for phase-1 smoke eval

### DIFF
--- a/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
+++ b/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
@@ -1,0 +1,27 @@
+---
+id: 554
+source: gh
+slug: phase1-eval-summary-tokens-not-populated
+title: "Phase-1 eval: surface token counts in summary.tokens rollup"
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches:
+  - scripts/run_phase1_eval.py
+  - docs/operations/llm-presence-classifier-phase1-eval-runbook.md
+discovered: 2026-05-07
+updated: 2026-05-07
+gh_issue: 554
+note: summary.tokens key in eval output is never populated; token counts from classify_segment and pipeline are discarded
+---
+
+### Problem
+
+Both Path A (`--path pipeline`) and Path B (`--path direct`) of `run_phase1_eval.py` discard token counts. Path B discards the `_tokens` dict returned by `classify_segment` (line with `results, _tokens = client.classify_segment(...)`). Path A token counts come from `LLMPresenceClassifierStage` inside the V2 pipeline and are equally unreachable post-run. The `summary.tokens` key referenced in the runbook ("total in/out, cache hit rate, $") is never written, so operators have no cost visibility when running the eval.
+
+### Next Steps
+
+- Accumulate token dicts from `classify_segment` (Path B) and `LLMPresenceClassifierStage` stage metadata (Path A) across all filings/segments.
+- Write a `summary.tokens` rollup: `{input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}`.
+- Update the runbook Path A cost range once real observed numbers are available.

--- a/docs/operations/llm-presence-classifier-phase1-eval-runbook.md
+++ b/docs/operations/llm-presence-classifier-phase1-eval-runbook.md
@@ -63,7 +63,8 @@ Exit codes:
   breakdown.
 - `2` — preconditions not met (missing `ANTHROPIC_API_KEY`, missing
   `DATABASE_URL` without `--gold-only`, gold corpus failed coverage,
-  `--path pipeline` selected). Re-run after fixing the precondition.
+  or `--path pipeline` preconditions not met — see Path selection below).
+  Re-run after fixing the precondition.
 
 ## Corpus selection
 
@@ -88,12 +89,35 @@ density. Filings already in the gold corpus are excluded by URL.
 paraphrase-eligible `v2_segments` (reviewed corpus) and calls
 `PresenceClassifierClient.classify_segment` directly. Mirrors the
 orchestration in `scripts/calibrate_llm_thresholds.run_sweep`. This is
-the cheap path used for the smoke test.
+the fast plumbing-test path: cheap, no HTML access required, but uses a
+biased sample (gold quotes are sparse; reviewed segments are pre-filtered).
+Supports `--dry-run`.
 
-`--path pipeline` is reserved for a follow-up. It would invoke the full
-V2 pipeline per filing with `enable_llm_presence_classifier=True` and
-`retain_context=True` to capture the real keyword + paraphrase merging
-that production will see. It returns exit code 2 today.
+`--path pipeline` runs the full V2 pipeline per filing with
+`enable_llm_presence_classifier=True` and `retain_context=True`, then
+reads `PipelineResult.context.llm_presence_signals` for classifier scores
+and `PipelineResult.context.candidates` for the keyword baseline. This is
+the production-representative path: classifier sees the same
+keyword-shortlisted + paraphrase-recall segments as live extraction.
+
+**Path A preconditions:**
+- `ANTHROPIC_API_KEY` required (no `--dry-run` equivalent).
+- `DATABASE_URL` required, even with `--gold-only` (gold filings need
+  DB lookup to resolve `html_storage_path`, `cik`, `accession_number`).
+- `--dry-run` is not supported; exit 2 if passed.
+
+**Path A cost:** ~$0.20–0.40 per filing on Haiku (real filings have
+hundreds of segments vs. the handful of gold quotes used in Path B).
+10-filing full run ≈ $2–4. Run with `--limit 1` to validate wiring before
+a full run.
+
+```bash
+# Validate one filing before paying for the full run:
+python3 scripts/run_phase1_eval.py --path pipeline --gold-only --limit 1
+
+# Full Path A run:
+python3 scripts/run_phase1_eval.py --path pipeline
+```
 
 ## Gold-negative caveat
 
@@ -104,8 +128,6 @@ annotates this. Recall is the trustworthy signal.
 
 ## Follow-ups not in this PR
 
-- Path A (`--path pipeline`) implementation. Requires HTML access via
-  `src/infra/filing_storage` to feed the V2 pipeline per filing.
 - Integration tests for the DB-touching helpers
   (`select_reviewed_corpus`, `build_reviewed_labels`,
   `keyword_baseline_path_b`). These are exercised end-to-end during the

--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -20,11 +20,12 @@ Paths
 
   Path A (``--path pipeline``)
       Runs the full V2 pipeline per filing with
-      ``enable_llm_presence_classifier=True`` and
-      ``retain_context=True``, then reads
-      ``PipelineResult.context.llm_presence_signals``. **Not implemented
-      in this PR** — opt-in opt-out follow-up. Selecting it returns exit
-      code 2.
+      ``enable_llm_presence_classifier=True`` and ``retain_context=True``,
+      then reads ``PipelineResult.context.llm_presence_signals`` for
+      classifier scores and ``PipelineResult.context.candidates`` for the
+      keyword baseline.  Requires both ``ANTHROPIC_API_KEY`` and
+      ``DATABASE_URL`` (gold filings need the DB for HTML path resolution).
+      ``--dry-run`` is not supported for Path A.
 
 Smoke-test exit codes
 ---------------------
@@ -614,6 +615,252 @@ def _load_paraphrase_segments(
 
 
 # ---------------------------------------------------------------------------
+# Path A helpers: HTML resolution, DB enrichment, pipeline evaluation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PathAFiling:
+    """Filing enriched with DB metadata for Path A (full V2 pipeline) evaluation."""
+
+    selection: FilingSelection
+    filing_id: int
+    html_storage_path: str | None
+    cik: str
+    accession_number: str
+
+
+def _enrich_filings_for_path_a(
+    filings: list[FilingSelection],
+    db_url: str,
+) -> list[_PathAFiling]:
+    """Query the DB to resolve html_storage_path, cik, and accession_number.
+
+    Gold filings (filing_id=None) are matched by html_url.  Reviewed filings
+    are matched by filing_id (already present on FilingSelection).
+
+    Raises RuntimeError if a gold filing's URL isn't found — it means the
+    gold corpus and the production DB have diverged.
+    """
+    import psycopg
+
+    gold = [f for f in filings if f.corpus == "gold"]
+    reviewed = [f for f in filings if f.corpus == "reviewed"]
+    result: list[_PathAFiling] = []
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        if gold:
+            cur.execute(
+                "SELECT filing_id, html_url, html_storage_path, cik, accession_number"
+                " FROM filings WHERE html_url = ANY(%s)",
+                ([f.filing_url for f in gold],),
+            )
+            by_url: dict[str, Any] = {row[1]: row for row in cur.fetchall()}
+            for f in gold:
+                row = by_url.get(f.filing_url)
+                if row is None:
+                    raise RuntimeError(
+                        f"Gold filing not found in DB (html_url={f.filing_url!r}). "
+                        "Corpus and DB have diverged; cannot run --path pipeline."
+                    )
+                filing_id, _, html_storage_path, cik, accession_number = row
+                result.append(
+                    _PathAFiling(
+                        selection=f,
+                        filing_id=int(filing_id),
+                        html_storage_path=html_storage_path,
+                        cik=cik or "",
+                        accession_number=accession_number or "",
+                    )
+                )
+
+        if reviewed:
+            ids = [f.filing_id for f in reviewed if f.filing_id is not None]
+            if ids:
+                cur.execute(
+                    "SELECT filing_id, html_storage_path, cik, accession_number"
+                    " FROM filings WHERE filing_id = ANY(%s)",
+                    (ids,),
+                )
+                by_id: dict[int, Any] = {int(row[0]): row for row in cur.fetchall()}
+                for f in reviewed:
+                    if f.filing_id is None:
+                        continue
+                    row = by_id.get(f.filing_id)
+                    if row is None:
+                        continue
+                    _, html_storage_path, cik, accession_number = row
+                    result.append(
+                        _PathAFiling(
+                            selection=f,
+                            filing_id=f.filing_id,
+                            html_storage_path=html_storage_path,
+                            cik=cik or "",
+                            accession_number=accession_number or "",
+                        )
+                    )
+
+    return result
+
+
+def _resolve_filing_html(paf: _PathAFiling) -> tuple[Path, Path | None]:
+    """Resolve a filing's HTML to a local path, downloading from R2 if needed.
+
+    Mirrors batch_v2_extraction.py:204-249 exactly.
+
+    Returns (resolved_path, temp_path):
+    - temp_path is set when a NamedTemporaryFile was created; caller must
+      delete it after use.
+    """
+    import os
+    import tempfile
+
+    html_path = paf.html_storage_path
+    temp_path: Path | None = None
+
+    if html_path and html_path.startswith("filings/"):
+        try:
+            from src.infra.filing_storage import get_filing_storage
+
+            data = get_filing_storage().get_bytes(html_path)
+            tmp = tempfile.NamedTemporaryFile(mode="wb", suffix=".htm", delete=False)
+            tmp.write(data)
+            tmp.close()
+            resolved = Path(tmp.name)
+            temp_path = resolved
+            logger.info(
+                "Path A filing %d: R2 key %s (%d bytes) -> %s",
+                paf.filing_id,
+                html_path,
+                len(data),
+                resolved,
+            )
+            return resolved, temp_path
+        except Exception as r2_err:
+            logger.warning(
+                "Path A filing %d: R2 read failed for %s: %s; falling through to disk",
+                paf.filing_id,
+                html_path,
+                r2_err,
+            )
+            html_path = None
+
+    if html_path:
+        resolved = Path(html_path)
+    else:
+        company_slug = (paf.selection.company or paf.selection.issuer_key).replace(" ", "_")
+        resolved = REPO_ROOT / "data" / "gold_standard" / company_slug / "filing.html"
+        if os.environ.get("APP_ENV") == "production":
+            raise RuntimeError(
+                f"Filing {paf.filing_id}: no html_storage_path; "
+                "refusing gold-standard fallback in production"
+            )
+        logger.warning(
+            "Path A filing %d: no html_storage_path; falling back to %s",
+            paf.filing_id,
+            resolved,
+        )
+
+    if not resolved.exists():
+        raise RuntimeError(f"Filing {paf.filing_id}: HTML not found: {resolved}")
+
+    return resolved, temp_path
+
+
+def evaluate_filing_pipeline(
+    paf: _PathAFiling,
+    metric_ids: list[str],
+) -> tuple[dict[str, _AggregatedScore], dict[str, bool], list[dict[str, Any]]]:
+    """Run the full V2 pipeline on a filing and extract LLM presence signals.
+
+    Returns ``(per_metric_aggregate, kw_present, errors)``.
+
+    ``kw_present[metric_id]`` is True iff CandidateGenerationStage emitted at
+    least one candidate for that metric — the keyword baseline for criterion #3.
+    """
+    from src.extraction_v2.pipeline import PipelineConfig, V2Pipeline
+
+    errors: list[dict[str, Any]] = []
+    resolved_path, temp_path = _resolve_filing_html(paf)
+
+    try:
+        pipeline_config = PipelineConfig(
+            enable_image_extraction=False,
+            enable_chart_extraction=False,
+            enable_llm_presence_classifier=True,
+            retain_context=True,
+        )
+        pipeline = V2Pipeline(config=pipeline_config)
+        result = pipeline.process(
+            html_path=resolved_path,
+            filing_id=paf.filing_id,
+            cik=paf.cik,
+            accession_number=paf.accession_number,
+        )
+    except Exception as exc:
+        errors.append(
+            {
+                "filing_url": paf.selection.filing_url,
+                "metric_id": None,
+                "exception": f"{type(exc).__name__}: {exc}",
+                "stage": "pipeline",
+            }
+        )
+        return {}, {}, errors
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+    if result.context is None:
+        errors.append(
+            {
+                "filing_url": paf.selection.filing_url,
+                "metric_id": None,
+                "exception": ("PipelineResult.context is None despite retain_context=True"),
+                "stage": "pipeline",
+            }
+        )
+        return {}, {}, errors
+
+    # Max-score aggregation per metric across all LLM signals.
+    aggregates: dict[str, _AggregatedScore] = {}
+    for sig in result.context.llm_presence_signals:
+        existing = aggregates.get(sig.metric_id)
+        if existing is None or sig.score > existing.score:
+            aggregates[sig.metric_id] = _AggregatedScore(
+                score=sig.score,
+                present=sig.present,
+                model=sig.model,
+                sonnet_fallback=sig.sonnet_fallback,
+                prompt_version=sig.prompt_version,
+                section_type=sig.section_type,
+            )
+
+    # Backfill metrics not scored (no matching segments / no signals).
+    for metric in metric_ids:
+        aggregates.setdefault(
+            metric,
+            _AggregatedScore(
+                score=0.0,
+                present=False,
+                model="(none)",
+                sonnet_fallback=False,
+                prompt_version="(none)",
+                section_type=None,
+            ),
+        )
+
+    # Keyword baseline: True iff CandidateGenerationStage produced at least
+    # one candidate for this metric.
+    kw_present = {m: any(c.metric_id == m for c in result.context.candidates) for m in metric_ids}
+
+    return aggregates, kw_present, errors
+
+
+# ---------------------------------------------------------------------------
 # Classifier orchestration (Path B)
 # ---------------------------------------------------------------------------
 
@@ -941,14 +1188,27 @@ def run_eval(
     run_started_at = datetime.now(UTC).isoformat()
 
     if path_mode == "pipeline":
-        return 2, {
-            "error": (
-                "--path pipeline (full V2 pipeline) is not implemented in this "
-                "PR. Use --path direct (default). Path A is documented as a "
-                "follow-up — see scripts/run_phase1_eval.py module docstring."
-            ),
-            "run_started_at": run_started_at,
-        }
+        if dry_run:
+            return 2, {
+                "error": (
+                    "--path pipeline does not support --dry-run. "
+                    "Use --path direct for dry-run corpus/label checks."
+                ),
+                "run_started_at": run_started_at,
+            }
+        if not os.environ.get("DATABASE_URL"):
+            return 2, {
+                "error": (
+                    "DATABASE_URL is required for --path pipeline "
+                    "(gold filings need DB for HTML path resolution)."
+                ),
+                "run_started_at": run_started_at,
+            }
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            return 2, {
+                "error": "ANTHROPIC_API_KEY is required for --path pipeline.",
+                "run_started_at": run_started_at,
+            }
 
     if gold_only and reviewed_only:
         return 2, {"error": "--gold-only and --reviewed-only are mutually exclusive"}
@@ -1070,67 +1330,97 @@ def run_eval(
     if reviewed_filing_ids and db_url:
         kw_baseline_reviewed = keyword_baseline_path_b(db_url, reviewed_filing_ids, metric_ids)
 
-    # Run classifier.
-    from src.llm.presence_classifier_client import PresenceClassifierClient
-
-    client = PresenceClassifierClient()
     rows: list[EvalRow] = []
     errors: list[dict[str, Any]] = []
 
-    # Gold filings: score gold-CSV quotes.
-    if gold_filings:
-        gold_quotes_map = _gold_quotes_per_filing(
-            GOLD_CSV, frozenset(f.filing_url for f in gold_filings)
-        )
-        for filing in gold_filings:
-            quotes = gold_quotes_map.get(filing.filing_url, [])
-            aggregates, fil_errors = evaluate_filing_direct(
-                filing,
-                metric_ids,
-                client,
-                gold_quotes=quotes,
-            )
+    if path_mode == "pipeline":
+        # Path A: run V2 pipeline per filing; keyword baseline from context.candidates.
+        try:
+            enriched = _enrich_filings_for_path_a(gold_filings + reviewed_filings, db_url)
+        except RuntimeError as enrich_err:
+            return 2, {"error": str(enrich_err), "run_started_at": run_started_at}
+
+        for paf in enriched:
+            aggregates_a, kw_present_a, fil_errors = evaluate_filing_pipeline(paf, metric_ids)
             errors.extend(fil_errors)
             for metric in metric_ids:
-                gt = gold_labels.get((filing.filing_url, metric))
+                if paf.selection.corpus == "gold":
+                    gt = gold_labels.get((paf.selection.filing_url, metric))
+                else:
+                    gt = reviewed_labels.get((paf.filing_id, metric))
                 rows.append(
                     _classify_eval_row(
                         run_id=run_id,
                         run_started_at=run_started_at,
-                        run_finished_at="",  # filled below
+                        run_finished_at="",
+                        filing=paf.selection,
+                        metric_id=metric,
+                        ground_truth=gt,
+                        aggregate=aggregates_a.get(metric),
+                        keyword_present=kw_present_a.get(metric),
+                    )
+                )
+
+    else:
+        # Path B (direct): call PresenceClassifierClient on gold quotes / v2_segments.
+        from src.llm.presence_classifier_client import PresenceClassifierClient
+
+        client = PresenceClassifierClient()
+
+        # Gold filings: score gold-CSV quotes.
+        if gold_filings:
+            gold_quotes_map = _gold_quotes_per_filing(
+                GOLD_CSV, frozenset(f.filing_url for f in gold_filings)
+            )
+            for filing in gold_filings:
+                quotes = gold_quotes_map.get(filing.filing_url, [])
+                aggregates, fil_errors = evaluate_filing_direct(
+                    filing,
+                    metric_ids,
+                    client,
+                    gold_quotes=quotes,
+                )
+                errors.extend(fil_errors)
+                for metric in metric_ids:
+                    gt = gold_labels.get((filing.filing_url, metric))
+                    rows.append(
+                        _classify_eval_row(
+                            run_id=run_id,
+                            run_started_at=run_started_at,
+                            run_finished_at="",  # filled below
+                            filing=filing,
+                            metric_id=metric,
+                            ground_truth=gt,
+                            aggregate=aggregates.get(metric),
+                            keyword_present=None,
+                        )
+                    )
+
+        # Reviewed filings: score paraphrase-eligible v2_segments.
+        for filing in reviewed_filings:
+            aggregates, fil_errors = evaluate_filing_direct(
+                filing,
+                metric_ids,
+                client,
+                db_url=db_url,
+                section_whitelist=section_whitelist,
+            )
+            errors.extend(fil_errors)
+            for metric in metric_ids:
+                gt = reviewed_labels.get((filing.filing_id, metric))
+                kw = kw_baseline_reviewed.get((filing.filing_id, metric))
+                rows.append(
+                    _classify_eval_row(
+                        run_id=run_id,
+                        run_started_at=run_started_at,
+                        run_finished_at="",
                         filing=filing,
                         metric_id=metric,
                         ground_truth=gt,
                         aggregate=aggregates.get(metric),
-                        keyword_present=None,
+                        keyword_present=kw,
                     )
                 )
-
-    # Reviewed filings: score paraphrase-eligible v2_segments.
-    for filing in reviewed_filings:
-        aggregates, fil_errors = evaluate_filing_direct(
-            filing,
-            metric_ids,
-            client,
-            db_url=db_url,
-            section_whitelist=section_whitelist,
-        )
-        errors.extend(fil_errors)
-        for metric in metric_ids:
-            gt = reviewed_labels.get((filing.filing_id, metric))
-            kw = kw_baseline_reviewed.get((filing.filing_id, metric))
-            rows.append(
-                _classify_eval_row(
-                    run_id=run_id,
-                    run_started_at=run_started_at,
-                    run_finished_at="",
-                    filing=filing,
-                    metric_id=metric,
-                    ground_truth=gt,
-                    aggregate=aggregates.get(metric),
-                    keyword_present=kw,
-                )
-            )
 
     run_finished_at = datetime.now(UTC).isoformat()
     for r in rows:

--- a/tests/unit/scripts/test_run_phase1_eval.py
+++ b/tests/unit/scripts/test_run_phase1_eval.py
@@ -86,10 +86,10 @@ def test_dry_run_gold_only_writes_csv_and_summary(cli, tmp_path, monkeypatch):
     assert len(summary_loaded["selected_gold_filings"]) >= 1
 
 
-def test_path_pipeline_returns_precondition_failure(cli, tmp_path):
-    """Selecting --path pipeline returns exit code 2 with a clear message."""
+def test_path_pipeline_dry_run_not_supported(cli, tmp_path):
+    """--path pipeline with --dry-run returns exit code 2 (dry-run unsupported for Path A)."""
     exit_code, summary = cli.run_eval(
-        run_id="testrun_pipeline",
+        run_id="testrun_pipeline_dryrun",
         out_dir=tmp_path,
         path_mode="pipeline",
         gold_only=True,
@@ -98,7 +98,7 @@ def test_path_pipeline_returns_precondition_failure(cli, tmp_path):
         dry_run=True,
     )
     assert exit_code == 2
-    assert "not implemented" in summary["error"].lower()
+    assert "dry-run" in summary["error"].lower() or "--dry-run" in summary["error"]
 
 
 def test_dry_run_reviewed_corpus_requires_database_url(cli, tmp_path, monkeypatch):

--- a/tests/unit/scripts/test_run_phase1_eval_pipeline.py
+++ b/tests/unit/scripts/test_run_phase1_eval_pipeline.py
@@ -1,0 +1,303 @@
+"""Unit tests for ``scripts/run_phase1_eval.py`` — Path A (``--path pipeline``).
+
+Covers:
+  - Precondition checks: missing ANTHROPIC_API_KEY / DATABASE_URL / --dry-run.
+  - HTML resolution helper: R2 key → tempfile, disk path → passthrough.
+  - Pipeline evaluation shape: correct max-score aggregation from LLMPresenceSignals.
+  - Keyword baseline extraction: context.candidates → kw_present per metric.
+
+V2Pipeline and get_filing_storage are mocked throughout; no live API or DB calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "run_phase1_eval.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    mod_name = "run_phase1_eval_pipeline_tests"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(mod_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _load_script_module()
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _make_paf(cli, *, html_storage_path: str | None, filing_id: int = 42):
+    return cli._PathAFiling(
+        selection=cli.FilingSelection(
+            corpus="gold",
+            filing_url="https://example.com/test.htm",
+            filing_id=None,
+            issuer_key="testco",
+            company="Test Co",
+        ),
+        filing_id=filing_id,
+        html_storage_path=html_storage_path,
+        cik="0001234567",
+        accession_number="0001234567-21-000001",
+    )
+
+
+class _FakeLLMSignal:
+    def __init__(self, metric_id: str, score: float, present: bool) -> None:
+        self.metric_id = metric_id
+        self.score = score
+        self.present = present
+        self.model = "claude-haiku-4-5-20251001"
+        self.sonnet_fallback = False
+        self.prompt_version = "0.1.0-test"
+        self.section_type = "mda"
+
+
+class _FakeCandidate:
+    def __init__(self, metric_id: str) -> None:
+        self.metric_id = metric_id
+
+
+def _make_fake_context(signals=None, candidates=None):
+    ctx = MagicMock()
+    ctx.llm_presence_signals = signals or []
+    ctx.candidates = candidates or []
+    return ctx
+
+
+def _make_fake_pipeline_result(context=None, success=True):
+    result = MagicMock()
+    result.success = success
+    result.context = context
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Precondition tests
+# ---------------------------------------------------------------------------
+
+
+def test_path_pipeline_requires_database_url(cli, tmp_path, monkeypatch):
+    """--path pipeline without DATABASE_URL returns exit 2."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+    exit_code, summary = cli.run_eval(
+        run_id="r",
+        out_dir=tmp_path,
+        path_mode="pipeline",
+        gold_only=True,
+        reviewed_only=False,
+        limit=1,
+        dry_run=False,
+    )
+    assert exit_code == 2
+    assert "DATABASE_URL" in summary["error"]
+
+
+def test_path_pipeline_requires_anthropic_api_key(cli, tmp_path, monkeypatch):
+    """--path pipeline without ANTHROPIC_API_KEY returns exit 2."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake/fake")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    exit_code, summary = cli.run_eval(
+        run_id="r",
+        out_dir=tmp_path,
+        path_mode="pipeline",
+        gold_only=True,
+        reviewed_only=False,
+        limit=1,
+        dry_run=False,
+    )
+    assert exit_code == 2
+    assert "ANTHROPIC_API_KEY" in summary["error"]
+
+
+# ---------------------------------------------------------------------------
+# HTML resolution tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_filing_html_r2_key_downloads_to_tempfile(cli, tmp_path, monkeypatch):
+    """html_storage_path starting with 'filings/' triggers R2 download."""
+    fake_bytes = b"<html>test</html>"
+
+    mock_storage = MagicMock()
+    mock_storage.get_bytes.return_value = fake_bytes
+
+    with patch("src.infra.filing_storage.get_filing_storage", return_value=mock_storage):
+        paf = _make_paf(cli, html_storage_path="filings/0001/acc/primary.htm")
+        resolved, temp_path = cli._resolve_filing_html(paf)
+
+    assert temp_path is not None
+    assert resolved == temp_path
+    assert resolved.exists()
+    assert resolved.read_bytes() == fake_bytes
+    mock_storage.get_bytes.assert_called_once_with("filings/0001/acc/primary.htm")
+
+    # Cleanup the temp file so it doesn't litter.
+    resolved.unlink(missing_ok=True)
+
+
+def test_resolve_filing_html_disk_path_passthrough(cli, tmp_path):
+    """Non-R2 html_storage_path (disk path) is returned as-is without R2 call."""
+    html_file = tmp_path / "filing.html"
+    html_file.write_text("<html>disk</html>")
+
+    paf = _make_paf(cli, html_storage_path=str(html_file))
+    resolved, temp_path = cli._resolve_filing_html(paf)
+
+    assert temp_path is None
+    assert resolved == html_file
+
+
+def test_resolve_filing_html_missing_disk_path_raises(cli, tmp_path):
+    """A disk path that doesn't exist raises RuntimeError."""
+    paf = _make_paf(cli, html_storage_path=str(tmp_path / "nonexistent.html"))
+    with pytest.raises(RuntimeError, match="HTML not found"):
+        cli._resolve_filing_html(paf)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_filing_pipeline — shape test
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_filing_pipeline_max_score_aggregation(cli, tmp_path):
+    """Multiple signals for the same metric → max score is kept."""
+    html_file = tmp_path / "filing.html"
+    html_file.write_text("<html/>")
+
+    signals = [
+        _FakeLLMSignal("cm_net_revenue_retention", 0.9, True),
+        _FakeLLMSignal("cm_net_revenue_retention", 0.6, True),  # lower — should be dropped
+        _FakeLLMSignal("cm_revenue_concentration", 0.3, False),
+    ]
+    fake_ctx = _make_fake_context(signals=signals, candidates=[])
+    fake_result = _make_fake_pipeline_result(context=fake_ctx)
+
+    metric_ids = [
+        "cm_net_revenue_retention",
+        "cm_revenue_concentration",
+        "cm_customer_acquisition_cost",  # not in signals → backfill
+    ]
+
+    with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
+        MockPipeline.return_value.process.return_value = fake_result
+        paf = _make_paf(cli, html_storage_path=str(html_file))
+        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+
+    assert errors == []
+    assert aggregates["cm_net_revenue_retention"].score == 0.9
+    assert aggregates["cm_net_revenue_retention"].present is True
+    assert aggregates["cm_net_revenue_retention"].model == "claude-haiku-4-5-20251001"
+    assert aggregates["cm_revenue_concentration"].score == 0.3
+    assert aggregates["cm_revenue_concentration"].present is False
+    # Backfilled metric
+    assert aggregates["cm_customer_acquisition_cost"].score == 0.0
+    assert aggregates["cm_customer_acquisition_cost"].present is False
+    assert aggregates["cm_customer_acquisition_cost"].model == "(none)"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_filing_pipeline — keyword baseline test
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_filing_pipeline_keyword_baseline(cli, tmp_path):
+    """context.candidates → kw_present per metric."""
+    html_file = tmp_path / "filing.html"
+    html_file.write_text("<html/>")
+
+    candidates = [
+        _FakeCandidate("cm_net_revenue_retention"),
+        _FakeCandidate("cm_net_revenue_retention"),  # duplicate is fine
+    ]
+    fake_ctx = _make_fake_context(signals=[], candidates=candidates)
+    fake_result = _make_fake_pipeline_result(context=fake_ctx)
+
+    metric_ids = ["cm_net_revenue_retention", "cm_revenue_concentration"]
+
+    with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
+        MockPipeline.return_value.process.return_value = fake_result
+        paf = _make_paf(cli, html_storage_path=str(html_file))
+        _aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+
+    assert errors == []
+    assert kw_present["cm_net_revenue_retention"] is True
+    assert kw_present["cm_revenue_concentration"] is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_filing_pipeline — EvalRow emission via _classify_eval_row
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_filing_pipeline_eval_row_keyword_present_set(cli, tmp_path):
+    """kw_present from context.candidates lands on the EvalRow.keyword_present field."""
+    html_file = tmp_path / "filing.html"
+    html_file.write_text("<html/>")
+
+    signals = [_FakeLLMSignal("cm_net_revenue_retention", 0.85, True)]
+    candidates = [_FakeCandidate("cm_net_revenue_retention")]
+    fake_ctx = _make_fake_context(signals=signals, candidates=candidates)
+    fake_result = _make_fake_pipeline_result(context=fake_ctx)
+
+    metric_ids = ["cm_net_revenue_retention"]
+
+    with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
+        MockPipeline.return_value.process.return_value = fake_result
+        paf = _make_paf(cli, html_storage_path=str(html_file))
+        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+
+    row = cli._classify_eval_row(
+        run_id="r",
+        run_started_at="t0",
+        run_finished_at="t1",
+        filing=paf.selection,
+        metric_id="cm_net_revenue_retention",
+        ground_truth=True,
+        aggregate=aggregates.get("cm_net_revenue_retention"),
+        keyword_present=kw_present.get("cm_net_revenue_retention"),
+    )
+
+    assert row.keyword_present is True
+    assert row.classifier_present is True
+    assert row.classification == "TP"
+
+
+def test_evaluate_filing_pipeline_pipeline_exception_returns_error(cli, tmp_path):
+    """If V2Pipeline.process raises, errors list is populated and empty dicts returned."""
+    html_file = tmp_path / "filing.html"
+    html_file.write_text("<html/>")
+
+    with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
+        MockPipeline.return_value.process.side_effect = RuntimeError("pipeline exploded")
+        paf = _make_paf(cli, html_storage_path=str(html_file))
+        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(
+            paf, ["cm_net_revenue_retention"]
+        )
+
+    assert aggregates == {}
+    assert kw_present == {}
+    assert len(errors) == 1
+    assert "pipeline exploded" in errors[0]["exception"]
+    assert errors[0]["stage"] == "pipeline"


### PR DESCRIPTION
## Summary

- Implements `--path pipeline` (Path A) in `scripts/run_phase1_eval.py`, replacing the exit-2 stub
- Path A runs the full V2 pipeline per filing with `enable_llm_presence_classifier=True` and `retain_context=True`, then reads real keyword candidates and LLM presence signals — making criterion #3 (catastrophic recall regression vs keyword baseline) non-vacuous for the first time
- Path B (`--path direct`) is completely unchanged

## Changes

**`scripts/run_phase1_eval.py`**
- New `_PathAFiling` dataclass: filing enriched with DB metadata
- `_enrich_filings_for_path_a`: DB lookup for `html_storage_path`, `cik`, `accession_number` (gold filings matched by `html_url`, reviewed by `filing_id`)
- `_resolve_filing_html`: R2 key → tempfile or disk passthrough; mirrors `batch_v2_extraction.py:204-249` exactly
- `evaluate_filing_pipeline`: runs `V2Pipeline(config=PipelineConfig(enable_image_extraction=False, enable_chart_extraction=False, enable_llm_presence_classifier=True, retain_context=True)).process(...)`, aggregates `context.llm_presence_signals` by max score per metric, and derives `kw_present` from `context.candidates`
- Preconditions: `ANTHROPIC_API_KEY` + `DATABASE_URL` required for Path A; `--dry-run` returns exit 2

**`tests/unit/scripts/test_run_phase1_eval_pipeline.py`** (new)
- Precondition tests (missing API key / DB URL)
- HTML resolution tests (R2 download via monkeypatched `get_filing_storage`, disk passthrough, missing path raises)
- Shape test: max-score aggregation from fake `LLMPresenceSignal` list
- Keyword baseline test: `context.candidates` → `kw_present` per metric
- EvalRow emission test: `keyword_present` field correctly set
- Pipeline exception test: error list populated, empty dicts returned

**`docs/operations/llm-presence-classifier-phase1-eval-runbook.md`**
- Path selection section updated to document Path A preconditions, cost estimate ($0.20–0.40/filing), and `--limit 1` validation tip

**Deferred (#554):** `summary.tokens` rollup (token counts from both paths are currently discarded).

## Test plan

- [ ] Unit tests pass: `pytest tests/unit/scripts/test_run_phase1_eval_pipeline.py tests/unit/scripts/test_run_phase1_eval.py -q` — 22 tests
- [ ] Full unit suite: `pytest tests/unit/ -x -q` — 4831 tests
- [ ] Live Path A validation: `python3 scripts/run_phase1_eval.py --path pipeline --gold-only --limit 1` (requires `ANTHROPIC_API_KEY` + `DATABASE_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)