### PR TITLE
feat(admin-review): in-context image inspection panel + deep-link

### DIFF
--- a/docs/operations/admin-review-runbook.md
+++ b/docs/operations/admin-review-runbook.md
@@ -67,6 +67,26 @@ Submitting an override here writes:
 - Audit-log `before_state` JSONB captures a snapshot of the reviewer row being superseded
 - The reviewer's original row is **kept** (not modified) — the admin's row coexists with it. The training pipeline sees both rows; the "any accept wins" aggregation in `scripts/export_image_training_data.py` means an admin accept overrides a reviewer reject at training-label level.
 
+## Inspecting an image in context
+
+Every Suppressed-Images card and every Reviewer-Audit row carries an **Inspect** button next to its **Override** button. Clicking **Inspect** expands an inline read-only panel below the card/row with everything a reviewer would see on `/v2/review/<filing_id>`:
+
+- Full-size image (served via `build_image_cache_url(...)`).
+- Filing / company / accession / form-type / filing-date header.
+- `classification`, `relevance_score`, `predicted_relevance`, `review_status`, image dimensions, and `section_path`.
+- Detected metrics chip rail (`v2_image_assets.detected_metrics`).
+- `nearby_text` and `ocr_text` blocks (collapsible — `nearby_text` auto-collapses when > 500 chars; OCR is collapsed by default).
+- The full chronological list of `v2_image_metric_confirmations` rows on the image (up to 50, oldest first). Admin rows (non-NULL `override_reason`) render with a warning highlight; their `override_reason` text appears under the metric cell.
+- A **View in regular review →** button that opens `/v2/review/<filing_id>?img_id=<uuid>&tab=images` in a new tab — useful when the inline panel isn't enough and you need the full reviewer interface (zoom, lightbox, navigation strip).
+
+The panel is **read-only**. It writes nothing to the database, does not change `v2_image_assets.review_status`, and does NOT write to `admin_audit_log`. All write actions still flow through the Override modal and the existing `/api/admin/image-decision-override` endpoints.
+
+The Override modal itself also renders a **compact** version of the same panel at the top (thumbnail + filing header + chip rail + confirmation count + "View in regular review" deep-link), so the admin can see what they are acting on while filling out the form. Opening the Override modal from a Reviewer-Audit row additionally pre-fills the Metric ID field with the row's `confirmed_metric_id` (or `detected_metric_id` when the row is a reject without a correction).
+
+Detail responses are cached per-session in the JS client, so re-toggling the same image's panel does not refetch.
+
+Backend: `GET /admin/review/image-detail/<uuid:img_id>` (admin-gated, returns the merged image + filing + confirmations + `deep_link_url` JSON blob).
+
 ## Useful audit queries
 
 **Recent admin actions:**

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -4110,6 +4110,105 @@ class DatabaseAdapter:
 
         return results, total
 
