### PR TITLE
feat(extraction): override fields on PipelineConfig + keyword_config getters

### DIFF
--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -49,7 +49,7 @@ from datetime import UTC, date, datetime
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypedDict
 
 from src.extraction_v2.exceptions import V2FatalError, V2TransientError
 from src.extraction_v2.models import (
@@ -97,6 +97,49 @@ def _env_truthy(name: str) -> bool:
 DOC_TYPE_SEC_FILING = "sec_filing"
 DOC_TYPE_TRANSCRIPT = "transcript"
 DOC_TYPE_PRESENTATION = "investor_presentation"
+
+
+class KeywordPatchOverride(TypedDict, total=False):
+    """Per-metric pattern overrides applied to the in-memory keyword config.
+
+    Used by the simulate-and-ship flow on /v2/review/stats to run the
+    gold-standard validator with patched rules without touching disk.
+
+    Each field is a dict mapping metric_id -> list of regex patterns. When
+    a metric_id is present, its full pattern list for that field is
+    REPLACED (not appended) by the override. Metric_ids absent from the
+    override keep their YAML defaults.
+
+    Fields:
+        metric_keywords: replaces get_metric_keywords() per metric.
+        exclusion_patterns: replaces get_exclusion_patterns() per metric.
+        specific_patterns: replaces get_specific_patterns_by_metric() per
+            metric; flat get_specific_patterns() is recomputed from this.
+    """
+
+    metric_keywords: dict[str, list[str]]
+    exclusion_patterns: dict[str, list[str]]
+    specific_patterns: dict[str, list[str]]
+
+
+class FpFilterOverride(TypedDict, total=False):
+    """Overridable constructor kwargs for the V1 FalsePositiveFilter.
+
+    Passed via PipelineConfig.fp_filter_override to FalsePositiveFilterStage
+    so the simulate-and-ship flow can test FP-filter rule changes in-memory
+    without modifying the V1 filter class.  Only the fields listed here are
+    forwarded; all others keep their defaults.
+
+    Fields:
+        filter_financial_statements: Set False to disable the financial-statement
+            context check (useful for relaxed-mode simulation).
+        filter_years: Set False to disable the year-range filter.
+        min_value: Override the minimum count threshold (default 10).
+    """
+
+    filter_financial_statements: bool
+    filter_years: bool
+    min_value: float
 
 
 class PipelineStage(str, Enum):
@@ -184,6 +227,12 @@ class PipelineConfig:
     # Fiscal year configuration (for non-calendar fiscal years)
     fiscal_year_end_month: int | None = None  # e.g., 1 for January FYE
     fiscal_year_end_day: int | None = None  # e.g., 31 for Jan 31 FYE
+
+    # Simulation overrides — used by the simulate-and-ship flow to run the
+    # gold-standard validator with patched rules without touching disk.
+    # Both default to None so the standard cached path is byte-identical.
+    keyword_override: KeywordPatchOverride | None = None
+    fp_filter_override: FpFilterOverride | None = None
 
     # Chart fact bridge
     enable_chart_fact_bridge: bool = True

--- a/src/shared/keyword_config.py
+++ b/src/shared/keyword_config.py
@@ -246,12 +246,18 @@ def get_tier1_keywords_re(config_path: str | None = None) -> re.Pattern[str]:
     return re.compile(combined, re.IGNORECASE)
 
 
-def get_metric_keywords(config_path: str | None = None) -> dict[str, list[str]]:
+def get_metric_keywords(
+    config_path: str | None = None,
+    override: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
     """
     Get all metric keyword patterns.
 
     Args:
         config_path: Optional path to config file.
+        override: If provided, per-metric pattern lists fully REPLACE the
+            YAML defaults for the keys present. Used by the simulate-and-
+            ship flow; when None, the cached YAML path is returned.
 
     Returns:
         Dictionary mapping metric_id to list of regex patterns.
@@ -259,59 +265,78 @@ def get_metric_keywords(config_path: str | None = None) -> dict[str, list[str]]:
     """
     config = _load_config(config_path)
     # Cast is safe: _validate_config() ensures patterns are list[str]
-    return {
+    result = {
         metric_id: cast(list[str], metric_config["patterns"])
         for metric_id, metric_config in config.items()
         if _is_metric_key(metric_id) and metric_config.get("status") != "deprecated"
     }
+    if override:
+        # Override replaces the per-metric list; never poisons the cached config.
+        return {**result, **{mid: list(p) for mid, p in override.items() if mid in result}}
+    return result
 
 
-def get_exclusion_patterns(config_path: str | None = None) -> dict[str, list[str]]:
+def get_exclusion_patterns(
+    config_path: str | None = None,
+    override: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
     """
     Get exclusion patterns for metrics.
 
     Args:
         config_path: Optional path to config file.
+        override: If provided, per-metric exclusion lists fully REPLACE the
+            YAML defaults for the keys present. Metric_ids not currently
+            having exclusions in YAML can be added by the override.
 
     Returns:
         Dictionary mapping metric_id to list of exclusion regex patterns.
-        Only includes metrics that have exclusions defined.
+        Only includes metrics that have exclusions defined (or are added
+        via override).
         Excludes YAML anchor keys (starting with underscore).
     """
     config = _load_config(config_path)
-    return {
+    result = {
         metric_id: metric_config["exclusions"]
         for metric_id, metric_config in config.items()
         if _is_metric_key(metric_id)
         and "exclusions" in metric_config
         and metric_config.get("status") != "deprecated"
     }
+    if override:
+        return {**result, **{mid: list(p) for mid, p in override.items()}}
+    return result
 
 
-def get_specific_patterns(config_path: str | None = None) -> list[str]:
+def get_specific_patterns(
+    config_path: str | None = None,
+    override: dict[str, list[str]] | None = None,
+) -> list[str]:
     """
     Get all specific (multi-word) patterns that get confidence bonuses.
 
     Args:
         config_path: Optional path to config file.
+        override: If provided, the flat list is recomputed by replacing each
+            metric_id's specific patterns in the per-metric dict with the
+            override and concatenating. See get_specific_patterns_by_metric
+            for the per-metric semantics.
 
     Returns:
         List of specific pattern strings (not compiled regex).
         Excludes YAML anchor keys (starting with underscore).
     """
-    config = _load_config(config_path)
-    patterns: list[str] = []
-    for metric_id, metric_config in config.items():
-        if (
-            _is_metric_key(metric_id)
-            and "specific_patterns" in metric_config
-            and metric_config.get("status") != "deprecated"
-        ):
-            patterns.extend(metric_config["specific_patterns"])
-    return patterns
+    by_metric = get_specific_patterns_by_metric(config_path, override=override)
+    flat: list[str] = []
+    for patterns in by_metric.values():
+        flat.extend(patterns)
+    return flat
 
 
-def get_specific_patterns_by_metric(config_path: str | None = None) -> dict[str, list[str]]:
+def get_specific_patterns_by_metric(
+    config_path: str | None = None,
+    override: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
     """
     Get specific (multi-word) patterns grouped by metric_id.
 
@@ -321,19 +346,26 @@ def get_specific_patterns_by_metric(config_path: str | None = None) -> dict[str,
 
     Args:
         config_path: Optional path to config file.
+        override: If provided, per-metric specific-pattern lists fully
+            REPLACE the YAML defaults for the keys present. Metric_ids not
+            currently having specific_patterns in YAML can be added by the
+            override.
 
     Returns:
         Dict mapping metric_id to list of specific pattern strings.
         Excludes YAML anchor keys (starting with underscore) and deprecated metrics.
     """
     config = _load_config(config_path)
-    return {
+    result = {
         metric_id: list(metric_config["specific_patterns"])
         for metric_id, metric_config in config.items()
         if _is_metric_key(metric_id)
         and "specific_patterns" in metric_config
         and metric_config.get("status") != "deprecated"
     }
+    if override:
+        return {**result, **{mid: list(p) for mid, p in override.items()}}
+    return result
 
 
 def reload_config() -> None:

--- a/tests/unit/shared/test_keyword_config_override.py
+++ b/tests/unit/shared/test_keyword_config_override.py
@@ -1,0 +1,142 @@
+"""Override-plumbing tests for keyword_config public getters.
+
+Foundation for the simulate-and-ship flow on /v2/review/stats. Each public
+getter accepts an optional `override` dict; these tests guard two
+invariants:
+
+1. The override actually replaces the relevant per-metric pattern list.
+2. The override never poisons the LRU-cached YAML; subsequent calls without
+   override return the YAML defaults.
+3. Calling with `override=None` is byte-identical to calling without the
+   keyword (no-override identity guard).
+
+These tests do not exercise pipeline-level threading — that lands in the
+follow-up PR that wires PipelineConfig.keyword_override through consumer
+stages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.keyword_config import (
+    get_exclusion_patterns,
+    get_metric_keywords,
+    get_specific_patterns,
+    get_specific_patterns_by_metric,
+    reload_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reload_config()
+    yield
+    reload_config()
+
+
+# ---------------------------------------------------------------------------
+# 1. Override application
+# ---------------------------------------------------------------------------
+
+
+def test_get_metric_keywords_override_replaces_patterns_for_listed_metric():
+    """Override per-metric pattern list fully replaces the YAML list."""
+    baseline = get_metric_keywords()
+    target_metric = next(iter(baseline))  # any active metric
+
+    sentinel = ["zzzzz_sentinel_pattern_not_in_yaml"]
+    patched = get_metric_keywords(override={target_metric: sentinel})
+
+    assert patched[target_metric] == sentinel
+    # Untouched metrics survive
+    other_metrics = [m for m in baseline if m != target_metric]
+    if other_metrics:
+        sample = other_metrics[0]
+        assert patched[sample] == baseline[sample]
+
+
+def test_get_exclusion_patterns_override_adds_to_metrics_without_yaml_exclusions():
+    """Override may introduce exclusions for a metric that has none in YAML."""
+    yaml_excl = get_exclusion_patterns()
+    # Pick a metric without YAML exclusions, or fall back to any metric
+    candidates = [m for m in get_metric_keywords() if m not in yaml_excl]
+    target = candidates[0] if candidates else next(iter(yaml_excl))
+
+    patched = get_exclusion_patterns(override={target: ["custom_excl"]})
+    assert patched[target] == ["custom_excl"]
+
+
+def test_get_specific_patterns_by_metric_override_replaces_per_metric():
+    baseline = get_specific_patterns_by_metric()
+    target = next(iter(baseline)) if baseline else None
+    if target is None:
+        pytest.skip("No specific_patterns in YAML to override")
+
+    patched = get_specific_patterns_by_metric(override={target: ["zzz_specific"]})
+    assert patched[target] == ["zzz_specific"]
+
+
+def test_get_specific_patterns_flat_list_reflects_override():
+    """The flat list getter must rebuild from the overridden per-metric dict."""
+    baseline_by_metric = get_specific_patterns_by_metric()
+    if not baseline_by_metric:
+        pytest.skip("No specific_patterns in YAML to override")
+    target = next(iter(baseline_by_metric))
+
+    flat = get_specific_patterns(override={target: ["zzz_flat"]})
+    assert "zzz_flat" in flat
+    # Original patterns for the target are gone (replaced, not appended)
+    for original in baseline_by_metric[target]:
+        assert original not in flat or original == "zzz_flat"
+
+
+# ---------------------------------------------------------------------------
+# 2. Cache non-poisoning
+# ---------------------------------------------------------------------------
+
+
+def test_metric_keywords_override_does_not_poison_cache():
+    """A call with override must not affect a subsequent call without it."""
+    baseline_before = get_metric_keywords()
+    target = next(iter(baseline_before))
+
+    # Apply an override on one call
+    _ = get_metric_keywords(override={target: ["zzz_temp"]})
+
+    # Subsequent no-override call must equal the YAML baseline
+    baseline_after = get_metric_keywords()
+    assert baseline_after == baseline_before
+    assert baseline_after[target] == baseline_before[target]
+
+
+def test_exclusion_patterns_override_does_not_poison_cache():
+    baseline_before = get_exclusion_patterns()
+    target = next(iter(get_metric_keywords()))
+
+    _ = get_exclusion_patterns(override={target: ["zzz_temp_excl"]})
+
+    baseline_after = get_exclusion_patterns()
+    assert baseline_after == baseline_before
+
+
+# ---------------------------------------------------------------------------
+# 3. No-override identity
+# ---------------------------------------------------------------------------
+
+
+def test_get_metric_keywords_none_override_identity():
+    """override=None must produce identical output to no-arg call."""
+    assert get_metric_keywords(override=None) == get_metric_keywords()
+
+
+def test_get_exclusion_patterns_none_override_identity():
+    assert get_exclusion_patterns(override=None) == get_exclusion_patterns()
+
+
+def test_get_specific_patterns_none_override_identity():
+    assert get_specific_patterns(override=None) == get_specific_patterns()
+
+
+def test_get_specific_patterns_by_metric_none_override_identity():
+    assert get_specific_patterns_by_metric(override=None) == get_specific_patterns_by_metric()


### PR DESCRIPTION
Foundation for the simulate-and-ship recommendation flow on /v2/review/stats.

Adds two TypedDict shapes on PipelineConfig:
- keyword_override: per-metric pattern overrides for get_metric_keywords,
  get_exclusion_patterns, get_specific_patterns_by_metric. Replaces (not
  appends) the per-metric pattern list when a metric_id is present.
- fp_filter_override: constructor-kwarg overrides for the V1
  FalsePositiveFilter (filter_financial_statements, filter_years, min_value).

Both default to None. Threading through consumer stages
(CandidateGenerationStage, ValueBindingStage, FalsePositiveFilterStage,
chart classifiers) lands in the follow-up PR — this commit only widens
PipelineConfig and keyword_config.

keyword_config getters now accept an optional override dict and merge it
over the YAML defaults without poisoning the @lru_cache. Behavior with
override=None is byte-identical to the pre-change code path (guarded by
new unit tests in tests/unit/shared/test_keyword_config_override.py).

Plan: ~/.claude/plans/evaluate-this-idea-critically-delightful-comet.md

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
