### PR TITLE
fix(eval): robust gold-dir fallback + --filing-url for surgical iteration

### DIFF
--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -727,6 +727,33 @@ def _enrich_filings_for_path_a(
     return result
 
 
+def _find_gold_filing_html(company: str, gold_root: Path) -> Path | None:
+    """Find a gold-standard cache directory for ``company`` regardless of
+    historical naming convention.
+
+    The local ``data/gold_standard/`` cache uses inconsistent slugs across
+    filings (some with trailing periods, some without; spaces, commas, and
+    periods all variously kept or replaced). This helper does a tolerant
+    match: lowercase, strip non-alphanumerics on both the company name and
+    each candidate directory name, then exact-match. Returns the path to
+    ``filing.html`` inside the matched directory if it exists.
+    """
+    if not gold_root.is_dir():
+        return None
+    needle = re.sub(r"[^a-z0-9]", "", company.lower())
+    if not needle:
+        return None
+    for d in gold_root.iterdir():
+        if not d.is_dir():
+            continue
+        slug = re.sub(r"[^a-z0-9]", "", d.name.lower())
+        if slug == needle:
+            html = d / "filing.html"
+            if html.exists():
+                return html
+    return None
+
+
 def _resolve_filing_html(paf: _PathAFiling) -> tuple[Path, Path | None]:
     """Resolve a filing's HTML to a local path, downloading from R2 if needed.
 
@@ -772,13 +799,16 @@ def _resolve_filing_html(paf: _PathAFiling) -> tuple[Path, Path | None]:
     if html_path:
         resolved = Path(html_path)
     else:
-        company_slug = (paf.selection.company or paf.selection.issuer_key).replace(" ", "_")
-        resolved = REPO_ROOT / "data" / "gold_standard" / company_slug / "filing.html"
         if os.environ.get("APP_ENV") == "production":
             raise RuntimeError(
                 f"Filing {paf.filing_id}: no html_storage_path; "
                 "refusing gold-standard fallback in production"
             )
+        company = paf.selection.company or paf.selection.issuer_key
+        gold_root = REPO_ROOT / "data" / "gold_standard"
+        resolved = _find_gold_filing_html(company, gold_root) or (
+            gold_root / company.replace(" ", "_") / "filing.html"
+        )
         logger.warning(
             "Path A filing %d: no html_storage_path; falling back to %s",
             paf.filing_id,
@@ -1211,8 +1241,14 @@ def run_eval(
     reviewed_only: bool,
     limit: int | None,
     dry_run: bool,
+    forced_gold_url: str | None = None,
 ) -> tuple[int, dict[str, Any]]:
-    """Execute the eval. Returns (exit_code, summary_dict)."""
+    """Execute the eval. Returns (exit_code, summary_dict).
+
+    ``forced_gold_url`` (--filing-url) bypasses the deterministic greedy
+    gold corpus selector and forces a single gold filing by its split-JSON
+    URL. Reviewed corpus is suppressed when it is set.
+    """
     run_started_at = datetime.now(UTC).isoformat()
 
     if path_mode == "pipeline":
@@ -1250,7 +1286,34 @@ def run_eval(
     # ---- Gold corpus ----
     gold_filings: list[FilingSelection] = []
     gold_missing: list[str] = []
-    if not reviewed_only:
+    if forced_gold_url and not reviewed_only:
+        # --filing-url overrides the deterministic greedy selector. The URL
+        # must match a row in split_v1.json (test or calibration only —
+        # never train, since few-shots were mined from train).
+        eligible = splits.test_urls | splits.calibration_urls
+        if forced_gold_url not in eligible:
+            return 2, {
+                "error": (
+                    f"--filing-url {forced_gold_url!r} is not in test or "
+                    f"calibration split. Eligible URLs: see split_v1.json. "
+                    f"Train-split URLs are deliberately excluded."
+                ),
+                "run_started_at": run_started_at,
+            }
+        gold_filings = [
+            FilingSelection(
+                corpus="gold",
+                filing_url=forced_gold_url,
+                filing_id=None,
+                issuer_key=splits.issuer_lookup.get(forced_gold_url, ""),
+                company=splits.company_lookup.get(forced_gold_url),
+            )
+        ]
+        gold_missing = []
+        # --filing-url implies single-filing iteration; reviewed corpus is
+        # noisy in that mode, suppress it.
+        gold_only = True
+    elif not reviewed_only:
         eligible = splits.test_urls | splits.calibration_urls
         gold_metrics_per_filing = _gold_metrics_per_filing(GOLD_CSV, eligible)
         gold_filings, gold_missing = select_gold_corpus(
@@ -1531,6 +1594,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--reviewed-only", action="store_true", help="skip gold corpus")
     p.add_argument("--limit", type=int, default=None, help="filings per corpus (default 5)")
     p.add_argument(
+        "--filing-url",
+        default=None,
+        help=(
+            "force-select a single gold-corpus filing by its split-JSON URL "
+            "(bypasses the deterministic greedy selector). Useful for "
+            "iterating on a specific filing — e.g. validating a prompt "
+            "tweak. Reviewed corpus is skipped when this flag is set; "
+            "use Path A only."
+        ),
+    )
+    p.add_argument(
         "--run-id",
         default=None,
         help="override timestamp run_id (default: UTC YYYYMMDDTHHMM)",
@@ -1571,6 +1645,7 @@ def main(argv: list[str] | None = None) -> int:
         reviewed_only=args.reviewed_only,
         limit=args.limit,
         dry_run=args.dry_run,
+        forced_gold_url=args.filing_url,
     )
     if exit_code != 0:
         logger.error(

--- a/tests/unit/scripts/test_run_phase1_eval_pipeline.py
+++ b/tests/unit/scripts/test_run_phase1_eval_pipeline.py
@@ -177,6 +177,47 @@ def test_resolve_filing_html_missing_disk_path_raises(cli, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# _find_gold_filing_html — robust slug match for the local cache
+# ---------------------------------------------------------------------------
+
+
+def test_find_gold_filing_html_alphanumeric_slug_match(cli, tmp_path):
+    """Finds a dir whose name normalizes to the same alphanum-only slug as
+    the company. Real-world: company 'Datadog, Inc.' → on-disk 'Datadog,_Inc_'.
+    """
+    gold_root = tmp_path
+    dir_actual = gold_root / "Datadog,_Inc_"
+    dir_actual.mkdir()
+    html = dir_actual / "filing.html"
+    html.write_text("<html/>")
+
+    found = cli._find_gold_filing_html("Datadog, Inc.", gold_root)
+    assert found == html
+
+
+def test_find_gold_filing_html_handles_mixed_case_punctuation(cli, tmp_path):
+    """Same company with different case + punctuation resolves to same dir."""
+    gold_root = tmp_path
+    (gold_root / "Snowflake_Inc").mkdir()
+    (gold_root / "Snowflake_Inc" / "filing.html").write_text("<html/>")
+
+    assert cli._find_gold_filing_html("Snowflake, Inc.", gold_root) is not None
+    assert cli._find_gold_filing_html("snowflake inc", gold_root) is not None
+    assert cli._find_gold_filing_html("SNOWFLAKE INC.", gold_root) is not None
+
+
+def test_find_gold_filing_html_returns_none_when_no_match(cli, tmp_path):
+    (tmp_path / "Other_Co").mkdir()
+    assert cli._find_gold_filing_html("Datadog, Inc.", tmp_path) is None
+
+
+def test_find_gold_filing_html_returns_none_when_html_missing(cli, tmp_path):
+    """Directory matches but filing.html doesn't exist → None."""
+    (tmp_path / "Datadog,_Inc_").mkdir()
+    assert cli._find_gold_filing_html("Datadog, Inc.", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
 # evaluate_filing_pipeline — shape test
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two ergonomics fixes for the Phase-1 smoke eval, surfaced when validating PR #568 on Snowflake.

After PR #568 merged with the cohort-revenue prompt fix, the operator re-ran `--limit 1` to validate. The runner picked Datadog (not Snowflake) because the gold-CSV correction the maintainer applied changed the deterministic greedy coverage; on Datadog, R2 didn't have the HTML and the local fallback dir name didn't match what the runner constructed. Two compounding bugs blocked validation.

## Bugs fixed

### 1. Gold-fallback slug mismatch

`_resolve_filing_html` constructs the local cache path with a bare `name.replace(' ', '_')` slug. The on-disk `data/gold_standard/` directories were created by a different (older?) tool that replaces *all* non-alphanumerics with `_` and inconsistently — Snowflake's dir omits the trailing period entirely (`Snowflake_Inc`) while Datadog's keeps the comma but replaces the period with underscore (`Datadog,_Inc_`). Net effect: the fallback never matched any real dir for any company name with `,` or `.` in it. Same bug is latent in `batch_v2_extraction.py` but not blocking anything there.

**Fix**: new `_find_gold_filing_html` helper does tolerant matching — lowercase + strip non-alphanumerics on both sides, exact-match. `Datadog, Inc.` → `datadoginc`; on-disk `Datadog,_Inc_` → `datadoginc`; match. Lowercases also resolve case variations.

### 2. `--filing-url URL` for surgical iteration

The deterministic greedy gold-corpus selector picks max-coverage filings. After a small gold-CSV correction (e.g. removing one mislabeled metric from a filing's gold rows), the next `--limit 1` run can silently reroute selection to a different filing. While iterating on a prompt fix targeting one filing's specific text, this is the wrong default.

**Fix**: new `--filing-url URL` flag bypasses the selector and runs Path A against exactly that one filing. URL must be in test or calibration split (train deliberately excluded — few-shots were mined from train, scoring train would leak the prompts). Reviewed corpus is suppressed in this mode (single-filing iteration is gold-only).

## Tests

- `test_find_gold_filing_html_alphanumeric_slug_match` — `Datadog, Inc.` finds `Datadog,_Inc_` on disk.
- `test_find_gold_filing_html_handles_mixed_case_punctuation` — case + punctuation invariance.
- `test_find_gold_filing_html_returns_none_when_no_match` — negative.
- `test_find_gold_filing_html_returns_none_when_html_missing` — dir matches but no `filing.html`.
- All 52 existing run_phase1_eval tests pass; ruff clean.

## Verified live

`python3 scripts/run_phase1_eval.py --path pipeline --filing-url "https://www.sec.gov/Archives/edgar/data/1640147/000162828020013518/"` selects only Snowflake (the prior `--limit 1` was rerouting to Datadog). Run completed in ~8 min, $2.67, all smoke criteria pass. errors=0 vs errors=1 in the prior run on the same filing — the bumped prompt_version caused a cache rebuild that incidentally fixed a Haiku JSON-shape glitch on one segment.

## Production safety

- `_resolve_filing_html` only changes the *fallback* path when there's no `html_storage_path` and no R2 hit — production never takes that branch (production has `APP_ENV=production` which raises). The change is local-only ergonomics.
- `--filing-url` is opt-in. Default behavior (deterministic greedy selection) is unchanged.
- Tier-1 zero-tolerance gate unaffected.

## Test plan

- [x] `pytest -x -q` (run_phase1_eval): 52 passed
- [x] `ruff check`: clean
- [x] Live `--filing-url` against Snowflake completed end-to-end
- [ ] CI: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright), Docker Build & Smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)
