### PR TITLE
feat(eval): surface token counts in summary.tokens rollup (gh-554)

### DIFF
--- a/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
+++ b/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
@@ -13,6 +13,8 @@ touches:
 discovered: 2026-05-07
 updated: 2026-05-08
 gh_issue: 554
+pr_refs:
+  - 586
 ---
 
 ### Problem

--- a/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
+++ b/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
@@ -4,27 +4,26 @@ source: gh
 slug: phase1-eval-summary-tokens-not-populated
 title: "Phase-1 eval: surface token counts in summary.tokens rollup"
 status: resolved
+pr_refs:
+  - 586
 severity: low
-autonomy: n/a
+autonomy: skip
 estimated: —
 touches:
   - scripts/run_phase1_eval.py
   - docs/operations/llm-presence-classifier-phase1-eval-runbook.md
 discovered: 2026-05-07
-updated: 2026-05-08
+updated: 2026-05-07
 gh_issue: 554
-pr_refs:
-  - 586
+note: summary.tokens key in eval output is never populated; token counts from classify_segment and pipeline are discarded
 ---
 
 ### Problem
 
 Both Path A (`--path pipeline`) and Path B (`--path direct`) of `run_phase1_eval.py` discard token counts. Path B discards the `_tokens` dict returned by `classify_segment` (line with `results, _tokens = client.classify_segment(...)`). Path A token counts come from `LLMPresenceClassifierStage` inside the V2 pipeline and are equally unreachable post-run. The `summary.tokens` key referenced in the runbook ("total in/out, cache hit rate, $") is never written, so operators have no cost visibility when running the eval.
 
-### Resolution
+### Next Steps
 
-- Path B: `evaluate_filing_direct` now unpacks `(results, seg_tokens)` from each `classify_segment` call and accumulates into `filing_tokens`; returns `(aggregates, errors, filing_tokens)` (3-tuple). `run_eval` sums `filing_tokens` across all filings into `total_tokens`.
-- Path A: `evaluate_filing_pipeline` reads `total_input_tokens` / `total_output_tokens` / `total_cache_read` / `total_cache_create` from `StageResult.metadata` for `PipelineStage.LLM_PRESENCE_CLASSIFIER`; returns `(aggregates, kw_present, errors, filing_tokens)` (4-tuple).
-- Both paths write `summary.tokens: {input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}` via `estimate_cost_usd_from_counts`.
-- Unit tests in `tests/unit/scripts/test_phase1_eval_tokens.py` assert token accumulation and summary key population with mocked classifier.
-- Callers of `evaluate_filing_pipeline` in `tests/unit/scripts/test_run_phase1_eval_pipeline.py` updated to unpack the new 4-tuple.
+- Accumulate token dicts from `classify_segment` (Path B) and `LLMPresenceClassifierStage` stage metadata (Path A) across all filings/segments.
+- Write a `summary.tokens` rollup: `{input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}`.
+- Update the runbook Path A cost range once real observed numbers are available.

--- a/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
+++ b/docs/known-issues/gh-554-phase1-eval-summary-tokens-not-populated.md
@@ -3,25 +3,26 @@ id: 554
 source: gh
 slug: phase1-eval-summary-tokens-not-populated
 title: "Phase-1 eval: surface token counts in summary.tokens rollup"
-status: open
+status: resolved
 severity: low
-autonomy: skip
+autonomy: n/a
 estimated: —
 touches:
   - scripts/run_phase1_eval.py
   - docs/operations/llm-presence-classifier-phase1-eval-runbook.md
 discovered: 2026-05-07
-updated: 2026-05-07
+updated: 2026-05-08
 gh_issue: 554
-note: summary.tokens key in eval output is never populated; token counts from classify_segment and pipeline are discarded
 ---
 
 ### Problem
 
 Both Path A (`--path pipeline`) and Path B (`--path direct`) of `run_phase1_eval.py` discard token counts. Path B discards the `_tokens` dict returned by `classify_segment` (line with `results, _tokens = client.classify_segment(...)`). Path A token counts come from `LLMPresenceClassifierStage` inside the V2 pipeline and are equally unreachable post-run. The `summary.tokens` key referenced in the runbook ("total in/out, cache hit rate, $") is never written, so operators have no cost visibility when running the eval.
 
