### PR TITLE
feat(analytics): tier-1 disclosure views for Metabase reporting

### DIFF
--- a/docs/operations/analytics-ui-runbook.md
+++ b/docs/operations/analytics-ui-runbook.md
@@ -4,13 +4,14 @@
 pointed at the filings database. Covers the read-only DB role, the
 `v_analytics_*` views, and the (future) self-hosted Metabase deployment.
 
-> **Pivot status (2026-04-25):** The presence-pivot adds a new doc-grain
-> view `v_doc_metric_presence` (UNION of `v2_text_metric_presence` and the
-> per-image `v2_image_metric_presence`, the latter landing with image-review
-> Wave 2). Existing `v_analytics_fact_wide` and `v_analytics_coverage_matrix`
-> views remain valid for advisory-fact analyses; presence-aware analytics
-> views are pending PR2 of the text-presence pivot. See
-> [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md).
+> **Pivot status (2026-05-13):** The presence-aware analytics surface
+> landed as `v_analytics_metric_presence` (and the company/tier-1 rollup
+> views) in migration `202605131507_tier1_disclosure_analytics.sql`. The
+> earlier-planned `v_doc_metric_presence` name is superseded. Existing
+> `v_analytics_fact_wide` and `v_analytics_coverage_matrix` remain valid
+> for advisory-fact analyses. See
+> [`text-pipeline-presence-pivot-plan.md`](text-pipeline-presence-pivot-plan.md)
+> and [`metabase-tier1-reporting.md`](metabase-tier1-reporting.md).
 
 ## What this layer is for
 
@@ -53,8 +54,18 @@ is deployed later via `render.yaml`.
 | View | Grain | Use |
 |------|-------|-----|
 | `v_analytics_fact_wide` | 1 row / primary `v2_metric_fact` (advisory under the pivot) | Surface for advisory-fact analysis (trends, QA, per-company values). Note: chart-native metrics no longer auto-populate facts post-#86. |
-| `v_analytics_coverage_matrix` | 1 row / (company × active metric) | Powers "who discloses what" heatmap dashboards. Includes `has_fact` / `has_accepted_fact` flags. PR2 of the text-presence pivot will switch the headline coverage flag from fact-presence to **doc-grain presence** via `v_doc_metric_presence`. |
-| `v_doc_metric_presence` (UNION view, planned) | 1 row / (filing × metric × source) | Primary presence surface — UNION of `v2_text_metric_presence` and per-image `v2_image_metric_presence`. Lands with image-review Wave 2; consumed by PR2 of the text-presence pivot for the Tier-1 gate. Pre-launch, query `v2_text_metric_presence` directly. |
+| `v_analytics_coverage_matrix` | 1 row / (company × active metric) | Powers "who discloses what" heatmap dashboards. Includes `has_fact` / `has_accepted_fact` flags. Superseded for presence-based coverage by `v_analytics_metric_presence` (below). |
+
+### Tier-1 disclosure views — `sql/202605131507_tier1_disclosure_analytics.sql`
+
+| View | Grain | Use |
+|------|-------|-----|
+| `v_analytics_metric_tiers` | 1 row / metric | Catalog of `metric_id → tier (1|2)`. Tier-1 list mirrors `config/metric_keywords.yaml`; if that set changes, edit the inline `CASE` and re-apply the migration. |
+| `v_analytics_metric_presence` | 1 row / (filing × metric) | Unified presence surface: FULL OUTER JOIN of `v2_text_metric_presence` and reviewer-confirmed `v2_image_metric_confirmations` (decisions `accept|correct|add`, superseded admin rows excluded). Carries `evidence_segment_ids` / `image_ids` JSONB for future drill-through. Supersedes the planned `v_doc_metric_presence` referenced in earlier drafts. |
+| `v_analytics_company_metric_disclosure` | 1 row / (company × metric) | Dedup of `v_analytics_metric_presence` across in-scope filings per company (`is_in_scope_phase1 = TRUE`). Joined to `industry_sic_buckets` and `v_analytics_metric_tiers`. |
+| `v_analytics_company_tier1_summary` | 1 row / in-scope company | Distinct count of Tier-1 metrics disclosed per company, plus the `0/1/2/3/4/5+` `disclosure_bucket` and `industry_bucket`. Primary surface for the four Metabase tier-1 reports — see [`metabase-tier1-reporting.md`](metabase-tier1-reporting.md). |
+
+The migration also creates the seed table `industry_sic_buckets` (SIC code → primary bucket, snapshot of `config/industry_sic_codes.yaml`). The companion doc `metabase-tier1-reporting.md` has copy-pastable SQL for the four reports.
 
 Both views use `CREATE OR REPLACE`, so the migration is safe to re-apply after
 editing. If a column or join changes, bump the migration number and add a new

