### PR TITLE
fix(image-model): backfill skips legacy absolute-path file_paths

### DIFF
--- a/scripts/backfill_image_classifications.py
+++ b/scripts/backfill_image_classifications.py
@@ -46,7 +46,7 @@ from dotenv import load_dotenv  # noqa: E402
 load_dotenv()
 
 from src.infra.db import DatabaseAdapter  # noqa: E402
-from src.infra.image_storage import get_image_storage  # noqa: E402
+from src.infra.image_storage import InvalidStorageKeyError, get_image_storage  # noqa: E402
 from src.infra.logging_config import configure_logging  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,7 @@ def _fetch_eligible_images(db: DatabaseAdapter) -> list[dict]:
         JOIN v2_image_metric_confirmations imc ON imc.img_id = ia.img_id
         WHERE ia.classification IN ('chart', 'table_image')
           AND ia.file_path IS NOT NULL
+          AND NOT starts_with(ia.file_path, '/')
           AND NOT EXISTS (
               SELECT 1
               FROM v2_image_classifications vic
@@ -173,7 +174,7 @@ def run(
 
         try:
             image_bytes = storage.get_bytes(file_path)
-        except (FileNotFoundError, OSError) as exc:
+        except (FileNotFoundError, OSError, InvalidStorageKeyError) as exc:
             logger.warning("img_id=%s: missing bytes path=%s err=%s", img_id, file_path, exc)
             api_errors += 1
             continue


### PR DESCRIPTION
## Summary

The backfill script (#565) crashed on 33 eligible images whose `file_path` is a local absolute path — OneDrive-backed gold-standard images and `/var/folders/.../filings_image_cache/...` leaks from test/dev runs — instead of an R2 storage key. `InvalidStorageKeyError` was raised but not caught.

**Two-layer fix** (small, defense-in-depth):
- SQL eligibility filter: `NOT starts_with(ia.file_path, '/')` — bad rows never reach the API call.
- Catch `InvalidStorageKeyError` at the `get_bytes` site alongside `FileNotFoundError` / `OSError` — same warn-and-skip path as a missing R2 object.

## Why this is one PR not two

The SQL filter alone would do it, but the runtime catch protects against any future key-validation rule that might fire mid-run on a row that passed the eligibility filter. Net change is +3 lines / -2 lines.

## Test plan

- [x] `ruff check` clean
- [x] `--help` runs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)