### PR TITLE
feat(auth): admin_required decorator + override columns on v2_image_metric_confirmations

### DIFF
--- a/sql/202605111319_add_override_columns_to_v2_image_metric_confirmations.sql
+++ b/sql/202605111319_add_override_columns_to_v2_image_metric_confirmations.sql
@@ -1,0 +1,39 @@
+-- Migration 202605111319: add_override_columns_to_v2_image_metric_confirmations
+--
+-- Adds two columns to support admin override provenance:
+--   override_reason         TEXT   — free-text reason; non-null marks an admin row.
+--   supersedes_confirmation_id UUID — FK to the confirmation row being reversed.
+--
+-- A CHECK constraint enforces that if supersedes_confirmation_id is set,
+-- override_reason must also be set (ordinary reviewer rows leave both NULL).
+-- Admin rows that review a suppressed image with no prior decision have
+-- override_reason set but supersedes_confirmation_id NULL — that is intentional
+-- and API-enforced, not database-enforced.
+--
+-- All existing rows have supersedes_confirmation_id IS NULL, so the CHECK
+-- passes by definition for every pre-existing row.
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS + DROP CONSTRAINT IF EXISTS before
+-- ADD CONSTRAINT so re-runs against a partially-applied DB succeed cleanly.
+
+BEGIN;
+
+ALTER TABLE v2_image_metric_confirmations
+    ADD COLUMN IF NOT EXISTS override_reason TEXT;
+
+ALTER TABLE v2_image_metric_confirmations
+    ADD COLUMN IF NOT EXISTS supersedes_confirmation_id UUID
+        REFERENCES v2_image_metric_confirmations(id);
+
+ALTER TABLE v2_image_metric_confirmations
+    DROP CONSTRAINT IF EXISTS v2_image_metric_confirmations_override_reason_required;
+
+ALTER TABLE v2_image_metric_confirmations
+    ADD CONSTRAINT v2_image_metric_confirmations_override_reason_required
+    CHECK (supersedes_confirmation_id IS NULL OR override_reason IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_v2_image_metric_confirmations_supersedes
+    ON v2_image_metric_confirmations (supersedes_confirmation_id)
+    WHERE supersedes_confirmation_id IS NOT NULL;
+
+COMMIT;

--- a/src/auth/admin.py
+++ b/src/auth/admin.py
@@ -1,0 +1,72 @@
+"""
+``admin_required`` — Flask route decorator that hard-gates admin-only routes.
+
+Unlike ``src.auth.middleware.require()``, this decorator does **NOT** consult
+the ``auth_enforcement_enabled`` feature flag.  It is always active regardless
+of the Stage B / Stage C rollout state.
+
+Rationale: admin pages must be protected from the moment they are deployed.
+The flag-gated ``require()`` is safe to merge pre-flip because it is a no-op
+until the operator flips the flag.  Admin pages do not have that luxury —
+an unprotected admin endpoint in a partially-deployed state is a security
+risk, not just an inconvenience.
+
+Usage::
+
+    from src.auth.admin import admin_required
+
+    @app.route("/admin/review")
+    @admin_required
+    def admin_review():
+        ...
+
+``g.user`` must be populated by ``load_session_user`` (registered as a
+``before_request`` hook on the Flask app) before this decorator runs.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from flask import g, jsonify
+
+logger = logging.getLogger(__name__)
+
+# Type alias for Flask view functions.
+_ViewFunc = Callable[..., Any]
+
+
+def admin_required(f: _ViewFunc) -> _ViewFunc:
+    """Decorator that restricts a Flask route to users with ``role='admin'``.
+
+    Returns a 403 JSON response when:
+    - ``g.user`` is ``None`` (unauthenticated).
+    - ``g.user.role`` is anything other than ``'admin'``.
+
+    Delegates to the wrapped function when ``g.user.role == 'admin'``.
+
+    This decorator is **flag-independent**: it does not consult
+    ``auth_enforcement_enabled`` and is always enforced.
+
+    Args:
+        f: The Flask view function to protect.
+
+    Returns:
+        The wrapped view function.
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        user = getattr(g, "user", None)
+        if user is None or getattr(user, "role", None) != "admin":
+            logger.debug(
+                "admin_required: access denied for %s",
+                getattr(user, "role", "anonymous"),
+            )
+            return jsonify({"error": "admin access required"}), 403
+        return f(*args, **kwargs)
+
+    return wrapper

--- a/tests/unit/test_admin_required_decorator.py
+++ b/tests/unit/test_admin_required_decorator.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for ``src.auth.admin.admin_required`` decorator.
+
+Verification:
+  - Anonymous (no g.user) → 403
+  - Reviewer role → 403
+  - Viewer role → 403
+  - Admin role → 200 (delegate to wrapped function)
+  - Feature-flag independence: auth_enforcement_enabled=False + reviewer → still 403
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask, g, jsonify
+
+from src.auth.admin import admin_required
+from src.auth.sessions import SessionUser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: str) -> SessionUser:
+    return SessionUser(
+        id="00000000-0000-0000-0000-000000000099",
+        email="testuser@example.com",
+        display_name="Test User",
+        role=role,
+        account_status="active",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app() -> Flask:
+    """Minimal Flask app with one admin_required-protected endpoint."""
+    flask_app = Flask(__name__)
+    flask_app.config["TESTING"] = True
+
+    @flask_app.route("/admin/secret")
+    @admin_required
+    def admin_endpoint():  # type: ignore[return]
+        return jsonify({"ok": True}), 200
+
+    return flask_app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminRequired:
+    def test_anonymous_returns_403(self, app: Flask) -> None:
+        """No g.user (unauthenticated) → 403 with 'admin access required'."""
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data is not None
+        assert "admin access required" in data.get("error", "")
+
+    def test_reviewer_role_returns_403(self, app: Flask) -> None:
+        """Authenticated reviewer → 403 (not admin)."""
+        reviewer = _make_user("reviewer")
+
+        @app.before_request
+        def inject_reviewer():
+            g.user = reviewer
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data is not None
+        assert "admin access required" in data.get("error", "")
+
+    def test_viewer_role_returns_403(self, app: Flask) -> None:
+        """Authenticated viewer → 403 (not admin)."""
+        viewer = _make_user("viewer")
+
+        @app.before_request
+        def inject_viewer():
+            g.user = viewer
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 403
+
+    def test_admin_role_returns_200(self, app: Flask) -> None:
+        """Authenticated admin → 200 (delegated to wrapped function)."""
+        admin = _make_user("admin")
+
+        @app.before_request
+        def inject_admin():
+            g.user = admin
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"ok": True}
+
+    def test_flag_off_still_blocks_reviewer(self, app: Flask, monkeypatch) -> None:
+        """Feature-flag independence: auth_enforcement_enabled=False + reviewer → 403.
+
+        admin_required is hard-gated and does NOT consult the feature flag.
+        The existing require() decorator is a no-op when the flag is False;
+        admin_required must NOT share that behavior.
+        """
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key: False)
+        reviewer = _make_user("reviewer")
+
+        @app.before_request
+        def inject_reviewer():
+            g.user = reviewer
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        # Must be 403 — flag-off must NOT grant a pass-through here.
+        assert resp.status_code == 403
+
+    def test_flag_off_still_blocks_anonymous(self, app: Flask, monkeypatch) -> None:
+        """Feature-flag independence: auth_enforcement_enabled=False + no user → 403."""
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key: False)
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 403
+
+    def test_flag_off_still_admits_admin(self, app: Flask, monkeypatch) -> None:
+        """Feature-flag independence: auth_enforcement_enabled=False + admin → 200."""
+        monkeypatch.setattr("src.auth.feature_flags.is_enabled", lambda key: False)
+        admin = _make_user("admin")
+
+        @app.before_request
+        def inject_admin():
+            g.user = admin
+
+        with app.test_client() as client:
+            resp = client.get("/admin/secret")
+        assert resp.status_code == 200
+
+    def test_functools_wraps_preserves_name(self) -> None:
+        """admin_required preserves the wrapped function's __name__ via functools.wraps."""
+
+        def my_view():  # type: ignore[return]
+            return jsonify(ok=True), 200
+
+        wrapped = admin_required(my_view)
+        assert wrapped.__name__ == "my_view"


