### PR TITLE
feat(web): add /version endpoint and --require-sha flag to verify-deploy (gh-570)

### DIFF
--- a/docs/known-issues/gh-570-version-endpoint-deployed-sha.md
+++ b/docs/known-issues/gh-570-version-endpoint-deployed-sha.md
@@ -11,6 +11,8 @@ touches: []
 discovered: 2026-05-08
 updated: 2026-05-08
 gh_issue: 570
+pr_refs:
+- 582
 note: lets verify-deploy.sh strictly assert the running deploy matches a requested SHA
 ---
 

--- a/docs/known-issues/gh-570-version-endpoint-deployed-sha.md
+++ b/docs/known-issues/gh-570-version-endpoint-deployed-sha.md
@@ -3,7 +3,7 @@ id: 570
 source: gh
 slug: version-endpoint-deployed-sha
 title: Add /version endpoint exposing deployed git SHA
-status: open
+status: resolved
 severity: low
 autonomy: skip
 estimated: —
@@ -18,8 +18,9 @@ note: lets verify-deploy.sh strictly assert the running deploy matches a request
 
 `scripts/verify-deploy.sh` (added 2026-05-08) verifies GitHub-required checks were green for a SHA and that the Render service is reachable via `/health`, but cannot prove the running deploy actually matches the requested SHA. A silently-failed deploy would still pass `verify-deploy.sh` as long as `/health` responds 200.
 
-### Next Steps
+### Resolution
 
-- Add a `/version` route in `src/web/app.py` returning `{"git_sha": "<...>"}` (and optionally `built_at`).
-- Wire the SHA in via env var at build time (e.g. `RENDER_GIT_COMMIT`) or via a generated constant in the Docker image.
-- Extend `scripts/verify-deploy.sh` with an optional strict mode that fetches `/version` and asserts the returned `git_sha` matches the requested SHA.
+- Added `GET /version` route in `src/web/app.py` via `_register_version_endpoint(app)`. Returns `{"git_sha": os.environ.get("RENDER_GIT_COMMIT", "unknown")}`. Registered directly on the app (same pattern as `/health`), no auth required.
+- `RENDER_GIT_COMMIT` is auto-injected by Render at deploy time — no `render.yaml` changes needed.
+- Added `--require-sha <SHA>` flag to `scripts/verify-deploy.sh`. After checks and `/health` pass, fetches `/version` and asserts the returned `git_sha` matches the provided value. New exit code 4 for mismatch.
+- Unit tests added at `tests/unit/web/test_version_endpoint.py`.

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -4,16 +4,18 @@
 # Checks (in order):
 #   1. All required GitHub Actions checks for <sha> have conclusion=success.
 #   2. The Render service /health endpoint returns 200.
+#   3. (optional) The Render service /version endpoint returns the expected SHA.
 #
 # Exit codes:
-#   0 — all required checks green AND /health returned 200
+#   0 — all required checks green AND /health returned 200 (AND SHA matched if --require-sha)
 #   1 — at least one required check failed/cancelled/timed_out
 #   2 — checks pending (no runs yet, or required check missing/in-progress/queued)
 #   3 — /health did not return 200
+#   4 — /version SHA mismatch (only when --require-sha is set)
 #   64 — usage error
 #
 # Usage:
-#   bash scripts/verify-deploy.sh <commit-sha> [--service filings-reviewer]
+#   bash scripts/verify-deploy.sh <commit-sha> [--service filings-reviewer] [--require-sha <SHA>]
 #
 # Required tools: git, gh (authenticated), curl, jq.
 
@@ -21,9 +23,10 @@ set -euo pipefail
 
 SERVICE="filings-reviewer"
 SHA=""
+REQUIRE_SHA=""
 
 usage() {
-    echo "Usage: $0 <commit-sha> [--service <name>]" >&2
+    echo "Usage: $0 <commit-sha> [--service <name>] [--require-sha <SHA>]" >&2
     exit 64
 }
 
@@ -31,6 +34,10 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --service)
             SERVICE="${2:?--service requires a value}"
+            shift 2
+            ;;
+        --require-sha)
+            REQUIRE_SHA="${2:?--require-sha requires a value}"
             shift 2
             ;;
         -h|--help)
@@ -152,7 +159,29 @@ if [[ "$http_code" != "200" ]]; then
     exit 3
 fi
 
-# --- Step 3: success ----------------------------------------------------------
+# --- Step 3: /version SHA assertion (only when --require-sha is set) ----------
 