--- a/docs/operations/metabase-tier1-reporting.md
+++ b/docs/operations/metabase-tier1-reporting.md
@@ -1,0 +1,156 @@
+# Tier-1 Disclosure Reports in Metabase
+
+Operator guide for the four recurring Tier-1 customer-metric disclosure
+reports against `v_analytics_company_tier1_summary` and
+`v_analytics_company_metric_disclosure`.
+
+## What "disclosed" means here
+
+A company is recorded as disclosing a metric in a given filing when **any**
+of the following is true:
+
+- A row exists in `v2_text_metric_presence` for `(filing_id, canonical_metric_id)` — text pipeline detected presence.
+- A reviewer-confirmed row exists in `v2_image_metric_confirmations` with
+  `decision IN ('accept','correct','add')` for an image attached to the filing
+  — image surface is **reviewer-confirmed only**, not raw pipeline output.
+  Rows superseded by a later admin override are excluded.
+
+Disclosure is **deduplicated** per `(company, metric)` across all of a
+company's in-scope filings: a company that discloses NRR in any of its
+S-1/F-1 filings counts once.
+
+## Universe
+
+The summary view restricts to `filings.is_in_scope_phase1 = TRUE`
+(first-time-issuer S-1/F-1, non-SPAC, not secondary-only — the project's
+canonical "relevant IPO" definition). Companies whose only filings are
+out-of-scope do not appear.
+
+## Tier-1 metric set
+
+Defined inline in `v_analytics_metric_tiers` (`sql/202605131507_tier1_disclosure_analytics.sql`),
+mirroring `config/metric_keywords.yaml`. If the YAML's tier-1 set changes,
+edit the `CASE` in the migration and re-apply (the view is
+`CREATE OR REPLACE`).
+
+## Metabase queries
+
+Paste these into a new Metabase question (Native SQL, against the
+`filings_analysis` database, user `metabase_ro`).
+
+### Q1 — Companies by # of Tier-1 metrics disclosed
+
+```sql
+SELECT
+    disclosure_bucket,
+    COUNT(*) AS company_count
+FROM v_analytics_company_tier1_summary
+GROUP BY disclosure_bucket
+ORDER BY
+    CASE disclosure_bucket
+        WHEN '0' THEN 0 WHEN '1' THEN 1 WHEN '2' THEN 2
+        WHEN '3' THEN 3 WHEN '4' THEN 4 WHEN '5+' THEN 5
+    END;
+```
+
+Bar chart: x = `disclosure_bucket`, y = `company_count`.
+
+### Q2 — Companies by industry
+
+```sql
+SELECT
+    industry_bucket,
+    COUNT(*) AS company_count
+FROM v_analytics_company_tier1_summary
+GROUP BY industry_bucket
+ORDER BY company_count DESC;
+```
+
+For an industry breakdown restricted to companies that disclosed at least
+one Tier-1 metric, add `WHERE tier1_metric_count > 0`.
+
+### Q3 — Per-industry % of IPOs at each disclosure bucket
+
+```sql
+WITH per_industry AS (
+    SELECT
+        industry_bucket,
+        disclosure_bucket,
+        COUNT(*) AS company_count
+    FROM v_analytics_company_tier1_summary
+    GROUP BY industry_bucket, disclosure_bucket
+),
+industry_totals AS (
+    SELECT industry_bucket, SUM(company_count) AS industry_total
+    FROM per_industry
+    GROUP BY industry_bucket
+)
+SELECT
+    p.industry_bucket,
+    p.disclosure_bucket,
+    p.company_count,
+    t.industry_total,
+    ROUND(100.0 * p.company_count / NULLIF(t.industry_total, 0), 1) AS pct_of_industry
+FROM per_industry p
+JOIN industry_totals t USING (industry_bucket)
+ORDER BY
+    p.industry_bucket,
+    CASE p.disclosure_bucket
+        WHEN '0' THEN 0 WHEN '1' THEN 1 WHEN '2' THEN 2
+        WHEN '3' THEN 3 WHEN '4' THEN 4 WHEN '5+' THEN 5
+    END;
+```
+
+In Metabase, set the visualization to **Pivot Table** with
+`industry_bucket` as the row dimension, `disclosure_bucket` as the column
+dimension, and `pct_of_industry` as the measure.
+
+### Q4 — Per Tier-1 metric: company count + company list
+
+```sql
+SELECT
+    d.canonical_metric_id,
+    d.metric_display_name,
+    COUNT(DISTINCT d.company_id) AS company_count,
+    jsonb_agg(DISTINCT d.company_name ORDER BY d.company_name) AS companies
+FROM v_analytics_company_metric_disclosure d
+WHERE d.tier = 1
+GROUP BY d.canonical_metric_id, d.metric_display_name
+ORDER BY company_count DESC;
+```
+
+For a flattened drill-down (one row per company × metric, sortable by
+metric or company), use:
+
+```sql
+SELECT
+    d.canonical_metric_id,
+    d.metric_display_name,
+    d.company_name,
+    d.ticker,
+    d.cik,
+    d.industry_bucket,
+    d.disclosed_via_text,
+    d.disclosed_via_image,
+    d.filing_ids
+FROM v_analytics_company_metric_disclosure d
+WHERE d.tier = 1
+ORDER BY d.canonical_metric_id, d.company_name;
+```
+
+## Future drill-through to evidence
+
+`v_analytics_metric_presence` already carries `evidence_segment_ids`
+(JSONB array of segment UUIDs from `v2_text_metric_presence`) and
+`image_ids` (JSONB array of `img_id` values from confirmed
+`v2_image_metric_confirmations`). A follow-up migration can add a
+`v_analytics_metric_evidence` view that resolves those to segment text or
+image storage keys without re-plumbing the underlying joins.
+
+## Related
+
+- `sql/202605131507_tier1_disclosure_analytics.sql` — view definitions
+- `sql/38_create_analytics_views.sql` — fact-grain views (advisory)
+- `docs/operations/analytics-ui-runbook.md` — Metabase deployment & role setup
+- `config/metric_keywords.yaml` — tier definitions
+- `config/industry_sic_codes.yaml` — SIC bucket definitions (source for `industry_sic_buckets`)

