### PR TITLE
fix(image-model): backfill treats empty predicted_metrics as done

### DIFF
--- a/scripts/backfill_image_classifications.py
+++ b/scripts/backfill_image_classifications.py
@@ -78,7 +78,6 @@ def _fetch_eligible_images(db: DatabaseAdapter) -> list[dict]:
               SELECT 1
               FROM v2_image_classifications vic
               WHERE vic.img_id = ia.img_id
-                AND jsonb_array_length(vic.predicted_metrics) > 0
           )
         GROUP BY ia.img_id, ia.file_path, ia.classification
         ORDER BY confirmation_count ASC, ia.img_id


### PR DESCRIPTION
## Summary

The eligibility query previously skipped only images with **non-empty** `predicted_metrics`. Images where Vision returned `[]` (88% of calls in the May 8 backfill — the model is conservative) stayed eligible and got re-classified on every restart.

Net change: -1 line. The `AND jsonb_array_length(vic.predicted_metrics) > 0` filter is removed from the `NOT EXISTS` clause. Empty `predicted_metrics` is a valid Vision opinion ("no relevant metric in this image") and should count as done.

## Verified locally

`--dry-run` against the current production DB:
- Before this fix: 1,613 eligible images
- After this fix: 1,031 eligible images (582 already-empty rows correctly excluded)

Saves ~$0.06 per restart on no-op re-classification calls.

## Test plan

- [x] `ruff check` clean
- [x] `--dry-run` produces sensible eligibility count
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)