### PR TITLE
feat(image-model): offline eval of Vision per-metric prediction scores

### DIFF
--- a/docs/operations/image-model-training-runbook.md
+++ b/docs/operations/image-model-training-runbook.md
@@ -213,3 +213,77 @@ The `GET /api/v2/models/training/<uuid>/status` poll endpoint surfaces `queued`,
     WHERE id = '<uuid>';
    ```
 5. **Click again.** With the row no longer at `queued`/`running`, the concurrency gate clears and the next click enqueues a fresh row.
+
+---
+
+## Phase 2 — Vision Per-Metric Score Calibration Eval
+
+`scripts/evaluate_vision_metric_scores.py` is a read-only offline eval that
+measures whether the confidence scores emitted by the Vision metric-classify
+step (`v2_image_classifications.predicted_metrics`) are calibrated enough to
+filter on.  **It does not modify any production data or route.**
+
+### When to run
+
+Run this script once a sufficient volume of per-metric reviewer decisions has
+accumulated in `v2_image_metric_confirmations` (a few hundred labeled images is
+a reasonable minimum).  Re-run after any substantial labeling session to check
+whether score calibration has shifted.
+
+### Usage
+
+```bash
+# Write the report to the default path.
+python3 scripts/evaluate_vision_metric_scores.py \
+    --database-url "$DATABASE_URL" \
+    --output data/vision_score_eval/report.txt
+
+# Preview to stdout without writing (useful during testing).
+python3 scripts/evaluate_vision_metric_scores.py --database-url "$DATABASE_URL" --dry-run
+
+# Limit rows fetched during development.
+python3 scripts/evaluate_vision_metric_scores.py --database-url "$DATABASE_URL" --limit 500
+```
+
+### What the report contains
+
+| Section | Description |
+|---------|-------------|
+| Header counts | Total labeled (img_id, metric_id) pairs, positives, negatives, positive rate |
+| AUC-ROC | Overall discriminative power across all metrics |
+| Average Precision | Area under the precision-recall curve |
+| Threshold sweep | Precision / recall / F1 at thresholds 0.1–0.9 |
+| Per-metric breakdown | AUC and AP per metric, shown only where ≥30 positive labels exist |
+
+### How to interpret the output
+
+**AUC-ROC:**
+
+| AUC | Interpretation |
+|-----|---------------|
+| < 0.70 | Scores not calibrated — do not filter |
+| 0.70–0.80 | Marginal — review per-metric breakdown before deciding |
+| ≥ 0.80 | Proceed to Phase 2b gating decision |
+
+**Phase 2b trigger condition (from the approved plan):**
+AUC ≥ 0.80 AND a threshold exists with ≥95% recall AND ≥40% precision.
+If the condition is met, open a Phase 2b PR to apply the filter at the
+`predicted_metrics` emission site in `src/web/routes/api_unified.py`.
+If not met, stop and revisit after Phase 3 (per-metric classifier) ships.
+
+**Threshold sweep:**
+Choose the threshold row where recall is closest to 0.95 (from above), then
+read the corresponding precision.  If precision ≥ 0.40, the filter is viable.
+
+**Per-metric breakdown:**
+Low AUC on a specific metric indicates the Vision model's score is noisy for
+that metric class.  Metrics below the breakdown threshold (< 30 positives)
+cannot be evaluated reliably.
+
+### Results
+
+*(Fill in after running the script against the production database.)*
+
+| Run date | N pairs | AUC-ROC | AP | Phase 2b trigger met? |
+|----------|---------|---------|-----|----------------------|
+| TBD | — | — | — | — |

--- a/scripts/evaluate_vision_metric_scores.py
+++ b/scripts/evaluate_vision_metric_scores.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+Offline evaluation of Vision per-metric prediction scores.
+
+Pulls (img_id, metric_id, predicted_score) from v2_image_classifications and
+compares against ground-truth labels derived from v2_image_metric_confirmations.
+Produces an AUC-ROC / average-precision report with a threshold sweep.
+
+Usage:
+    python3 scripts/evaluate_vision_metric_scores.py
+    python3 scripts/evaluate_vision_metric_scores.py --output data/vision_score_eval/report.txt
+    python3 scripts/evaluate_vision_metric_scores.py --dry-run
+    python3 scripts/evaluate_vision_metric_scores.py --limit 500
+
+Output:
+    Plain-text report with overall AUC-ROC, average precision, a threshold sweep
+    (0.1–0.9) reporting precision/recall/F1, and a per-metric breakdown for
+    metrics with ≥30 positive labels.
+
+Phase 2 of the image-classifier improvement plan.  Implementation of any
+production filter is a Phase 2b decision gated on this report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+from src.infra.logging_config import configure_logging
+
+logger = logging.getLogger(__name__)
+
+# Minimum positive labels in a metric bucket to include in the per-metric breakdown.
+PER_METRIC_MIN_POSITIVES = 30
+
+# Threshold sweep points.
+THRESHOLDS = [round(t / 10, 1) for t in range(1, 10)]
+
+# Default output path.
+DEFAULT_OUTPUT = Path("data/vision_score_eval/report.txt")
+
+
+# ---------------------------------------------------------------------------
+# Database queries
+# ---------------------------------------------------------------------------
+
+_PREDICTIONS_SQL = """
+WITH latest_classifications AS (
+    -- One row per img_id: pick the most-recent classification run.
+    SELECT DISTINCT ON (img_id)
+        img_id,
+        predicted_metrics
+    FROM v2_image_classifications
+    ORDER BY img_id, created_at DESC
+),
+-- Only include images that have at least one confirmation row.
+images_with_confirmations AS (
+    SELECT DISTINCT img_id
+    FROM v2_image_metric_confirmations
+),
+-- Unnest the predicted_metrics JSONB array into (img_id, metric_id, score).
+unnested AS (
+    SELECT
+        lc.img_id,
+        (elem->>'metric_id')  AS metric_id,
+        (elem->>'score')::float AS predicted_score
+    FROM latest_classifications lc
+    JOIN images_with_confirmations iwc USING (img_id),
+    jsonb_array_elements(lc.predicted_metrics) AS elem
+    WHERE jsonb_array_length(lc.predicted_metrics) > 0
+)
+SELECT img_id::text, metric_id, predicted_score
+FROM unnested
+{limit_clause}
+ORDER BY img_id, metric_id
+"""
+
+_CONFIRMATIONS_SQL = """
+SELECT
+    img_id::text,
+    detected_metric_id,
+    confirmed_metric_id,
+    decision,
+    rejection_reason
+FROM v2_image_metric_confirmations
+WHERE img_id IN (
+    SELECT DISTINCT img_id
+    FROM v2_image_classifications
+)
+ORDER BY img_id, created_at
+"""
+
+
+# ---------------------------------------------------------------------------
+# Label derivation
+# ---------------------------------------------------------------------------
+
+
+def build_label_map(
+    confirmations: list[dict[str, Any]],
+    all_vision_metrics_by_image: dict[str, set[str]],
+) -> dict[tuple[str, str], int]:
+    """
+    Return a map of (img_id, metric_id) → label (0 or 1).
+
+    Label rules (any-accept-wins):
+      1. Sentinel reject (both IDs NULL, rejection_reason='no_relevant_metrics'):
+         → label=0 for ALL Vision-predicted metrics on that image.
+      2. decision in ('accept', 'correct', 'add') with confirmed_metric_id matching
+         a Vision-predicted metric_id → label=1.
+      3. decision='reject' with confirmed_metric_id or detected_metric_id matching
+         a Vision-predicted metric_id → label=0.
+    Any (img_id, metric_id) pair with at least one accept/correct/add
+    confirmation wins label=1 regardless of other reject rows.
+    """
+    # Track positives and negatives separately; any positive wins.
+    positives: set[tuple[str, str]] = set()
+    negatives: set[tuple[str, str]] = set()
+
+    for row in confirmations:
+        img_id: str = row["img_id"]
+        detected_mid: str | None = row["detected_metric_id"]
+        confirmed_mid: str | None = row["confirmed_metric_id"]
+        decision: str = row["decision"]
+        rejection_reason: str | None = row["rejection_reason"]
+
+        # Sentinel: "Reject all — no relevant metrics".
+        is_sentinel = (
+            decision == "reject"
+            and detected_mid is None
+            and confirmed_mid is None
+            and rejection_reason == "no_relevant_metrics"
+        )
+        if is_sentinel:
+            # All Vision-predicted metrics for this image get label=0 (unless
+            # another confirmation positively accepts one).
+            for metric_id in all_vision_metrics_by_image.get(img_id, set()):
+                negatives.add((img_id, metric_id))
+            continue
+
+        # Accepting decisions.
+        if decision in ("accept", "correct", "add") and confirmed_mid:
+            positives.add((img_id, confirmed_mid))
+
+        # Rejecting decisions — map to Vision-predicted metric via either ID.
+        if decision == "reject":
+            reject_metric = confirmed_mid or detected_mid
+            if reject_metric:
+                negatives.add((img_id, reject_metric))
+
+    # Merge: positives override negatives.
+    label_map: dict[tuple[str, str], int] = {}
+    for key in negatives:
+        label_map[key] = 0
+    for key in positives:
+        label_map[key] = 1
+
+    return label_map
+
+
+# ---------------------------------------------------------------------------
+# Metrics computation
+# ---------------------------------------------------------------------------
+
+
+def _prf1(y_true: list[int], y_pred: list[int]) -> tuple[float, float, float]:
+    """Precision, recall, F1 at a threshold (binary predictions)."""
+    tp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t == 1 and p == 1)
+    fp = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t == 0 and p == 1)
+    fn = sum(1 for t, p in zip(y_true, y_pred, strict=True) if t == 1 and p == 0)
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1
+
+
+def _auc_roc(y_true: list[int], y_score: list[float]) -> float:
+    """Trapezoidal AUC-ROC (no sklearn dependency)."""
+    pairs = sorted(zip(y_score, y_true, strict=True), reverse=True)
+    n_pos = sum(y_true)
+    n_neg = len(y_true) - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+
+    auc = 0.0
+    tp = 0
+    fp = 0
+    prev_fp = 0
+    prev_tp = 0
+    prev_score = None
+
+    for score, label in pairs:
+        if score != prev_score and prev_score is not None:
+            # Accumulate trapezoid.
+            auc += (fp - prev_fp) * (tp + prev_tp) / 2.0
+            prev_fp = fp
+            prev_tp = tp
+        if label == 1:
+            tp += 1
+        else:
+            fp += 1
+        prev_score = score
+
+    # Final trapezoid.
+    auc += (fp - prev_fp) * (tp + prev_tp) / 2.0
+    return auc / (n_pos * n_neg)
+
+
+def _average_precision(y_true: list[int], y_score: list[float]) -> float:
+    """Average precision (area under precision-recall curve, step interpolation)."""
+    pairs = sorted(zip(y_score, y_true, strict=True), reverse=True)
+    n_pos = sum(y_true)
+    if n_pos == 0:
+        return float("nan")
+
+    ap = 0.0
+    tp = 0
+    for i, (_, label) in enumerate(pairs):
+        if label == 1:
+            tp += 1
+            precision_at_i = tp / (i + 1)
+            ap += precision_at_i
+    return ap / n_pos
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def _fmt(v: float, width: int = 6) -> str:
+    if v != v:  # NaN
+        return " " * (width - 3) + "n/a"
+    return f"{v:{width}.4f}"
+
+
+def generate_report(
+    pairs: list[tuple[str, str, float, int]],  # (img_id, metric_id, score, label)
+    *,
+    dry_run: bool = False,
+) -> str:
+    """Produce the eval report text."""
+    lines: list[str] = []
+    sep = "=" * 72
+
+    lines.append(sep)
+    lines.append("Vision Per-Metric Score Calibration Eval")
+    lines.append(sep)
+
+    if dry_run:
+        lines.append("[DRY RUN — no output written]")
+        lines.append("")
+
+    y_true = [label for _, _, _, label in pairs]
+    y_score = [score for _, _, _, score in pairs]
+
+    n_total = len(pairs)
+    n_pos = sum(y_true)
+    n_neg = n_total - n_pos
+
+    lines.append(f"Total labeled (img_id, metric_id) pairs : {n_total}")
+    lines.append(f"  Positives (label=1)                   : {n_pos}")
+    lines.append(f"  Negatives (label=0)                   : {n_neg}")
+    if n_total > 0:
+        lines.append(f"  Positive rate                         : {n_pos / n_total:.1%}")
+    lines.append("")
+
+    if n_total == 0 or n_pos == 0:
+        lines.append("WARNING: No labeled pairs found. Cannot compute metrics.")
+        return "\n".join(lines)
+
+    auc = _auc_roc(y_true, y_score)
+    ap = _average_precision(y_true, y_score)
+
+    lines.append(f"AUC-ROC          : {_fmt(auc)}")
+    lines.append(f"Average Precision: {_fmt(ap)}")
+    lines.append("")
+
+    # Threshold sweep.
+    lines.append("Threshold Sweep")
+    lines.append("-" * 60)
+    lines.append(
+        f"{'Threshold':>10} {'Precision':>10} {'Recall':>10} {'F1':>10} {'Predicted+':>12}"
+    )
+    lines.append("-" * 60)
+    for thresh in THRESHOLDS:
+        y_pred = [1 if s >= thresh else 0 for s in y_score]
+        prec, rec, f1 = _prf1(y_true, y_pred)
+        n_pred_pos = sum(y_pred)
+        lines.append(f"{thresh:>10.1f} {prec:>10.4f} {rec:>10.4f} {f1:>10.4f} {n_pred_pos:>12}")
+    lines.append("-" * 60)
+    lines.append("")
+
+    # Per-metric breakdown.
+    by_metric: dict[str, list[tuple[float, int]]] = defaultdict(list)
+    for _, metric_id, score, label in pairs:
+        by_metric[metric_id].append((score, label))
+
+    eligible = [
+        (mid, entries)
+        for mid, entries in sorted(by_metric.items())
+        if sum(label for _, label in entries) >= PER_METRIC_MIN_POSITIVES
+    ]
+
+    lines.append(f"Per-Metric Breakdown (metrics with ≥{PER_METRIC_MIN_POSITIVES} positives)")
+    lines.append("-" * 72)
+    if not eligible:
+        lines.append(
+            f"  No metric has ≥{PER_METRIC_MIN_POSITIVES} positive labels — "
+            "more labeled data needed."
+        )
+    else:
+        lines.append(f"  {'Metric':<40} {'N':>6} {'Pos':>6} {'AUC':>8} {'AP':>8}")
+        lines.append("  " + "-" * 68)
+        for mid, entries in eligible:
+            mt = [label for _, label in entries]
+            ms = [score for score, _ in entries]
+            m_auc = _auc_roc(mt, ms)
+            m_ap = _average_precision(mt, ms)
+            lines.append(
+                f"  {mid:<40} {len(entries):>6} {sum(mt):>6} {_fmt(m_auc, 8)} {_fmt(m_ap, 8)}"
+            )
+    lines.append("")
+
+    lines.append(sep)
+    lines.append("Interpretation")
+    lines.append(sep)
+    lines.append("AUC-ROC ≥ 0.80 AND a threshold with ≥95% recall AND ≥40% precision")
+    lines.append("would trigger Phase 2b (production filter implementation).")
+    lines.append("")
+    lines.append("If AUC < 0.70: scores are not calibrated — do not filter.")
+    lines.append("If 0.70 ≤ AUC < 0.80: marginal — review per-metric breakdown first.")
+    lines.append("If AUC ≥ 0.80: proceed to Phase 2b gating decision.")
+    lines.append(sep)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run(db: Any, *, limit: int | None = None, dry_run: bool = False) -> str:
+    """Pull data, derive labels, generate report. Returns the report text."""
+    logger.info("Fetching Vision classification predictions...")
+
+    limit_clause = f"LIMIT {limit}" if limit else ""
+    predictions = db.query(_PREDICTIONS_SQL.format(limit_clause=limit_clause), {})
+    logger.info("Fetched %d (img_id, metric_id) prediction rows", len(predictions))
+
+    if not predictions:
+        logger.warning("No predictions found — ensure ENABLE_METRIC_CLASSIFY=true has run.")
+        return generate_report([], dry_run=dry_run)
+
+    # Build set of Vision-predicted metrics per image for sentinel expansion.
+    all_vision_metrics_by_image: dict[str, set[str]] = defaultdict(set)
+    for row in predictions:
+        all_vision_metrics_by_image[row["img_id"]].add(row["metric_id"])
+
+    logger.info("Fetching reviewer confirmations...")
+    confirmations = db.query(_CONFIRMATIONS_SQL, {})
+    logger.info("Fetched %d confirmation rows", len(confirmations))
+
+    label_map = build_label_map(
+        [dict(r) for r in confirmations],
+        all_vision_metrics_by_image,
+    )
+    logger.info("Derived %d (img_id, metric_id) labels", len(label_map))
+
+    # Join predictions to labels (only keep pairs that have a label).
+    pairs: list[tuple[str, str, float, int]] = []
+    for row in predictions:
+        key = (row["img_id"], row["metric_id"])
+        if key in label_map:
+            pairs.append((row["img_id"], row["metric_id"], row["predicted_score"], label_map[key]))
+
+    logger.info(
+        "Matched %d prediction rows to ground-truth labels (%d predictions had no label)",
+        len(pairs),
+        len(predictions) - len(pairs),
+    )
+
+    return generate_report(pairs, dry_run=dry_run)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Offline eval of Vision per-metric prediction scores",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/evaluate_vision_metric_scores.py
+  python3 scripts/evaluate_vision_metric_scores.py --output data/vision_score_eval/report.txt
+  python3 scripts/evaluate_vision_metric_scores.py --dry-run
+  python3 scripts/evaluate_vision_metric_scores.py --limit 500
+        """,
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=str(DEFAULT_OUTPUT),
+        help=f"Output file path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run queries and compute metrics but do not write the output file",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of prediction rows fetched (for testing)",
+    )
+    parser.add_argument(
+        "--database-url",
+        type=str,
+        default=None,
+        help="Database connection string (default: DATABASE_URL env var)",
+    )
+    args = parser.parse_args()
+
+    configure_logging(level="INFO")
+
+    load_dotenv()
+    db_url = args.database_url or os.getenv("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set. Use --database-url or set DATABASE_URL in .env")
+        sys.exit(1)
+
+    from src.infra.db import DatabaseAdapter
+
+    db = DatabaseAdapter(db_url)
+
+    try:
+        report = run(db, limit=args.limit, dry_run=args.dry_run)
+    finally:
+        db.close()
+
+    if args.dry_run:
+        print(report)
+        logger.info("Dry run — output not written.")
+        return
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    logger.info("Report written to %s", output_path)
+
+    # Print a summary to stdout.
+    for line in report.splitlines():
+        if any(kw in line for kw in ("AUC-ROC", "Average Precision", "Total labeled", "WARNING")):
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_evaluate_vision_metric_scores.py
+++ b/tests/integration/test_evaluate_vision_metric_scores.py
@@ -1,0 +1,454 @@
+"""Integration tests for scripts/evaluate_vision_metric_scores.py.
+
+Covers:
+  - Happy path: positives + negatives produce a sensible report with AUC/AP.
+  - Sentinel-reject expansion: one sentinel row yields label=0 for all
+    Vision-predicted metrics on that image.
+  - Label precedence: any accept beats a reject on the same (img_id, metric_id).
+  - Empty data path: no classifications → warning line in report.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "evaluate_vision_metric_scores.py"
+
+
+# ---------------------------------------------------------------------------
+# Module loader
+# ---------------------------------------------------------------------------
+
+
+def _load_script() -> ModuleType:
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    mod_name = "evaluate_vision_metric_scores_integration"
+    spec = importlib.util.spec_from_file_location(mod_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cli() -> ModuleType:
+    return _load_script()
+
+
+# ---------------------------------------------------------------------------
+# DB seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_filing(db) -> tuple[int, int]:
+    """Create minimal company + filing rows; return (company_id, filing_id)."""
+    company_id = db.upsert_company(
+        cik="0009990001",
+        company_name="VisionEval Test Co",
+        ticker=None,
+        industry_code=None,
+    )
+    filing_id = db.upsert_filing(
+        company_id=company_id,
+        cik="0009990001",
+        accession_number="0009990001-99-000001",
+        form_type="S-1",
+        filing_date="2024-01-01",
+        sec_html_url="https://www.sec.gov/test/0009990001",
+        is_post_combination=False,
+        is_investment_vehicle=False,
+        is_resource_extraction=False,
+    )
+    return company_id, filing_id
+
+
+def _insert_image(db, filing_id: int, filename: str = "chart1.png") -> str:
+    """Insert a v2_image_assets row and return img_id as string."""
+    rows = db.query(
+        """
+        INSERT INTO v2_image_assets (
+            filing_id, filename, classification, width, height,
+            page_number, file_path
+        )
+        VALUES (
+            %(filing_id)s, %(filename)s, 'chart', 800, 600, 1, %(file_path)s
+        )
+        ON CONFLICT (filing_id, filename) DO UPDATE SET classification = EXCLUDED.classification
+        RETURNING img_id::text
+        """,
+        {"filing_id": filing_id, "filename": filename, "file_path": f"pipeline/test/{filename}"},
+    )
+    return rows[0]["img_id"]
+
+
+def _insert_classification(
+    db,
+    img_id: str,
+    predicted_metrics: list[dict],
+    confidence: float = 0.9,
+) -> None:
+    """Insert a v2_image_classifications row."""
+    db.query(
+        """
+        INSERT INTO v2_image_classifications (
+            img_id, predicted_metrics, confidence, provider, model,
+            prompt_version, cost_usd, latency_ms
+        )
+        VALUES (
+            %(img_id)s::uuid,
+            %(predicted_metrics)s::jsonb,
+            %(confidence)s,
+            'openai',
+            'gpt-4o',
+            1,
+            0.001,
+            500
+        )
+        """,
+        {
+            "img_id": img_id,
+            "predicted_metrics": json.dumps(predicted_metrics),
+            "confidence": confidence,
+        },
+    )
+
+
+def _insert_confirmation(
+    db,
+    img_id: str,
+    *,
+    decision: str,
+    detected_metric_id: str | None = None,
+    confirmed_metric_id: str | None = None,
+    rejection_reason: str | None = None,
+    reviewer_id: str = "test_reviewer",
+) -> None:
+    """Insert a v2_image_metric_confirmations row."""
+    db.query(
+        """
+        INSERT INTO v2_image_metric_confirmations (
+            img_id, detected_metric_id, confirmed_metric_id,
+            decision, rejection_reason, reviewer_id
+        )
+        VALUES (
+            %(img_id)s::uuid,
+            %(detected_metric_id)s,
+            %(confirmed_metric_id)s,
+            %(decision)s,
+            %(rejection_reason)s,
+            %(reviewer_id)s
+        )
+        """,
+        {
+            "img_id": img_id,
+            "detected_metric_id": detected_metric_id,
+            "confirmed_metric_id": confirmed_metric_id,
+            "decision": decision,
+            "rejection_reason": rejection_reason,
+            "reviewer_id": reviewer_id,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    """Happy path: positives + negatives produce sensible report metrics."""
+
+    def test_report_contains_auc_and_ap(self, clean_db, cli):
+        """With balanced labels, AUC-ROC and Average Precision appear in report."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_happy.png")
+
+        # Predict two metrics with distinct scores.
+        _insert_classification(
+            clean_db,
+            img_id,
+            [
+                {"metric_id": "cm_customers_period_end", "score": 0.85},
+                {"metric_id": "cm_net_revenue_retention", "score": 0.25},
+            ],
+        )
+
+        # Accept the high-score metric, reject the low-score metric.
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="accept",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id="cm_customers_period_end",
+        )
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="reject",
+            detected_metric_id="cm_net_revenue_retention",
+            rejection_reason="wrong_metric",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        assert "AUC-ROC" in report
+        assert "Average Precision" in report
+        # Should have 2 labeled pairs (one positive, one negative).
+        assert "Total labeled" in report
+        assert "Positives (label=1)" in report
+
+    def test_threshold_sweep_rows_present(self, clean_db, cli):
+        """Report includes 9 threshold rows (0.1–0.9)."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_sweep.png")
+
+        _insert_classification(
+            clean_db,
+            img_id,
+            [{"metric_id": "cm_customers_period_end", "score": 0.7}],
+        )
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="accept",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id="cm_customers_period_end",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        # All 9 threshold values should appear as separate lines.
+        for thresh in [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]:
+            assert f"{thresh:.1f}" in report
+
+
+class TestSentinelRejectExpansion:
+    """Sentinel 'no_relevant_metrics' → label=0 for ALL predicted metrics."""
+
+    def test_sentinel_generates_negatives_for_all_predicted_metrics(self, clean_db, cli):
+        """One sentinel row produces a negative label for each Vision-predicted metric."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_sentinel.png")
+
+        predicted = [
+            {"metric_id": "cm_customers_period_end", "score": 0.9},
+            {"metric_id": "cm_net_revenue_retention", "score": 0.8},
+            {"metric_id": "cm_revenue_concentration", "score": 0.75},
+        ]
+        _insert_classification(clean_db, img_id, predicted)
+
+        # Sentinel: both IDs null, rejection_reason='no_relevant_metrics'.
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="reject",
+            detected_metric_id=None,
+            confirmed_metric_id=None,
+            rejection_reason="no_relevant_metrics",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        # All 3 predicted metrics have label=0 → 0 positives, 3 negatives.
+        assert "Positives (label=1)                   : 0" in report
+        assert "Total labeled (img_id, metric_id) pairs : 3" in report
+
+    def test_sentinel_negatives_overridden_by_accept(self, clean_db, cli):
+        """If another confirmation accepts a metric that was sentinel-rejected, label=1 wins."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_sentinel_override.png")
+
+        _insert_classification(
+            clean_db,
+            img_id,
+            [
+                {"metric_id": "cm_customers_period_end", "score": 0.9},
+                {"metric_id": "cm_net_revenue_retention", "score": 0.3},
+            ],
+        )
+
+        # Sentinel reject from reviewer A.
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="reject",
+            detected_metric_id=None,
+            confirmed_metric_id=None,
+            rejection_reason="no_relevant_metrics",
+            reviewer_id="reviewer_a",
+        )
+        # Accept from reviewer B overrides the sentinel for that metric.
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="accept",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id="cm_customers_period_end",
+            reviewer_id="reviewer_b",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        # cm_customers_period_end → label=1 (accept wins)
+        # cm_net_revenue_retention → label=0 (only sentinel)
+        assert "Positives (label=1)                   : 1" in report
+        assert "Negatives (label=0)                   : 1" in report
+
+
+class TestLabelPrecedence:
+    """any-accept-wins: a reject row loses to a concurrent accept on the same pair."""
+
+    def test_accept_beats_reject_on_same_metric(self, clean_db, cli):
+        """When both accept and reject exist for same (img_id, metric_id), label=1."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_precedence.png")
+
+        _insert_classification(
+            clean_db,
+            img_id,
+            [{"metric_id": "cm_customers_period_end", "score": 0.65}],
+        )
+
+        # Reviewer A rejects.
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="reject",
+            detected_metric_id="cm_customers_period_end",
+            rejection_reason="wrong_metric",
+            reviewer_id="reviewer_a",
+        )
+        # Reviewer B accepts (any-accept-wins policy).
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="accept",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id="cm_customers_period_end",
+            reviewer_id="reviewer_b",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        assert "Positives (label=1)                   : 1" in report
+        assert "Negatives (label=0)                   : 0" in report
+
+    def test_correct_decision_treated_as_positive(self, clean_db, cli):
+        """'correct' decision (different confirmed_metric_id) → label=1 for confirmed metric."""
+        _, filing_id = _seed_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id, "chart_correct.png")
+
+        # Predict cm_net_revenue_retention; reviewer corrects it to cm_gross_revenue_retention.
+        _insert_classification(
+            clean_db,
+            img_id,
+            [
+                {"metric_id": "cm_net_revenue_retention", "score": 0.6},
+                {"metric_id": "cm_gross_revenue_retention", "score": 0.55},
+            ],
+        )
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            decision="correct",
+            detected_metric_id="cm_net_revenue_retention",
+            confirmed_metric_id="cm_gross_revenue_retention",
+        )
+
+        report = cli.run(clean_db, dry_run=True)
+
+        # cm_gross_revenue_retention is confirmed → label=1 (if also predicted).
+        # cm_net_revenue_retention has no accept → not labeled positive.
+        assert "Positives (label=1)                   : 1" in report
+
+
+class TestEmptyData:
+    """When no classifications exist, the report includes a warning."""
+
+    def test_no_classifications_emits_warning(self, clean_db, cli):
+        """With no v2_image_classifications rows, report warns and returns gracefully."""
+        report = cli.run(clean_db, dry_run=True)
+        assert "WARNING" in report or "No labeled pairs" in report or "0" in report
+
+
+class TestBuildLabelMap:
+    """Unit-level tests for the label-derivation logic (pure Python, no DB)."""
+
+    def test_accept_generates_positive(self, cli):
+        confirmations = [
+            {
+                "img_id": "img1",
+                "detected_metric_id": "cm_customers_period_end",
+                "confirmed_metric_id": "cm_customers_period_end",
+                "decision": "accept",
+                "rejection_reason": None,
+            }
+        ]
+        vision_metrics = {"img1": {"cm_customers_period_end"}}
+        label_map = cli.build_label_map(confirmations, vision_metrics)
+        assert label_map[("img1", "cm_customers_period_end")] == 1
+
+    def test_reject_generates_negative(self, cli):
+        confirmations = [
+            {
+                "img_id": "img1",
+                "detected_metric_id": "cm_net_revenue_retention",
+                "confirmed_metric_id": None,
+                "decision": "reject",
+                "rejection_reason": "wrong_metric",
+            }
+        ]
+        vision_metrics = {"img1": {"cm_net_revenue_retention"}}
+        label_map = cli.build_label_map(confirmations, vision_metrics)
+        assert label_map[("img1", "cm_net_revenue_retention")] == 0
+
+    def test_sentinel_expands_to_all_predicted(self, cli):
+        confirmations = [
+            {
+                "img_id": "img1",
+                "detected_metric_id": None,
+                "confirmed_metric_id": None,
+                "decision": "reject",
+                "rejection_reason": "no_relevant_metrics",
+            }
+        ]
+        vision_metrics = {"img1": {"cm_customers_period_end", "cm_net_revenue_retention"}}
+        label_map = cli.build_label_map(confirmations, vision_metrics)
+        assert label_map[("img1", "cm_customers_period_end")] == 0
+        assert label_map[("img1", "cm_net_revenue_retention")] == 0
+
+    def test_accept_overrides_sentinel(self, cli):
+        confirmations = [
+            {
+                "img_id": "img1",
+                "detected_metric_id": None,
+                "confirmed_metric_id": None,
+                "decision": "reject",
+                "rejection_reason": "no_relevant_metrics",
+            },
+            {
+                "img_id": "img1",
+                "detected_metric_id": "cm_customers_period_end",
+                "confirmed_metric_id": "cm_customers_period_end",
+                "decision": "accept",
+                "rejection_reason": None,
+            },
+        ]
+        vision_metrics = {"img1": {"cm_customers_period_end", "cm_net_revenue_retention"}}
+        label_map = cli.build_label_map(confirmations, vision_metrics)
+        assert label_map[("img1", "cm_customers_period_end")] == 1  # accept wins
+        assert label_map[("img1", "cm_net_revenue_retention")] == 0  # only sentinel

--- a/tests/integration/test_evaluate_vision_metric_scores.py
+++ b/tests/integration/test_evaluate_vision_metric_scores.py
@@ -107,7 +107,7 @@ def _insert_classification(
     confidence: float = 0.9,
 ) -> None:
     """Insert a v2_image_classifications row."""
-    db.query(
+    db.execute(
         """
         INSERT INTO v2_image_classifications (
             img_id, predicted_metrics, confidence, provider, model,
@@ -143,7 +143,7 @@ def _insert_confirmation(
     reviewer_id: str = "test_reviewer",
 ) -> None:
     """Insert a v2_image_metric_confirmations row."""
-    db.query(
+    db.execute(
         """
         INSERT INTO v2_image_metric_confirmations (
             img_id, detected_metric_id, confirmed_metric_id,

--- a/tests/integration/test_evaluate_vision_metric_scores.py
+++ b/tests/integration/test_evaluate_vision_metric_scores.py
@@ -82,15 +82,20 @@ def _insert_image(db, filing_id: int, filename: str = "chart1.png") -> str:
         """
         INSERT INTO v2_image_assets (
             filing_id, filename, classification, width, height,
-            file_path
+            dom_locator, file_path
         )
         VALUES (
-            %(filing_id)s, %(filename)s, 'chart', 800, 600, %(file_path)s
+            %(filing_id)s, %(filename)s, 'chart', 800, 600, %(dom_locator)s, %(file_path)s
         )
         ON CONFLICT (filing_id, filename) DO UPDATE SET classification = EXCLUDED.classification
         RETURNING img_id::text
         """,
-        {"filing_id": filing_id, "filename": filename, "file_path": f"pipeline/test/{filename}"},
+        {
+            "filing_id": filing_id,
+            "filename": filename,
+            "dom_locator": f"body > img[src='{filename}']",
+            "file_path": f"pipeline/test/{filename}",
+        },
     )
     return rows[0]["img_id"]
 

--- a/tests/integration/test_evaluate_vision_metric_scores.py
+++ b/tests/integration/test_evaluate_vision_metric_scores.py
@@ -82,10 +82,10 @@ def _insert_image(db, filing_id: int, filename: str = "chart1.png") -> str:
         """
         INSERT INTO v2_image_assets (
             filing_id, filename, classification, width, height,
-            page_number, file_path
+            file_path
         )
         VALUES (
-            %(filing_id)s, %(filename)s, 'chart', 800, 600, 1, %(file_path)s
+            %(filing_id)s, %(filename)s, 'chart', 800, 600, %(file_path)s
         )
         ON CONFLICT (filing_id, filename) DO UPDATE SET classification = EXCLUDED.classification
         RETURNING img_id::text


### PR DESCRIPTION
## Summary

Phase 2 of the image-classifier improvement plan (`~/.claude/plans/we-have-processed-a-cryptic-pelican.md`).

- New script: `scripts/evaluate_vision_metric_scores.py` — pulls `(img_id, metric_id, score)` triples from `v2_image_classifications.predicted_metrics` and grades them against ground-truth labels in `v2_image_metric_confirmations`.
- Integration test: `tests/integration/test_evaluate_vision_metric_scores.py` — 11 tests covering happy path, sentinel-reject expansion, label precedence, empty-data path, and the pure `build_label_map` logic.
- Runbook updated: `docs/operations/image-model-training-runbook.md` describes when to run, how to interpret, and the Phase 2b decision rule.

**No production code is modified.** This is an eval-only PR. A runtime filter on `predicted_metrics` is Phase 2b — gated on the eval result (trigger: AUC ≥ 0.80 AND a threshold with ≥95% recall and ≥40% precision).

## Label rules

- `decision IN ('accept','correct','add')` AND `confirmed_metric_id = predicted metric_id` → label 1
- `decision = 'reject'` AND `confirmed_metric_id` (or `detected_metric_id`) = predicted metric_id → label 0
- Sentinel `no_relevant_metrics` reject (NULL ids, `rejection_reason='no_relevant_metrics'`) → label 0 across **all** Vision-predicted metrics for that image
- Any-accept-wins for reviewer disagreements

## Test plan

- [x] `ruff check` clean
- [x] `--help` runs cleanly
- [x] 11 integration tests collect cleanly (CI runs them with live DB)
- [ ] CI green on Lint + Unit Tests + Integration Tests + Vulnerability Scan + UI E2E + Docker Build
- [ ] After merge: operator runs `python3 scripts/evaluate_vision_metric_scores.py` against prod and reads the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)