### PR TITLE
docs(known-issues): log gh-574, gh-575, gh-576 — Phase-1 eval gaps

### DIFF
--- a/docs/known-issues/gh-574-datadog-section-classification-toc-anchor-gap.md
+++ b/docs/known-issues/gh-574-datadog-section-classification-toc-anchor-gap.md
@@ -1,0 +1,31 @@
+---
+id: 574
+source: gh
+slug: datadog-section-classification-toc-anchor-gap
+title: "section_classification: TOC-anchor heading markup detects 0 whitelisted sections, paraphrase path inert"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches:
+  - src/extraction_v2/stages/section_classification.py
+  - tests/unit/extraction_v2/stages/test_section_classification.py
+discovered: 2026-05-08
+updated: 2026-05-08
+gh_issue: 574
+note: Datadog S-1 and similar TOC-anchor-wrapped markup match no SECTION_PATTERNS; paraphrase recall path completely inert
+---
+
+### Problem
+
+Phase-1 smoke eval (run_id `20260508T1743`) revealed Datadog's S-1 (filing 1539) is the only filing of 5 in the gold corpus where `section_classification` detects **zero** whitelisted sections (MDA, Business, Risk Factors). Detected map: `{COVER: 0, FINANCIALS: 3}`. As a result, the LLM paraphrase-recall path was completely inert — `paraphrase_segs=0` versus the other 4 filings' 604–891 paraphrase candidates.
+
+The other 4 gold filings (1545, 1550, 191794, 1146) all match `MDA: 1`, meaning the heading-pattern regex finds the start of MD&A and propagates the section tag forward. Datadog's HTML wraps heading text inside `<TD><P><A HREF="#anchor">RISK FACTORS</A></P></TD>` table cells — `_is_section_heading()` and the anchored regexes in `SECTION_PATTERNS` don't match the resulting segment text shape.
+
+Not a smoke-gate blocker (catastrophic-regression check passed), but a systematic gap that hurts Tier-1 recall on Datadog-style filings and likely contributes to gh-575 (LTV-per-customer 0-recall).
+
+### Next Steps
+
+- Inspect the `segment.text` values around Datadog's MD&A / Risk Factors anchors after ingestion to see what shape they take.
+- Either extend `SECTION_PATTERNS` to cover the variants observed, or relax `_is_section_heading()` to admit TOC-anchor segment shapes.
+- Re-run Phase-1 smoke eval; confirm Datadog `paraphrase_segs > 0`.

--- a/docs/known-issues/gh-575-ltv-per-customer-zero-recall.md
+++ b/docs/known-issues/gh-575-ltv-per-customer-zero-recall.md
@@ -1,0 +1,33 @@
+---
+id: 575
+source: gh
+slug: ltv-per-customer-zero-recall
+title: "Phase-1 eval: cm_lifetime_value_per_customer 0 recall on gold corpus"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches:
+  - config/llm_classifier/prompts/cm_lifetime_value_per_customer.yaml
+  - config/llm_classifier/thresholds.yaml
+discovered: 2026-05-08
+updated: 2026-05-08
+gh_issue: 575
+note: classifier never predicts present for cm_lifetime_value_per_customer; Tier-1 metric, F1 0.00 on n=5 gold
+---
+
+### Problem
+
+Phase-1 smoke eval (run_id `20260508T1743`) shows `cm_lifetime_value_per_customer` with precision=0.00, recall=0.00, F1=0.00 across all 5 gold filings. The classifier never predicts `present=true` despite at least one gold positive in the corpus.
+
+This is a Tier-1 metric per `CLAUDE.md`. While the catastrophic-regression smoke gate passed (likely because keyword baseline is also poor and n=5 is too small to count), 0 recall on a Tier-1 metric is unacceptable for the quantitative gate that follows.
+
+The cohort-revenue fix (PR #568) provides a working template — `cm_revenue_by_cohort` was at F1=0.0, then jumped to F1=0.57 after a 2-bucket form definition + hand-authored few-shot. Datadog's section_classification gap (gh-574) may compound this if any LTV-per-customer gold positive sits in Datadog's MD&A.
+
+### Next Steps
+
+- Pull gold-positive segments for `cm_lifetime_value_per_customer` from `data/gold_standard/` and inspect their language.
+- Read the current prompt YAML; check whether positive_signal covers the variants observed.
+- Add a hand-authored few-shot covering the missed variant (sidecar examples file pattern, deduped by text per PR #568's merge contract in `presence_classifier_client.py::load_metric_prompt`).
+- Optional: re-mine few-shots, re-sweep threshold, bump `prompt_version`.
+- Re-run smoke eval; target F1 >= 0.5 on gold.

--- a/docs/known-issues/gh-576-ltv-to-cac-by-cohort-zero-recall.md
+++ b/docs/known-issues/gh-576-ltv-to-cac-by-cohort-zero-recall.md
@@ -1,0 +1,30 @@
+---
+id: 576
+source: gh
+slug: ltv-to-cac-by-cohort-zero-recall
+title: "Phase-1 eval: cm_ltv_to_cac_ratio_by_cohort 0 recall on gold corpus"
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches:
+  - config/llm_classifier/prompts/cm_ltv_to_cac_ratio_by_cohort.yaml
+  - config/llm_classifier/thresholds.yaml
+discovered: 2026-05-08
+updated: 2026-05-08
+gh_issue: 576
+note: classifier never predicts present; base cm_ltv_to_cac_ratio scores F1=1.00, so issue is the cohort-disaggregation distinction
+---
+
+### Problem
+
+Phase-1 smoke eval (run_id `20260508T1743`) shows `cm_ltv_to_cac_ratio_by_cohort` with precision=1.00, recall=0.00, F1=0.00 across all 5 gold filings. Precision is 1.0 only because the classifier never predicts present (zero false positives, zero true positives). At least one gold positive exists.
+
+This is a Tier-1 metric per `CLAUDE.md`. The base `cm_ltv_to_cac_ratio` metric scored F1=1.00 in the same run, so the issue is specifically the cohort-disaggregation distinction. The "by-cohort" suffix likely makes this prompt narrow — the classifier may require explicit cohort-vintage language in the same segment as the LTV/CAC discussion, but real disclosures often split context across paragraphs.
+
+### Next Steps
+
+- Pull gold-positive segments for `cm_ltv_to_cac_ratio_by_cohort` and inspect language; confirm whether positives sit in a single segment or span paragraphs.
+- Read `config/llm_classifier/prompts/cm_ltv_to_cac_ratio_by_cohort.yaml`; check whether positive_signal admits cross-paragraph cohort context.
+- If cross-segment context is required, this metric may genuinely need multi-segment classification (out of scope for prompt-only fix); if not, add hand-authored few-shots covering the observed positives.
+- Re-run smoke eval; target recall > 0.


### PR DESCRIPTION
- gh-574: section_classification fails on TOC-anchor heading markup (Datadog)
- gh-575: cm_lifetime_value_per_customer 0 recall on gold corpus
- gh-576: cm_ltv_to_cac_ratio_by_cohort 0 recall on gold corpus
