### PR TITLE
fix(review): drop panzoom contain mode so wheel zoom and pan work

### DIFF
--- a/src/web/templates/unified_review.html
+++ b/src/web/templates/unified_review.html
@@ -1654,7 +1654,7 @@ document.addEventListener('keydown', function(e) {
 
   modalEl.addEventListener('shown.bs.modal', function () {
     if (typeof Panzoom === 'undefined') return;  // CDN failed; image still visible at 1:1
-    pz = Panzoom(imgEl, { maxScale: 8, minScale: 1, contain: 'inside' });
+    pz = Panzoom(imgEl, { maxScale: 8, minScale: 1 });
     wrapEl.addEventListener('wheel', onWheel, { passive: false });
     imgEl.addEventListener('panzoomstart', onStart);
     imgEl.addEventListener('panzoomend', onEnd);


### PR DESCRIPTION
PR #553 switched the lightbox panzoom contain mode from 'outside' to
'inside' to allow horizontal pan, but 'inside' clamps maxScale to
fit-inside-parent — wheel zoom does nothing because the image is not
allowed to grow past the modal viewport, and the residual asymmetric
pan slack is also a contain-bounds artifact.

Removing contain entirely gives free transform: wheel zoom up to 8x,
drag pans in any direction. minScale=1 keeps the image from shrinking
below CSS-fit, so the modal still opens fully-fit and centered via the
existing flex-centering wrap. Trade-off: at scale 1 the image can be
dragged off-screen; the existing Reset zoom button and ESC dismiss
handle recovery.