-### Next Steps
+### Resolution
 
-- Accumulate token dicts from `classify_segment` (Path B) and `LLMPresenceClassifierStage` stage metadata (Path A) across all filings/segments.
-- Write a `summary.tokens` rollup: `{input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}`.
-- Update the runbook Path A cost range once real observed numbers are available.
+- Path B: `evaluate_filing_direct` now unpacks `(results, seg_tokens)` from each `classify_segment` call and accumulates into `filing_tokens`; returns `(aggregates, errors, filing_tokens)` (3-tuple). `run_eval` sums `filing_tokens` across all filings into `total_tokens`.
+- Path A: `evaluate_filing_pipeline` reads `total_input_tokens` / `total_output_tokens` / `total_cache_read` / `total_cache_create` from `StageResult.metadata` for `PipelineStage.LLM_PRESENCE_CLASSIFIER`; returns `(aggregates, kw_present, errors, filing_tokens)` (4-tuple).
+- Both paths write `summary.tokens: {input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}` via `estimate_cost_usd_from_counts`.
+- Unit tests in `tests/unit/scripts/test_phase1_eval_tokens.py` assert token accumulation and summary key population with mocked classifier.
+- Callers of `evaluate_filing_pipeline` in `tests/unit/scripts/test_run_phase1_eval_pipeline.py` updated to unpack the new 4-tuple.

--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -824,16 +824,25 @@ def _resolve_filing_html(paf: _PathAFiling) -> tuple[Path, Path | None]:
 def evaluate_filing_pipeline(
     paf: _PathAFiling,
     metric_ids: list[str],
-) -> tuple[dict[str, _AggregatedScore], dict[str, bool], list[dict[str, Any]]]:
+) -> tuple[dict[str, _AggregatedScore], dict[str, bool], list[dict[str, Any]], dict[str, int]]:
     """Run the full V2 pipeline on a filing and extract LLM presence signals.
 
-    Returns ``(per_metric_aggregate, kw_present, errors)``.
+    Returns ``(per_metric_aggregate, kw_present, errors, token_totals)``.
 
     ``kw_present[metric_id]`` is True iff CandidateGenerationStage emitted at
     least one candidate for that metric — the keyword baseline for criterion #3.
-    """
-    from src.extraction_v2.pipeline import PipelineConfig, V2Pipeline
 
+    ``token_totals`` is ``{input_tokens, output_tokens, cache_read, cache_create}``
+    extracted from the LLMPresenceClassifierStage StageResult metadata.
+    """
+    from src.extraction_v2.pipeline import PipelineConfig, PipelineStage, V2Pipeline
+
+    _zero_tokens: dict[str, int] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_create": 0,
+    }
     errors: list[dict[str, Any]] = []
     resolved_path, temp_path = _resolve_filing_html(paf)
 
@@ -864,7 +873,7 @@ def evaluate_filing_pipeline(
                 "stage": "pipeline",
             }
         )
-        return {}, {}, errors
+        return {}, {}, errors, dict(_zero_tokens)
     finally:
         if temp_path is not None:
             try:
@@ -881,7 +890,19 @@ def evaluate_filing_pipeline(
                 "stage": "pipeline",
             }
         )
-        return {}, {}, errors
+        return {}, {}, errors, dict(_zero_tokens)
+
+    # Extract token counts from the LLMPresenceClassifierStage StageResult
+    # metadata. The stage accumulates per-segment token dicts and writes them
+    # into StageResult.metadata as total_input_tokens / total_output_tokens /
+    # total_cache_read / total_cache_create.
+    filing_tokens: dict[str, int] = dict(_zero_tokens)
+    for sr in result.stage_results:
+        if sr.stage == PipelineStage.LLM_PRESENCE_CLASSIFIER:
+            filing_tokens["input_tokens"] += sr.metadata.get("total_input_tokens", 0)
+            filing_tokens["output_tokens"] += sr.metadata.get("total_output_tokens", 0)
+            filing_tokens["cache_read"] += sr.metadata.get("total_cache_read", 0)
+            filing_tokens["cache_create"] += sr.metadata.get("total_cache_create", 0)
 
     # Max-score aggregation per metric across all LLM signals.
     aggregates: dict[str, _AggregatedScore] = {}
@@ -915,7 +936,7 @@ def evaluate_filing_pipeline(
     # one candidate for this metric.
     kw_present = {m: any(c.metric_id == m for c in result.context.candidates) for m in metric_ids}
 
-    return aggregates, kw_present, errors
+    return aggregates, kw_present, errors, filing_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -941,15 +962,17 @@ def evaluate_filing_direct(
     gold_quotes: list[str] | None = None,
     db_url: str | None = None,
     section_whitelist: list[str] | None = None,
-) -> tuple[dict[str, _AggregatedScore], list[dict[str, Any]]]:
+) -> tuple[dict[str, _AggregatedScore], list[dict[str, Any]], dict[str, int]]:
     """Run the classifier across one filing's relevant texts.
 
     For ``corpus='gold'``: ``gold_quotes`` MUST be provided.
     For ``corpus='reviewed'``: ``db_url`` and ``section_whitelist`` MUST be
     provided (segments are loaded from DB).
 
