### PR TITLE
close(gh-548): add cross-reference comments to shared image-candidate FROM/JOIN methods

### DIFF
--- a/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
+++ b/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
@@ -14,6 +14,7 @@ updated: 2026-05-08
 gh_issue: 548
 pr_refs:
   - 549
+  - 584
 note: two DB helpers share the same complex JOIN aliases with no shared helper; silent drift risk if primary method evolves
 ---
 

--- a/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
+++ b/docs/known-issues/gh-548-db-image-candidate-join-duplication.md
@@ -3,15 +3,17 @@ id: 548
 source: gh
 slug: db-image-candidate-join-duplication
 title: "db.py: get_images_with_decision_type duplicates JOIN structure from get_image_review_candidate_v2"
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches:
   - src/infra/db.py
 discovered: 2026-05-07
-updated: 2026-05-07
+updated: 2026-05-08
 gh_issue: 548
+pr_refs:
+  - 549
 note: two DB helpers share the same complex JOIN aliases with no shared helper; silent drift risk if primary method evolves
 ---
 
@@ -23,3 +25,9 @@ note: two DB helpers share the same complex JOIN aliases with no shared helper; 
 
 - Evaluate whether a shared `_build_image_candidate_query` helper would reduce duplication without over-abstracting
 - At minimum, add a comment in both methods cross-referencing the other so maintainers know to update both
+
+### Resolution
+
+PR #549 consolidated the `_V2_IMAGE_CONFIRMATION_ROLLUP_JOIN` fragment (the most complex part of the shared skeleton) into a single class attribute, eliminating that duplication.
+
+The remaining FROM/JOIN skeleton shared by the three methods (`get_image_review_candidate_v2`, `get_image_review_candidates_for_filing_v2`, and `get_images_with_decision_type`) now has explicit cross-reference comments added directly above each method's SQL assignment, instructing maintainers to update all three in sync. No shared helper was introduced — the queries differ enough in WHERE clauses and projections that a single builder function would over-abstract.

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -2158,6 +2158,7 @@ class DatabaseAdapter:
         # rows per physical image. Keep the most recent row per filename —
         # prefer rows that already have a review decision so reviewer work
         # is not hidden behind a newer un-reviewed duplicate.
+        # FROM/JOIN mirrors get_image_review_candidate_v2 and get_images_with_decision_type — update in sync.
         sql = f"""
             WITH deduped_img AS (
                 SELECT DISTINCT ON (filing_id, filename) img_id
@@ -2205,6 +2206,7 @@ class DatabaseAdapter:
 
     def get_image_review_candidate_v2(self, img_id: str) -> dict | None:
         """V2-native single-image fetch with decision (if any)."""
+        # FROM/JOIN mirrors get_image_review_candidates_for_filing_v2 and get_images_with_decision_type — update in sync.
         sql = f"""
             SELECT {self._V2_IMAGE_CANDIDATE_SELECT},
                 f.accession_number, c.company_name, c.cik, c.ticker,
@@ -2274,6 +2276,7 @@ class DatabaseAdapter:
         else:
             raise ValueError(f"Unknown decision_type: {decision_type!r}")
 
+        # FROM/JOIN mirrors get_image_review_candidate_v2 and get_image_review_candidates_for_filing_v2 — update in sync.
         sql = f"""
             SELECT {self._V2_IMAGE_CANDIDATE_SELECT},
                 f.accession_number, c.company_name, c.cik, c.ticker,


### PR DESCRIPTION
## Summary

- Closes gh-548: adds explicit cross-reference comments above each of the three shared image-candidate FROM/JOIN query methods in `src/infra/db.py` (`get_image_review_candidate_v2`, `get_image_review_candidates_for_filing_v2`, `get_images_with_decision_type`) instructing maintainers to update all three in sync
- PR #549 previously consolidated the `_V2_IMAGE_CONFIRMATION_ROLLUP_JOIN` fragment; this PR completes the closure by documenting the remaining skeleton duplication
- Marks known-issue fragment `gh-548-db-image-candidate-join-duplication.md` as `resolved`

## Test plan

- [ ] No logic changes — comments only; existing unit + integration tests cover the query methods
- [ ] `pytest -x -q` passes in CI

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)