### PR TITLE
feat(extraction): simulate-accepted endpoint + script + migration

### DIFF
--- a/scripts/simulate_text_pattern_changes.py
+++ b/scripts/simulate_text_pattern_changes.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""
+Simulate accepted exclusion-pattern recommendations against the gold-standard
+corpus and persist R/P/F1 deltas + Tier-1 regression status.
+
+Powers the "Simulate accepted recommendations" button on /v2/review/stats.
+The script runs two validator passes (baseline + patched) on the subset of
+gold-standard companies that carry any of the affected metrics, then persists
+one text_pattern_simulation_runs row and one text_pattern_simulation_deltas
+row per (rec, metric_id).
+
+Usage:
+    python3 scripts/simulate_text_pattern_changes.py \\
+        --database-url "$TEST_DATABASE_URL"
+
+    # Web-triggered invocation writes status back via --run-id:
+    python3 scripts/simulate_text_pattern_changes.py \\
+        --run-id <uuid> --database-url "$DATABASE_URL"
+
+What it does:
+  1. Resolve accepted recs: SELECT from text_pattern_recommendation_decisions
+     WHERE decision='accepted' AND pr_number IS NULL.
+  2. Filter to supported rule types: only rule='exclusion_pattern' is
+     simulated. Other rule types are skipped (simulation_not_supported).
+  3. Build a KeywordPatchOverride by appending each rec's decision_key
+     (the phrase) to the metric's existing YAML exclusions. The override is
+     existing + [phrase, ...] for each affected metric_id.
+  4. Resolve affected companies: find which gold-standard companies have rows
+     for any affected metric_id.
+  5. Run baseline validation (no override) and patched validation on the
+     same companies set.
+  6. Re-run the patched validation a second time (gh-273 retry pattern).
+     If both patched runs agree on tier1_presence_recall (within 0.0001
+     epsilon), set runs_agree=True.
+  7. Compute coverage stats per metric from the gold-standard CSV.
+  8. Persist results in a single transaction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import sys
+import uuid as _uuid
+from dataclasses import replace as dc_replace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import psycopg
+from psycopg.rows import dict_row
+
+from src.extraction_v2.config_hash import compute_config_hash
+from src.extraction_v2.pipeline import KeywordPatchOverride, PipelineConfig
+from src.gold_standard.v2_validator import GOLD_STANDARD_CSV, V2GoldStandardValidator
+from src.infra.logging_config import configure_logging
+from src.shared.keyword_config import get_exclusion_patterns
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Phrases that get APPENDED (not replaced) to existing YAML exclusions.
+# Only exclusion_pattern recs are simulated in v1.
+_SUPPORTED_RULE = "exclusion_pattern"
+
+# Agreement epsilon for gh-273 retry pattern.
+_AGREEMENT_EPS = 0.0001
+
+# Tier-1 regression floor: any drop larger than this (in absolute recall
+# units) is a regression. Strict — even tiny drops count.
+_REGRESSION_EPS = 0.0001
+
+
+# ---------------------------------------------------------------------------
+# Override construction
+# ---------------------------------------------------------------------------
+
+
+def _build_patched_override(recs: list[dict]) -> KeywordPatchOverride:
+    """Build a KeywordPatchOverride from accepted exclusion_pattern recs.
+
+    For each metric_id, the patched exclusion list is:
+        existing YAML exclusions + [phrase1, phrase2, ...]
+
+    This is an APPEND override (existing kept), not a replace override.
+    The KeywordPatchOverride exclusion_patterns field replaces the full list
+    per metric, so we must include the existing exclusions too.
+    """
+    # Group phrases by metric_id.
+    by_metric: dict[str, list[str]] = {}
+    for rec in recs:
+        metric_id = rec["metric_id"]
+        phrase = rec["decision_key"]
+        by_metric.setdefault(metric_id, []).append(phrase)
+
+    if not by_metric:
+        return KeywordPatchOverride()
+
+    existing = get_exclusion_patterns()
+    patched: dict[str, list[str]] = {}
+    for metric_id, new_phrases in by_metric.items():
+        base = list(existing.get(metric_id) or [])
+        patched[metric_id] = base + new_phrases
+
+    return KeywordPatchOverride(exclusion_patterns=patched)
+
+
+# ---------------------------------------------------------------------------
+# Gold-standard CSV helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_affected_companies(
+    affected_metric_ids: set[str],
+    max_companies: int | None,
+) -> list[str]:
+    """Return company names from the gold-standard CSV that have rows for any
+    of the affected metric_ids.
+
+    Returns an empty list if the CSV has no rows for the given metrics (not
+    an error — the endpoint already validated that recs exist).
+    """
+    csv_path = GOLD_STANDARD_CSV
+    if not csv_path.exists():
+        logger.warning("Gold-standard CSV not found at %s — returning empty company list", csv_path)
+        return []
+
+    companies: set[str] = set()
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            raw_metric = (row.get("Standard Metric Name") or "").strip()
+            # Normalize: lowercase + underscores (mirrors v2_validator.normalize_metric_id)
+            metric_id = _normalize_metric_id(raw_metric)
+            if metric_id in affected_metric_ids:
+                company = (row.get("Company") or "").strip()
+                if company:
+                    companies.add(company)
+
+    result = sorted(companies)
+    if max_companies is not None:
+        result = result[:max_companies]
+    logger.info(
+        "Affected companies for metrics %s: %d (max_companies=%s)",
+        sorted(affected_metric_ids),
+        len(result),
+        max_companies,
+    )
+    return result
+
+
+def _compute_coverage(affected_metric_ids: set[str]) -> dict[str, dict]:
+    """Return {metric_id: {coverage_filings, coverage_facts}} from the CSV.
+
+    coverage_filings = distinct company names carrying this metric.
+    coverage_facts = raw row count for this metric.
+    """
+    out: dict[str, dict] = {
+        m: {"coverage_filings": 0, "coverage_facts": 0} for m in affected_metric_ids
+    }
+    csv_path = GOLD_STANDARD_CSV
+    if not csv_path.exists():
+        return out
+
+    filing_sets: dict[str, set[str]] = {m: set() for m in affected_metric_ids}
+    fact_counts: dict[str, int] = {m: 0 for m in affected_metric_ids}
+
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            raw_metric = (row.get("Standard Metric Name") or "").strip()
+            metric_id = _normalize_metric_id(raw_metric)
+            if metric_id in affected_metric_ids:
+                company = (row.get("Company") or "").strip()
+                if company:
+                    filing_sets[metric_id].add(company)
+                fact_counts[metric_id] = fact_counts[metric_id] + 1
+
+    for metric_id in affected_metric_ids:
+        out[metric_id] = {
+            "coverage_filings": len(filing_sets[metric_id]),
+            "coverage_facts": fact_counts[metric_id],
+        }
+    return out
+
+
+def _normalize_metric_id(raw: str) -> str:
+    """Minimal normalization matching v2_validator.normalize_metric_id."""
+    return raw.lower().replace(" ", "_").replace("-", "_")
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_validation(
+    override: KeywordPatchOverride | None,
+    companies: list[str] | None,
+) -> V2GoldStandardValidator:
+    """Construct a validator with the given override and run validate_all.
+
+    Returns the validator so the caller can call compute_metrics() on it.
+    """
+    base_config = PipelineConfig()
+    config = dc_replace(base_config, keyword_override=override if override else None)
+    validator = V2GoldStandardValidator(v2_config=config)
+    # Trigger validation; results are stored in the returned validator.
+    results = validator.validate_all(
+        max_workers=1,
+        companies=companies if companies else None,
+    )
+    # Attach results for compute_metrics below.
+    validator._sim_results = results  # type: ignore[attr-defined]
+    return validator
+
+
+def _get_metrics(validator: V2GoldStandardValidator) -> AggregateMetrics:  # noqa: F821
+    return validator.compute_metrics(validator._sim_results)  # type: ignore[attr-defined]
+
+
+def _presence_recall_for_metric(agg, metric_id: str) -> float | None:
+    scores = (agg.presence_by_metric or {}).get(metric_id)
+    return scores.recall if scores is not None else None
+
+
+def _presence_precision_for_metric(agg, metric_id: str) -> float | None:
+    scores = (agg.presence_by_metric or {}).get(metric_id)
+    return scores.precision if scores is not None else None
+
+
+def _presence_f1_for_metric(agg, metric_id: str) -> float | None:
+    scores = (agg.presence_by_metric or {}).get(metric_id)
+    if scores is None:
+        return None
+    p, r = scores.precision, scores.recall
+    return (2 * p * r / (p + r)) if (p + r) > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_accepted_recs(conn: psycopg.Connection) -> list[dict]:
+    """Return accepted recs that have not yet been shipped (pr_number IS NULL)."""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT id, metric_id, rule, decision_key
+              FROM text_pattern_recommendation_decisions
+             WHERE decision = 'accepted'
+               AND pr_number IS NULL
+             ORDER BY metric_id, decision_key
+            """
+        )
+        return [dict(r) for r in cur.fetchall()]
+
+
+def _mark_failed(database_url: str | None, run_id: str | None, error: str) -> None:
+    """Best-effort UPDATE to flip the run row to status='failed'."""
+    if not (database_url and run_id):
+        return
+    try:
+        with psycopg.connect(database_url) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE text_pattern_simulation_runs
+                   SET status = 'failed',
+                       error  = %(error)s,
+                       completed_at = NOW()
+                 WHERE id = %(run_id)s
+                """,
+                {"run_id": run_id, "error": error[:1000]},
+            )
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to mark simulation run %s failed: %s", run_id, exc)
+
+
+def _ensure_run_row(conn: psycopg.Connection, *, run_id: str | None, triggered_by: str) -> str:
+    """Insert a 'running' row when the script runs standalone (no --run-id).
+
+    When invoked from the web endpoint, the caller pre-inserts the row and
+    passes its UUID via --run-id; we just use that id.
+    """
+    if run_id:
+        return run_id
+    new_id = str(_uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO text_pattern_simulation_runs (id, status, triggered_by)
+            VALUES (%(id)s, 'running', %(triggered_by)s)
+            """,
+            {"id": new_id, "triggered_by": triggered_by},
+        )
+    conn.commit()
+    return new_id
+
+
+def _persist(
+    conn: psycopg.Connection,
+    *,
+    run_id: str,
+    supported_recs: list[dict],
+    all_recs: list[dict],
+    baseline_agg,
+    patched_agg,
+    patched_agg2,
+    affected_metric_ids: set[str],
+    num_companies: int,
+    coverage: dict[str, dict],
+) -> None:
+    """Write all results and flip the run row to 'succeeded'. Single transaction."""
+
+    tier1_baseline = baseline_agg.tier1_presence_recall
+    tier1_patched = patched_agg.tier1_presence_recall
+    tier1_patched2 = patched_agg2.tier1_presence_recall
+
+    tier2_baseline = baseline_agg.tier2_presence_recall
+    tier2_patched = patched_agg.tier2_presence_recall
+
+    # Tier-1 regression: any drop past the epsilon floor is a regression.
+    if tier1_baseline is not None and tier1_patched is not None:
+        tier1_regressed = (tier1_patched - tier1_baseline) < -_REGRESSION_EPS
+    else:
+        tier1_regressed = False
+
+    # Both retry runs must agree within epsilon.
+    if tier1_patched is not None and tier1_patched2 is not None:
+        runs_agree = abs(tier1_patched - tier1_patched2) <= _AGREEMENT_EPS
+    else:
+        runs_agree = tier1_patched == tier1_patched2  # Both None → agree
+
+    num_recs_simulated = len(supported_recs)
+
+    with conn.cursor() as cur:
+        # Update the run row with results.
+        cur.execute(
+            """
+            UPDATE text_pattern_simulation_runs
+               SET status                         = 'succeeded',
+                   completed_at                   = NOW(),
+                   num_recs_simulated             = %(num_recs)s,
+                   num_companies_validated        = %(num_companies)s,
+                   tier1_presence_recall_baseline = %(t1_base)s,
+                   tier1_presence_recall_patched  = %(t1_patched)s,
+                   tier2_presence_recall_baseline = %(t2_base)s,
+                   tier2_presence_recall_patched  = %(t2_patched)s,
+                   tier1_regressed                = %(regressed)s,
+                   runs_agree                     = %(agree)s
+             WHERE id = %(run_id)s
+            """,
+            {
+                "run_id": run_id,
+                "num_recs": num_recs_simulated,
+                "num_companies": num_companies,
+                "t1_base": tier1_baseline,
+                "t1_patched": tier1_patched,
+                "t2_base": tier2_baseline,
+                "t2_patched": tier2_patched,
+                "regressed": tier1_regressed,
+                "agree": runs_agree,
+            },
+        )
+
+        # Build delta rows: one per (rec, affected_metric_id).
+        # For each supported rec, emit a delta for its own metric_id.
+        for rec in supported_recs:
+            metric_id = rec["metric_id"]
+            cov = coverage.get(metric_id, {})
+            cur.execute(
+                """
+                INSERT INTO text_pattern_simulation_deltas
+                    (run_id, recommendation_decision_id, metric_id,
+                     baseline_recall, baseline_precision, baseline_f1,
+                     patched_recall,  patched_precision,  patched_f1,
+                     coverage_filings, coverage_facts)
+                VALUES
+                    (%(run_id)s, %(rec_id)s, %(metric_id)s,
+                     %(b_recall)s, %(b_prec)s, %(b_f1)s,
+                     %(p_recall)s, %(p_prec)s, %(p_f1)s,
+                     %(cov_filings)s, %(cov_facts)s)
+                """,
+                {
+                    "run_id": run_id,
+                    "rec_id": str(rec["id"]),
+                    "metric_id": metric_id,
+                    "b_recall": _presence_recall_for_metric(baseline_agg, metric_id),
+                    "b_prec": _presence_precision_for_metric(baseline_agg, metric_id),
+                    "b_f1": _presence_f1_for_metric(baseline_agg, metric_id),
+                    "p_recall": _presence_recall_for_metric(patched_agg, metric_id),
+                    "p_prec": _presence_precision_for_metric(patched_agg, metric_id),
+                    "p_f1": _presence_f1_for_metric(patched_agg, metric_id),
+                    "cov_filings": cov.get("coverage_filings"),
+                    "cov_facts": cov.get("coverage_facts"),
+                },
+            )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _orchestrate(args: argparse.Namespace) -> None:
+    """Connect, resolve, validate, persist."""
+    if not args.database_url:
+        raise RuntimeError(
+            "No database URL available. Set $TEST_DATABASE_URL or pass --database-url."
+        )
+
+    with psycopg.connect(args.database_url, autocommit=False) as conn:
+        run_id = _ensure_run_row(
+            conn,
+            run_id=args.run_id,
+            triggered_by=args.triggered_by or "cli",
+        )
+
+        config_snapshot_hash = compute_config_hash()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE text_pattern_simulation_runs
+                   SET config_snapshot_hash = %(hash)s
+                 WHERE id = %(run_id)s
+                """,
+                {"hash": config_snapshot_hash, "run_id": run_id},
+            )
+        conn.commit()
+        logger.info("Config snapshot hash: %s", config_snapshot_hash[:12])
+
+        all_recs = _fetch_accepted_recs(conn)
+        logger.info("Found %d accepted recs (pr_number IS NULL)", len(all_recs))
+
+        supported_recs = [r for r in all_recs if r["rule"] == _SUPPORTED_RULE]
+        unsupported_recs = [r for r in all_recs if r["rule"] != _SUPPORTED_RULE]
+        if unsupported_recs:
+            logger.info(
+                "Skipping %d unsupported rec(s) (rules: %s) — simulation_not_supported",
+                len(unsupported_recs),
+                sorted({r["rule"] for r in unsupported_recs}),
+            )
+
+        affected_metric_ids = {r["metric_id"] for r in supported_recs}
+        logger.info("Affected metric_ids: %s", sorted(affected_metric_ids))
+
+        # Resolve affected companies from the gold-standard CSV.
+        companies = _load_affected_companies(affected_metric_ids, args.max_companies)
+
+        # Zero coverage is OK — record the run as succeeded with no deltas.
+        if not companies and affected_metric_ids:
+            logger.warning(
+                "No gold-standard coverage for affected metrics — run will succeed "
+                "with num_companies_validated=0"
+            )
+
+        # Coverage stats (cheap — CSV already loaded above).
+        coverage = _compute_coverage(affected_metric_ids)
+
+        # Build override.
+        override = _build_patched_override(supported_recs) if supported_recs else None
+        logger.info("Running baseline validation on %d companies...", len(companies))
+
+        companies_arg = companies if companies else None
+
+        # Baseline (no override).
+        baseline_validator = _run_validation(None, companies_arg)
+        baseline_agg = _get_metrics(baseline_validator)
+        logger.info(
+            "Baseline: tier1_presence_recall=%s",
+            baseline_agg.tier1_presence_recall,
+        )
+
+        # Patched (first run).
+        logger.info("Running patched validation (run 1)...")
+        patched_validator1 = _run_validation(override, companies_arg)
+        patched_agg1 = _get_metrics(patched_validator1)
+        logger.info(
+            "Patched run 1: tier1_presence_recall=%s",
+            patched_agg1.tier1_presence_recall,
+        )
+
+        # Patched (second run — gh-273 retry pattern).
+        logger.info("Running patched validation (run 2, gh-273 retry)...")
+        patched_validator2 = _run_validation(override, companies_arg)
+        patched_agg2 = _get_metrics(patched_validator2)
+        logger.info(
+            "Patched run 2: tier1_presence_recall=%s",
+            patched_agg2.tier1_presence_recall,
+        )
+
+        _persist(
+            conn,
+            run_id=run_id,
+            supported_recs=supported_recs,
+            all_recs=all_recs,
+            baseline_agg=baseline_agg,
+            patched_agg=patched_agg1,
+            patched_agg2=patched_agg2,
+            affected_metric_ids=affected_metric_ids,
+            num_companies=len(companies),
+            coverage=coverage,
+        )
+        conn.commit()
+        logger.info("Simulation complete. Run id: %s", run_id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Simulate accepted exclusion-pattern recommendations against the "
+            "gold-standard corpus and persist R/P/F1 deltas."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--database-url",
+        type=str,
+        default=os.environ.get("TEST_DATABASE_URL"),
+        help=(
+            "Database connection string. Defaults to $TEST_DATABASE_URL. "
+            "Pass the Neon URL for production runs."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help=(
+            "Optional text_pattern_simulation_runs.id (UUID). When set, the script "
+            "writes status/metrics/error back to that row (web-triggered invocation). "
+            "When unset, the script inserts its own 'running' row at start (CLI use)."
+        ),
+    )
+    parser.add_argument(
+        "--triggered-by",
+        type=str,
+        default=None,
+        help="Reviewer name / 'cli' / 'cron' — written to triggered_by when --run-id is unset.",
+    )
+    parser.add_argument(
+        "--max-companies",
+        type=int,
+        default=None,
+        help=(
+            "Cap the number of gold-standard companies validated. Useful for "
+            "development; production calls should omit this flag."
+        ),
+    )
+    args = parser.parse_args()
+
+    configure_logging(level="INFO")
+
+    if args.run_id:
+        try:
+            _orchestrate(args)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Simulation failed: %s", exc)
+            _mark_failed(args.database_url, args.run_id, str(exc))
+            sys.exit(1)
+    else:
+        _orchestrate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/202605121359_add_text_pattern_simulation_runs.sql
+++ b/sql/202605121359_add_text_pattern_simulation_runs.sql
@@ -1,0 +1,62 @@
+-- Migration 202605121359: add_text_pattern_simulation_runs
+--
+-- Adds two tables for the simulate-and-ship flow on /v2/review/stats.
+-- When an admin accepts an exclusion_pattern recommendation they can
+-- click "Simulate accepted recommendations" to see per-metric R/P/F1
+-- deltas and Tier-1 regression status before the change ships.
+--
+--   text_pattern_simulation_runs   — one row per button click
+--   text_pattern_simulation_deltas — one row per (run, rec, metric_id)
+--
+-- Both FK to text_pattern_recommendation_decisions (must exist first,
+-- created by 202605012056_add_recommendation_decisions.sql).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS text_pattern_simulation_runs (
+    id                              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    status                          TEXT NOT NULL
+        CHECK (status IN ('running', 'succeeded', 'failed')),
+    started_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at                    TIMESTAMPTZ,
+    num_recs_simulated              INTEGER,
+    num_companies_validated         INTEGER,
+    tier1_presence_recall_baseline  NUMERIC(6,4),
+    tier1_presence_recall_patched   NUMERIC(6,4),
+    tier2_presence_recall_baseline  NUMERIC(6,4),
+    tier2_presence_recall_patched   NUMERIC(6,4),
+    tier1_regressed                 BOOLEAN NOT NULL DEFAULT FALSE,
+    runs_agree                      BOOLEAN NOT NULL DEFAULT FALSE,
+    config_snapshot_hash            TEXT,
+    triggered_by                    TEXT,
+    error                           TEXT,
+    created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Used by the stale-row sweep (status='running' AND started_at < NOW()-1h)
+-- and by status polling on the most-recent run.
+CREATE INDEX IF NOT EXISTS idx_tpsr_status_started
+    ON text_pattern_simulation_runs (status, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS text_pattern_simulation_deltas (
+    id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id                    UUID NOT NULL
+        REFERENCES text_pattern_simulation_runs(id) ON DELETE CASCADE,
+    recommendation_decision_id UUID
+        REFERENCES text_pattern_recommendation_decisions(id) ON DELETE SET NULL,
+    metric_id                 TEXT NOT NULL,
+    baseline_recall           NUMERIC(6,4),
+    baseline_precision        NUMERIC(6,4),
+    baseline_f1               NUMERIC(6,4),
+    patched_recall            NUMERIC(6,4),
+    patched_precision         NUMERIC(6,4),
+    patched_f1                NUMERIC(6,4),
+    coverage_filings          INTEGER,
+    coverage_facts            INTEGER,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tpsd_run_id
+    ON text_pattern_simulation_deltas (run_id);
+
+COMMIT;

--- a/src/web/routes/api_unified.py
+++ b/src/web/routes/api_unified.py
@@ -41,6 +41,7 @@ register_timing(api_unified_bp)
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _RETRAIN_SCRIPT = _PROJECT_ROOT / "scripts" / "retrain_image_triage.py"
 _TEXT_ANALYSIS_SCRIPT = _PROJECT_ROOT / "scripts" / "analyze_text_decision_patterns.py"
+_SIMULATION_SCRIPT = _PROJECT_ROOT / "scripts" / "simulate_text_pattern_changes.py"
 
 # Image-classifier retrain thresholds. Both must be exceeded for the UI button
 # to activate AND for the endpoint to accept a retrain request. Configurable
@@ -1571,6 +1572,195 @@ def get_text_analysis_run_status(run_id):
         row["started_at"] = row["started_at"].isoformat()
     if row.get("completed_at"):
         row["completed_at"] = row["completed_at"].isoformat()
+    return jsonify(row), 200
+
+
+# =============================================================================
+# Text-pattern simulation (Track B of the simulate-and-ship flow)
+# =============================================================================
+
+
+def _spawn_simulation_runner(run_id: str, *, database_url: str) -> bool:
+    """Spawn the simulation script as a detached subprocess. Fire-and-forget;
+    subprocess writes status back via --run-id.
+    """
+    log_dir = _PROJECT_ROOT / "logs"
+    log_dir.mkdir(exist_ok=True)
+    log_path = log_dir / f"simulation_{run_id}.log"
+    log_fh = open(log_path, "ab")
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                str(_SIMULATION_SCRIPT),
+                "--run-id",
+                run_id,
+                "--database-url",
+                database_url,
+            ],
+            start_new_session=True,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            cwd=str(_PROJECT_ROOT),
+        )
+        logger.info("Spawned simulation runner for run_id=%s", run_id)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to spawn simulation runner for run_id=%s: %s", run_id, exc)
+        return False
+    finally:
+        log_fh.close()
+
+
+@api_unified_bp.route("/extraction/simulate-accepted", methods=["POST"])
+@require(INGEST_RUN)
+def trigger_text_pattern_simulation():
+    """Kick off a simulation run over accepted-but-not-shipped recommendations.
+
+    Gates:
+      - Reviewer name required (matches per-decision-write contract).
+      - Stale-row sweep: any 'running' row older than 1 hour is flipped to
+        'failed' before the concurrency check (SIGKILL/OOM bypass guard,
+        mirrors the analysis sweep above).
+      - Concurrency: rejects if a 'running' simulation row already exists.
+      - Affected-recs: rejects if zero accepted (pr_number IS NULL) recs
+        exist — there's nothing to simulate.
+    """
+    data = request.get_json(silent=True) or {}
+    reviewer_id, gate_reject = _require_reviewer_id(data)
+    if gate_reject is not None:
+        return gate_reject
+
+    db = get_db()
+
+    db.execute(
+        """
+        UPDATE text_pattern_simulation_runs
+           SET status = 'failed',
+               error  = 'auto-cleanup: stale running row (>1h)',
+               completed_at = NOW()
+         WHERE status = 'running'
+           AND started_at < NOW() - INTERVAL '1 hour'
+        """
+    )
+
+    running_rows = db.query(
+        "SELECT id FROM text_pattern_simulation_runs WHERE status = 'running' LIMIT 1"
+    )
+    if running_rows:
+        return (
+            jsonify(
+                {
+                    "error": "simulation_already_running",
+                    "running_run_id": str(running_rows[0]["id"]),
+                }
+            ),
+            409,
+        )
+
+    accepted_rows = db.query(
+        """
+        SELECT COUNT(*) AS n
+          FROM text_pattern_recommendation_decisions
+         WHERE decision = 'accepted'
+           AND pr_number IS NULL
+        """
+    )
+    if not accepted_rows or (accepted_rows[0]["n"] or 0) == 0:
+        return jsonify({"error": "no_accepted_recs"}), 409
+
+    run_id = str(_uuid.uuid4())
+    database_url = os.environ.get("DATABASE_URL", "")
+    db.execute(
+        """
+        INSERT INTO text_pattern_simulation_runs (id, status, triggered_by)
+        VALUES (%(id)s, 'running', %(triggered_by)s)
+        """,
+        {"id": run_id, "triggered_by": reviewer_id},
+    )
+
+    spawned = _spawn_simulation_runner(run_id, database_url=database_url)
+    if not spawned:
+        db.execute(
+            """
+            UPDATE text_pattern_simulation_runs
+               SET status = 'failed',
+                   error  = 'subprocess_spawn_failed',
+                   completed_at = NOW()
+             WHERE id = %(id)s
+            """,
+            {"id": run_id},
+        )
+        return jsonify({"error": "subprocess_spawn_failed", "run_id": run_id}), 500
+
+    return jsonify({"run_id": run_id, "status": "running"}), 202
+
+
+@api_unified_bp.route("/extraction/simulation-runs/<uuid:run_id>/status", methods=["GET"])
+@require(PROTECTED_READ)
+def get_text_pattern_simulation_status(run_id):
+    """Return the simulation run row plus all delta rows for the polling UI."""
+    db = get_db()
+    rows = db.query(
+        """
+        SELECT id, status, started_at, completed_at,
+               num_recs_simulated, num_companies_validated,
+               tier1_presence_recall_baseline, tier1_presence_recall_patched,
+               tier2_presence_recall_baseline, tier2_presence_recall_patched,
+               tier1_regressed, runs_agree, config_snapshot_hash,
+               triggered_by, error
+          FROM text_pattern_simulation_runs
+         WHERE id = %(id)s
+        """,
+        {"id": str(run_id)},
+    )
+    if not rows:
+        return jsonify({"error": "not_found"}), 404
+    row = dict(rows[0])
+    row["id"] = str(row["id"])
+    for ts_field in ("started_at", "completed_at"):
+        if row.get(ts_field):
+            row[ts_field] = row[ts_field].isoformat()
+    # Decimal -> float for JSON serialization
+    for num_field in (
+        "tier1_presence_recall_baseline",
+        "tier1_presence_recall_patched",
+        "tier2_presence_recall_baseline",
+        "tier2_presence_recall_patched",
+    ):
+        if row.get(num_field) is not None:
+            row[num_field] = float(row[num_field])
+
+    delta_rows = db.query(
+        """
+        SELECT id, recommendation_decision_id, metric_id,
+               baseline_recall, baseline_precision, baseline_f1,
+               patched_recall, patched_precision, patched_f1,
+               coverage_filings, coverage_facts
+          FROM text_pattern_simulation_deltas
+         WHERE run_id = %(run_id)s
+         ORDER BY metric_id
+        """,
+        {"run_id": str(run_id)},
+    )
+    deltas = []
+    for d in delta_rows:
+        d = dict(d)
+        d["id"] = str(d["id"])
+        if d.get("recommendation_decision_id"):
+            d["recommendation_decision_id"] = str(d["recommendation_decision_id"])
+        for num in (
+            "baseline_recall",
+            "baseline_precision",
+            "baseline_f1",
+            "patched_recall",
+            "patched_precision",
+            "patched_f1",
+        ):
+            if d.get(num) is not None:
+                d[num] = float(d[num])
+        deltas.append(d)
+    row["deltas"] = deltas
     return jsonify(row), 200
 
 

--- a/tests/integration/test_simulate_text_pattern_changes.py
+++ b/tests/integration/test_simulate_text_pattern_changes.py
@@ -165,7 +165,7 @@ def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_
     monkeypatch.setattr(
         cli,
         "_compute_coverage",
-        lambda metric_ids: {m: {"filings": 5, "facts": 12} for m in metric_ids},
+        lambda metric_ids: {m: {"coverage_filings": 5, "coverage_facts": 12} for m in metric_ids},
     )
 
     args = _make_args(test_db_url, run_id=run_id)

--- a/tests/integration/test_simulate_text_pattern_changes.py
+++ b/tests/integration/test_simulate_text_pattern_changes.py
@@ -109,7 +109,7 @@ def _make_args(database_url: str, run_id: str | None = None) -> Namespace:
 # ---------------------------------------------------------------------------
 
 
-def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_database_url):
+def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_db_url):
     """Seed one accepted exclusion_pattern rec, run script, assert persistence."""
     metric_id = "cm_active_customers_total"
     _seed_accepted_rec(
@@ -168,7 +168,7 @@ def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_
         lambda metric_ids: {m: {"filings": 5, "facts": 12} for m in metric_ids},
     )
 