### PR DESCRIPTION
## Summary

This is **PR 1 of 3** in the admin-review-tool plan (`~/.claude/plans/we-have-processed-a-cryptic-pelican.md`). PR 2 adds the backend routes and DB methods; PR 3 adds the frontend template and JS.

### Schema additions (`sql/202605111319_...sql`)

Extends `v2_image_metric_confirmations` with two new nullable columns:

- `override_reason TEXT` — free-text reason for an admin override. Non-null marks an admin row (convention used by the reviewer-audit UI and future trainer weighting).
- `supersedes_confirmation_id UUID REFERENCES v2_image_metric_confirmations(id)` — FK to the original reviewer row being reversed. NULL when admin adds a decision on a suppressed image with no prior decision.

A `CHECK` constraint enforces: `supersedes_confirmation_id IS NULL OR override_reason IS NOT NULL`. All existing rows satisfy this trivially (both columns NULL). A partial index on `supersedes_confirmation_id` supports override-lookup queries.

Migration uses `ADD COLUMN IF NOT EXISTS` + `DROP CONSTRAINT IF EXISTS` before `ADD CONSTRAINT` for clean idempotency on partial-apply DBs.

### `admin_required` decorator (`src/auth/admin.py`)

A new hard-gated Flask route decorator:

- Returns `{"error": "admin access required"}, 403` when `g.user` is None or `g.user.role != "admin"`.
- Delegates to the wrapped function when `g.user.role == "admin"`.
- **Does NOT consult `auth_enforcement_enabled`** — unlike the existing `require()` which is a no-op before Stage C's flag flip, `admin_required` is always enforced. This ensures admin pages are protected from the moment they are deployed, regardless of rollout stage.

### Unit tests (`tests/unit/test_admin_required_decorator.py`)

8 tests covering all branches:
- Anonymous → 403
- Reviewer role → 403
- Viewer role → 403
- Admin role → 200
- `auth_enforcement_enabled=False` + reviewer → 403 (flag-independence)
- `auth_enforcement_enabled=False` + anonymous → 403 (flag-independence)
- `auth_enforcement_enabled=False` + admin → 200
- `functools.wraps` preserves `__name__`

## Migration validation

`psql` not available in this environment against a test DB, so migration syntax is validated by CI's integration-test run. The SQL uses standard `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` patterns consistent with the existing migration corpus. The CHECK constraint references only columns being added in this same migration.

## Test plan

- [x] `pytest -x -q tests/unit/test_admin_required_decorator.py` — 8/8 passed locally
- [x] `ruff check src/auth/admin.py tests/unit/test_admin_required_decorator.py` — clean
- [x] `ruff format` — no changes
- [x] All pre-commit hooks passed on commit and push (including pre-push unit test suite)
- [ ] CI: Lint, Unit Tests, Integration Tests, Docker Build & Smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)