### PR TITLE
fix(ingestion): retain short anchor-bearing heading paragraphs (gh-574)

### DIFF
--- a/docs/known-issues/gh-574-datadog-section-classification-toc-anchor-gap.md
+++ b/docs/known-issues/gh-574-datadog-section-classification-toc-anchor-gap.md
@@ -8,24 +8,30 @@ severity: medium
 autonomy: skip
 estimated: —
 touches:
-  - src/extraction_v2/stages/section_classification.py
-  - tests/unit/extraction_v2/stages/test_section_classification.py
+  - src/extraction_v2/stages/ingestion.py
+  - tests/unit/extraction_v2/test_ingestion.py
 discovered: 2026-05-08
 updated: 2026-05-08
 gh_issue: 574
-note: Datadog S-1 and similar TOC-anchor-wrapped markup match no SECTION_PATTERNS; paraphrase recall path completely inert
+note: "Root cause is the 50-char MIN_PARAGRAPH_CHARS floor in ingestion (not section_classification). Datadog's bare-heading <P>s carry an `<a name>` anchor target but text below the floor, and get filtered before Stage 2 sees them. Fix retains short paragraphs that carry an anchor target."
 ---
 
 ### Problem
 
 Phase-1 smoke eval (run_id `20260508T1743`) revealed Datadog's S-1 (filing 1539) is the only filing of 5 in the gold corpus where `section_classification` detects **zero** whitelisted sections (MDA, Business, Risk Factors). Detected map: `{COVER: 0, FINANCIALS: 3}`. As a result, the LLM paraphrase-recall path was completely inert — `paraphrase_segs=0` versus the other 4 filings' 604–891 paraphrase candidates.
 
-The other 4 gold filings (1545, 1550, 191794, 1146) all match `MDA: 1`, meaning the heading-pattern regex finds the start of MD&A and propagates the section tag forward. Datadog's HTML wraps heading text inside `<TD><P><A HREF="#anchor">RISK FACTORS</A></P></TD>` table cells — `_is_section_heading()` and the anchored regexes in `SECTION_PATTERNS` don't match the resulting segment text shape.
+### Root cause (verified 2026-05-08)
+
+The fragment originally hypothesized TOC-anchor markup in `<TD>` cells. **Re-investigation against the cached gold HTML showed a different cause** in ingestion, not section_classification:
+
+- Datadog's section-START headings are plain `<P>` elements containing an `<a name="...">` anchor target. Examples (`data/gold_standard/Datadog,_Inc_/filing.html`): line 2408 `<P ... ALIGN="center"><B><A NAME="toc745413_2"></A>RISK FACTORS </B></P>` (text length 12); lines 6036–6037 split MD&A across two short `<P>`s (39 + 45 chars).
+- All three are below `IngestionStage.DEFAULT_MIN_PARAGRAPH_CHARS = 50` and are dropped at `_extract_paragraph_segments_with_elements` line 590 — **before** they reach Stage 2. `SECTION_PATTERNS` and `_is_section_heading()` work correctly; the segments they would match are already gone.
+- Working filings (e.g., Maplebear) survive because the full title is in one paragraph (85 chars), comfortably above the floor.
 
 Not a smoke-gate blocker (catastrophic-regression check passed), but a systematic gap that hurts Tier-1 recall on Datadog-style filings and likely contributes to gh-575 (LTV-per-customer 0-recall).
 
-### Next Steps
+### Fix
 
-- Inspect the `segment.text` values around Datadog's MD&A / Risk Factors anchors after ingestion to see what shape they take.
-- Either extend `SECTION_PATTERNS` to cover the variants observed, or relax `_is_section_heading()` to admit TOC-anchor segment shapes.
-- Re-run Phase-1 smoke eval; confirm Datadog `paraphrase_segs > 0`.
+Retain short paragraphs (below `MIN_PARAGRAPH_CHARS`) when they contain an `<a name>` or `<a id>` anchor target — the standard SEC section-anchor signal. `<a href>` (link) does NOT count, to keep TOC entries from flooding through. Purely additive change: long paragraphs unaffected.
+
+Verification on filing 1539 post-fix: `section_classification` detects `risk_factors: 1`, `mda: 1`, `business: 1` (was zero).

--- a/src/extraction_v2/stages/ingestion.py
+++ b/src/extraction_v2/stages/ingestion.py
@@ -309,6 +309,25 @@ class IngestionStage:
 
         return True
 
