### PR TITLE
feat(llm): cohort-revenue prompt covers two-bucket form + sidecar merge

### DIFF
--- a/config/llm_classifier/prompts/cm_revenue_by_cohort.yaml
+++ b/config/llm_classifier/prompts/cm_revenue_by_cohort.yaml
@@ -7,11 +7,14 @@
 # typically references "cohort revenue", "revenue by signup year",
 # or "revenue by vintage".
 #
-# Few-shot examples are owned by automation; they live in the sidecar
-# cm_revenue_by_cohort.few_shots.yaml written by
-# scripts/calibrate_llm_thresholds.py. Do not hand-edit them here.
+# Few-shot examples come from two sources merged at load time:
+# 1. ``few_shot_examples:`` here (hand-authored, persistent across mining runs)
+# 2. ``cm_revenue_by_cohort.few_shots.yaml`` sidecar (automation-owned;
+#    overwritten by ``scripts/calibrate_llm_thresholds.py --mode mine``)
+# The loader dedupes by ``text``. Hand-author examples here when mining
+# cannot produce diverse-enough prose for a real disclosure shape.
 
-prompt_version: "0.1.0-template"
+prompt_version: "0.2.0"
 metric_id: cm_revenue_by_cohort
 
 definition: |
@@ -22,11 +25,29 @@ definition: |
   year", "revenue by customer tenure", "ARR by cohort", "GMV by cohort".
   Tracks how much each cohort contributes to total revenue over time.
 
+  Includes the simple two-bucket form: "X% of our revenue was derived
+  from existing customers, Y% from new customers" (or equivalent
+  phrasing splitting revenue between customers acquired in the current
+  period vs prior periods). This is a coarse tenure-cohort split and
+  qualifies as cohort revenue even though only two buckets are
+  reported.
+
 positive_signals:
   - Explicit phrase like "revenue by cohort", "cohort revenue", "revenue by signup year", "revenue by vintage"
   - Reference to a table or chart that splits revenue across acquisition years or tenure buckets
   - Discussion of cohort retention or expansion expressed in dollars (not just retention percentage)
   - Statements such as "our 2018 cohort generated $X in 2022", "older cohorts contribute Y% of revenue"
+  - Two-bucket revenue splits like "X% of our revenue was derived from existing customers, Y% from new customers" or "X% of revenue was attributable to customers acquired in fiscal year Y"
+
+# Hand-authored examples (loader merges these with the sidecar). Use this
+# slot when mining cannot produce a representative example. Each example's
+# ``text`` is what the classifier sees as the few-shot prose; other fields
+# are metadata for audit / future re-mining.
+few_shot_examples:
+  - text: "Approximately 70% of our revenue during the most recent fiscal year was derived from existing customers under their subscription agreements, while approximately 30% of our revenue was derived from new customers acquired during the period. We expect this mix to continue as our installed base grows."
+    label: true
+    issuer: synthetic_template
+    source: hand_authored
 
 negative_signals:
   - Revenue by product or geography without a cohort dimension (out of scope)

--- a/src/llm/presence_classifier_client.py
+++ b/src/llm/presence_classifier_client.py
@@ -201,14 +201,21 @@ def load_thresholds(path: Path | None = None) -> ThresholdsConfig:
 
 
 def load_metric_prompt(metric_id: str, prompts_dir: Path | None = None) -> MetricPrompt:
-    """Load a metric prompt, merging an optional sidecar few-shots file.
+    """Load a metric prompt, merging hand-authored + mined few-shots.
 
     The main file ``<metric_id>.yaml`` is human-authored: definition, signals,