-log "OK $SHA checks=green health=200"
+if [[ -n "$REQUIRE_SHA" ]]; then
+    version_url="https://${SERVICE}.onrender.com/version"
+    log "probing $version_url (require-sha=$REQUIRE_SHA)"
+
+    version_body="$(curl -sS --max-time 30 "$version_url" 2>/dev/null || true)"
+    deployed_sha="$(jq -r '.git_sha // empty' <<<"$version_body" 2>/dev/null || true)"
+
+    if [[ -z "$deployed_sha" ]]; then
+        log "FAILED /version returned unexpected body: $version_body"
+        exit 4
+    fi
+
+    if [[ "$deployed_sha" != "$REQUIRE_SHA" ]]; then
+        log "FAILED SHA mismatch: deployed=$deployed_sha expected=$REQUIRE_SHA"
+        exit 4
+    fi
+
+    log "SHA verified: deployed=$deployed_sha"
+fi
+
+# --- Step 4: success ----------------------------------------------------------
+
+log "OK $SHA checks=green health=200${REQUIRE_SHA:+ sha=verified}"
 exit 0

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -306,6 +306,9 @@ def create_app(
     # Register health check endpoint
     _register_health_check(app)
 
+    # Register version endpoint
+    _register_version_endpoint(app)
+
     # Register blueprints (routes will be added in later tasks)
     _register_blueprints(app)
 
@@ -447,6 +450,26 @@ def _register_health_check(app: Flask) -> None:
                 ),
                 503,
             )
+
+
+def _register_version_endpoint(app: Flask) -> None:
+    """
+    Register /version endpoint exposing the deployed git SHA.
+
+    Returns the value of the RENDER_GIT_COMMIT environment variable, which
+    Render injects automatically at deploy time. Returns "unknown" when the
+    variable is absent (local dev, test). Does not require authentication.
+    """
+
+    @app.route("/version")
+    def version():
+        """
+        Version endpoint for deploy verification.
+
+        Returns:
+            JSON response with the deployed git SHA.
+        """
+        return jsonify({"git_sha": os.environ.get("RENDER_GIT_COMMIT", "unknown")})
 
 
 def _register_blueprints(app: Flask) -> None:

--- a/tests/unit/web/test_version_endpoint.py
+++ b/tests/unit/web/test_version_endpoint.py
@@ -1,0 +1,59 @@
+"""Unit tests for the /version endpoint registered in src/web/app.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.web.app import create_app
+
+
+@pytest.fixture()
+def client():
+    """Flask test client for a testing-config app."""
+    app = create_app("testing")
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestVersionEndpoint:
+    def test_returns_200(self, client):
+        resp = client.get("/version")
+        assert resp.status_code == 200
+
+    def test_content_type_is_json(self, client):
+        resp = client.get("/version")
+        assert "application/json" in resp.content_type
+
+    def test_sha_present_in_env(self, client, monkeypatch):
+        """When RENDER_GIT_COMMIT is set the endpoint returns its value."""
+        monkeypatch.setenv("RENDER_GIT_COMMIT", "abc1234def5678")
+        resp = client.get("/version")
+        body = json.loads(resp.data)
+        assert body["git_sha"] == "abc1234def5678"
+
+    def test_sha_absent_returns_unknown(self, client, monkeypatch):
+        """When RENDER_GIT_COMMIT is absent the endpoint returns 'unknown'."""
+        monkeypatch.delenv("RENDER_GIT_COMMIT", raising=False)
+        resp = client.get("/version")
+        body = json.loads(resp.data)
+        assert body["git_sha"] == "unknown"
+
+    def test_no_auth_required(self, monkeypatch):
+        """The endpoint must be reachable without an API key."""
+        # Use a production-like config with API_KEY_REQUIRED=True to verify
+        # the endpoint is exempt from auth gating.
+        monkeypatch.setenv("RENDER_GIT_COMMIT", "deadbeef")
+        app = create_app(
+            "testing",
+            config_override={"API_KEY_REQUIRED": True, "API_KEY": "secret"},
+        )
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            resp = c.get("/version")
+        # Should succeed without any Authorization header
+        assert resp.status_code == 200
+        body = json.loads(resp.data)
+        assert body["git_sha"] == "deadbeef"


### PR DESCRIPTION
## Summary

- Adds `GET /version` route in `src/web/app.py` returning `{"git_sha": os.environ.get("RENDER_GIT_COMMIT", "unknown")}`. No auth required; same registration pattern as `/health`.
- `RENDER_GIT_COMMIT` is auto-injected by Render at deploy time — no `render.yaml` changes needed.
- Adds `--require-sha <SHA>` flag to `scripts/verify-deploy.sh`. After checks and `/health` pass, fetches `/version` and asserts the returned `git_sha` matches. New exit code 4 for SHA mismatch.
- Closes gh-570. Fragment updated to `status: resolved`.

## Test plan

- [ ] `pytest tests/unit/web/test_version_endpoint.py` — 5 tests, all pass (no env var → unknown, with env var → sha returned, no auth required)
- [ ] Manual: deploy to Render, run `bash scripts/verify-deploy.sh <sha> --require-sha <sha>` → exit 0
- [ ] Manual: run with wrong SHA → exit 4

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)