### PR TITLE
fix(eval): threshold sweep reads score column, not label (gh-577)

### DIFF
--- a/docs/known-issues/gh-577-eval-threshold-sweep-score-mismatch.md
+++ b/docs/known-issues/gh-577-eval-threshold-sweep-score-mismatch.md
@@ -4,6 +4,8 @@ discovered: '2026-05-08'
 estimated: S
 gh_issue: 577
 id: 577
+pr_refs:
+  - 579
 severity: medium
 slug: eval-threshold-sweep-score-mismatch
 source: gh

--- a/docs/known-issues/gh-577-eval-threshold-sweep-score-mismatch.md
+++ b/docs/known-issues/gh-577-eval-threshold-sweep-score-mismatch.md
@@ -1,5 +1,5 @@
 ---
-autonomy: review
+autonomy: n/a
 discovered: '2026-05-08'
 estimated: S
 gh_issue: 577
@@ -7,7 +7,7 @@ id: 577
 severity: medium
 slug: eval-threshold-sweep-score-mismatch
 source: gh
-status: open
+status: resolved
 title: evaluate_vision_metric_scores threshold sweep contradicts DB score distribution
 touches:
   - scripts/evaluate_vision_metric_scores.py
@@ -72,3 +72,23 @@ GROUP BY 1 ORDER BY 1;
 
 - Whether Vision per-metric scores are calibrated enough to filter on (that's the Phase 2b decision).
 - Sentinel-reject label semantics (separate question of whether expansion is appropriate).
+
+### Resolution
+
+None of the three hypotheses in this fragment was the actual cause. The bug was a list-comprehension destructuring error in `generate_report` (`scripts/evaluate_vision_metric_scores.py`):
+
+```python
+y_true = [label for _, _, _, label in pairs]
+y_score = [score for _, _, _, score in pairs]   # bug: extracts pos 4 (label), not pos 3 (score)
+```
+
+Both list comprehensions extract the same tuple position (the 4th, the label) — the variable name (`score` vs `label`) does not affect what gets bound. As a result `y_score` was actually the label list, and the threshold sweep collapsed to "Predicted+ = count of positives" at every threshold, with AUC and AP both spuriously 1.0.
+
+Fix: use index-based extraction so the column position is unambiguous:
+
+```python
+y_true = [p[3] for p in pairs]
+y_score = [p[2] for p in pairs]
+```
+
+Re-running the eval after the fix produces the expected varying threshold sweep that matches the DB score distribution (e.g. 382 Predicted+ at thresh=0.5, dropping to 75 at thresh=0.9). Regression coverage added in `tests/integration/test_evaluate_vision_metric_scores.py::TestThresholdSweep`: `test_sweep_uses_score_not_label` would return Predicted+ = 3 at every threshold under the bug; `test_auc_reflects_score_distribution` would return AUC=1.0 under the bug.

--- a/scripts/evaluate_vision_metric_scores.py
+++ b/scripts/evaluate_vision_metric_scores.py
@@ -260,8 +260,8 @@ def generate_report(
         lines.append("[DRY RUN — no output written]")
         lines.append("")
 
-    y_true = [label for _, _, _, label in pairs]
-    y_score = [score for _, _, _, score in pairs]
+    y_true = [p[3] for p in pairs]
+    y_score = [p[2] for p in pairs]
 
     n_total = len(pairs)
     n_pos = sum(y_true)

--- a/tests/integration/test_evaluate_vision_metric_scores.py
+++ b/tests/integration/test_evaluate_vision_metric_scores.py
@@ -457,3 +457,51 @@ class TestBuildLabelMap:
         label_map = cli.build_label_map(confirmations, vision_metrics)
         assert label_map[("img1", "cm_customers_period_end")] == 1  # accept wins
         assert label_map[("img1", "cm_net_revenue_retention")] == 0  # only sentinel
+
+
+class TestThresholdSweep:
+    """Threshold sweep must read score column (pos 2), not label column (pos 3).
+
+    Regression for gh-577: `[score for _, _, _, score in pairs]` extracts position 3
+    (the label) regardless of variable name, collapsing Predicted+ to a constant
+    (= count of positives) at every threshold and inflating AUC/AP to 1.0.
+    """
+
+    def _predicted_positive_at(self, report: str, threshold: float) -> int:
+        prefix = f"{threshold:>10.1f}"
+        for line in report.splitlines():
+            if line.startswith(prefix):
+                return int(line.split()[-1])
+        raise AssertionError(f"threshold {threshold} not found in report:\n{report}")
+
+    def test_sweep_uses_score_not_label(self, cli):
+        # 3 positives, 3 negatives. Score distribution chosen so each tested
+        # threshold yields a count different from 3 — the bug would always
+        # return 3 (count of positives) regardless of threshold.
+        pairs = [
+            ("img1", "m1", 0.95, 1),
+            ("img2", "m2", 0.85, 0),
+            ("img3", "m3", 0.55, 0),
+            ("img4", "m4", 0.55, 1),
+            ("img5", "m5", 0.15, 0),
+            ("img6", "m6", 0.15, 1),
+        ]
+        report = cli.generate_report(pairs)
+
+        assert self._predicted_positive_at(report, 0.1) == 6
+        assert self._predicted_positive_at(report, 0.5) == 4
+        assert self._predicted_positive_at(report, 0.9) == 1
+
+    def test_auc_reflects_score_distribution(self, cli):
+        # Negatives have higher scores than positives — AUC must be < 0.5,
+        # not 1.0 (which would mean y_score is being read as y_true).
+        pairs = [
+            ("img1", "m1", 0.1, 1),
+            ("img2", "m2", 0.2, 1),
+            ("img3", "m3", 0.8, 0),
+            ("img4", "m4", 0.9, 0),
+        ]
+        report = cli.generate_report(pairs)
+        auc_line = next(line for line in report.splitlines() if line.startswith("AUC-ROC"))
+        auc = float(auc_line.split(":")[1].strip())
+        assert auc < 0.5, f"AUC={auc} indicates score/label confusion (gh-577 regression)"


### PR DESCRIPTION
`generate_report` extracted `y_score` and `y_true` from the same tuple
position via `[score for _, _, _, score in pairs]` and `[label for _, _, _, label in pairs]`.
The variable name doesn't affect the binding — both list comprehensions
extract the 4th element (the label). Result: the threshold sweep reported
constant Predicted+ = (count of positives) at every threshold and AUC/AP = 1.0,
contradicting the actual score distribution.

Fixed via index-based extraction (`p[2]` / `p[3]`). Adds two pure-Python
regression tests under TestThresholdSweep that would each fail under the
prior bug.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