+    def _has_anchor_target(self, element: etree._Element) -> bool:
+        """
+        Detect whether `element` contains an `<a name>` or `<a id>` anchor target.
+
+        Anchor *targets* (destinations) mark document structure — typically a
+        section heading. Anchor *links* (`<a href="#x">`) do not, and must not
+        admit short table-of-contents entries through the length floor.
+
+        Args:
+            element: lxml Element to inspect (descendant `<a>` tags considered).
+
+        Returns:
+            True if any descendant `<a>` has a `name` or `id` attribute.
+        """
+        for anchor in element.iter("a"):
+            if anchor.get("name") or anchor.get("id"):
+                return True
+        return False
+
     def _is_invisible_alt_text(self, element: etree._Element) -> bool:
         """
         Check if element contains only invisible accessibility fallback text.
@@ -586,8 +605,16 @@ class IngestionStage:
             text_content = element.text_content() if hasattr(element, "text_content") else ""
             normalized_text = normalize_text(text_content)
 
-            # Apply length filters
-            if len(normalized_text) < self.MIN_PARAGRAPH_CHARS:
+            # Apply length filters. Short paragraphs are retained when they
+            # carry an `<a name>` / `<a id>` anchor *target* — SEC S-1s
+            # (Datadog 2019 vintage, gh-574) place section-START headings in
+            # standalone <P> elements whose text falls below the floor; the
+            # anchor target marks them as document structure rather than body
+            # copy. Bare `<a href>` links are NOT a target signal — that would
+            # let table-of-contents entries flood through.
+            if len(normalized_text) < self.MIN_PARAGRAPH_CHARS and not self._has_anchor_target(
+                element
+            ):
                 continue
             if len(normalized_text) > self.MAX_PARAGRAPH_CHARS:
                 normalized_text = normalized_text[: self.MAX_PARAGRAPH_CHARS]

--- a/tests/unit/extraction_v2/test_ingestion.py
+++ b/tests/unit/extraction_v2/test_ingestion.py
@@ -606,6 +606,169 @@ class TestParagraphDetection:
         assert segments[2].sequence == 2
 
 
+class TestAnchorBearingShortHeadings:
+    """gh-574: short paragraphs carrying an `<a name>` / `<a id>` section anchor.
+
+    SEC S-1s (Datadog 2019 vintage) place section-START headings in standalone
+    `<P>` elements whose text is shorter than `MIN_PARAGRAPH_CHARS`. The default
+    length floor would drop them, leaving section_classification with nothing to
+    detect on. Paragraphs containing an anchor *target* (`<a name>` or `<a id>`,
+    not an `<a href>`) are retained regardless of length.
+    """
+
+    def test_retain_short_paragraph_with_a_name_anchor(self, tmp_path: Path) -> None:
+        """`<P><B><A NAME="x"></A>RISK FACTORS</B></P>` (12 chars) survives."""
+        html_content = b"""
+        <html>
+        <body>
+            <p><b><a name="toc745413_2"></a>RISK FACTORS </b></p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        stage = IngestionStage()
+        tree = stage._parse_html(html_file)
+        assert tree is not None
+
+        segments = stage._extract_paragraph_segments(tree, filing_id=12345)
+
+        assert len(segments) == 1
+        assert segments[0].text == "RISK FACTORS"
+
+    def test_retain_short_paragraph_with_a_id_anchor(self, tmp_path: Path) -> None:
+        """`<a id="...">` (HTML5 form) is treated equivalently to `<a name>`."""
+        html_content = b"""
+        <html>
+        <body>
+            <p><a id="sec-mda"></a>MD&amp;A</p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        stage = IngestionStage()
+        tree = stage._parse_html(html_file)
+        assert tree is not None
+
+        segments = stage._extract_paragraph_segments(tree, filing_id=12345)
+
+        assert len(segments) == 1
+        assert segments[0].text == "MD&A"
+
+    def test_retain_split_mda_first_paragraph(self, tmp_path: Path) -> None:
+        """Datadog splits MD&A across two `<P>`s; the anchor-bearing first one survives."""
+        html_content = b"""
+        <html>
+        <body>
+            <p><b><a name="toc745413_10"></a>MANAGEMENT'S DISCUSSION AND ANALYSIS OF </b></p>
+            <p><b>FINANCIAL CONDITION AND RESULTS OF OPERATIONS </b></p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        stage = IngestionStage()
+        tree = stage._parse_html(html_file)
+        assert tree is not None
+
+        segments = stage._extract_paragraph_segments(tree, filing_id=12345)
+
+        # First paragraph has the anchor and survives. Second is below the
+        # floor with no anchor, so it gets filtered (acceptable — the first
+        # half is enough for `_detect_section_type` to match the MDA pattern).
+        assert len(segments) == 1
+        assert segments[0].text.startswith("MANAGEMENT'S DISCUSSION AND ANALYSIS")
+
+    def test_short_paragraph_without_anchor_still_filtered(self, tmp_path: Path) -> None:
+        """The retain rule is purely additive — non-anchor short paragraphs still drop."""
+        html_content = b"""
+        <html>
+        <body>
+            <p>NO ANCHOR HERE</p>
+            <p>This longer paragraph is over the fifty character floor and should survive.</p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        stage = IngestionStage()
+        tree = stage._parse_html(html_file)
+        assert tree is not None
+
+        segments = stage._extract_paragraph_segments(tree, filing_id=12345)
+
+        assert len(segments) == 1
+        assert "longer paragraph" in segments[0].text
+
+    def test_anchor_link_href_does_not_count_as_anchor_target(self, tmp_path: Path) -> None:
+        """`<a href>` (link) is NOT an anchor *target*; short hyperlink paragraphs still drop.
+
+        Otherwise TOC entries would all flood through ingestion.
+        """
+        html_content = b"""
+        <html>
+        <body>
+            <p><a href="#toc745413_2">RISK FACTORS</a></p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        stage = IngestionStage()
+        tree = stage._parse_html(html_file)
+        assert tree is not None
+
+        segments = stage._extract_paragraph_segments(tree, filing_id=12345)
+
+        assert len(segments) == 0
+
+    def test_anchor_bearing_heading_flows_to_section_classification(self, tmp_path: Path) -> None:
+        """End-to-end: a Datadog-shaped fixture produces MDA + RISK_FACTORS detections."""
+        from src.extraction_v2.models import SectionType
+        from src.extraction_v2.pipeline import PipelineContext
+        from src.extraction_v2.stages.section_classification import (
+            SectionClassificationStage,
+        )
+
+        html_content = b"""
+        <html>
+        <body>
+            <p>This intro paragraph is long enough to clear the fifty character minimum and reach Stage 2.</p>
+            <p><b><a name="toc745413_2"></a>RISK FACTORS </b></p>
+            <p>This longer paragraph should be tagged RISK_FACTORS by section propagation across more than fifty characters.</p>
+            <p><b><a name="toc745413_10"></a>MANAGEMENT'S DISCUSSION AND ANALYSIS OF </b></p>
+            <p>This MD&amp;A body paragraph is also clearly over the fifty character floor and should pick up the MDA section tag.</p>
+        </body>
+        </html>
+        """
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html_content)
+
+        ingest = IngestionStage()
+        tree = ingest._parse_html(html_file)
+        assert tree is not None
+        segments = ingest._extract_paragraph_segments(tree, filing_id=42)
+
+        ctx = PipelineContext(
+            html_path=html_file,
+            filing_id=42,
+            config=PipelineConfig(),
+            segments=segments,
+        )
+
+        result = SectionClassificationStage().process(ctx)
+        assert result.success
+        sections = {k: v for k, v in result.metadata["sections_detected"].items()}
+        assert sections.get(SectionType.RISK_FACTORS.value, 0) >= 1, sections
+        assert sections.get(SectionType.MDA.value, 0) >= 1, sections
+
+
 class TestTableDetection:
     """Test table detection with div-wrapper deduplication (AC-6)."""
 
@@ -1643,9 +1806,7 @@ class TestInvisibleAltTextSuppression:
         from lxml import html as lhtml
 
         stage = IngestionStage()
-        element = lhtml.fragment_fromstring(
-            '<p style="font-size:1pt;color:white">Hidden text</p>'
-        )
+        element = lhtml.fragment_fromstring('<p style="font-size:1pt;color:white">Hidden text</p>')
         assert stage._is_invisible_alt_text(element) is True
 
     def test_is_invisible_alt_text_detects_with_spaces(self) -> None:


### PR DESCRIPTION
Datadog's S-1 places section-START headings (RISK FACTORS, MD&A) in
short <P> elements (12-45 chars) carrying an <a name="..."> anchor
target. The 50-char MIN_PARAGRAPH_CHARS floor in ingestion drops them
before section_classification runs, leaving the LLM paraphrase recall
path inert on Datadog-style filings.

Retain short paragraphs that contain an <a name>/<a id> anchor target.
<a href> links don't count, so TOC entries stay filtered. Purely
additive — long paragraphs unaffected. On filing 1539 post-fix:
section_classification detects risk_factors, mda, business each >=1
(was zero).