--- a/sql/202605131507_tier1_disclosure_analytics.sql
+++ b/sql/202605131507_tier1_disclosure_analytics.sql
@@ -1,0 +1,330 @@
+-- Migration 202605131507: tier1_disclosure_analytics
+--
+-- Adds the analytics surface for Tier-1 customer-metric disclosure reporting
+-- in Metabase. Answers four recurring questions:
+--   1. Histogram of in-scope companies by # of Tier-1 metrics disclosed
+--   2. Industry breakdown of those companies
+--   3. Per-industry % of IPOs disclosing 1/2/3/4/5+ Tier-1 metrics
+--   4. Per-metric: count of disclosing companies + drillable company list
+--
+-- "Disclosed" is presence-based and deduplicated across two surfaces:
+--   - Text: any row in v2_text_metric_presence for (filing, metric)
+--   - Image: a v2_image_metric_confirmations row with decision in
+--     ('accept','correct','add'), excluding rows superseded by a later
+--     admin override.
+--
+-- Universe filter: filings.is_in_scope_phase1 = TRUE.
+--
+-- New objects:
+--   industry_sic_buckets               (seed table, sic_code -> primary bucket)
+--   v_analytics_metric_tiers           (catalog of metric_id -> tier)
+--   v_analytics_metric_presence        (per filing x metric, text+image unioned)
+--   v_analytics_company_metric_disclosure  (per company x metric, deduped)
+--   v_analytics_company_tier1_summary  (per company, tier-1 count + bucket)
+--
+-- Default privileges (sql/37_create_analytics_role.sql) grant SELECT on new
+-- tables/views to metabase_ro automatically; no explicit GRANT here.
+
+BEGIN;
+
+-- ============================================================================
+-- industry_sic_buckets
+-- ----------------------------------------------------------------------------
+-- Snapshot of config/industry_sic_codes.yaml flattened to (sic_code, bucket).
+-- The YAML is many-to-many (one SIC can appear in several buckets); for
+-- aggregation we collapse each SIC to its *first-listed* bucket in the YAML
+-- so every company falls into exactly one bucket.
+--
+-- To regenerate after editing the YAML:
+--
+--   python3 - <<'PY'
+--   import yaml
+--   cfg = yaml.safe_load(open('config/industry_sic_codes.yaml'))
+--   seen = {}
+--   for bucket, body in cfg['industries'].items():
+--       for code in body.get('sic_codes', []):
+--           seen.setdefault(code, bucket)
+--   for code in sorted(seen):
+--       print(f"    ('{code}', '{seen[code]}'),")
+--   PY
+--
+-- ON CONFLICT DO UPDATE makes the migration safely re-runnable.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS industry_sic_buckets (
+    sic_code    TEXT PRIMARY KEY,
+    bucket_name TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE industry_sic_buckets IS
+    'Snapshot of config/industry_sic_codes.yaml: SIC code -> primary (first-listed) bucket. Source of truth is the YAML; regenerate via the script in the migration comment.';
+
+INSERT INTO industry_sic_buckets (sic_code, bucket_name) VALUES
+    ('1311', 'oil_gas_exploration'),
+    ('1381', 'oil_gas_exploration'),
+    ('1531', 'homebuilding'),
+    ('2711', 'media_publishing'),
+    ('2721', 'media_publishing'),
+    ('2731', 'media_publishing'),
+    ('2834', 'pharmaceuticals'),
+    ('2835', 'pharmaceuticals'),
+    ('2836', 'biotech'),
+    ('2911', 'oil_gas_refining'),
+    ('3576', 'computer_hardware'),
+    ('3577', 'computer_hardware'),
+    ('3661', 'telecom_equipment'),
+    ('3663', 'telecom_equipment'),
+    ('3672', 'computer_hardware'),
+    ('3674', 'semiconductors'),
+    ('3721', 'aerospace_defense'),
+    ('3728', 'aerospace_defense'),
+    ('3812', 'aerospace_defense'),
+    ('3841', 'medical_devices'),
+    ('3842', 'medical_devices'),
+    ('3845', 'medical_devices'),
+    ('4210', 'logistics_supply_chain'),
+    ('4213', 'logistics_supply_chain'),
+    ('4215', 'logistics_supply_chain'),
+    ('4400', 'logistics_supply_chain'),
+    ('4522', 'logistics_supply_chain'),
+    ('4731', 'logistics_supply_chain'),
+    ('4813', 'consumer_internet'),
+    ('4911', 'electric_utilities'),
+    ('4931', 'electric_utilities'),
+    ('5047', 'healthtech_digital_health'),
+    ('5211', 'home_improvement_retail'),
+    ('5251', 'home_improvement_retail'),
+    ('5411', 'grocery_retail'),
+    ('5511', 'auto_dealers'),
+    ('5521', 'auto_dealers'),
+    ('5621', 'apparel_retail'),
+    ('5651', 'apparel_retail'),
+    ('5661', 'apparel_retail'),
+    ('5699', 'apparel_retail'),
+    ('5812', 'restaurants'),
+    ('5900', 'marketplace_ecommerce'),
+    ('5940', 'marketplace_ecommerce'),
+    ('5961', 'marketplace_ecommerce'),
+    ('5999', 'marketplace_ecommerce'),
+    ('6020', 'commercial_banking'),
+    ('6021', 'commercial_banking'),
+    ('6022', 'commercial_banking'),
+    ('6029', 'commercial_banking'),
+    ('6099', 'fintech_payments'),
+    ('6141', 'fintech_payments'),
+    ('6153', 'fintech_payments'),
+    ('6159', 'fintech_payments'),
+    ('6199', 'fintech_payments'),
+    ('6211', 'fintech_payments'),
+    ('6282', 'investment_management'),
+    ('6311', 'insurtech'),
+    ('6321', 'insurtech'),
+    ('6331', 'insurtech'),
+    ('6351', 'insurtech'),
+    ('6399', 'insurtech'),
+    ('6411', 'insurtech'),
+    ('6500', 'proptech'),
+    ('6510', 'proptech'),
+    ('6512', 'proptech'),
+    ('6531', 'proptech'),
+    ('6552', 'proptech'),
+    ('6726', 'investment_management'),
+    ('7361', 'hr_tech'),
+    ('7370', 'software'),
+    ('7371', 'software'),
+    ('7372', 'software'),
+    ('7373', 'software'),
+    ('7374', 'software'),
+    ('7375', 'consumer_internet'),
+    ('7377', 'software'),
+    ('7379', 'saas_cloud'),
+    ('7382', 'cybersecurity'),
+    ('7389', 'industrial_services'),
+    ('7812', 'consumer_internet'),
+    ('7941', 'consumer_internet'),
+    ('7993', 'gaming_entertainment'),
+    ('8000', 'healthtech_digital_health'),
+    ('8011', 'healthtech_digital_health'),
+    ('8049', 'healthtech_digital_health'),
+    ('8099', 'healthtech_digital_health'),
+    ('8200', 'edtech'),
+    ('8211', 'edtech'),
+    ('8220', 'edtech'),
+    ('8249', 'edtech'),
+    ('8731', 'biotech')
+ON CONFLICT (sic_code) DO UPDATE SET bucket_name = EXCLUDED.bucket_name;
+
+-- ============================================================================
+-- v_analytics_metric_tiers
+-- ----------------------------------------------------------------------------
+-- Grain: one row per row in `metrics`.
+-- Tier 1 = the must-not-miss set defined in config/metric_keywords.yaml.
+-- Embedded inline to avoid adding a tier column to v2_metric_definitions /
+-- metrics; if the YAML's tier-1 set changes, edit this list and re-apply.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_analytics_metric_tiers AS
+SELECT
+    m.metric_id AS canonical_metric_id,
+    m.display_name AS metric_display_name,
+    CASE WHEN m.metric_id IN (
+        'cm_new_customers_acquired',
+        'cm_large_customers_period_end',
+        'cm_customers_period_end_by_tenure',
+        'cm_revenue_by_cohort',
+        'cm_transactions_by_cohort',
+        'cm_customer_acquisition_cost',
+        'cm_customer_retention_rate',
+        'cm_net_revenue_retention',
+        'cm_gross_revenue_retention',
+        'cm_balance_by_cohort',
+        'cm_gross_margin_by_cohort',
+        'cm_expansion_revenue',
+        'cm_revenue_concentration',
+        'cm_lifetime_value_per_customer',
+        'cm_ltv_to_cac_ratio',
+        'cm_ltv_to_cac_ratio_by_cohort'
+    ) THEN 1 ELSE 2 END AS tier
+FROM metrics m;
+
+COMMENT ON VIEW v_analytics_metric_tiers IS
+    'Metric tier annotation (1 = must-not-miss, 2 = nice-to-have). Source: config/metric_keywords.yaml. Edit the inline list if the tier-1 set changes.';
+
+-- ============================================================================
+-- v_analytics_metric_presence
+-- ----------------------------------------------------------------------------
+-- Grain: one row per (filing_id, canonical_metric_id) where any presence
+-- signal exists. Built by FULL OUTER JOIN of text-presence rows and reviewer-
+-- confirmed image rows, both keyed on (filing_id, metric_id). Carries
+-- lightweight evidence pointers so future drill-down views can resolve
+-- segment text / image URLs without re-plumbing.
+--
+-- Image side: only decisions in ('accept','correct','add') count as
+-- "disclosed". Rows superseded by a later admin override (see migration
+-- 202605111319) are excluded.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_analytics_metric_presence AS
+WITH text_per_pair AS (
+    SELECT
+        p.filing_id,
+        p.canonical_metric_id,
+        p.evidence_segment_ids
+    FROM v2_text_metric_presence p
+),
+image_per_pair AS (
+    SELECT
+        a.filing_id,
+        COALESCE(c.confirmed_metric_id, c.detected_metric_id) AS canonical_metric_id,
+        jsonb_agg(DISTINCT to_jsonb(c.img_id::text)) AS image_ids
+    FROM v2_image_metric_confirmations c
+    JOIN v2_image_assets a ON a.img_id = c.img_id
+    WHERE c.decision IN ('accept', 'correct', 'add')
+      AND COALESCE(c.confirmed_metric_id, c.detected_metric_id) IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM v2_image_metric_confirmations c2
+          WHERE c2.supersedes_confirmation_id = c.id
+      )
+    GROUP BY a.filing_id, COALESCE(c.confirmed_metric_id, c.detected_metric_id)
+)
+SELECT
+    COALESCE(t.filing_id, i.filing_id)                  AS filing_id,
+    COALESCE(t.canonical_metric_id, i.canonical_metric_id) AS canonical_metric_id,
+    (t.filing_id IS NOT NULL)                           AS text_disclosed,
+    (i.filing_id IS NOT NULL)                           AS image_disclosed,
+    TRUE                                                AS any_disclosed,
+    COALESCE(t.evidence_segment_ids, '[]'::jsonb)       AS evidence_segment_ids,
+    COALESCE(i.image_ids, '[]'::jsonb)                  AS image_ids
+FROM text_per_pair t
+FULL OUTER JOIN image_per_pair i
+    ON t.filing_id = i.filing_id
+   AND t.canonical_metric_id = i.canonical_metric_id;
+
+COMMENT ON VIEW v_analytics_metric_presence IS
+    'Per (filing, metric) unified presence signal: UNION of v2_text_metric_presence and reviewer-confirmed v2_image_metric_confirmations. Evidence pointers (segment_ids, image_ids) included for future drill-through.';
+
+-- ============================================================================
+-- v_analytics_company_metric_disclosure
+-- ----------------------------------------------------------------------------
+-- Grain: one row per (company_id, canonical_metric_id) where the company has
+-- at least one *in-scope* filing (is_in_scope_phase1 = TRUE) disclosing the
+-- metric. Joins industry_sic_buckets for industry bucket (default 'other')
+-- and v_analytics_metric_tiers for tier annotation.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_analytics_company_metric_disclosure AS
+SELECT
+    c.company_id,
+    c.cik,
+    c.ticker,
+    c.company_name,
+    c.industry_code,
+    COALESCE(b.bucket_name, 'other')               AS industry_bucket,
+    p.canonical_metric_id,
+    mt.metric_display_name,
+    mt.tier,
+    BOOL_OR(p.text_disclosed)                      AS disclosed_via_text,
+    BOOL_OR(p.image_disclosed)                     AS disclosed_via_image,
+    jsonb_agg(DISTINCT to_jsonb(fi.filing_id))     AS filing_ids
+FROM v_analytics_metric_presence p
+JOIN filings fi                  ON fi.filing_id = p.filing_id
+JOIN companies c                 ON c.company_id = fi.company_id
+LEFT JOIN industry_sic_buckets b ON b.sic_code   = c.industry_code
+LEFT JOIN v_analytics_metric_tiers mt
+                                 ON mt.canonical_metric_id = p.canonical_metric_id
+WHERE fi.is_in_scope_phase1 = TRUE
+GROUP BY
+    c.company_id, c.cik, c.ticker, c.company_name, c.industry_code,
+    COALESCE(b.bucket_name, 'other'),
+    p.canonical_metric_id, mt.metric_display_name, mt.tier;
+
+COMMENT ON VIEW v_analytics_company_metric_disclosure IS
+    'Per (company, metric) deduplicated disclosure across in-scope filings (is_in_scope_phase1). Each row means the company disclosed the metric in at least one IPO filing via text and/or image.';
+
+-- ============================================================================
+-- v_analytics_company_tier1_summary
+-- ----------------------------------------------------------------------------
+-- Grain: one row per company that has >=1 in-scope filing. Counts distinct
+-- Tier-1 metrics disclosed; companies with zero Tier-1 disclosures still
+-- appear (count = 0, bucket = '0').
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_analytics_company_tier1_summary AS
+WITH in_scope_companies AS (
+    SELECT DISTINCT fi.company_id
+    FROM filings fi
+    WHERE fi.is_in_scope_phase1 = TRUE
+),
+tier1_per_company AS (
+    SELECT
+        d.company_id,
+        COUNT(DISTINCT d.canonical_metric_id) AS tier1_metric_count,
+        jsonb_agg(DISTINCT d.canonical_metric_id ORDER BY d.canonical_metric_id) AS tier1_metric_ids
+    FROM v_analytics_company_metric_disclosure d
+    WHERE d.tier = 1
+    GROUP BY d.company_id
+)
+SELECT
+    c.company_id,
+    c.cik,
+    c.ticker,
+    c.company_name,
+    c.industry_code,
+    COALESCE(b.bucket_name, 'other')               AS industry_bucket,
+    COALESCE(t.tier1_metric_count, 0)              AS tier1_metric_count,
+    COALESCE(t.tier1_metric_ids, '[]'::jsonb)      AS tier1_metric_ids,
+    CASE
+        WHEN COALESCE(t.tier1_metric_count, 0) >= 5 THEN '5+'
+        ELSE COALESCE(t.tier1_metric_count, 0)::text
+    END                                            AS disclosure_bucket
+FROM in_scope_companies isc
+JOIN companies c                 ON c.company_id = isc.company_id
+LEFT JOIN industry_sic_buckets b ON b.sic_code   = c.industry_code
+LEFT JOIN tier1_per_company t    ON t.company_id = c.company_id;
+
+COMMENT ON VIEW v_analytics_company_tier1_summary IS
+    'One row per in-scope company (is_in_scope_phase1) with count of distinct Tier-1 metrics disclosed and a 0/1/2/3/4/5+ disclosure bucket. Primary surface for the Metabase tier-1 disclosure reports.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds the analytics surface for four recurring Metabase reports on Tier-1 customer-metric disclosure:

1. Histogram of in-scope companies by # of Tier-1 metrics disclosed (`0 / 1 / 2 / 3 / 4 / 5+`)
2. Industry breakdown of those companies
3. Per-industry % of IPOs at each disclosure bucket
4. Per Tier-1 metric: company count + drillable company list

Disclosure is **presence-based** and **deduplicated** across two surfaces:

- **Text** — any row in `v2_text_metric_presence` for `(filing_id, canonical_metric_id)`
- **Image** — reviewer-confirmed `v2_image_metric_confirmations` rows (`decision IN ('accept','correct','add')`), excluding admin-superseded rows

Universe filter: `filings.is_in_scope_phase1 = TRUE` (first-time-issuer S-1/F-1, non-SPAC, not secondary-only).

## What's new

- `sql/202605131507_tier1_disclosure_analytics.sql` — one migration creating:
  - `industry_sic_buckets` seed table (snapshot of `config/industry_sic_codes.yaml`, first-listed bucket wins to resolve SIC→bucket overlaps; regeneration snippet in the migration comments)
  - `v_analytics_metric_tiers` — metric → tier (1/2) catalog, mirroring `config/metric_keywords.yaml`
  - `v_analytics_metric_presence` — FULL OUTER JOIN of text + reviewer-confirmed image presence, carrying `evidence_segment_ids` and `image_ids` JSONB for future drill-through (supersedes the planned `v_doc_metric_presence`)
  - `v_analytics_company_metric_disclosure` — per (company × metric), deduped across in-scope filings, joined to industry bucket + tier
  - `v_analytics_company_tier1_summary` — one row per in-scope company with `tier1_metric_count`, `tier1_metric_ids` JSONB, and the `0/1/2/3/4/5+` `disclosure_bucket`
