### PR TITLE
feat(extraction): thread keyword + FP-filter overrides through stages

### DIFF
--- a/src/extraction_v2/chart/metric_classifier.py
+++ b/src/extraction_v2/chart/metric_classifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from src.extraction_v2.chart.unit_inference import infer_unit_and_currency
 from src.extraction_v2.models import ChartData, ChartType, Unit
@@ -9,6 +10,9 @@ from src.shared.keyword_config import (
     get_metric_keywords,
     get_specific_patterns_by_metric,
 )
+
+if TYPE_CHECKING:
+    from src.extraction_v2.pipeline import PipelineConfig
 
 # ---------------------------------------------------------------------------
 # Supported metrics — expanded to cover Tier-1 chart-friendly metrics (gh-289).
@@ -277,10 +281,13 @@ def _score_metric(
 
 
 class ChartMetricClassifier:
-    def __init__(self) -> None:
-        self._keywords = get_metric_keywords()
-        self._specific = get_specific_patterns_by_metric()
-        self._exclusions = get_exclusion_patterns()
+    def __init__(self, config: PipelineConfig | None = None) -> None:
+        kw_override = (config.keyword_override or {}) if config else {}
+        self._keywords = get_metric_keywords(override=kw_override.get("metric_keywords"))
+        self._specific = get_specific_patterns_by_metric(
+            override=kw_override.get("specific_patterns")
+        )
+        self._exclusions = get_exclusion_patterns(override=kw_override.get("exclusion_patterns"))
 
     def _build_candidates(self, chart: ChartData, nearby_text: str) -> list[tuple[str, float]]:
         """Compute gated candidate list (shared by classify and classify_all)."""

--- a/src/extraction_v2/chart/table_metric_classifier.py
+++ b/src/extraction_v2/chart/table_metric_classifier.py
@@ -35,6 +35,7 @@ src.shared.keyword_config.
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from src.extraction_v2.models import Table
 from src.shared.keyword_config import (
@@ -42,6 +43,9 @@ from src.shared.keyword_config import (
     get_metric_keywords,
     get_specific_patterns_by_metric,
 )
+
+if TYPE_CHECKING:
+    from src.extraction_v2.pipeline import KeywordPatchOverride
 
 # Must stay in sync with ChartMetricClassifier._SUPPORTED_METRICS
 # (src/extraction_v2/chart/metric_classifier.py).
@@ -188,6 +192,8 @@ def _score_metric_on_table(
 def score_ocr_table(
     table: Table,
     nearby_text: str = "",
+    *,
+    keyword_override: KeywordPatchOverride | None = None,
 ) -> list[tuple[str, float]]:
     """Score an OCR-reconstructed table for per-metric presence.
 
@@ -198,14 +204,17 @@ def score_ocr_table(
     Args:
         table: Reconstructed Table from OCR (header_path / stub_path populated).
         nearby_text: Caption or nearby paragraph text used as a title proxy.
+        keyword_override: Optional per-metric pattern overrides
+            (simulate-and-ship flow). When None, YAML defaults are used.
 
     Returns:
         List of (metric_id, score) tuples sorted score-descending.
         All supported metrics are always included (score may be 0.0).
     """
-    keywords = get_metric_keywords()
-    specific = get_specific_patterns_by_metric()
-    exclusions = get_exclusion_patterns()
+    override = keyword_override or {}
+    keywords = get_metric_keywords(override=override.get("metric_keywords"))
+    specific = get_specific_patterns_by_metric(override=override.get("specific_patterns"))
+    exclusions = get_exclusion_patterns(override=override.get("exclusion_patterns"))
 
     results: list[tuple[str, float]] = []
     for metric_id in _SUPPORTED_METRICS:

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -678,7 +678,9 @@ class V2Pipeline:
             self._stages.append((PipelineStage.IMAGE_CLASSIFY, ImageClassifyStage()))
 
         # Stage 6: Metric Candidate Generation
-        self._stages.append((PipelineStage.CANDIDATE_GENERATION, CandidateGenerationStage()))
+        self._stages.append(
+            (PipelineStage.CANDIDATE_GENERATION, CandidateGenerationStage(config=self.config))
+        )
 
         # Stage 6.5: LLM Presence Classifier (shadow mode — no-op when flag is off)
         if self.config.enable_llm_presence_classifier:
@@ -687,10 +689,12 @@ class V2Pipeline:
             )
 
         # Stage 7: Value Binding
-        self._stages.append((PipelineStage.VALUE_BINDING, ValueBindingStage()))
+        self._stages.append((PipelineStage.VALUE_BINDING, ValueBindingStage(config=self.config)))
 
         # Stage 7.5: False Positive Filter
-        self._stages.append((PipelineStage.FALSE_POSITIVE_FILTER, FalsePositiveFilterStage()))
+        self._stages.append(
+            (PipelineStage.FALSE_POSITIVE_FILTER, FalsePositiveFilterStage(config=self.config))
+        )
 
         # Stage 8: Period Inference
         self._stages.append((PipelineStage.PERIOD_INFERENCE, PeriodInferenceStage()))

--- a/src/extraction_v2/stages/candidate_generation.py
+++ b/src/extraction_v2/stages/candidate_generation.py
@@ -37,7 +37,7 @@ from src.shared.keyword_config import (
 
 if TYPE_CHECKING:
     from src.extraction_v2.models import Segment, Table
-    from src.extraction_v2.pipeline import PipelineContext, StageResult
+    from src.extraction_v2.pipeline import PipelineConfig, PipelineContext, StageResult
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +71,13 @@ class CandidateGenerationStage:
     SECTION_BONUS: float = 0.1
     HIGH_VALUE_SECTIONS: set[SectionType] = {SectionType.MDA, SectionType.BUSINESS}
 
-    def __init__(self) -> None:
-        """Initialize stage with compiled regex patterns from V1 config."""
+    def __init__(self, config: PipelineConfig | None = None) -> None:
+        """Initialize stage with compiled regex patterns from V1 config.
+
+        When `config.keyword_override` is set (simulate-and-ship flow), each
+        per-metric override REPLACES the YAML pattern list for that metric.
+        """
+        self._config = config
         self._keywords: dict[str, list[str]] = {}
         self._exclusions: dict[str, list[str]] = {}
         self._specific_patterns: list[str] = []
@@ -94,16 +99,20 @@ class CandidateGenerationStage:
         if self._initialized:
             return True
 
+        kw_override = (self._config.keyword_override or {}) if self._config else {}
+
         try:
-            all_keywords = get_metric_keywords()
+            all_keywords = get_metric_keywords(override=kw_override.get("metric_keywords"))
             self._keywords = {
                 mid: p for mid, p in all_keywords.items() if not is_metric_deprecated(mid)
             }
-            all_exclusions = get_exclusion_patterns()
+            all_exclusions = get_exclusion_patterns(override=kw_override.get("exclusion_patterns"))
             self._exclusions = {
                 mid: p for mid, p in all_exclusions.items() if not is_metric_deprecated(mid)
             }
-            self._specific_patterns = get_specific_patterns()
+            self._specific_patterns = get_specific_patterns(
+                override=kw_override.get("specific_patterns")
+            )
             self._compile_patterns()
             self._initialized = True
             deprecated_count = len(all_keywords) - len(self._keywords)

--- a/src/extraction_v2/stages/chart_fact_bridge.py
+++ b/src/extraction_v2/stages/chart_fact_bridge.py
@@ -30,7 +30,8 @@ class ChartFactBridgeStage:
                 items_output=0,
             )
 
-        classifier = ChartMetricClassifier()
+        classifier = ChartMetricClassifier(config=context.config)
+        kw_override = context.config.keyword_override
 
         images_scanned = 0
         metrics_detected = 0
@@ -72,7 +73,11 @@ class ChartFactBridgeStage:
                 # v2_image_assets.detected_metrics via the same channel charts use.
                 images_scanned += 1
 
-                candidates = score_ocr_table(image.ocr_table, image.nearby_text or "")
+                candidates = score_ocr_table(
+                    image.ocr_table,
+                    image.nearby_text or "",
+                    keyword_override=kw_override,
+                )
                 image.detected_metrics = [
                     DetectedMetric(metric_id=m, score=s)
                     for m, s in candidates

--- a/src/extraction_v2/stages/false_positive_filter.py
+++ b/src/extraction_v2/stages/false_positive_filter.py
@@ -40,7 +40,7 @@ from src.review.number_parsing import NumberMatch
 
 if TYPE_CHECKING:
     from src.extraction_v2.models import Segment, Table
-    from src.extraction_v2.pipeline import PipelineContext, StageResult
+    from src.extraction_v2.pipeline import PipelineConfig, PipelineContext, StageResult
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,7 @@ _RANKING_NAME_RE = re.compile(
 # (e.g., "3 million", "1.5 billion", "400,000").  Bare single/double-digit
 # numbers without these suffixes are almost always noise in transcript text
 # (slide numbers, quarter refs like "Q4", "5G", multipliers like "4 times").
-_HAS_SCALE_SUFFIX_RE = re.compile(
-    r"(?:million|billion|thousand|,\d{3})", re.IGNORECASE
-)
+_HAS_SCALE_SUFFIX_RE = re.compile(r"(?:million|billion|thousand|,\d{3})", re.IGNORECASE)
 
 _BARE_SMALL_NUMBER_THRESHOLD = 50
 # Prepared-remarks sections in transcript mode: raise the threshold to 400 to
@@ -93,49 +91,57 @@ _BARE_SMALL_NUMBER_THRESHOLD_QA = 500
 # (e.g., "$224 million" extracted as cm_monthly_active_users).
 # Used for percent-rejection in _rule_percent_on_count_metric (MAU/DAU have
 # a special YoY escape hatch, so other count metrics are listed separately).
-_COUNT_ONLY_METRICS = frozenset({
-    "cm_monthly_active_users",
-    "cm_daily_active_users",
-    "cm_active_customers_total",
-    "cm_customers_period_end",
-    "cm_new_customers_acquired",
-    "cm_large_customers_period_end",
-})
+_COUNT_ONLY_METRICS = frozenset(
+    {
+        "cm_monthly_active_users",
+        "cm_daily_active_users",
+        "cm_active_customers_total",
+        "cm_customers_period_end",
+        "cm_new_customers_acquired",
+        "cm_large_customers_period_end",
+    }
+)
 
 # Extended set for currency-unit rejection: adds metrics where dollar values
 # are always FPs but percent growth rates may appear in transcripts (so they
 # are not gated by _COUNT_ONLY_METRICS percent check above).
-_DOLLAR_REJECT_METRICS = _COUNT_ONLY_METRICS | frozenset({
-    "cm_customers_period_end_by_tenure",
-    "cm_purchase_transactions_overall",
-    "cm_transactions_by_cohort",
-    "cm_cac_payback_period",
-})
+_DOLLAR_REJECT_METRICS = _COUNT_ONLY_METRICS | frozenset(
+    {
+        "cm_customers_period_end_by_tenure",
+        "cm_purchase_transactions_overall",
+        "cm_transactions_by_cohort",
+        "cm_cac_payback_period",
+    }
+)
 
 # Retention metrics that can legitimately co-occur in the same filing segment.
 # GRR, NRR, and customer retention rate measure different retention concepts
 # and should not be cross-metric-deduped against each other.
-_RETENTION_FAMILY = frozenset({
-    "cm_gross_revenue_retention",
-    "cm_net_revenue_retention",
-    "cm_customer_retention_rate",
-})
+_RETENTION_FAMILY = frozenset(
+    {
+        "cm_gross_revenue_retention",
+        "cm_net_revenue_retention",
+        "cm_customer_retention_rate",
+    }
+)
 
 # Metrics whose values (percentages, ratios, small counts) are semantically
 # incompatible with financial statement line items. V1 financial_line_item
 # positional checks can fire for these metrics when they appear near financial
 # tables, but the extracted values can never be revenue, cost, or balance-sheet
 # amounts. Override V1 fp classification for this set.
-_V1_FINANCIAL_OVERRIDE_METRICS = frozenset({
-    "cm_repeat_purchase_rate",
-    "cm_customer_retention_rate",
-    "cm_customer_churn_rate",
-    "cm_net_revenue_retention",
-    "cm_gross_revenue_retention",
-    "cm_ltv_to_cac_ratio",
-    "cm_ltv_to_cac_ratio_by_cohort",
-    "cm_cac_payback_period",
-})
+_V1_FINANCIAL_OVERRIDE_METRICS = frozenset(
+    {
+        "cm_repeat_purchase_rate",
+        "cm_customer_retention_rate",
+        "cm_customer_churn_rate",
+        "cm_net_revenue_retention",
+        "cm_gross_revenue_retention",
+        "cm_ltv_to_cac_ratio",
+        "cm_ltv_to_cac_ratio_by_cohort",
+        "cm_cac_payback_period",
+    }
+)
 
 # Metrics whose values are expressed in time units (days/weeks/months/years) and
 # thus legitimately use bare word-numbers like "six months" — without a scale
@@ -143,17 +149,21 @@ _V1_FINANCIAL_OVERRIDE_METRICS = frozenset({
 # See ValueBindingStage.TIME_UNIT_VALUED_METRICS in value_binding.py — the two
 # sets must stay consistent; both are kept local to their respective stages so
 # each change is reviewed against its own FP/binding surface.
-_V1_SPELLED_OUT_OVERRIDE_METRICS = frozenset({
-    "cm_cac_payback_period",
-})
+_V1_SPELLED_OUT_OVERRIDE_METRICS = frozenset(
+    {
+        "cm_cac_payback_period",
+    }
+)
 
 # Metrics where percent values need conjunction-clause gating (relaxed mode).
 # In transcript text like "TPV grew 50% and MAAs grew 30%", both values
 # fall in the 400-char proximity window, but only "30%" belongs to MAU.
-_PERCENT_CLAUSE_GATE_METRICS = frozenset({
-    "cm_monthly_active_users",
-    "cm_daily_active_users",
-})
+_PERCENT_CLAUSE_GATE_METRICS = frozenset(
+    {
+        "cm_monthly_active_users",
+        "cm_daily_active_users",
+    }
+)
 
 # Conjunction/clause boundary pattern for splitting compound sentences.
 _CONJUNCTION_RE = re.compile(r"\b(?:and|or|but|while)\b|;", re.IGNORECASE)
@@ -384,8 +394,9 @@ def _rule_truncated_year(bv: BoundValue, source_text: str, metric_id: str) -> st
             n = int(raw)
             prev_str = str(n - 1).zfill(2)
             next_str = str(n + 1).zfill(2)
-            if re.search(rf"\b{re.escape(prev_str)}\b", source_text) or \
-               re.search(rf"\b{re.escape(next_str)}\b", source_text):
+            if re.search(rf"\b{re.escape(prev_str)}\b", source_text) or re.search(
+                rf"\b{re.escape(next_str)}\b", source_text
+            ):
                 return "v2_two_digit_year_header"
 
     return None
@@ -416,9 +427,7 @@ _POSITIVE_ONLY_METRICS: frozenset[str] = frozenset(
 )
 
 
-def _rule_negative_value(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_negative_value(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block negative values on metrics that are definitionally non-negative.
 
     Negative metric values arise when a proximity window captures a subtraction
@@ -495,7 +504,9 @@ def _rule_per_share(bv: BoundValue, source_text: str, metric_id: str) -> str | N
     return None
 
 
-def _rule_revenue_concentration_context(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
+def _rule_revenue_concentration_context(
+    bv: BoundValue, source_text: str, metric_id: str
+) -> str | None:
     """Geographic, CapEx, or cost-structure revenue context for cm_revenue_concentration.
 
     Fires when the percent value is near:
@@ -523,7 +534,9 @@ def _rule_revenue_concentration_context(bv: BoundValue, source_text: str, metric
         return "v2_capex_revenue"
     # Use finditer to find the nearest cost-structure pattern occurrence;
     # source_text.search() only finds the first match which may be far from the value.
-    if any(abs(m.start() - value_pos) <= 200 for m in _COST_STRUCTURE_REVENUE_RE.finditer(source_text)):
+    if any(
+        abs(m.start() - value_pos) <= 200 for m in _COST_STRUCTURE_REVENUE_RE.finditer(source_text)
+    ):
         return "v2_cost_structure_revenue"
     # "Repeat/existing customers accounted for X% of net sales" describes
     # repeat purchase rate, not customer revenue concentration.
@@ -605,9 +618,7 @@ def _rule_tier_qualifier(bv: BoundValue, source_text: str, metric_id: str) -> st
     return "v2_tier_qualifier"
 
 
-def _rule_dollar_threshold_customer(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_dollar_threshold_customer(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Dollar-threshold customer subset counts.
 
     Suppresses FPs where source context contains a dollar threshold customer
@@ -625,7 +636,10 @@ def _rule_dollar_threshold_customer(
     dollar threshold is a legitimate NRR/GRR disclosure, not a count FP.
     (Flywire NRR 110-125% was incorrectly filtered by this rule.)
     """
-    if not source_text or metric_id in ("cm_large_customers_period_end", "cm_revenue_concentration"):
+    if not source_text or metric_id in (
+        "cm_large_customers_period_end",
+        "cm_revenue_concentration",
+    ):
         return None
     if bv.unit == Unit.PERCENT:
         return None
@@ -655,23 +669,27 @@ _SCALE_COUNT_RE = re.compile(
 )
 
 # Metrics that are counts — a percent value for these metrics may be a growth rate.
-_COUNT_TYPE_METRICS: frozenset[str] = frozenset({
-    "cm_monthly_active_users",
-    "cm_daily_active_users",
-    "cm_active_customers_total",
-    "cm_customers_period_end",
-    "cm_new_customers_acquired",
-    "cm_large_customers_period_end",
-})
+_COUNT_TYPE_METRICS: frozenset[str] = frozenset(
+    {
+        "cm_monthly_active_users",
+        "cm_daily_active_users",
+        "cm_active_customers_total",
+        "cm_customers_period_end",
+        "cm_new_customers_acquired",
+        "cm_large_customers_period_end",
+    }
+)
 
 # Pure count metrics — MAU, DAU.  For these, a percent value with a growth-rate
 # verb prefix is ALWAYS a growth rate (not the metric value), even when no
 # scale-suffixed count appears in the same segment.  Unlike generic count metrics,
 # MAU/DAU are never reported as percentages in earnings disclosures.
-_PURE_COUNT_METRICS: frozenset[str] = frozenset({
-    "cm_monthly_active_users",
-    "cm_daily_active_users",
-})
+_PURE_COUNT_METRICS: frozenset[str] = frozenset(
+    {
+        "cm_monthly_active_users",
+        "cm_daily_active_users",
+    }
+)
 
 
 # Delta/growth count patterns — "increase of", "up by", "net additions of".
@@ -720,12 +738,14 @@ _TRANSACTIONS_PER_ACCOUNT_RE = re.compile(
     re.IGNORECASE,
 )
 
-_CUSTOMER_COUNT_METRICS: frozenset[str] = frozenset({
-    "cm_customers_period_end",
-    "cm_active_customers_total",
-    "cm_new_customers_acquired",
-    "cm_large_customers_period_end",
-})
+_CUSTOMER_COUNT_METRICS: frozenset[str] = frozenset(
+    {
+        "cm_customers_period_end",
+        "cm_active_customers_total",
+        "cm_new_customers_acquired",
+        "cm_large_customers_period_end",
+    }
+)
 
 
 def _rule_content_engagement(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
@@ -744,9 +764,7 @@ def _rule_content_engagement(bv: BoundValue, source_text: str, metric_id: str) -
     return None
 
 
-def _rule_transactions_per_account(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_transactions_per_account(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Suppress TPA (transactions per active account) ratio values mis-classified
     as active account counts.
 
@@ -986,6 +1004,7 @@ def _rule_percent_on_count_metric(bv: BoundValue, source_text: str, metric_id: s
 # registry loop because they require the section_type argument, which rule
 # functions in the registry do not receive.
 
+
 def _qa_hedging_percent_near_value(source_text: str, value_raw: str) -> bool:
     """
     Return True if Q&A hedging language appears within ~10 words of the value.
@@ -1006,7 +1025,6 @@ def _qa_hedging_percent_near_value(source_text: str, value_raw: str) -> bool:
     return bool(_QA_HEDGING_RE.search(window))
 
 
-
 # NRR context keywords — net revenue retention / net dollar retention.
 # Used to suppress cm_customer_retention_rate FPs where the source text
 # describes NRR/NDR (which can exceed 100%) rather than customer retention.
@@ -1018,9 +1036,7 @@ _NRR_CONTEXT_RE = re.compile(
 )
 
 
-def _rule_retention_rate_over_100(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_retention_rate_over_100(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block cm_customer_retention_rate for values >100 or in NRR context.
 
     Customer retention rate is 0-100%. Any value above 100 is NRR (net
@@ -1049,28 +1065,25 @@ def _rule_retention_rate_over_100(
     return None
 
 
-
 # Maximum plausible values per metric (to catch magnitude errors from cross-metric mis-binding).
 _METRIC_MAX_VALUE: dict[str, float] = {
-    "cm_lifetime_value_per_customer": 10_000_000,   # $10M max LTV
-    "cm_ltv_to_cac_ratio": 25,                       # 25x max LTV/CAC; real ratios rarely exceed 20x
-    "cm_customer_acquisition_cost": 50_000,          # $50K max CAC; larger values are financial figures
-    "cm_revenue_per_customer": 100_000,              # $100K max ARPU
-    "cm_large_customers_period_end": 20_000,         # >20K would be total customers, not "large" segment
-    "cm_net_revenue_retention": 250,                 # >250% NRR is a financial figure, not NRR
+    "cm_lifetime_value_per_customer": 10_000_000,  # $10M max LTV
+    "cm_ltv_to_cac_ratio": 25,  # 25x max LTV/CAC; real ratios rarely exceed 20x
+    "cm_customer_acquisition_cost": 50_000,  # $50K max CAC; larger values are financial figures
+    "cm_revenue_per_customer": 100_000,  # $100K max ARPU
+    "cm_large_customers_period_end": 20_000,  # >20K would be total customers, not "large" segment
+    "cm_net_revenue_retention": 250,  # >250% NRR is a financial figure, not NRR
 }
 
 # Minimum plausible values for specific metrics.
 # Used by _rule_magnitude_sanity alongside _METRIC_MAX_VALUE.
 _METRIC_MIN_VALUE: dict[str, float] = {
-    "cm_net_revenue_retention": 31,                  # <31% NRR is implausible; blocks 30.0 mis-binding; active gold min is 44% (Samsara)
-    "cm_customer_retention_rate": 50,                # <50% CRR is implausible; active gold min is 66% (Chewy)
+    "cm_net_revenue_retention": 31,  # <31% NRR is implausible; blocks 30.0 mis-binding; active gold min is 44% (Samsara)
+    "cm_customer_retention_rate": 50,  # <50% CRR is implausible; active gold min is 66% (Chewy)
 }
 
 
-def _rule_magnitude_sanity(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_magnitude_sanity(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block values outside the plausible range for a metric.
 
     Catches cross-metric mis-binding where financial figures (revenue,
@@ -1114,10 +1127,12 @@ _LTV_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 
-_CUSTOMER_COUNT_METRICS = frozenset({
-    "cm_active_customers_total",
-    "cm_customers_period_end",
-})
+_CUSTOMER_COUNT_METRICS = frozenset(
+    {
+        "cm_active_customers_total",
+        "cm_customers_period_end",
+    }
+)
 
 
 _TABLE_BINDING_TYPES = frozenset({"table_header", "table_stub"})
@@ -1229,9 +1244,11 @@ _FINANCIAL_CONTEXT_KEYWORD_RE = re.compile(
 # appears in their disclosures. Table bindings use the rule broadly; text
 # bindings require proximity since financial keywords may appear in the same
 # section without directly labeling the value.
-_FINANCIAL_CONTEXT_BLOCKED_METRICS = _COUNT_ONLY_METRICS | frozenset({
-    "cm_large_customers_period_end",
-})
+_FINANCIAL_CONTEXT_BLOCKED_METRICS = _COUNT_ONLY_METRICS | frozenset(
+    {
+        "cm_large_customers_period_end",
+    }
+)
 
 
 def _rule_financial_context_on_customer_metric(
@@ -1261,10 +1278,7 @@ def _rule_financial_context_on_customer_metric(
         # blocking when value is in a plausible customer count range (100-1M).
         # Large customer counts commonly appear in tables alongside financial
         # keywords (gross margin, total revenue) without being financial values.
-        if (
-            metric_id == "cm_large_customers_period_end"
-            and 100 <= bv.value <= 1_000_000
-        ):
+        if metric_id == "cm_large_customers_period_end" and 100 <= bv.value <= 1_000_000:
             return None
         if _FINANCIAL_CONTEXT_KEYWORD_RE.search(source_text):
             return "v2_financial_context_customer_metric"
@@ -1278,7 +1292,7 @@ def _rule_financial_context_on_customer_metric(
     if loc is None:
         return None
     _, value_pos = loc
-    pre_window = source_text[max(0, value_pos - 100):value_pos]
+    pre_window = source_text[max(0, value_pos - 100) : value_pos]
     if _FINANCIAL_CONTEXT_KEYWORD_RE.search(pre_window):
         return "v2_financial_context_customer_metric"
     return None
@@ -1321,9 +1335,7 @@ _METRIC_DEFINITION_THRESHOLD_POST_RE = re.compile(
 )
 
 
-def _rule_metric_definition_value(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_metric_definition_value(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block currency values that represent metric definition thresholds, not reported values.
 
     Customer tier descriptions like 'customers with >$100K ARR' or 'defined as
@@ -1347,7 +1359,7 @@ def _rule_metric_definition_value(
     # Post-value window: catches "$X ARR customers", "$X or more in ARR"
     raw_len = len(bv.value_raw or "")
     post_end = min(len(source_text), value_pos + raw_len + 80)
-    post_window = source_text[value_pos + raw_len:post_end]
+    post_window = source_text[value_pos + raw_len : post_end]
     if _METRIC_DEFINITION_THRESHOLD_POST_RE.search(post_window):
         return "v2_metric_definition_value"
     return None
@@ -1370,9 +1382,7 @@ _CHART_CAGR_RE = re.compile(
 _CHART_BINDING_TYPES = frozenset({"chart_label", "chart_annotation"})
 
 
-def _rule_chart_pricing_label(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_chart_pricing_label(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block chart-sourced values with pricing or CAGR labels.
 
     Chart extractions that carry pricing language ("per user per month", "per seat")
@@ -1408,12 +1418,14 @@ _TAM_MARKET_SIZE_RE = re.compile(
 )
 
 # Metrics that should never take a total-market-size value.
-_TAM_BLOCKED_METRICS = _FINANCIAL_CONTEXT_BLOCKED_METRICS | frozenset({
-    "cm_lifetime_value_per_customer",
-    "cm_ltv_to_cac_ratio",
-    "cm_revenue_per_customer",
-    "cm_revenue_by_cohort",
-})
+_TAM_BLOCKED_METRICS = _FINANCIAL_CONTEXT_BLOCKED_METRICS | frozenset(
+    {
+        "cm_lifetime_value_per_customer",
+        "cm_ltv_to_cac_ratio",
+        "cm_revenue_per_customer",
+        "cm_revenue_by_cohort",
+    }
+)
 
 
 def _rule_tam_market_size(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
@@ -1560,9 +1572,7 @@ _STUB_DOMAIN_CONTRADICTIONS: dict[str, re.Pattern] = {
 }
 
 
-def _rule_stub_metric_contradiction(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_stub_metric_contradiction(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block table column-header bindings where the stub row labels a different metric.
 
     When a column header contains a metric keyword, the value-binding stage binds
@@ -1591,9 +1601,7 @@ def _rule_stub_metric_contradiction(
     return None
 
 
-def _rule_stub_financial_line_item(
-    bv: BoundValue, source_text: str, metric_id: str
-) -> str | None:
+def _rule_stub_financial_line_item(bv: BoundValue, source_text: str, metric_id: str) -> str | None:
     """Block table column-header bindings where source text contains a financial
     statement line-item label (margin, EBITDA, gross profit, accounts payable, etc.).
 
@@ -1678,30 +1686,32 @@ def _rule_revenue_concentration_ratio_suffix(
 # `cm_revenue_concentration` has its own rule (_rule_revenue_concentration_ratio_suffix).
 # Ratio metrics explicitly NOT in this set: cm_ltv_to_cac_ratio,
 # cm_ltv_to_cac_ratio_by_cohort.
-_RATIO_SUFFIX_COUNT_METRICS = frozenset({
-    # Count metrics
-    "cm_new_customers_acquired",
-    "cm_customers_period_end",
-    "cm_active_customers_total",
-    "cm_large_customers_period_end",
-    "cm_customers_period_end_by_tenure",
-    "cm_purchase_transactions_overall",
-    "cm_transactions_by_cohort",
-    # Currency metrics
-    "cm_customer_acquisition_cost",
-    "cm_lifetime_value_per_customer",
-    "cm_average_order_value",
-    "cm_arpu",
-    "cm_revenue_by_cohort",
-    "cm_balance_by_cohort",
-    # Rate / percentage metrics
-    "cm_customer_retention_rate",
-    "cm_net_revenue_retention",
-    "cm_gross_revenue_retention",
-    "cm_gross_margin_by_cohort",
-    # Time metrics
-    "cm_cac_payback_period",
-})
+_RATIO_SUFFIX_COUNT_METRICS = frozenset(
+    {
+        # Count metrics
+        "cm_new_customers_acquired",
+        "cm_customers_period_end",
+        "cm_active_customers_total",
+        "cm_large_customers_period_end",
+        "cm_customers_period_end_by_tenure",
+        "cm_purchase_transactions_overall",
+        "cm_transactions_by_cohort",
+        # Currency metrics
+        "cm_customer_acquisition_cost",
+        "cm_lifetime_value_per_customer",
+        "cm_average_order_value",
+        "cm_arpu",
+        "cm_revenue_by_cohort",
+        "cm_balance_by_cohort",
+        # Rate / percentage metrics
+        "cm_customer_retention_rate",
+        "cm_net_revenue_retention",
+        "cm_gross_revenue_retention",
+        "cm_gross_margin_by_cohort",
+        # Time metrics
+        "cm_cac_payback_period",
+    }
+)
 
 
 def _rule_ratio_suffix_on_count_metric(
@@ -1875,7 +1885,8 @@ def _is_v2_false_positive(
     # Slide numbers, footnote references, and other ordinals appear as small
     # integers (< 1000) in presentation context without scale suffixes.
     if (
-        section_type in (SectionType.PRESENTATION_SLIDE, SectionType.TITLE_SLIDE, SectionType.APPENDIX)
+        section_type
+        in (SectionType.PRESENTATION_SLIDE, SectionType.TITLE_SLIDE, SectionType.APPENDIX)
         and bv.value is not None
         and bv.value < 1000
         and bv.unit in (Unit.COUNT, Unit.OTHER)
@@ -1923,7 +1934,6 @@ def _is_v2_false_positive(
 
     # Q&A-specific rules (only applied in Q&A sections in relaxed mode).
     if relaxed and section_type == SectionType.QA:
-
         # Rule: Q&A hedging percent.
         # Analysts frequently repeat growth rates speculatively or ask
         # "was it 20%?" / "assuming 15% margin" — these are not metric
@@ -2105,19 +2115,31 @@ class FalsePositiveFilterStage:
     checks that cause excessive false negatives on spoken content.
     """
 
-    def __init__(self) -> None:
-        """Initialize with V1 FalsePositiveFilter instances (normal + relaxed)."""
-        self._filter = FalsePositiveFilter()
+    def __init__(self, config: PipelineConfig | None = None) -> None:
+        """Initialize with V1 FalsePositiveFilter instances (normal + relaxed).
+
+        When `config.fp_filter_override` is set (simulate-and-ship flow), the
+        override TypedDict kwargs (filter_financial_statements / filter_years /
+        min_value) are forwarded into BOTH V1 filter instantiations.
+        """
+        fp_override = (
+            dict(config.fp_filter_override) if (config and config.fp_filter_override) else {}
+        )
+        self._filter = FalsePositiveFilter(**fp_override)
         # Relaxed filter for transcripts/presentations:
         # - Disables financial statement context check (SEC-specific)
         # - Disables V1 year filtering (V2 rule 1 already catches year values)
         # - Lowers min_metric_value to 2 (transcripts report small growth
         #   percentages like "4%" that would be filtered at the default of 10)
-        self._filter_relaxed = FalsePositiveFilter(
-            filter_financial_statements=False,
-            filter_years=False,
-            min_value=2,
-        )
+        relaxed_kwargs: dict[str, Any] = {
+            "filter_financial_statements": False,
+            "filter_years": False,
+            "min_value": 2,
+        }
+        # Override wins over relaxed defaults so simulation can patch the
+        # transcript path too.
+        relaxed_kwargs.update(fp_override)
+        self._filter_relaxed = FalsePositiveFilter(**relaxed_kwargs)
 
     def process(self, context: PipelineContext) -> StageResult:
         """
@@ -2212,8 +2234,10 @@ class FalsePositiveFilterStage:
                         is_fp
                         and reason is not None
                         and reason.startswith("financial_line_item")
-                        and (metric_id in _V1_FINANCIAL_OVERRIDE_METRICS
-                             or bv.binding_confidence >= _SOFT_RULE_CONFIDENCE_FLOOR)
+                        and (
+                            metric_id in _V1_FINANCIAL_OVERRIDE_METRICS
+                            or bv.binding_confidence >= _SOFT_RULE_CONFIDENCE_FLOOR
+                        )
                     ):
                         is_fp = False
                         reason = None
@@ -2252,22 +2276,16 @@ class FalsePositiveFilterStage:
                     # percent is in the same clause as the keyword.
                     if relaxed and bv.unit == Unit.PERCENT:
                         cand_gate = candidate_map.get(bv.candidate_id)
-                        if (
-                            cand_gate
-                            and cand_gate.metric_id in _PERCENT_CLAUSE_GATE_METRICS
-                        ):
+                        if cand_gate and cand_gate.metric_id in _PERCENT_CLAUSE_GATE_METRICS:
                             if not _is_percent_in_keyword_clause(
                                 source_text,
                                 cand_gate.source_locator.text_span,
                                 bv.value_raw or "",
                             ):
                                 reason_str = "v2_percent_wrong_clause"
-                                filter_reasons[reason_str] = (
-                                    filter_reasons.get(reason_str, 0) + 1
-                                )
+                                filter_reasons[reason_str] = filter_reasons.get(reason_str, 0) + 1
                                 logger.debug(
-                                    "FP filter rejected percent in wrong clause "
-                                    "for %s: %s raw=%r",
+                                    "FP filter rejected percent in wrong clause for %s: %s raw=%r",
                                     cand_gate.metric_id,
                                     bv.value,
                                     bv.value_raw,
@@ -2283,9 +2301,7 @@ class FalsePositiveFilterStage:
                     if bv.unit == Unit.CURRENCY:
                         if candidate and candidate.metric_id in _DOLLAR_REJECT_METRICS:
                             reason_str = "v2_currency_on_count_metric"
-                            filter_reasons[reason_str] = (
-                                filter_reasons.get(reason_str, 0) + 1
-                            )
+                            filter_reasons[reason_str] = filter_reasons.get(reason_str, 0) + 1
                             logger.debug(
                                 "FP filter rejected currency on count metric %s: %s raw=%r",
                                 candidate.metric_id,

--- a/src/extraction_v2/stages/value_binding.py
+++ b/src/extraction_v2/stages/value_binding.py
@@ -39,17 +39,19 @@ from src.shared.keyword_config import get_specific_patterns_by_metric
 
 if TYPE_CHECKING:
     from src.extraction_v2.models import Cell, Segment, Table
-    from src.extraction_v2.pipeline import PipelineContext, StageResult
+    from src.extraction_v2.pipeline import PipelineConfig, PipelineContext, StageResult
 
 logger = logging.getLogger(__name__)
 
-_WIDER_PROXIMITY_METRICS: frozenset[str] = frozenset({
-    "cm_balance_by_cohort",
-    "cm_gross_margin_by_cohort",
-    "cm_ltv_to_cac_ratio",
-    "cm_ltv_to_cac_ratio_by_cohort",
-    "cm_cac_payback_period",
-})
+_WIDER_PROXIMITY_METRICS: frozenset[str] = frozenset(
+    {
+        "cm_balance_by_cohort",
+        "cm_gross_margin_by_cohort",
+        "cm_ltv_to_cac_ratio",
+        "cm_ltv_to_cac_ratio_by_cohort",
+        "cm_cac_payback_period",
+    }
+)
 
 # Pattern matching financial statement line-item labels in table stub rows.
 # When a customer-metric keyword triggers a column-header binding, rows whose
@@ -72,10 +74,12 @@ _FINANCIAL_LINE_ITEM_STUB_RE: re.Pattern = re.compile(
 
 # Metrics for which financial line-item stubs are acceptable row labels
 # (e.g., cm_gross_margin_by_cohort legitimately measures a margin metric).
-_FINANCIAL_LINE_ITEM_STUB_ALLOW: frozenset[str] = frozenset({
-    "cm_gross_margin_by_cohort",
-    "cm_revenue_concentration",
-})
+_FINANCIAL_LINE_ITEM_STUB_ALLOW: frozenset[str] = frozenset(
+    {
+        "cm_gross_margin_by_cohort",
+        "cm_revenue_concentration",
+    }
+)
 
 
 class ValueBindingStage:
@@ -179,18 +183,28 @@ class ValueBindingStage:
     # Metrics whose gold values are expressed in time units (days/weeks/months/years/quarters).
     # Only candidates for these metrics get the WORD_NUMBER_TIME_PATTERN parser run on their
     # proximity window. Widening this set requires re-checking for FP risk across the GS suite.
-    TIME_UNIT_VALUED_METRICS: frozenset[str] = frozenset({
-        "cm_cac_payback_period",
-    })
+    TIME_UNIT_VALUED_METRICS: frozenset[str] = frozenset(
+        {
+            "cm_cac_payback_period",
+        }
+    )
 
-    def __init__(self, proximity_window: int = 100) -> None:
+    def __init__(
+        self,
+        proximity_window: int = 100,
+        config: PipelineConfig | None = None,
+    ) -> None:
         """
         Initialize the value binding stage.
 
         Args:
             proximity_window: Max characters to search for values near text keywords (default: 100)
+            config: When set, `config.keyword_override["specific_patterns"]`
+                replaces YAML specific_patterns per metric (simulate-and-ship
+                flow).
         """
         self.proximity_window = proximity_window
+        self._config = config
         self._unit_filtered_count = 0
         # Lazily populated: metric_id -> compiled specific_patterns.
         # Used by _stub_matches_different_metric() to detect when a cell's
@@ -209,7 +223,8 @@ class ValueBindingStage:
         """
         if self._stub_metric_patterns is not None:
             return
-        raw = get_specific_patterns_by_metric()
+        kw_override = (self._config.keyword_override or {}) if self._config else {}
+        raw = get_specific_patterns_by_metric(override=kw_override.get("specific_patterns"))
         self._stub_metric_patterns = {
             metric_id: [re.compile(r"\A" + p, re.IGNORECASE) for p in patterns]
             for metric_id, patterns in raw.items()
@@ -616,13 +631,10 @@ class ValueBindingStage:
             # the matched keyword in that case, so binding is correct by construction.
             if iterate_rows and cell.stub_path:
                 stub_text = " ".join(cell.stub_path)
-                conflicting = self._stub_matches_different_metric(
-                    stub_text, candidate.metric_id
-                )
+                conflicting = self._stub_matches_different_metric(stub_text, candidate.metric_id)
                 if conflicting:
                     logger.debug(
-                        "Skipping column-scan binding for %s at row %d: "
-                        "stub_path %r matches %s",
+                        "Skipping column-scan binding for %s at row %d: stub_path %r matches %s",
                         candidate.metric_id,
                         idx,
                         cell.stub_path,
@@ -630,7 +642,11 @@ class ValueBindingStage:
                     )
                     continue
 
-            if iterate_rows and cell.stub_path and candidate.metric_id not in _FINANCIAL_LINE_ITEM_STUB_ALLOW:
+            if (
+                iterate_rows
+                and cell.stub_path
+                and candidate.metric_id not in _FINANCIAL_LINE_ITEM_STUB_ALLOW
+            ):
                 stub_text = " ".join(cell.stub_path)
                 if _FINANCIAL_LINE_ITEM_STUB_RE.search(stub_text):
                     logger.debug(
@@ -1340,9 +1356,7 @@ class ValueBindingStage:
 
         return results
 
-    def _parse_word_number_time(
-        self, match: re.Match[str]
-    ) -> tuple[float, Unit, str] | None:
+    def _parse_word_number_time(self, match: re.Match[str]) -> tuple[float, Unit, str] | None:
         """Parse a word-number + time-unit match (e.g., 'six months' → 6).
 
         Returns (value, unit, raw) where unit is Unit.COUNT (the number itself is

--- a/tests/unit/extraction/test_pipeline_config_override.py
+++ b/tests/unit/extraction/test_pipeline_config_override.py
@@ -1,0 +1,145 @@
+"""End-to-end safety guards for PipelineConfig override threading.
+
+PR-A2 of the simulate-and-ship recommendation flow. PR #607 (foundation)
+added the TypedDict fields + getter `override` params. This PR wires
+`PipelineConfig.keyword_override` and `PipelineConfig.fp_filter_override`
+through to CandidateGenerationStage, ValueBindingStage,
+FalsePositiveFilterStage, and the chart classifiers via ChartFactBridgeStage.
+
+Two safety gates here:
+
+1. **Override-threading completeness**: an explicit override on a target
+   metric must reach every consumer's compiled-pattern state, NOT just
+   pass through silently.
+2. **fp_filter_override propagates**: the TypedDict kwargs must land on
+   the V1 FalsePositiveFilter constructor (both normal + relaxed
+   instances).
+
+These tests do not exercise full pipeline.process() — they verify the
+stage-level construction contract that the simulation script will rely
+on. The byte-identity (`config=None` default) guard already lives in
+`tests/unit/shared/test_keyword_config_override.py` (PR #607).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.extraction_v2.chart.metric_classifier import ChartMetricClassifier
+from src.extraction_v2.pipeline import PipelineConfig
+from src.extraction_v2.stages.candidate_generation import CandidateGenerationStage
+from src.extraction_v2.stages.false_positive_filter import FalsePositiveFilterStage
+from src.extraction_v2.stages.value_binding import ValueBindingStage
+from src.shared.keyword_config import get_metric_keywords, reload_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reload_config()
+    yield
+    reload_config()
+
+
+# ---------------------------------------------------------------------------
+# 1. Override-threading completeness
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_generation_uses_keyword_override():
+    """CandidateGenerationStage must compile from the override, not the YAML."""
+    target = next(iter(get_metric_keywords()))
+    sentinel = r"\bzzzzz_override_sentinel\b"
+
+    config = PipelineConfig(keyword_override={"metric_keywords": {target: [sentinel]}})
+    stage = CandidateGenerationStage(config=config)
+    assert stage._ensure_initialized() is True
+
+    assert stage._keywords[target] == [sentinel]
+    # Compiled patterns must reflect the sentinel (not the YAML patterns)
+    compiled_for_target = stage._compiled_patterns.get(target, [])
+    assert any(p.pattern == sentinel for p in compiled_for_target)
+
+
+def test_candidate_generation_none_config_uses_yaml_defaults():
+    """No config = no override = byte-identical to pre-PR behavior."""
+    stage_default = CandidateGenerationStage()
+    stage_none = CandidateGenerationStage(config=None)
+    stage_no_override = CandidateGenerationStage(config=PipelineConfig())
+
+    assert stage_default._ensure_initialized() is True
+    assert stage_none._ensure_initialized() is True
+    assert stage_no_override._ensure_initialized() is True
+
+    assert stage_default._keywords == stage_none._keywords
+    assert stage_default._keywords == stage_no_override._keywords
+
+
+def test_value_binding_uses_specific_patterns_override():
+    """ValueBindingStage stub-pattern compilation must reflect the override."""
+    config = PipelineConfig(
+        keyword_override={
+            "specific_patterns": {
+                "cm_active_customers_total": [r"override_only_specific"],
+            }
+        }
+    )
+    stage = ValueBindingStage(config=config)
+    stage._ensure_stub_patterns()
+
+    assert stage._stub_metric_patterns is not None
+    target_patterns = stage._stub_metric_patterns.get("cm_active_customers_total")
+    assert target_patterns is not None
+    # Pattern is anchored with \A prefix; sentinel must appear in compiled regex
+    assert any("override_only_specific" in p.pattern for p in target_patterns)
+
+
+def test_chart_classifier_uses_keyword_override():
+    """ChartMetricClassifier must read from the override."""
+    sentinel_pattern = r"\bchart_sentinel_xyz\b"
+    config = PipelineConfig(
+        keyword_override={"metric_keywords": {"cm_revenue_by_cohort": [sentinel_pattern]}}
+    )
+    classifier = ChartMetricClassifier(config=config)
+
+    assert classifier._keywords["cm_revenue_by_cohort"] == [sentinel_pattern]
+
+
+# ---------------------------------------------------------------------------
+# 2. fp_filter_override propagation
+# ---------------------------------------------------------------------------
+
+
+def test_fp_filter_override_lands_on_normal_v1_instance():
+    """fp_filter_override kwargs must flow into the V1 FalsePositiveFilter."""
+    config = PipelineConfig(fp_filter_override={"min_value": 999999, "filter_years": False})
+    stage = FalsePositiveFilterStage(config=config)
+
+    # The V1 filter's min_value attribute name may differ; assert via the
+    # constructor-stored params we know are public.
+    assert stage._filter.min_value == 999999
+    assert stage._filter.filter_years is False
+
+
+def test_fp_filter_override_also_lands_on_relaxed_v1_instance():
+    """Both normal and relaxed V1 filters receive the override (override wins)."""
+    config = PipelineConfig(fp_filter_override={"min_value": 12345})
+    stage = FalsePositiveFilterStage(config=config)
+
+    # Relaxed defaults set filter_financial_statements=False, filter_years=False,
+    # min_value=2. Override should bump min_value to 12345 while preserving
+    # the relaxed defaults for unmentioned kwargs.
+    assert stage._filter_relaxed.min_value == 12345
+    assert stage._filter_relaxed.filter_financial_statements is False
+    assert stage._filter_relaxed.filter_years is False
+
+
+def test_fp_filter_no_override_preserves_defaults():
+    """config=None / no fp_filter_override keeps the historical defaults."""
+    stage_default = FalsePositiveFilterStage()
+    stage_explicit = FalsePositiveFilterStage(config=PipelineConfig())
+
+    # Normal filter uses V1 defaults (min_value=10 historically)
+    assert stage_default._filter.min_value == stage_explicit._filter.min_value
+    # Relaxed filter still hard-codes its relaxed kwargs
+    assert stage_default._filter_relaxed.min_value == 2
+    assert stage_explicit._filter_relaxed.min_value == 2


### PR DESCRIPTION
Wires PipelineConfig.keyword_override and PipelineConfig.fp_filter_override
from V2Pipeline through to CandidateGenerationStage, ValueBindingStage,
FalsePositiveFilterStage, and the chart classifiers via ChartFactBridgeStage.

Stages accept `config: PipelineConfig | None = None` and pull the override
slice when present, passing through to the keyword_config getters that
landed in PR #607. Default (config=None) behavior is byte-identical to
pre-PR — guarded by the no-config / no-override tests below.

End-to-end safety guards in tests/unit/extraction/test_pipeline_config_override.py:
  * CandidateGenerationStage compiled patterns reflect keyword override
  * ValueBindingStage stub patterns reflect specific_patterns override
  * ChartMetricClassifier internal state reflects override
  * fp_filter_override lands on BOTH V1 FalsePositiveFilter constructors
    (normal + relaxed; override wins over relaxed defaults)
  * config=None / no-override path preserves V1 defaults

Foundation: PR #607.
Plan: ~/.claude/plans/evaluate-this-idea-critically-delightful-comet.md

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