-    decision_format, prompt_version. The sidecar ``<metric_id>.few_shots.yaml``
-    is automation-owned (written by ``scripts/calibrate_llm_thresholds.py``).
-    Splitting them avoids the calibration script clobbering hand-authored
-    content. If the main file carries a ``few_shot_examples`` key (legacy or
-    inline overrides), the sidecar takes precedence when present.
+    decision_format, prompt_version, and (optionally) ``few_shot_examples``
+    that the maintainer wants to ship regardless of mining state.
+
+    The sidecar ``<metric_id>.few_shots.yaml`` is automation-owned (written
+    by ``scripts/calibrate_llm_thresholds.py``). Splitting them avoids the
+    calibration script clobbering hand-authored content.
+
+    Few-shot merge contract: hand-authored examples appear first, followed
+    by mined examples. Duplicates (same ``text`` field) are dropped. This
+    lets a maintainer hand-author an example for a metric where mining
+    can't produce diverse enough prose (e.g. tabular S-1 cohort tables)
+    without that example getting dropped on the next ``--mode mine`` run.
     """
     base_dir = prompts_dir or (CONFIG_ROOT / "prompts")
     main_path = base_dir / f"{metric_id}.yaml"
@@ -218,19 +225,31 @@ def load_metric_prompt(metric_id: str, prompts_dir: Path | None = None) -> Metri
         f"prompt YAML at {main_path} declares metric_id={raw['metric_id']!r} "
         f"but filename stem is {metric_id!r}; rename the file or fix the YAML"
     )
-    few_shots = raw.get("few_shot_examples", []) or []
+    main_few_shots: list[dict[str, Any]] = raw.get("few_shot_examples", []) or []
+    sidecar_few_shots: list[dict[str, Any]] = []
     sidecar_path = base_dir / f"{metric_id}.few_shots.yaml"
     if sidecar_path.exists():
         with sidecar_path.open() as f:
             sidecar = yaml.safe_load(f) or {}
-        few_shots = sidecar.get("few_shot_examples", []) or []
+        sidecar_few_shots = sidecar.get("few_shot_examples", []) or []
+
+    # Merge hand-authored first, then mined; dedupe by text.
+    seen_texts: set[str] = set()
+    merged: list[dict[str, Any]] = []
+    for ex in (*main_few_shots, *sidecar_few_shots):
+        text = (ex or {}).get("text") or ""
+        if text in seen_texts:
+            continue
+        seen_texts.add(text)
+        merged.append(ex)
+
     return MetricPrompt(
         metric_id=raw["metric_id"],
         prompt_version=raw["prompt_version"],
         definition=raw["definition"].strip(),
         positive_signals=tuple(raw.get("positive_signals", [])),
         negative_signals=tuple(raw.get("negative_signals", [])),
-        few_shot_examples=tuple(few_shots),
+        few_shot_examples=tuple(merged),
         decision_format=raw.get("decision_format", "").strip(),
     )
 

--- a/tests/unit/llm/test_presence_classifier_client.py
+++ b/tests/unit/llm/test_presence_classifier_client.py
@@ -133,6 +133,85 @@ def test_load_metric_prompt(config_root: Path) -> None:
     assert prompt.decision_format.startswith('{"present"')
 
 
+def test_load_metric_prompt_merges_main_and_sidecar_few_shots(tmp_path: Path) -> None:
+    """Hand-authored examples in the main YAML must survive an empty or
+    populated sidecar. The loader merges main + sidecar, deduped by text.
+    """
+    prompts = tmp_path / "prompts"
+    _write(
+        prompts / "cm_test_metric.yaml",
+        """\
+        prompt_version: "0.2.0"
+        metric_id: cm_test_metric
+        definition: test
+        decision_format: "{}"
+        few_shot_examples:
+          - text: "hand-authored example A"
+            label: true
+            source: hand_authored
+        """,
+    )
+
+    # Case 1: sidecar absent → main-only.
+    p = load_metric_prompt("cm_test_metric", prompts_dir=prompts)
+    assert [ex["text"] for ex in p.few_shot_examples] == ["hand-authored example A"]
+
+    # Case 2: empty sidecar → main-only (regression: pre-merge code clobbered
+    # main-prompt examples with the empty list).
+    _write(
+        prompts / "cm_test_metric.few_shots.yaml",
+        """\
+        metric_id: cm_test_metric
+        few_shot_examples: []
+        """,
+    )
+    p = load_metric_prompt("cm_test_metric", prompts_dir=prompts)
+    assert [ex["text"] for ex in p.few_shot_examples] == ["hand-authored example A"]
+
+    # Case 3: populated sidecar → main-first union.
+    _write(
+        prompts / "cm_test_metric.few_shots.yaml",
+        """\
+        metric_id: cm_test_metric
+        few_shot_examples:
+          - text: "mined example B"
+            label: true
+            source: gold
+          - text: "mined example C"
+            label: true
+            source: gold
+        """,
+    )
+    p = load_metric_prompt("cm_test_metric", prompts_dir=prompts)
+    assert [ex["text"] for ex in p.few_shot_examples] == [
+        "hand-authored example A",
+        "mined example B",
+        "mined example C",
+    ]
+
+    # Case 4: dupe by text → kept once, hand-authored wins (it appears first).
+    _write(
+        prompts / "cm_test_metric.few_shots.yaml",
+        """\
+        metric_id: cm_test_metric
+        few_shot_examples:
+          - text: "hand-authored example A"
+            label: true
+            source: gold
+          - text: "mined example C"
+            label: true
+            source: gold
+        """,
+    )
+    p = load_metric_prompt("cm_test_metric", prompts_dir=prompts)
+    assert [ex["text"] for ex in p.few_shot_examples] == [
+        "hand-authored example A",
+        "mined example C",
+    ]
+    # The retained one must be the hand-authored copy (source=hand_authored).
+    assert p.few_shot_examples[0]["source"] == "hand_authored"
+
+
 def test_load_metric_prompt_rejects_mismatched_metric_id(tmp_path: Path) -> None:
     prompts = tmp_path / "prompts"
     _write(


### PR DESCRIPTION
## Summary

Fixes a classifier blindspot surfaced by the first live Path A run on Snowflake S-1 (PR #564). The classifier was scoring `cm_revenue_by_cohort` ≤0.05 on the actual MD&A disclosure ("Approximately 84% of our revenue from existing customers, approximately 12% from new customers") — a coarse 2-bucket tenure-cohort split that the prompt's positive signals didn't anticipate. Per the maintainer this 2-bucket form is common across S-1 MD&A sections, so the fix needs to land before the next eval run produces meaningful signal on this metric.

## Two coupled changes

### 1. Loader merges hand-authored + mined few-shots (`presence_classifier_client.py:load_metric_prompt`)

`load_metric_prompt` previously had the sidecar **overwrite** the main prompt's `few_shot_examples`, even when the sidecar carried `few_shot_examples: []`. That meant any hand-authored example placed in the main prompt was silently dropped whenever a sidecar existed — which is whenever `--mode mine` has ever run, regardless of whether mining produced anything.

New contract:
- Hand-authored examples appear first.
- Mined examples follow.
- Dedupe by `text` field.

Hand-authored examples persist through every `--mode mine` run because the mining script only writes the sidecar.

### 2. `cm_revenue_by_cohort.yaml` recognizes the two-bucket form

- **Definition**: expanded with a paragraph explaining the 2-bucket tenure form qualifies even though only two buckets are reported.
- **Positive signals**: one new bullet naming the pattern explicitly: `"Two-bucket revenue splits like 'X% of our revenue was derived from existing customers, Y% from new customers' or 'X% of revenue was attributable to customers acquired in fiscal year Y'"`.
- **`few_shot_examples:`**: one hand-authored example modeling the form. Synthetic template (no leak from any held-out filing).
- **`prompt_version`**: bumped `0.1.0-template` → `0.2.0` so old runs stay diffable in `v2_text_metric_presence.classifier_metadata.prompt_version`.

## Tests

- New `test_load_metric_prompt_merges_main_and_sidecar_few_shots` covers four cases: sidecar absent, sidecar empty (regression case for the silent-drop bug), both populated, dedupe by text. Prevents the regression from recurring.
- All existing 25 prompt-loader tests pass unchanged at default behavior (existing fixtures used either main-only or sidecar-only, so the merge change is backward-compatible).
- Total: 4886 unit + extraction_v2 tests pass; ruff clean.

## Production safety

- The loader change is fully backward-compatible: any prompt YAML without `few_shot_examples:` still gets sidecar examples only (existing behavior). Any prompt with `few_shot_examples:` and no sidecar gets main-only (existing behavior). Only the both-populated case changes — and previously, any main-prompt examples in that case were dropped, which was a silent bug.
- `cm_revenue_by_cohort.yaml` is a config change isolated to one metric. No other metric's prompt is touched.
- Tier-1 zero-tolerance gate unaffected.
- The classifier defaults to off (`presence_classifier_enabled` flag and `enable_llm_presence_classifier` config field both default `False`); no production extraction behavior change.

## Live re-eval expected after merge

```bash
python3 scripts/run_phase1_eval.py --path pipeline --gold-only --limit 1
```

Should produce a `cm_revenue_by_cohort` score above threshold on the Snowflake MD&A 84%/12% segment, replacing the previous artifactual FN with a real TP. Cost ~$3, wall clock ~8 min.

## Out of scope

- The maintainer separately corrected the `golden_set_260408.csv` row that mislabeled an NRR row as `cm_revenue_by_cohort` for Snowflake. That fix lives outside this PR.
- The runbook's per-filing cost estimate (`$0.20–0.40`) still underestimates reality (~$2–3/filing on Path A). Worth a runbook update later; not in scope here.

## Test plan

- [x] `pytest -x -q` (unit + extraction_v2): 4886 passed
- [x] `ruff check src/ tests/`: clean
- [x] New merge-semantics test catches the silent-drop regression
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright), Docker Build & Smoke
- [ ] Manual: re-run `--limit 1` against Snowflake after merge, confirm `cm_revenue_by_cohort` lands above threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)