-    args = _make_args(test_database_url, run_id=run_id)
+    args = _make_args(test_db_url, run_id=run_id)
     cli._orchestrate(args)
 
     # Assert run row succeeded
@@ -204,7 +204,7 @@ def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_
     assert delta["coverage_filings"] == 5
 
 
-def test_no_accepted_recs_still_succeeds(cli, clean_db, monkeypatch, test_database_url):
+def test_no_accepted_recs_still_succeeds(cli, clean_db, monkeypatch, test_db_url):
     """Zero accepted recs is a valid (no-op) run — script should still succeed.
 
     The endpoint blocks this case with 409 'no_accepted_recs', but the script
@@ -225,7 +225,7 @@ def test_no_accepted_recs_still_succeeds(cli, clean_db, monkeypatch, test_databa
     monkeypatch.setattr(cli, "_load_affected_companies", lambda metric_ids, max_companies: [])
     monkeypatch.setattr(cli, "_compute_coverage", lambda metric_ids: {})
 
-    args = _make_args(test_database_url, run_id=run_id)
+    args = _make_args(test_db_url, run_id=run_id)
     cli._orchestrate(args)
 
     run_rows = clean_db.query(
@@ -237,7 +237,7 @@ def test_no_accepted_recs_still_succeeds(cli, clean_db, monkeypatch, test_databa
     assert run_rows[0]["num_recs_simulated"] == 0
 
 
-def test_unsupported_rule_type_silently_skipped(cli, clean_db, monkeypatch, test_database_url):
+def test_unsupported_rule_type_silently_skipped(cli, clean_db, monkeypatch, test_db_url):
     """keyword_overlap recs are skipped; num_recs_simulated reflects supported only."""
     _seed_accepted_rec(
         clean_db,
@@ -261,7 +261,7 @@ def test_unsupported_rule_type_silently_skipped(cli, clean_db, monkeypatch, test
     monkeypatch.setattr(cli, "_load_affected_companies", lambda metric_ids, max_companies: [])
     monkeypatch.setattr(cli, "_compute_coverage", lambda metric_ids: {})
 
-    args = _make_args(test_database_url, run_id=run_id)
+    args = _make_args(test_db_url, run_id=run_id)
     cli._orchestrate(args)
 
     run_rows = clean_db.query(

--- a/tests/integration/test_simulate_text_pattern_changes.py
+++ b/tests/integration/test_simulate_text_pattern_changes.py
@@ -46,6 +46,20 @@ def cli():
     return _load_script_module()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_simulation_tables(clean_db):
+    """Truncate simulation-related tables before each test.
+
+    `clean_db` doesn't include text_pattern_recommendation_decisions or
+    text_pattern_simulation_{runs,deltas}, so rows from sibling tests
+    (e.g. test_link_text_recommendation_to_pr.py) leak across the xdist
+    worker and inflate the script's accepted-rec count.
+    """
+    clean_db.execute("TRUNCATE TABLE text_pattern_simulation_deltas CASCADE")
+    clean_db.execute("TRUNCATE TABLE text_pattern_simulation_runs CASCADE")
+    clean_db.execute("TRUNCATE TABLE text_pattern_recommendation_decisions CASCADE")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_simulate_text_pattern_changes.py
+++ b/tests/integration/test_simulate_text_pattern_changes.py
@@ -1,0 +1,279 @@
+"""Integration test for scripts/simulate_text_pattern_changes.py.
+
+Covers the DB-touching orchestration path:
+  - accepted-rec fetch from text_pattern_recommendation_decisions
+  - supported / unsupported rule-type partitioning
+  - persistence of text_pattern_simulation_runs + _deltas
+
+V2GoldStandardValidator is too slow + external-resource-heavy for an
+integration test, so `_run_validation` and `_get_metrics` are monkey-
+patched to return deterministic stub AggregateMetrics. The test
+verifies orchestration + persistence shape, not validator behavior.
+
+The script is loaded via importlib (sibling pattern, see
+test_analyze_text_decision_patterns.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import uuid
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "simulate_text_pattern_changes.py"
+
+
+def _load_script_module():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    mod_name = "simulate_text_pattern_changes_integration"
+    spec = importlib.util.spec_from_file_location(mod_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _load_script_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_aggregate_metrics(
+    *,
+    tier1_presence_recall: float = 0.85,
+    tier2_presence_recall: float = 0.62,
+    presence_by_metric: dict | None = None,
+):
+    """Build a stub AggregateMetrics-like object good enough for the script."""
+    metrics = MagicMock()
+    metrics.tier1_presence_recall = tier1_presence_recall
+    metrics.tier2_presence_recall = tier2_presence_recall
+    metrics.presence_by_metric = presence_by_metric or {}
+    return metrics
+
+
+def _seed_accepted_rec(
+    db,
+    *,
+    metric_id: str,
+    rule: str,
+    decision_key: str,
+    reviewer_id: str = "test-reviewer",
+) -> str:
+    """Insert an 'accepted' rec into text_pattern_recommendation_decisions.
+
+    Returns the inserted row id.
+    """
+    rows = db.query(
+        """
+        INSERT INTO text_pattern_recommendation_decisions
+            (metric_id, rule, decision_key, decision, reviewer_id)
+        VALUES
+            (%(metric_id)s, %(rule)s, %(decision_key)s, 'accepted', %(reviewer_id)s)
+        RETURNING id
+        """,
+        {
+            "metric_id": metric_id,
+            "rule": rule,
+            "decision_key": decision_key,
+            "reviewer_id": reviewer_id,
+        },
+    )
+    return str(rows[0]["id"])
+
+
+def _make_args(database_url: str, run_id: str | None = None) -> Namespace:
+    return Namespace(
+        database_url=database_url,
+        run_id=run_id,
+        triggered_by="test",
+        max_companies=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_one_accepted_exclusion_rec(cli, clean_db, monkeypatch, test_database_url):
+    """Seed one accepted exclusion_pattern rec, run script, assert persistence."""
+    metric_id = "cm_active_customers_total"
+    _seed_accepted_rec(
+        clean_db,
+        metric_id=metric_id,
+        rule="exclusion_pattern",
+        decision_key="accounts receivable",
+    )
+
+    # Pre-insert a 'running' row so the script picks up our run_id and
+    # only does the UPDATE-to-succeeded path (mirrors the web-trigger path).
+    run_id = str(uuid.uuid4())
+    clean_db.execute(
+        """
+        INSERT INTO text_pattern_simulation_runs (id, status, triggered_by)
+        VALUES (%(id)s, 'running', 'test')
+        """,
+        {"id": run_id},
+    )
+
+    # Stub the validator paths. Return deterministic AggregateMetrics with
+    # a presence_by_metric entry for the affected metric.
+    stub_baseline = _make_stub_aggregate_metrics(
+        presence_by_metric={
+            metric_id: MagicMock(precision=0.9, recall=0.8, f1=0.85),
+        },
+    )
+    stub_patched = _make_stub_aggregate_metrics(
+        tier1_presence_recall=0.85,  # equal — no regression
+        presence_by_metric={
+            metric_id: MagicMock(precision=0.95, recall=0.8, f1=0.87),
+        },
+    )
+
+    def _stub_run_validation(override, companies):
+        return MagicMock()  # validator object; _get_metrics resolves it
+
+    call_count = {"n": 0}
+
+    def _stub_get_metrics(validator):
+        call_count["n"] += 1
+        # First call = baseline; subsequent calls = patched (both retry runs).
+        return stub_baseline if call_count["n"] == 1 else stub_patched
+
+    monkeypatch.setattr(cli, "_run_validation", _stub_run_validation)
+    monkeypatch.setattr(cli, "_get_metrics", _stub_get_metrics)
+    # Skip the gold-standard CSV loader; just claim every metric is covered.
+    monkeypatch.setattr(
+        cli,
+        "_load_affected_companies",
+        lambda metric_ids, max_companies: ["Stub Company"],
+    )
+    monkeypatch.setattr(
+        cli,
+        "_compute_coverage",
+        lambda metric_ids: {m: {"filings": 5, "facts": 12} for m in metric_ids},
+    )
+
+    args = _make_args(test_database_url, run_id=run_id)
+    cli._orchestrate(args)
+
+    # Assert run row succeeded
+    run_rows = clean_db.query(
+        "SELECT status, num_recs_simulated, num_companies_validated, "
+        "tier1_presence_recall_baseline, tier1_presence_recall_patched, "
+        "tier1_regressed, runs_agree "
+        "FROM text_pattern_simulation_runs WHERE id = %(id)s",
+        {"id": run_id},
+    )
+    assert len(run_rows) == 1
+    row = dict(run_rows[0])
+    assert row["status"] == "succeeded"
+    assert row["num_recs_simulated"] == 1
+    assert row["num_companies_validated"] == 1
+    assert float(row["tier1_presence_recall_baseline"]) == pytest.approx(0.85)
+    assert float(row["tier1_presence_recall_patched"]) == pytest.approx(0.85)
+    assert row["tier1_regressed"] is False
+    assert row["runs_agree"] is True
+
+    # Assert at least one delta row exists for the affected metric
+    deltas = clean_db.query(
+        "SELECT metric_id, baseline_recall, patched_recall, coverage_filings "
+        "FROM text_pattern_simulation_deltas WHERE run_id = %(id)s",
+        {"id": run_id},
+    )
+    assert len(deltas) >= 1
+    metric_ids = {d["metric_id"] for d in deltas}
+    assert metric_id in metric_ids
+    delta = next(d for d in deltas if d["metric_id"] == metric_id)
+    assert float(delta["baseline_recall"]) == pytest.approx(0.8)
+    assert float(delta["patched_recall"]) == pytest.approx(0.8)
+    assert delta["coverage_filings"] == 5
+
+
+def test_no_accepted_recs_still_succeeds(cli, clean_db, monkeypatch, test_database_url):
+    """Zero accepted recs is a valid (no-op) run — script should still succeed.
+
+    The endpoint blocks this case with 409 'no_accepted_recs', but the script
+    itself shouldn't fail.
+    """
+    run_id = str(uuid.uuid4())
+    clean_db.execute(
+        """
+        INSERT INTO text_pattern_simulation_runs (id, status, triggered_by)
+        VALUES (%(id)s, 'running', 'test')
+        """,
+        {"id": run_id},
+    )
+
+    stub_metrics = _make_stub_aggregate_metrics()
+    monkeypatch.setattr(cli, "_run_validation", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(cli, "_get_metrics", lambda v: stub_metrics)
+    monkeypatch.setattr(cli, "_load_affected_companies", lambda metric_ids, max_companies: [])
+    monkeypatch.setattr(cli, "_compute_coverage", lambda metric_ids: {})
+
+    args = _make_args(test_database_url, run_id=run_id)
+    cli._orchestrate(args)
+
+    run_rows = clean_db.query(
+        "SELECT status, num_recs_simulated FROM text_pattern_simulation_runs WHERE id = %(id)s",
+        {"id": run_id},
+    )
+    assert len(run_rows) == 1
+    assert run_rows[0]["status"] == "succeeded"
+    assert run_rows[0]["num_recs_simulated"] == 0
+
+
+def test_unsupported_rule_type_silently_skipped(cli, clean_db, monkeypatch, test_database_url):
+    """keyword_overlap recs are skipped; num_recs_simulated reflects supported only."""
+    _seed_accepted_rec(
+        clean_db,
+        metric_id="cm_active_customers_total",
+        rule="keyword_overlap",
+        decision_key="cm_some_other_metric",
+    )
+
+    run_id = str(uuid.uuid4())
+    clean_db.execute(
+        """
+        INSERT INTO text_pattern_simulation_runs (id, status, triggered_by)
+        VALUES (%(id)s, 'running', 'test')
+        """,
+        {"id": run_id},
+    )
+
+    stub_metrics = _make_stub_aggregate_metrics()
+    monkeypatch.setattr(cli, "_run_validation", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(cli, "_get_metrics", lambda v: stub_metrics)
+    monkeypatch.setattr(cli, "_load_affected_companies", lambda metric_ids, max_companies: [])
+    monkeypatch.setattr(cli, "_compute_coverage", lambda metric_ids: {})
+
+    args = _make_args(test_database_url, run_id=run_id)
+    cli._orchestrate(args)
+
+    run_rows = clean_db.query(
+        "SELECT status, num_recs_simulated FROM text_pattern_simulation_runs WHERE id = %(id)s",
+        {"id": run_id},
+    )
+    assert run_rows[0]["status"] == "succeeded"
+    assert run_rows[0]["num_recs_simulated"] == 0
+
+    # No deltas for the unsupported rec
+    delta_count = clean_db.query(
+        "SELECT COUNT(*) AS n FROM text_pattern_simulation_deltas WHERE run_id = %(id)s",
+        {"id": run_id},
+    )
+    assert delta_count[0]["n"] == 0


### PR DESCRIPTION
Track B of the simulate-and-ship recommendation flow on /v2/review/stats.
Builds the simulation pathway that will gate Ship-to-PR (Track D) with
R/P/F1 deltas and Tier-1 regression checks.

Schema (timestamp migration 202605121359):
  text_pattern_simulation_runs    — one row per click; status + tier deltas
  text_pattern_simulation_deltas  — one row per (run, rec, metric_id) with
                                    baseline + patched R/P/F1 + coverage

Script (scripts/simulate_text_pattern_changes.py):
  - Pulls accepted (not-yet-shipped) recs from
    text_pattern_recommendation_decisions
  - Partitions on rule type: exclusion_pattern is simulated; other rules
    are skipped (simulation_not_supported) until LLM-drafted patches land
  - Builds a KeywordPatchOverride by appending each rec's phrase to the
    metric's YAML exclusions
  - Resolves affected companies from gold-standard CSV
  - Runs V2GoldStandardValidator three times: baseline + patched x2 (gh-273
    retry pattern). runs_agree flag set when the two patched runs match on
    Tier-1 within 0.0001 epsilon
  - Persists Tier-1/Tier-2 + per-metric deltas + coverage stats; flips run
    row to 'failed' on any exception

Endpoints (src/web/routes/api_unified.py):
  POST /api/v2/extraction/simulate-accepted          — admin-gated, spawns
       Gates: reviewer_name, 1h stale-row sweep, no_accepted_recs (409),
              simulation_already_running (409)
  GET  /api/v2/extraction/simulation-runs/<id>/status — returns run row +
                                                       all delta rows

Tests (tests/integration/test_simulate_text_pattern_changes.py):
  - Happy path: seeded exclusion_pattern rec produces run row + deltas
  - No accepted recs: script still succeeds with num_recs_simulated=0
  - Unsupported rule type silently skipped

V2GoldStandardValidator is monkeypatched in tests (too slow + external-
dependent for an integration test). Test verifies orchestration +
persistence shape; validator behavior is covered separately.

Foundation: PRs #607, #608.
Plan: ~/.claude/plans/evaluate-this-idea-critically-delightful-comet.md

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