+    def get_image_detail_for_admin(self, img_id: str) -> dict[str, Any] | None:
+        """Return merged image + filing + confirmations context for the admin
+        review tool's in-context inspection panel.
+
+        Read-only. Used by ``GET /admin/review/image-detail/<img_id>``.
+
+        Returns a dict with keys ``image``, ``filing``, ``confirmations`` — or
+        ``None`` if *img_id* is unknown. The ``confirmations`` list is ordered
+        ASC by ``created_at`` and capped at 50 rows to bound the response on
+        heavily-reviewed images.
+        """
+        image_rows = self.query(
+            """
+            SELECT
+                ia.img_id::text AS img_id,
+                ia.filename,
+                ia.file_path,
+                ia.width,
+                ia.height,
+                ia.nearby_text,
+                ia.section_path,
+                ia.section_type,
+                ia.classification,
+                ia.relevance_score,
+                ia.predicted_relevance,
+                ia.review_status,
+                ia.ocr_text,
+                ia.detected_metrics,
+                ia.created_at,
+                f.filing_id,
+                f.accession_number,
+                f.form_type,
+                f.filing_date::text AS filing_date,
+                c.company_id,
+                c.cik,
+                c.company_name
+            FROM v2_image_assets ia
+            JOIN filings f ON f.filing_id = ia.filing_id
+            JOIN companies c ON c.company_id = f.company_id
+            WHERE ia.img_id = %(img_id)s
+            """,
+            {"img_id": img_id},
+        )
+        if not image_rows:
+            return None
+        row = image_rows[0]
+
+        confirmation_rows = self.query(
+            """
+            SELECT
+                id::text AS confirmation_id,
+                reviewer_id,
+                decision,
+                detected_metric_id,
+                confirmed_metric_id,
+                rejection_reason,
+                reviewer_notes,
+                override_reason,
+                supersedes_confirmation_id::text AS supersedes_confirmation_id,
+                created_at,
+                updated_at
+            FROM v2_image_metric_confirmations
+            WHERE img_id = %(img_id)s
+            ORDER BY created_at ASC
+            LIMIT 50
+            """,
+            {"img_id": img_id},
+        )
+
+        return {
+            "image": {
+                "img_id": row["img_id"],
+                "filename": row["filename"],
+                "file_path": row["file_path"],
+                "width": row["width"],
+                "height": row["height"],
+                "nearby_text": row["nearby_text"],
+                "section_path": row["section_path"],
+                "section_type": row["section_type"],
+                "classification": row["classification"],
+                "relevance_score": row["relevance_score"],
+                "predicted_relevance": row["predicted_relevance"],
+                "review_status": row["review_status"],
+                "ocr_text": row["ocr_text"],
+                "detected_metrics": row["detected_metrics"],
+                "created_at": row["created_at"],
+            },
+            "filing": {
+                "filing_id": row["filing_id"],
+                "accession_number": row["accession_number"],
+                "form_type": row["form_type"],
+                "filing_date": row["filing_date"],
+                "company_id": row["company_id"],
+                "cik": row["cik"],
+                "company_name": row["company_name"],
+            },
+            "confirmations": confirmation_rows,
+        }
+
     def insert_admin_override(
         self,
         img_id: str,

--- a/src/web/routes/admin_review.py
+++ b/src/web/routes/admin_review.py
@@ -2,14 +2,16 @@
 Admin review tool endpoints.
 
 All routes are protected by @admin_required (flag-independent, always active).
-Provides five endpoints for auditing suppressed images, reviewing decisions by
-reviewer, and writing / undoing admin override rows on v2_image_metric_confirmations.
+Provides endpoints for auditing suppressed images, reviewing decisions by
+reviewer, inspecting an image in context, and writing / undoing admin
+override rows on v2_image_metric_confirmations.
 
 Endpoints:
-  GET  /admin/review                          — placeholder HTML (PR 3 ships the real UI)
-  GET  /admin/review/suppressed               — JSON: paginated suppressed images
-  GET  /admin/review/by-reviewer              — JSON: paginated decisions for one reviewer
-  POST /api/admin/image-decision-override     — write an admin override row
+  GET  /admin/review                            — composite UI
+  GET  /admin/review/suppressed                 — JSON: paginated suppressed images
+  GET  /admin/review/by-reviewer                — JSON: paginated decisions for one reviewer
+  GET  /admin/review/image-detail/<img_id>      — JSON: read-only image context
+  POST /api/admin/image-decision-override       — write an admin override row
   DELETE /api/admin/image-decision-override/<id> — undo an admin override row
 """
 
@@ -21,10 +23,11 @@ import uuid as _uuid
 from typing import Any
 
 import psycopg
-from flask import Blueprint, g, jsonify, render_template, request
+from flask import Blueprint, g, jsonify, render_template, request, url_for
 
 from src.auth.admin import admin_required
 from src.web.app import get_db
+from src.web.url_builders import build_image_cache_url
 
 admin_review_bp = Blueprint("admin_review", __name__)
 logger = logging.getLogger(__name__)
@@ -283,6 +286,60 @@ def admin_review_by_reviewer():
                 dec[k] = v.isoformat()
 
     return jsonify({"decisions": decisions, "total": total, "limit": limit, "offset": offset})
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/review/image-detail/<img_id>
+# ---------------------------------------------------------------------------
+
+
+@admin_review_bp.route("/admin/review/image-detail/<uuid:img_id>", methods=["GET"])
+@admin_required
+def admin_review_image_detail(img_id):
+    """Return read-only context for a single image in the admin tool.
+
+    Response shape:
+      {
+        "image": {...image cols + image_url for <img src>...},
+        "filing": {...filing + company cols...},
+        "confirmations": [...per-metric rows, ASC by created_at, up to 50...],
+        "deep_link_url": "/v2/review/<filing_id>?img_id=<uuid>&tab=images"
+      }
+
+    Read-only: does NOT write to admin_audit_log.
+    """
+    db = get_db()
+    try:
+        detail = db.get_image_detail_for_admin(str(img_id))
+    except psycopg.DatabaseError as exc:
+        logger.error("DB error in admin_review_image_detail: %s", exc, exc_info=True)
+        return jsonify({"error": "database error"}), 500
+
+    if detail is None:
+        return jsonify({"error": "image not found"}), 404
+
+    filing = detail["filing"]
+    image = detail["image"]
+
+    image["image_url"] = build_image_cache_url(
+        filing.get("cik"),
+        filing.get("accession_number"),
+        image["filename"],
+    )
+
+    deep_link_path = url_for("review_unified.review_filing", filing_id=filing["filing_id"])
+    detail["deep_link_url"] = f"{deep_link_path}?img_id={image['img_id']}&tab=images"
+
+    for section in (image, filing):
+        for k, v in list(section.items()):
+            if hasattr(v, "isoformat"):
+                section[k] = v.isoformat()
+    for conf in detail["confirmations"]:
+        for k, v in list(conf.items()):
+            if hasattr(v, "isoformat"):
+                conf[k] = v.isoformat()
+
+    return jsonify(detail)
 
 
 # ---------------------------------------------------------------------------

--- a/src/web/static/js/admin_review.js
+++ b/src/web/static/js/admin_review.js
@@ -3,6 +3,7 @@
  * Backend: src/web/routes/admin_review.py
  *   GET    /admin/review/suppressed
  *   GET    /admin/review/by-reviewer
+ *   GET    /admin/review/image-detail/<img_id>   (read-only detail panel)
  *   POST   /api/admin/image-decision-override
  *   DELETE /api/admin/image-decision-override/<id>
  */
@@ -14,6 +15,8 @@
     suppressed: { offset: 0, lastFilters: {} },
     audit: { offset: 0, lastFilters: {} },
   };
+  // Session-scoped cache of detail responses keyed by img_id.
+  const detailCache = new Map();
 
   // ----------------------------------------------------------------
   // Helpers
@@ -79,6 +82,180 @@
   }
 
   // ----------------------------------------------------------------
+  // Image detail panel (read-only inspection)
+  // ----------------------------------------------------------------
+  async function loadImageDetail(imgId) {
+    if (!imgId) return null;
+    if (detailCache.has(imgId)) return detailCache.get(imgId);
+    const resp = await fetch(`/admin/review/image-detail/${encodeURIComponent(imgId)}`, {
+      credentials: "same-origin",
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      toast(`Detail load failed: ${body.error || resp.status}`, true);
+      return null;
+    }
+    const data = await resp.json();
+    detailCache.set(imgId, data);
+    return data;
+  }
+
+  function buildDetailHtml(detail, opts) {
+    const compact = opts && opts.compact;
+    const img = detail.image || {};
+    const filing = detail.filing || {};
+    const confs = detail.confirmations || [];
+    const deepLink = detail.deep_link_url || "";
+
+    const detectedMetrics = Array.isArray(img.detected_metrics) ? img.detected_metrics : [];
+    const chipRail = detectedMetrics.length
+      ? detectedMetrics.map((m) => {
+          const metricId = m && (m.metric_id || m.id || m.name) || String(m);
+          const score = m && (m.score != null ? m.score : m.confidence);
+          const scoreTxt = score != null ? ` <span class="text-muted">(${Number(score).toFixed(2)})</span>` : "";
+          return `<span class="badge bg-light text-dark border me-1">${escapeHtml(metricId)}${scoreTxt}</span>`;
+        }).join("")
+      : "<span class='text-muted small'>(no detected metrics)</span>";
+
+    const nearby = img.nearby_text || "";
+    const nearbyLong = nearby.length > 500;
+    const nearbyHtml = nearby
+      ? `<details ${nearbyLong ? "" : "open"}>
+           <summary class="small text-muted">Nearby text${nearbyLong ? ` (${nearby.length} chars — click to expand)` : ""}</summary>
+           <pre class="small bg-light p-2 mt-1" style="white-space:pre-wrap;max-height:300px;overflow:auto">${escapeHtml(nearby)}</pre>
+         </details>`
+      : "<div class='small text-muted'>(no nearby text)</div>";
+
+    const ocr = img.ocr_text || "";
+    const ocrHtml = ocr
+      ? `<details>
+           <summary class="small text-muted">OCR text (${ocr.length} chars)</summary>
+           <pre class="small bg-light p-2 mt-1" style="white-space:pre-wrap;max-height:240px;overflow:auto">${escapeHtml(ocr)}</pre>
+         </details>`
+      : "<div class='small text-muted'>(no OCR text)</div>";
+
+    const confRows = confs.map((c) => {
+      const isAdmin = !!c.override_reason;
+      const metric = c.confirmed_metric_id || c.detected_metric_id || "(sentinel)";
+      const reviewer = (c.reviewer_id || "").slice(0, 12);
+      const cls = isAdmin ? "table-warning" : "";
+      const adminBadge = isAdmin ? `<span class="badge bg-warning text-dark ms-1">admin</span>` : "";
+      const overrideReason = isAdmin
+        ? `<div class="text-muted" style="font-size:0.75em">${escapeHtml(c.override_reason || "")}</div>`
+        : "";
+      return `<tr class="${cls}">
+        <td class="small">${escapeHtml(fmtDate(c.created_at))}</td>
+        <td class="small">${escapeHtml(reviewer)}${adminBadge}</td>
+        <td class="small">${escapeHtml(c.decision || "")}</td>
+        <td class="small">${escapeHtml(metric)}</td>
+        <td class="small">${escapeHtml(c.rejection_reason || "")}${overrideReason}</td>
+      </tr>`;
+    }).join("");
+    const confTable = confs.length
+      ? `<table class="table table-sm mb-0">
+           <thead><tr><th>When</th><th>Reviewer</th><th>Decision</th><th>Metric</th><th>Notes</th></tr></thead>
+           <tbody>${confRows}</tbody>
+         </table>`
+      : "<div class='small text-muted'>(no confirmations on this image)</div>";
+
+    const imgUrl = img.image_url || "";
+    const imgStyle = compact
+      ? "max-height:160px;max-width:240px;object-fit:contain"
+      : "max-height:480px;max-width:100%;object-fit:contain";
+    const imageBlock = imgUrl
+      ? `<img src="${escapeHtml(imgUrl)}" alt="${escapeHtml(img.filename || "")}" style="${imgStyle}" class="border bg-white">`
+      : `<div class="text-muted small">(image bytes unavailable)</div>`;
+
+    const dims = img.width && img.height ? `${img.width}×${img.height}` : "—";
+    const sectionPath = Array.isArray(img.section_path) ? img.section_path.join(" › ") : (img.section_path || "");
+    const meta = `
+      <div class="small text-muted">
+        <strong>${escapeHtml(filing.company_name || "")}</strong>
+        — ${escapeHtml(filing.form_type || "")} ${escapeHtml(fmtDate(filing.filing_date))}
+        — accession ${escapeHtml(filing.accession_number || "")}
+      </div>
+      <div class="small text-muted">
+        <span class="badge bg-info">${escapeHtml(img.classification || "")}</span>
+        relevance ${fmtScore(img.relevance_score)} · predicted ${fmtScore(img.predicted_relevance)}
+        · status <code>${escapeHtml(img.review_status || "")}</code>
+        · dims ${escapeHtml(dims)}
+        ${sectionPath ? `· section <em>${escapeHtml(sectionPath)}</em>` : ""}
+      </div>
+    `;
+
+    const deepLinkBtn = deepLink
+      ? `<a class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener" href="${escapeHtml(deepLink)}">
+           View in regular review →
+         </a>`
+      : "";
+
+    if (compact) {
+      return `
+        <div class="border rounded p-2 bg-light">
+          <div class="d-flex gap-2 align-items-start">
+            <div>${imageBlock}</div>
+            <div class="flex-grow-1">
+              ${meta}
+              <div class="mt-1">${chipRail}</div>
+              <div class="mt-2">${deepLinkBtn}</div>
+            </div>
+          </div>
+          <div class="mt-2"><strong class="small">Other confirmations on this image:</strong> ${confs.length}</div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="border rounded p-3 bg-white admin-detail-panel">
+        <div class="row g-3">
+          <div class="col-md-5">
+            ${imageBlock}
+          </div>
+          <div class="col-md-7">
+            ${meta}
+            <div class="mt-2"><strong class="small">Detected metrics:</strong></div>
+            <div>${chipRail}</div>
+            <div class="mt-2">${deepLinkBtn}</div>
+          </div>
+        </div>
+        <hr>
+        <div class="mb-2">${nearbyHtml}</div>
+        <div class="mb-2">${ocrHtml}</div>
+        <div>
+          <div class="small text-muted mb-1">Confirmations on this image (${confs.length}, oldest first, up to 50):</div>
+          ${confTable}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderDetailPanel(detail, containerEl, opts) {
+    if (!detail || !containerEl) return;
+    containerEl.innerHTML = buildDetailHtml(detail, opts || {});
+  }
+
+  async function toggleInspectPanel(slotEl, imgId) {
+    if (!slotEl || !imgId) return;
+    if (slotEl.dataset.open === "1") {
+      slotEl.dataset.open = "0";
+      slotEl.classList.add("d-none");
+      return;
+    }
+    slotEl.classList.remove("d-none");
+    slotEl.dataset.open = "1";
+    if (slotEl.dataset.loaded !== "1") {
+      slotEl.innerHTML = "<div class='text-muted small p-2'>Loading…</div>";
+      const detail = await loadImageDetail(imgId);
+      if (!detail) {
+        slotEl.innerHTML = "<div class='text-danger small p-2'>Failed to load detail.</div>";
+        return;
+      }
+      renderDetailPanel(detail, slotEl);
+      slotEl.dataset.loaded = "1";
+    }
+  }
+
+  // ----------------------------------------------------------------
   // Suppressed Images tab
   // ----------------------------------------------------------------
   async function loadSuppressed(filters, offset) {
@@ -116,33 +293,42 @@
 
   function suppressedCard(img) {
     const div = document.createElement("div");
-    div.className = "col-md-4 col-lg-3";
+    div.className = "col-12";
     const reasonBadges = (img.suppression_reasons || [])
       .map((r) => `<span class="badge bg-secondary me-1">${escapeHtml(r)}</span>`)
       .join("");
     div.innerHTML = `
-      <div class="card h-100">
+      <div class="card">
         <div class="card-body">
-          <h6 class="card-title small text-truncate" title="${escapeHtml(img.filename || "")}">
-            ${escapeHtml(img.filename || "(no name)")}
-          </h6>
-          <div class="small text-muted mb-1">
-            ${escapeHtml(img.company_name || "")}
+          <div class="row g-2 align-items-start">
+            <div class="col-md-6">
+              <h6 class="card-title small text-truncate mb-1" title="${escapeHtml(img.filename || "")}">
+                ${escapeHtml(img.filename || "(no name)")}
+              </h6>
+              <div class="small text-muted">${escapeHtml(img.company_name || "")}</div>
+              <div class="small text-muted">
+                ${escapeHtml(img.accession_number || "")} · ${escapeHtml(fmtDate(img.filing_date))}
+              </div>
+            </div>
+            <div class="col-md-3 small">
+              <span class="badge bg-info">${escapeHtml(img.classification || "")}</span>
+              <span class="text-muted ms-1">score ${fmtScore(img.predicted_relevance)}</span>
+              <div class="mt-1">${reasonBadges}</div>
+            </div>
+            <div class="col-md-3 d-flex gap-2 justify-content-end">
+              <button class="btn btn-sm btn-outline-secondary inspect-btn"
+                      data-img-id="${escapeHtml(img.img_id)}"
+                      title="Inspect in context">
+                Inspect
+              </button>
+              <button class="btn btn-sm btn-warning override-btn"
+                      data-img-id="${escapeHtml(img.img_id)}"
+                      data-context="${escapeHtml(img.company_name || "")} / ${escapeHtml(img.filename || "")}">
+                Override
+              </button>
+            </div>
           </div>
-          <div class="small mb-2">
-            <span class="badge bg-info">${escapeHtml(img.classification || "")}</span>
-            <span class="text-muted ms-1">score ${fmtScore(img.predicted_relevance)}</span>
-          </div>
-          <div class="mb-2">${reasonBadges}</div>
-          <div class="small text-muted mb-2">
-            ${escapeHtml(img.accession_number || "")}<br>
-            ${escapeHtml(fmtDate(img.filing_date))}
-          </div>
-          <button class="btn btn-sm btn-warning override-btn"
-                  data-img-id="${escapeHtml(img.img_id)}"
-                  data-context="${escapeHtml(img.company_name || "")} / ${escapeHtml(img.filename || "")}">
-            Override
-          </button>
+          <div class="admin-inspect-slot d-none mt-3" data-img-id="${escapeHtml(img.img_id)}"></div>
         </div>
       </div>
     `;
@@ -200,7 +386,8 @@
     `;
     const tbody = table.querySelector("tbody");
     for (const d of data.decisions || []) {
-      tbody.appendChild(auditRow(d));
+      const rows = auditRow(d);
+      rows.forEach((r) => tbody.appendChild(r));
     }
     list.appendChild(table);
     renderPagination("audit", data.total || 0);
@@ -220,6 +407,8 @@
          </div>`
       : "<span class='text-muted small'>none</span>";
     const img = d.image || {};
+    // metric_id for modal pre-fill — confirmed wins, detected falls back, sentinel rows stay blank
+    const prefillMetric = d.confirmed_metric_id || d.detected_metric_id || "";
     tr.innerHTML = `
       <td><span class="badge bg-secondary">${escapeHtml(d.decision || "")}</span></td>
       <td class="small">${escapeHtml(metric)}<br><span class="text-muted">${escapeHtml(d.rejection_reason || "")}</span></td>
@@ -227,15 +416,28 @@
       <td class="small">${escapeHtml(fmtDate(d.created_at))}</td>
       <td>${overrideCell}</td>
       <td>
+        <button class="btn btn-sm btn-outline-secondary inspect-btn me-1"
+                data-img-id="${escapeHtml(d.img_id)}"
+                title="Inspect in context">
+          Inspect
+        </button>
         <button class="btn btn-sm btn-outline-warning override-btn"
                 data-img-id="${escapeHtml(d.img_id)}"
                 data-supersedes-id="${escapeHtml(d.confirmation_id || "")}"
+                data-prefill-metric="${escapeHtml(prefillMetric)}"
                 data-context="Reverse ${escapeHtml(d.decision || "")} on ${escapeHtml(metric)} for ${escapeHtml(img.company_name || "")}">
           Override
         </button>
       </td>
     `;
-    return tr;
+    const slotTr = document.createElement("tr");
+    slotTr.innerHTML = `
+      <td colspan="6" class="p-0">
+        <div class="admin-inspect-slot d-none p-2 bg-body-tertiary"
+             data-img-id="${escapeHtml(d.img_id)}"></div>
+      </td>
+    `;
+    return [tr, slotTr];
   }
 
   // ----------------------------------------------------------------
@@ -260,14 +462,28 @@
   // ----------------------------------------------------------------
   // Override modal
   // ----------------------------------------------------------------
-  function openOverrideModal(imgId, supersedesId, context) {
+  async function openOverrideModal(imgId, supersedesId, context, prefillMetric) {
     document.getElementById("override-img-id").value = imgId || "";
     document.getElementById("override-supersedes-id").value = supersedesId || "";
     document.getElementById("override-reason").value = "";
-    document.getElementById("override-metric-id").value = "";
+    document.getElementById("override-metric-id").value = prefillMetric || "";
     document.getElementById("override-context").textContent = context || "";
+    const slot = document.getElementById("override-detail-slot");
+    if (slot) {
+      slot.innerHTML = imgId
+        ? "<div class='text-muted small'>Loading detail…</div>"
+        : "";
+    }
     const modal = new bootstrap.Modal(document.getElementById("overrideModal"));
     modal.show();
+    if (slot && imgId) {
+      const detail = await loadImageDetail(imgId);
+      if (detail) {
+        renderDetailPanel(detail, slot, { compact: true });
+      } else {
+        slot.innerHTML = "<div class='text-danger small'>Failed to load detail.</div>";
+      }
+    }
   }
 
   async function submitOverride() {
@@ -367,12 +583,33 @@
 
     // Delegate clicks for dynamic buttons
     document.body.addEventListener("click", (e) => {
+      const inspBtn = e.target.closest(".inspect-btn");
+      if (inspBtn) {
+        const imgId = inspBtn.dataset.imgId;
+        // Find the panel slot scoped to this card/row.
+        // Suppressed card: slot is a sibling inside the same .card-body.
+        // Audit row: slot lives in the next <tr>.
+        let slot = null;
+        const cardBody = inspBtn.closest(".card-body");
+        if (cardBody) {
+          slot = cardBody.querySelector(":scope > .admin-inspect-slot");
+        }
+        if (!slot) {
+          const tr = inspBtn.closest("tr");
+          if (tr && tr.nextElementSibling) {
+            slot = tr.nextElementSibling.querySelector(".admin-inspect-slot");
+          }
+        }
+        toggleInspectPanel(slot, imgId);
+        return;
+      }
       const ovrBtn = e.target.closest(".override-btn");
       if (ovrBtn) {
         openOverrideModal(
           ovrBtn.dataset.imgId,
           ovrBtn.dataset.supersedesId,
           ovrBtn.dataset.context,
+          ovrBtn.dataset.prefillMetric,
         );
         return;
       }

--- a/src/web/templates/admin_review.html
+++ b/src/web/templates/admin_review.html
@@ -162,6 +162,7 @@
       </div>
       <div class="modal-body">
         <div id="override-context" class="alert alert-info small"></div>
+        <div id="override-detail-slot" class="mb-3"></div>
         <form id="override-form">
           <input type="hidden" id="override-img-id">
           <input type="hidden" id="override-supersedes-id">

--- a/tests/integration/test_admin_review_routes.py
+++ b/tests/integration/test_admin_review_routes.py
@@ -463,3 +463,109 @@ class TestOverrideDelete:
         resp = client.delete(f"/api/admin/image-decision-override/{reviewer_conf_id}")
         assert resp.status_code == 400
         assert "not an admin override" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Image-detail (read-only inspection panel)
+# ---------------------------------------------------------------------------
+
+
+class TestImageDetailEndpoint:
+    def test_reviewer_blocked(self, app, clean_db, reviewer_user_id):
+        client = _client_as(app, _reviewer_user(reviewer_user_id))
+        bogus = str(_uuid.uuid4())
+        resp = client.get(f"/admin/review/image-detail/{bogus}")
+        assert resp.status_code == 403
+
+    def test_404_on_unknown_img(self, app, clean_db, admin_user_id):
+        client = _client_as(app, _admin_user(admin_user_id))
+        bogus = str(_uuid.uuid4())
+        resp = client.get(f"/admin/review/image-detail/{bogus}")
+        assert resp.status_code == 404
+
+    def test_200_returns_expected_shape(self, app, clean_db, admin_user_id, reviewer_user_id):
+        _, filing_id = create_test_company_and_filing(clean_db)
+        img_id = _insert_image(
+            clean_db, filing_id, classification="chart", predicted_relevance=0.42
+        )
+        # One reviewer row + one admin override row on the same image
+        reviewer_conf_id = _insert_confirmation(
+            clean_db,
+            img_id,
+            reviewer_user_id,
+            decision="reject",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id=None,
+            rejection_reason="not_present",
+        )
+        _insert_confirmation(
+            clean_db,
+            img_id,
+            admin_user_id,
+            decision="accept",
+            detected_metric_id="cm_customers_period_end",
+            confirmed_metric_id="cm_customers_period_end",
+            override_reason="reviewer wrong; chart clearly shows customers",
+            supersedes_id=reviewer_conf_id,
+        )
+
+        client = _client_as(app, _admin_user(admin_user_id))
+        resp = client.get(f"/admin/review/image-detail/{img_id}")
+        assert resp.status_code == 200, resp.data
+        body = resp.get_json()
+
+        assert set(body.keys()) >= {"image", "filing", "confirmations", "deep_link_url"}
+
+        # Image block carries the columns the panel needs
+        image = body["image"]
+        assert image["img_id"] == img_id
+        for key in (
+            "filename",
+            "classification",
+            "predicted_relevance",
+            "review_status",
+            "nearby_text",
+            "ocr_text",
+            "detected_metrics",
+            "image_url",
+        ):
+            assert key in image, f"image missing {key!r}: {image}"
+
+        # Filing block carries company + accession + cik for the deep-link
+        filing = body["filing"]
+        assert filing["filing_id"] == filing_id
+        assert filing["accession_number"] == "0001234567-24-000001"
+        assert filing["cik"] == "0001234567"
+        assert filing["company_name"] == "Test Corp"
+
+        # Confirmations carry both rows (reviewer + admin)
+        confs = body["confirmations"]
+        assert len(confs) == 2
+        reviewer_ids = {c["reviewer_id"] for c in confs}
+        assert reviewer_user_id in reviewer_ids
+        assert admin_user_id in reviewer_ids
+        admin_rows = [c for c in confs if c["override_reason"]]
+        assert len(admin_rows) == 1
+        assert admin_rows[0]["supersedes_confirmation_id"] == reviewer_conf_id
+
+        # Deep link is well-formed
+        assert body["deep_link_url"] == f"/v2/review/{filing_id}?img_id={img_id}&tab=images"
+
+    def test_read_only_no_audit_log_write(self, app, clean_db, admin_user_id):
+        _, filing_id = create_test_company_and_filing(clean_db)
+        img_id = _insert_image(clean_db, filing_id)
+
+        before = clean_db.query(
+            "SELECT COUNT(*) AS n FROM admin_audit_log WHERE actor_user_id = %(uid)s",
+            {"uid": admin_user_id},
+        )[0]["n"]
+
+        client = _client_as(app, _admin_user(admin_user_id))
+        resp = client.get(f"/admin/review/image-detail/{img_id}")
+        assert resp.status_code == 200
+
+        after = clean_db.query(
+            "SELECT COUNT(*) AS n FROM admin_audit_log WHERE actor_user_id = %(uid)s",
+            {"uid": admin_user_id},
+        )[0]["n"]
+        assert before == after, "read-only GET must not write admin_audit_log"


### PR DESCRIPTION
Add a read-only detail panel to /admin/review so admins can judge whether a
suppression or reviewer decision should stand without leaving the tool. Each
Suppressed card and Reviewer-Audit row gets an Inspect button that toggles an
inline panel (image, nearby/OCR text, classification + score, detected
metrics, chronological confirmation trail with admin rows highlighted) and a
"View in regular review" deep-link. The Override modal renders a compact
version of the same panel and pre-fills the Metric ID from the row.

- New JSON endpoint GET /admin/review/image-detail/<img_id> (admin-gated,
  no audit-log writes, confirmations capped at 50)
- New DB method get_image_detail_for_admin in src/infra/db.py
- JS: lazy-load + session cache; div-based panel (no table-clone quirks)
- Tests: 403 / 404 / 200-shape / read-only audit-log invariant
- Runbook: new "Inspecting an image in context" section
