### PR TITLE
feat(image-model): emit 90/95% recall thresholds in retrain report

### DIFF
--- a/scripts/train_image_relevance_model.py
+++ b/scripts/train_image_relevance_model.py
@@ -52,16 +52,16 @@ def precision_at_recall(precisions, recalls, target_recall: float) -> float:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Train image relevance model"
-    )
+    parser = argparse.ArgumentParser(description="Train image relevance model")
     parser.add_argument("--input", type=str, default=str(DEFAULT_INPUT))
     parser.add_argument("--output", type=str, default=str(DEFAULT_MODEL))
     parser.add_argument("--report", type=str, default=str(DEFAULT_REPORT))
     parser.add_argument(
-        "--model-type", choices=["logistic", "gbt"], default="logistic",
+        "--model-type",
+        choices=["logistic", "gbt"],
+        default="logistic",
         help="Model class to train (default: logistic). Use 'gbt' to evaluate "
-             "HistGradientBoostingClassifier. Adopt gbt only if AUC>=+0.03 or AP>=+0.05 vs logistic.",
+        "HistGradientBoostingClassifier. Adopt gbt only if AUC>=+0.03 or AP>=+0.05 vs logistic.",
     )
     args = parser.parse_args()
 
@@ -84,8 +84,12 @@ def main() -> None:
 
     n_pos = y.sum()
     n_neg = len(y) - n_pos
-    logger.info("Class distribution: %d relevant (%.1f%%), %d not_relevant",
-                n_pos, 100 * n_pos / len(y), n_neg)
+    logger.info(
+        "Class distribution: %d relevant (%.1f%%), %d not_relevant",
+        n_pos,
+        100 * n_pos / len(y),
+        n_neg,
+    )
 
     model_type = args.model_type
     logger.info("Model type: %s", model_type)
@@ -93,27 +97,37 @@ def main() -> None:
     if model_type == "gbt":
         # HistGradientBoostingClassifier: no scaling needed, handles mixed features well.
         # Conservative hyperparams to avoid overfitting on ~600 samples.
-        pipeline = Pipeline([
-            ("clf", HistGradientBoostingClassifier(
-                max_iter=200,
-                max_depth=4,
-                min_samples_leaf=10,
-                learning_rate=0.1,
-                class_weight="balanced",
-                random_state=42,
-            )),
-        ])
+        pipeline = Pipeline(
+            [
+                (
+                    "clf",
+                    HistGradientBoostingClassifier(
+                        max_iter=200,
+                        max_depth=4,
+                        min_samples_leaf=10,
+                        learning_rate=0.1,
+                        class_weight="balanced",
+                        random_state=42,
+                    ),
+                ),
+            ]
+        )
     else:
         # Logistic regression with class weighting to handle imbalance
-        pipeline = Pipeline([
-            ("scaler", StandardScaler()),
-            ("clf", LogisticRegression(
-                class_weight="balanced",
-                max_iter=1000,
-                C=1.0,
-                solver="lbfgs",
-            )),
-        ])
+        pipeline = Pipeline(
+            [
+                ("scaler", StandardScaler()),
+                (
+                    "clf",
+                    LogisticRegression(
+                        class_weight="balanced",
+                        max_iter=1000,
+                        C=1.0,
+                        solver="lbfgs",
+                    ),
+                ),
+            ]
+        )
 
     # Cross-validation to get unbiased probability estimates
     cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
@@ -127,12 +141,17 @@ def main() -> None:
     p_at_90 = precision_at_recall(precisions, recalls, 0.90)
     p_at_95 = precision_at_recall(precisions, recalls, 0.95)
 
-    # Find threshold that gives ~80% recall
+    # Find thresholds that give ~80%, ~90%, ~95% recall
     thresh_80 = None
+    thresh_90 = None
+    thresh_95 = None
     for t, _p, r in zip(thresholds, precisions, recalls, strict=False):
-        if r <= 0.80:
+        if r <= 0.80 and thresh_80 is None:
             thresh_80 = t
-            break
+        if r <= 0.90 and thresh_90 is None:
+            thresh_90 = t
+        if r <= 0.95 and thresh_95 is None:
+            thresh_95 = t
 
     logger.info("Cross-validated metrics (5-fold stratified):")
     logger.info("  AUC-ROC:           %.3f", auc_roc)
@@ -142,6 +161,10 @@ def main() -> None:
     logger.info("  Precision@95%%recall: %.3f", p_at_95)
     if thresh_80 is not None:
         logger.info("  Score threshold for ~80%% recall: %.3f", thresh_80)
+    if thresh_90 is not None:
+        logger.info("  Score threshold for ~90%% recall: %.3f", thresh_90)
+    if thresh_95 is not None:
+        logger.info("  Score threshold for ~95%% recall: %.3f", thresh_95)
 
     # Fit on all data for deployment
     pipeline.fit(X, y)
@@ -152,29 +175,38 @@ def main() -> None:
         # HistGradientBoostingClassifier removed feature_importances_ in recent sklearn;
         # use permutation importance on the full training set as a proxy.
         from sklearn.inspection import permutation_importance