- `docs/operations/metabase-tier1-reporting.md` — operator guide with copy-pastable Native-SQL queries for the four reports
- `docs/operations/analytics-ui-runbook.md` — references the new views; the stale "v_doc_metric_presence (planned)" note is replaced with the actual landing

No Python or pipeline changes. Default privileges (`sql/37_create_analytics_role.sql`) auto-grant `SELECT` to `metabase_ro` on the new tables and views.

## Test plan

- [ ] Migration applies cleanly to a Neon branch / dev DB (`psql -f sql/202605131507_tier1_disclosure_analytics.sql`)
- [ ] `SELECT COUNT(*) FROM industry_sic_buckets;` returns 92
- [ ] `SELECT disclosure_bucket, COUNT(*) FROM v_analytics_company_tier1_summary GROUP BY 1 ORDER BY 1;` returns sensible histogram across `0 / 1 / 2 / 3 / 4 / 5+`
- [ ] `SELECT COUNT(*) FROM v_analytics_metric_presence WHERE text_disclosed AND image_disclosed;` confirms the FULL OUTER JOIN dedupes filings with both surfaces
- [ ] Spot-check at least one Tier-1 metric appears in `v_analytics_company_metric_disclosure WHERE tier = 1`
- [ ] Run the four queries from `docs/operations/metabase-tier1-reporting.md` as `metabase_ro` in Metabase; all return within the 30s `statement_timeout`
- [ ] CI required checks all green: Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E (Playwright), Docker Build & Smoke

https://claude.ai/code/session_01Wyk264hiHCVNp89DL5YqkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wyk264hiHCVNp89DL5YqkB)_