-    Returns ``(per_metric_aggregate, errors)`` — errors are a list of
-    ``{"filing_url", "metric_id"|None, "exception", "stage"}`` dicts.
+    Returns ``(per_metric_aggregate, errors, token_totals)`` — errors are a
+    list of ``{"filing_url", "metric_id"|None, "exception", "stage"}`` dicts.
+    ``token_totals`` is ``{input_tokens, output_tokens, cache_read, cache_create}``
+    accumulated across all ``classify_segment`` calls for this filing.
     """
     if filing.corpus == "gold":
         if gold_quotes is None:
@@ -965,14 +988,16 @@ def evaluate_filing_direct(
 
     aggregates: dict[str, _AggregatedScore] = {}
     errors: list[dict[str, Any]] = []
+    filing_tokens: dict[str, int] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_create": 0,
+    }
 
     for text, section_type in texts:
         try:
-            # ``classify_segment`` returns ``(classifications, token_counts)``
-            # since the gh-531 token-threading fix (PR #535). Token totals
-            # are discarded here — see follow-up fragment for surfacing them
-            # in summary.tokens.
-            results, _tokens = client.classify_segment(text, metric_ids)
+            results, seg_tokens = client.classify_segment(text, metric_ids)
         except ValueError as exc:  # parse / shape errors — hard fail per criterion #1
             errors.append(
                 {
@@ -993,6 +1018,11 @@ def evaluate_filing_direct(
                 }
             )
             continue
+        # Accumulate token counts from each classify_segment call.
+        filing_tokens["input_tokens"] += seg_tokens.get("input_tokens", 0)
+        filing_tokens["output_tokens"] += seg_tokens.get("output_tokens", 0)
+        filing_tokens["cache_read"] += seg_tokens.get("cache_read", 0)
+        filing_tokens["cache_create"] += seg_tokens.get("cache_create", 0)
         for sc in results:
             existing = aggregates.get(sc.metric_id)
             if existing is None or sc.score > existing.score:
@@ -1019,7 +1049,7 @@ def evaluate_filing_direct(
                 section_type=None,
             ),
         )
-    return aggregates, errors
+    return aggregates, errors, filing_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -1434,6 +1464,13 @@ def run_eval(
 
     rows: list[EvalRow] = []
     errors: list[dict[str, Any]] = []
+    # Accumulated token counts across all filings (both corpora, both paths).
+    total_tokens: dict[str, int] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_create": 0,
+    }
 
     if path_mode == "pipeline":
         # Path A: run V2 pipeline per filing; keyword baseline from context.candidates.
@@ -1443,8 +1480,12 @@ def run_eval(
             return 2, {"error": str(enrich_err), "run_started_at": run_started_at}
 
         for paf in enriched:
-            aggregates_a, kw_present_a, fil_errors = evaluate_filing_pipeline(paf, metric_ids)
+            aggregates_a, kw_present_a, fil_errors, fil_tokens = evaluate_filing_pipeline(
+                paf, metric_ids
+            )
             errors.extend(fil_errors)
+            for k in total_tokens:
+                total_tokens[k] += fil_tokens.get(k, 0)
             for metric in metric_ids:
                 if paf.selection.corpus == "gold":
                     gt = gold_labels.get((paf.selection.filing_url, metric))
@@ -1476,13 +1517,15 @@ def run_eval(
             )
             for filing in gold_filings:
                 quotes = gold_quotes_map.get(filing.filing_url, [])
-                aggregates, fil_errors = evaluate_filing_direct(
+                aggregates, fil_errors, fil_tokens = evaluate_filing_direct(
                     filing,
                     metric_ids,
                     client,
                     gold_quotes=quotes,
                 )
                 errors.extend(fil_errors)
+                for k in total_tokens:
+                    total_tokens[k] += fil_tokens.get(k, 0)
                 for metric in metric_ids:
                     gt = gold_labels.get((filing.filing_url, metric))
                     rows.append(
@@ -1500,7 +1543,7 @@ def run_eval(
 
         # Reviewed filings: score paraphrase-eligible v2_segments.
         for filing in reviewed_filings:
-            aggregates, fil_errors = evaluate_filing_direct(
+            aggregates, fil_errors, fil_tokens = evaluate_filing_direct(
                 filing,
                 metric_ids,
                 client,
@@ -1508,6 +1551,8 @@ def run_eval(
                 section_whitelist=section_whitelist,
             )
             errors.extend(fil_errors)
+            for k in total_tokens:
+                total_tokens[k] += fil_tokens.get(k, 0)
             for metric in metric_ids:
                 gt = reviewed_labels.get((filing.filing_id, metric))
                 kw = kw_baseline_reviewed.get((filing.filing_id, metric))
@@ -1530,6 +1575,18 @@ def run_eval(
 
     # Smoke-test criteria.
     smoke = compute_smoke_criteria(rows, errors)
+
+    # Token cost rollup — use Haiku pricing as the dominant model assumption.
+    # Mixed Haiku+Sonnet runs will underestimate cost; accurate for Haiku-only
+    # runs. The per-call Sonnet cost is already logged by classify_segment.
+    from src.llm.presence_classifier_client import estimate_cost_usd_from_counts
+
+    estimated_cost_usd = estimate_cost_usd_from_counts(
+        input_tokens=total_tokens["input_tokens"],
+        output_tokens=total_tokens["output_tokens"],
+        cache_read=total_tokens["cache_read"],
+        cache_create=total_tokens["cache_create"],
+    )
 
     # Output.
     csv_path = out_dir / f"phase1_10filing_{run_id}.csv"
@@ -1571,6 +1628,13 @@ def run_eval(
             "catastrophic_metrics": smoke.catastrophic_metrics,
             "disagreements_total": smoke.disagreements_total,
             "stratified_30_sample": smoke.stratified_30_sample,
+        },
+        "tokens": {
+            "input_tokens": total_tokens["input_tokens"],
+            "output_tokens": total_tokens["output_tokens"],
+            "cache_read_tokens": total_tokens["cache_read"],
+            "cache_create_tokens": total_tokens["cache_create"],
+            "estimated_cost_usd": round(estimated_cost_usd, 6),
         },
         "errors": errors,
     }

--- a/tests/unit/scripts/test_phase1_eval_tokens.py
+++ b/tests/unit/scripts/test_phase1_eval_tokens.py
@@ -1,0 +1,269 @@
+"""Unit tests for ``summary.tokens`` rollup in ``scripts/run_phase1_eval.py``.
+
+Verifies that token counts returned by ``classify_segment`` are accumulated
+across filings and written into ``summary.tokens`` in the output JSON (gh-554).
+
+Does NOT call the Anthropic API — the classifier client is fully mocked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "run_phase1_eval.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    mod_name = "run_phase1_eval_tokens_unit"
+    spec = importlib.util.spec_from_file_location(mod_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _load_script_module()
+
+
+# ---------------------------------------------------------------------------
+# Fake classifier client that returns known token counts
+# ---------------------------------------------------------------------------
+
+
+class _FakeClassification:
+    """Minimal SegmentClassification stand-in."""
+
+    def __init__(self, metric_id: str) -> None:
+        self.metric_id = metric_id
+        self.score = 0.9
+        self.present = True
+        self.model = "claude-haiku-4-5-20251001"
+        self.sonnet_fallback = False
+        self.prompt_version = "0.1.0-test"
+        self.rationale = "test"
+
+
+class _FakeClientWithTokens:
+    """Returns a fixed token dict per classify_segment call.
+
+    Each call returns ``(classifications, token_counts)`` where
+    ``token_counts`` contains known values so the rollup is predictable.
+    """
+
+    def __init__(
+        self,
+        metric_ids: list[str],
+        tokens_per_call: dict[str, int],
+    ) -> None:
+        self._metric_ids = metric_ids
+        self._tokens_per_call = tokens_per_call
+
+    def classify_segment(
+        self, text: str, metric_ids: list[str]
+    ) -> tuple[list[_FakeClassification], dict[str, int]]:
+        classifications = [_FakeClassification(m) for m in metric_ids]
+        return classifications, dict(self._tokens_per_call)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_filing_direct token accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_filing_direct_accumulates_tokens_across_segments(cli):
+    """Token counts from multiple classify_segment calls are summed."""
+    filing = cli.FilingSelection(
+        corpus="gold",
+        filing_url="https://example.com/f1.htm",
+        filing_id=None,
+        issuer_key="alpha",
+        company="Alpha Inc",
+    )
+    tokens_per_call = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read": 80,
+        "cache_create": 20,
+    }
+    client = _FakeClientWithTokens(["cm_net_revenue_retention"], tokens_per_call)
+
+    # Two gold quotes → two classify_segment calls.
+    quotes = [
+        "NRR was 132% reflecting strong expansion revenue.",
+        "Net revenue retention reached 125% in the fiscal year.",
+    ]
+    aggregates, errors, filing_tokens = cli.evaluate_filing_direct(
+        filing,
+        ["cm_net_revenue_retention"],
+        client,
+        gold_quotes=quotes,
+    )
+
+    assert errors == []
+    # Two calls × 100 input_tokens = 200.
+    assert filing_tokens["input_tokens"] == 200
+    assert filing_tokens["output_tokens"] == 100
+    assert filing_tokens["cache_read"] == 160
+    assert filing_tokens["cache_create"] == 40
+
+
+def test_evaluate_filing_direct_returns_zero_tokens_for_empty_quotes(cli):
+    """No quotes → no classify_segment calls → all token fields are zero."""
+    filing = cli.FilingSelection(
+        corpus="gold",
+        filing_url="https://example.com/f2.htm",
+        filing_id=None,
+        issuer_key="beta",
+        company="Beta Corp",
+    )
+    client = _FakeClientWithTokens(
+        ["cm_net_revenue_retention"],
+        {"input_tokens": 100, "output_tokens": 50, "cache_read": 80, "cache_create": 20},
+    )
+    aggregates, errors, filing_tokens = cli.evaluate_filing_direct(
+        filing,
+        ["cm_net_revenue_retention"],
+        client,
+        gold_quotes=[],  # no quotes → no API calls
+    )
+    assert errors == []
+    assert filing_tokens == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_create": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# summary.tokens written by run_eval (Path B, gold-only, mocked API)
+# ---------------------------------------------------------------------------
+
+
+def test_run_eval_writes_summary_tokens_path_b(cli, tmp_path, monkeypatch):
+    """``summary.tokens`` is populated with non-zero counts in a live Path B run.
+
+    We bypass the real API by monkey-patching ``PresenceClassifierClient``
+    with a fake that returns known token counts, and fake the gold-corpus
+    file-loading helpers to avoid touching the filesystem.
+    """
+    # A single gold quote per filing ensures one classify_segment call.
+    tokens_per_call = {
+        "input_tokens": 200,
+        "output_tokens": 80,
+        "cache_read": 150,
+        "cache_create": 50,
+    }
+
+    # Patch PresenceClassifierClient inside the already-loaded script module.
+    class _FakePresenceClassifierClient:
+        def classify_segment(
+            self, text: str, metric_ids: list[str]
+        ) -> tuple[list[_FakeClassification], dict[str, int]]:
+            return [_FakeClassification(m) for m in metric_ids], dict(tokens_per_call)
+
+    # --- Patch the imports that run_eval uses for the live path ---
+    import types
+
+    fake_pcc_module = types.ModuleType("src.llm.presence_classifier_client_fake")
+    fake_pcc_module.PresenceClassifierClient = _FakePresenceClassifierClient  # type: ignore[attr-defined]
+    fake_pcc_module.estimate_cost_usd_from_counts = (  # type: ignore[attr-defined]
+        lambda input_tokens, output_tokens, cache_read, cache_create, model=None: 0.001234
+    )
+
+    # Override the module import inside run_eval's namespace by patching
+    # the script module's sys.modules entry for the real client module.
+    real_module_name = "src.llm.presence_classifier_client"
+    original = sys.modules.get(real_module_name)
+    sys.modules[real_module_name] = fake_pcc_module  # type: ignore[assignment]
+
+    # Patch gold-CSV helpers to return a single filing with one usable quote.
+    FAKE_URL = "https://www.sec.gov/Archives/edgar/data/999/fake/f1.htm"
+
+    def _fake_load_splits():
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeSplits:
+            train_urls: frozenset = frozenset()
+            test_urls: frozenset = frozenset([FAKE_URL])
+            calibration_urls: frozenset = frozenset()
+            issuer_lookup: dict = None  # type: ignore[assignment]
+            company_lookup: dict = None  # type: ignore[assignment]
+
+            def __post_init__(self):
+                self.issuer_lookup = {FAKE_URL: "fakeissuer"}
+                self.company_lookup = {FAKE_URL: "Fake Co"}
+
+        return FakeSplits()
+
+    def _fake_gold_metrics_per_filing(gold_csv, target_urls):
+        # Report one required metric for the fake filing.
+        return {FAKE_URL: {"cm_net_revenue_retention"}}
+
+    def _fake_gold_quotes_per_filing(gold_csv, target_urls):
+        return {FAKE_URL: ["NRR was 132% reflecting strong expansion revenue."]}
+
+    def _fake_load_recall_augmentation():
+        return ["cm_net_revenue_retention"], ["risk_factors"]
+
+    monkeypatch.setattr(cli, "_load_splits", _fake_load_splits)
+    monkeypatch.setattr(cli, "_gold_metrics_per_filing", _fake_gold_metrics_per_filing)
+    monkeypatch.setattr(cli, "_gold_quotes_per_filing", _fake_gold_quotes_per_filing)
+    monkeypatch.setattr(cli, "_load_recall_augmentation", _fake_load_recall_augmentation)
+    # Force enrolled list so discover_required_gold_metrics works.
+    monkeypatch.setattr(
+        cli,
+        "PLAN_REQUIRED_GOLD_METRICS",
+        ("cm_net_revenue_retention",),
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    try:
+        exit_code, summary = cli.run_eval(
+            run_id="tokentest",
+            out_dir=tmp_path,
+            path_mode="direct",
+            gold_only=True,
+            reviewed_only=False,
+            limit=1,
+            dry_run=False,
+        )
+    finally:
+        # Restore the real module.
+        if original is not None:
+            sys.modules[real_module_name] = original
+        else:
+            sys.modules.pop(real_module_name, None)
+
+    assert exit_code == 0, f"run_eval failed: {summary}"
+
+    # ``summary.tokens`` must be present and populated.
+    assert "tokens" in summary, "summary.tokens key missing from output"
+    tok = summary["tokens"]
+    required_keys = {
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_create_tokens",
+        "estimated_cost_usd",
+    }
+    assert required_keys == set(tok.keys()), f"unexpected token keys: {set(tok.keys())}"
+
+    # One gold filing × one quote → one classify_segment call.
+    assert tok["input_tokens"] == 200
+    assert tok["output_tokens"] == 80
+    assert tok["cache_read_tokens"] == 150
+    assert tok["cache_create_tokens"] == 50
+    assert tok["estimated_cost_usd"] == 0.001234

--- a/tests/unit/scripts/test_run_phase1_eval.py
+++ b/tests/unit/scripts/test_run_phase1_eval.py
@@ -405,7 +405,7 @@ def test_evaluate_filing_direct_unpacks_classify_segment_tuple(cli):
     client = _FakeClassifierClient(
         {"cm_net_revenue_retention": 0.92, "cm_revenue_concentration": 0.10}
     )
-    aggregates, errors = cli.evaluate_filing_direct(
+    aggregates, errors, _tokens = cli.evaluate_filing_direct(
         filing,
         ["cm_net_revenue_retention", "cm_revenue_concentration"],
         client,

--- a/tests/unit/scripts/test_run_phase1_eval_pipeline.py
+++ b/tests/unit/scripts/test_run_phase1_eval_pipeline.py
@@ -244,7 +244,7 @@ def test_evaluate_filing_pipeline_max_score_aggregation(cli, tmp_path):
     with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
         MockPipeline.return_value.process.return_value = fake_result
         paf = _make_paf(cli, html_storage_path=str(html_file))
-        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+        aggregates, kw_present, errors, _tokens = cli.evaluate_filing_pipeline(paf, metric_ids)
 
     assert errors == []
     assert aggregates["cm_net_revenue_retention"].score == 0.9
@@ -280,7 +280,7 @@ def test_evaluate_filing_pipeline_keyword_baseline(cli, tmp_path):
     with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
         MockPipeline.return_value.process.return_value = fake_result
         paf = _make_paf(cli, html_storage_path=str(html_file))
-        _aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+        _aggregates, kw_present, errors, _tokens = cli.evaluate_filing_pipeline(paf, metric_ids)
 
     assert errors == []
     assert kw_present["cm_net_revenue_retention"] is True
@@ -307,7 +307,7 @@ def test_evaluate_filing_pipeline_eval_row_keyword_present_set(cli, tmp_path):
     with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
         MockPipeline.return_value.process.return_value = fake_result
         paf = _make_paf(cli, html_storage_path=str(html_file))
-        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(paf, metric_ids)
+        aggregates, kw_present, errors, _tokens = cli.evaluate_filing_pipeline(paf, metric_ids)
 
     row = cli._classify_eval_row(
         run_id="r",
@@ -333,7 +333,7 @@ def test_evaluate_filing_pipeline_pipeline_exception_returns_error(cli, tmp_path
     with patch("src.extraction_v2.pipeline.V2Pipeline") as MockPipeline:
         MockPipeline.return_value.process.side_effect = RuntimeError("pipeline exploded")
         paf = _make_paf(cli, html_storage_path=str(html_file))
-        aggregates, kw_present, errors = cli.evaluate_filing_pipeline(
+        aggregates, kw_present, errors, _tokens = cli.evaluate_filing_pipeline(
             paf, ["cm_net_revenue_retention"]
         )
 


### PR DESCRIPTION
## Summary

- Path B (`--path direct`): `evaluate_filing_direct` now unpacks the `(results, seg_tokens)` 2-tuple from `classify_segment`, accumulates per-segment, and returns a 3-tuple `(aggregates, errors, filing_tokens)`. `run_eval` sums across all filings into `total_tokens`.
- Path A (`--path pipeline`): `evaluate_filing_pipeline` reads token metadata from `LLMPresenceClassifierStage` `StageResult.metadata` and returns a 4-tuple. Callers updated to unpack the new signature.
- Both paths write `summary.tokens: {input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, estimated_cost_usd}` via `estimate_cost_usd_from_counts`.
- Unit tests in `test_phase1_eval_tokens.py` assert token accumulation and summary key population with a mocked classifier.

Closes #554.

## Test plan

- [x] `pytest tests/unit/scripts/test_phase1_eval_tokens.py` — 3 new token tests pass
- [x] `pytest tests/unit/scripts/test_run_phase1_eval.py` — existing tests pass including `test_evaluate_filing_direct_unpacks_classify_segment_tuple`
- [x] `pytest tests/unit/scripts/test_run_phase1_eval_pipeline.py` — updated 4-tuple unpacking tests pass
- [x] `ruff check` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)