-        perm = permutation_importance(pipeline, X, y, n_repeats=10, random_state=42, scoring="average_precision")
+
+        perm = permutation_importance(
+            pipeline, X, y, n_repeats=10, random_state=42, scoring="average_precision"
+        )
         importances = perm.importances_mean
         logger.info("\nFeature importances (GBT, permutation on train set):")
-        feat_imp = sorted(zip(FEATURE_NAMES, importances, strict=True), key=lambda x: x[1], reverse=True)
+        feat_imp = sorted(
+            zip(FEATURE_NAMES, importances, strict=True), key=lambda x: x[1], reverse=True
+        )
         for name, imp in feat_imp:
             logger.info("  %s: %.4f", name, imp)
     else:
         coef = clf.coef_[0]
         logger.info("\nFeature importances (logistic regression coefficients):")
-        feat_imp = sorted(zip(FEATURE_NAMES, coef, strict=True), key=lambda x: abs(x[1]), reverse=True)
+        feat_imp = sorted(
+            zip(FEATURE_NAMES, coef, strict=True), key=lambda x: abs(x[1]), reverse=True
+        )
         for name, c in feat_imp:
             logger.info("  %s: %+.3f", name, c)
 
     # Baseline comparison: what does the current tier system achieve?
-    tier_1_mask = np.array([
-        1 if r["detection_tier"] == "tier_1_cohort" else 0 for r in rows
-    ])
+    tier_1_mask = np.array([1 if r["detection_tier"] == "tier_1_cohort" else 0 for r in rows])
     tier_1_precision = y[tier_1_mask == 1].mean() if tier_1_mask.sum() > 0 else 0
     tier_1_recall = (y[tier_1_mask == 1].sum() / n_pos) if n_pos > 0 else 0
     logger.info("\nBaseline (tier_1_cohort only):")
-    logger.info("  Precision: %.3f | Recall: %.3f | Coverage: %d/%d images",
-                tier_1_precision, tier_1_recall,
-                tier_1_mask.sum(), len(rows))
+    logger.info(
+        "  Precision: %.3f | Recall: %.3f | Coverage: %d/%d images",
+        tier_1_precision,
+        tier_1_recall,
+        tier_1_mask.sum(),
+        len(rows),
+    )
 
     # Save model
     output_path = Path(args.output)
@@ -187,8 +219,8 @@ def main() -> None:
     report.write("Image Relevance Model Report\n")
     report.write("=" * 40 + "\n\n")
     report.write(f"Training samples: {len(rows)}\n")
-    report.write(f"  Relevant: {int(n_pos)} ({100*n_pos/len(y):.1f}%)\n")
-    report.write(f"  Not relevant: {int(n_neg)} ({100*n_neg/len(y):.1f}%)\n\n")
+    report.write(f"  Relevant: {int(n_pos)} ({100 * n_pos / len(y):.1f}%)\n")
+    report.write(f"  Not relevant: {int(n_neg)} ({100 * n_neg / len(y):.1f}%)\n\n")
     report.write("Cross-validated metrics (5-fold stratified):\n")
     report.write(f"  AUC-ROC:               {auc_roc:.3f}\n")
     report.write(f"  Avg precision (AP):    {avg_precision:.3f}\n")
@@ -197,6 +229,10 @@ def main() -> None:
     report.write(f"  Precision @ 95% recall: {p_at_95:.3f}\n")
     if thresh_80 is not None:
         report.write(f"  Score threshold for ~80% recall: {thresh_80:.3f}\n")
+    if thresh_90 is not None:
+        report.write(f"  Score threshold for ~90% recall: {thresh_90:.3f}\n")
+    if thresh_95 is not None:
+        report.write(f"  Score threshold for ~95% recall: {thresh_95:.3f}\n")
     report.write("\nBaseline (current tier_1_cohort system):\n")
     report.write(f"  Precision: {tier_1_precision:.3f}\n")
     report.write(f"  Recall:    {tier_1_recall:.3f}\n")


### PR DESCRIPTION
## Summary

- Extend `scripts/train_image_relevance_model.py` to compute score thresholds for ~90% and ~95% recall in addition to the existing ~80% threshold
- Log all three thresholds via `logger.info` alongside existing metrics
- Write all three to the text report file (alongside existing thresh_80 line)
- Single-file change; no refactoring, no new deps

## Motivation

Phase 1 of the image-classifier improvement plan (we-have-processed-a-cryptic-pelican) requires the 95%-recall threshold value from the retrain report to set `LEARNED_TRIAGE_MIN` in production. The 90%-recall value is also captured for the planned follow-on threshold raise.

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `python3 scripts/train_image_relevance_model.py --help` parses cleanly
- [x] Pre-push unit tests pass (CI will also run integration suite)
- [x] Integration test `test_retrain_image_triage_upload.py` mocks the subprocess call and is unaffected by this change; fails locally only due to missing test DB (pre-existing env issue)

Plan: `/Users/rgmarkey/.claude/plans/we-have-processed-a-cryptic-pelican.md` (Phase 0, step 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)