### PR TITLE
fix(eval): Phase-1/Phase-2 reuse — companies.company_name + 4-tuple unpack

### DIFF
--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -432,14 +432,14 @@ def select_reviewed_corpus(
     sql = """
         SELECT f.filing_id,
                f.sec_html_url AS html_url,
-               c.name AS company_name,
+               c.company_name AS company_name,
                COUNT(rd.decision_id) AS decision_count
           FROM v2_review_decisions rd
           JOIN v2_metric_facts mf ON mf.fact_id = rd.fact_id
           JOIN filings f ON f.filing_id = mf.filing_id
           JOIN companies c ON c.cik = f.cik
          WHERE mf.source_type = 'text'
-         GROUP BY f.filing_id, f.sec_html_url, c.name
+         GROUP BY f.filing_id, f.sec_html_url, c.company_name
          ORDER BY decision_count DESC, f.filing_id ASC
          LIMIT 50
     """

--- a/scripts/run_phase2_quantitative_eval.py
+++ b/scripts/run_phase2_quantitative_eval.py
@@ -925,13 +925,12 @@ def run_eval(
         )
 
         fil_t0 = time.monotonic()
-        aggregates, kw_present, fil_errors = p1.evaluate_filing_pipeline(paf, metric_ids)
+        aggregates, kw_present, fil_errors, _fil_tokens = p1.evaluate_filing_pipeline(
+            paf, metric_ids
+        )
         fil_elapsed = time.monotonic() - fil_t0
         errors.extend(fil_errors)
 
-        # Approximate cost from token counts if available (pipeline errors → 0).
-        # The pipeline doesn't surface token counts directly via Path A; use
-        # filing-count × average estimate for now.
         total_cost_usd += _COST_PER_FILING_USD
 
         filing_rows: list[Phase2Row] = []


### PR DESCRIPTION
## Summary

Two latent bugs in the Phase-1 helpers that Phase-2 inherits via reuse, both surfaced when first running the Phase-2 quantitative gate against the live reviewed corpus.

1. **Reviewed-corpus query column rename**: `select_reviewed_corpus` (added in PR #539) referenced `companies.name`, which does not exist — the column is `companies.company_name`. Never surfaced because Phase-1 smoke runs used `--gold-only`. Phase-2 hits it immediately and exits with `psycopg.errors.UndefinedColumn`.

2. **`evaluate_filing_pipeline` arity drift**: PR #586 (gh-554) added `token_totals` as the 4th return value to support `summary.tokens` cost rollups. Phase-2 (PR #598) was authored against the pre-#586 3-tuple signature and crashes with `ValueError: too many values to unpack (expected 3)` after the first filing's classification completes — losing the API spend on that filing's signals.

This is exactly the Phase-1 reuse drift the Phase-2 worker prompt explicitly called out (precedent: PR #547 after PR #535). The drift-guard test landed in #598 either didn't cover this signature or was mocked.

Phase-2 still discards the captured token dict; proper `summary.tokens` rollup is a follow-up.

## Test plan

- [x] Verified `select_reviewed_corpus` returns 5 filings cleanly against live DB after fix
- [x] Verified Phase-2 gate processes filing 1539 end-to-end (was crashing post-classification before)
- [ ] Will follow up with proper token rollup into Phase-2's `summary.tokens` + a real drift-guard test asserting the unpack arity

🤖 Generated with [Claude Code](https://claude.com/claude-code)