### PR TITLE
fix(render): unbreak filings-extraction cron (OOM) + track follow-ups

### DIFF
--- a/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
+++ b/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
@@ -1,0 +1,40 @@
+---
+id: 619
+source: gh
+slug: extraction-image-pipeline-silently-dark
+title: "filings-extraction image pipeline silently dark: OPENAI_API_KEY guard ignores Gemini provider"
+status: open
+severity: medium
+autonomy: review
+estimated: —
+touches:
+  - src/extraction_v2/pipeline.py
+  - render.yaml
+discovered: 2026-05-13
+updated: 2026-05-13
+gh_issue: 619
+note: Discovered while debugging the 2026-05-12 filings-extraction OOM. The OOM and this guard issue are independent — both surfaced in the same log.
+---
+
+### Problem
+
+`src/extraction_v2/pipeline.py:629` (`_check_vision_api_availability`) disables image triage (Stage 4) and chart OCR (Stage 5) whenever `OPENAI_API_KEY` is missing — even when the cron is explicitly configured to use Gemini for vision via gh-441 / gh-469.
+
+The 2026-05-12 `filings-extraction` cron log emitted:
+
+```
+WARNING:src.extraction_v2.pipeline:OPENAI_API_KEY is not set. Disabling image and chart extraction (Stages 4 and 5). Text extraction will proceed normally.
+```
+
+despite `render.yaml:62-71` configuring `ENABLE_METRIC_CLASSIFY=true`, `VISION_CLASSIFY_PROVIDER=gemini`, `VISION_CLASSIFY_MODEL=gemini-2.5-flash-lite`, and `GOOGLE_API_KEY` (set via dashboard).
+
+Net effect: the cron has likely been running text-only for image stages since the gh-441 flip (2026-05-04), even though Gemini classify is provisioned.
+
+### Next Steps
+
+Two possibilities to resolve first:
+
+1. **Stale guard.** Replace `OPENAI_API_KEY`-only check with a provider-aware check that maps `VISION_CLASSIFY_PROVIDER` → required env var. Add a unit test asserting image stages remain enabled when only `GOOGLE_API_KEY` is set under Gemini config.
+2. **Intentional scoping.** Full-page OCR / chart OCR genuinely still requires OpenAI, only metric-classify is on Gemini. Fix the warning copy to clarify and add a positive log line for the Gemini classify substage.
+
+Then: query prod to confirm what fraction of `filings-extraction` runs since 2026-05-04 produced `v2_image_classifications` / `v2_image_assets.detected_metrics` rows, to quantify how much image work has been missed.

--- a/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
+++ b/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
@@ -6,7 +6,7 @@ title: "nightly-sweep: late-failing GH_TOKEN 401 — add gh api user probe to fa
 status: open
 severity: low
 autonomy: safe
-estimated: 15min
+estimated: XS
 touches:
   - scripts/run_nightly_sweep.sh
 discovered: 2026-05-13

--- a/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
+++ b/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
@@ -1,0 +1,41 @@
+---
+id: 620
+source: gh
+slug: sweeper-gh-token-401-fail-fast
+title: "nightly-sweep: late-failing GH_TOKEN 401 — add gh api user probe to fail-fast"
+status: open
+severity: low
+autonomy: safe
+estimated: 15min
+touches:
+  - scripts/run_nightly_sweep.sh
+discovered: 2026-05-13
+updated: 2026-05-13
+gh_issue: 620
+note: Token rotation is the operator fix; this fragment tracks the diagnostic improvement so the next expiry surfaces in one log line instead of dozens.
+---
+
+### Problem
+
+When `GH_TOKEN` is expired or revoked, `scripts/run_nightly_sweep.sh` does not fail until well into the run, scattering symptoms across dozens of log lines.
+
+From the 2026-05-13 06:00 cron failure:
+
+- `gh auth setup-git` at line 104 succeeds — it doesn't probe the API.
+- Fragment-status sync emits per-fragment warnings like `gh pr view 382 failed (exit 1): HTTP 401: Bad credentials` but downgrades them to a per-fragment "1 failure" summary line and continues.
+- Many seconds later, the selector's `gh pr list` finally exits non-zero with `error: gh pr list failed (1). Use --no-pr-dedupe to skip.`
+- Script exits 2.
+
+A one-second `gh api user` probe right after `gh auth setup-git` would catch the 401 immediately with a clear "token rotation needed" message, before any work is attempted.
+
+### Next Steps
+
+- Insert after the existing `gh auth setup-git` block (~line 104 of `scripts/run_nightly_sweep.sh`):
+  ```bash
+  gh api user --jq .login >/dev/null 2>&1 || {
+    log "FATAL: gh api user failed (GH_TOKEN expired/revoked? rotate in Render env group filings-claude-secrets)"
+    exit 1
+  }
+  ```
+- Consider a single retry for transient network errors so a flaky tick doesn't take the sweeper down.
+- Optional: surface the failed-PR-lookup count in the run digest so token-expiry symptoms aren't buried in mid-log warnings.

--- a/render.yaml
+++ b/render.yaml
@@ -55,7 +55,8 @@ services:
     region: ohio
     runtime: docker
     dockerfilePath: ./Dockerfile
-    dockerCommand: python3 scripts/batch_v2_extraction.py --status fetched --workers 2 --limit 50
+    plan: standard
+    dockerCommand: python3 scripts/batch_v2_extraction.py --status fetched --workers 1 --limit 50
     schedule: "0 6 * * *"  # Daily at 6am UTC
     envVars:
       - fromGroup: filings-shared-secrets


### PR DESCRIPTION
## Summary

Unbreaks the `filings-extraction` Render cron, which OOMed on the 2026-05-12 06:00 run, and files two follow-up known-issue fragments for orthogonal problems surfaced while debugging.

### `filings-extraction` (the actual fix)

- **Root cause.** Two-worker `ProcessPoolExecutor` on the 512Mi Starter plan; worker B drew a **23.2 MB filing HTML** (filing 100 — 3103 paragraph segments + 1393 table segments) at the same time worker A was processing filing 183. RSS doubled, kernel killed the cron: `Out of memory (used over 512Mi)`. Vision was not involved (`OPENAI_API_KEY is not set` warning shows image stages were disabled — see gh-619 below).
- **Fix.** Two-line `render.yaml` change:
  - `plan: standard` — off the 512Mi ceiling (precedent: `filings-metabase` at line 164).
  - `--workers 2 → --workers 1` — removes the dual-large-filing race shape. Wall time ~21 → ~42 min; no upstream consumer depends on the latency.

### Follow-up fragments (filed, not fixed in this PR)

- **gh-619 — image pipeline silently dark.** `src/extraction_v2/pipeline.py:629` keys the image/chart-stage enable on `OPENAI_API_KEY` only. The cron is configured for Gemini classify (gh-441), so this guard has likely been disabling image stages on every cron run since 2026-05-04. Could be stale guard or intentional scoping — needs investigation before fixing.
- **gh-620 — sweeper 401 fail-fast.** `scripts/run_nightly_sweep.sh:104` runs `gh auth setup-git`, which doesn't probe the API. A revoked `GH_TOKEN` then fails dozens of log lines later at the selector's `gh pr list`. A `gh api user` probe right after setup-git would surface the rotation need immediately. (The current `filings-nightly-sweep` failure on 2026-05-13 is exactly this case; operator action is to rotate `GH_TOKEN` in env group `filings-claude-secrets`.)

## Test plan

- [ ] CI green on all required checks (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E, Docker Build & Smoke).
- [ ] After merge: confirm in Render dashboard that `filings-extraction` deploys with instance type **Standard** and command `--workers 1`.
- [ ] Manually "Trigger run" on `filings-extraction` cron; verify exit 0 in logs and memory headroom in the metrics tab.
- [ ] Spot-check `SELECT count(*) FROM v2_documents WHERE created_at > NOW() - INTERVAL '1 hour'` shows one row per filing in the batch (filing 183 in the failing run produced 0 facts but is still a successful pipeline run, so don't count `v2_metric_facts`).
- [ ] **Operator-only, not part of this PR**: rotate `GH_TOKEN` in env group `filings-claude-secrets` to unblock `filings-nightly-sweep`.

## Out of scope

- Size-gated filing deferral in `batch_v2_extraction.py` so we can safely return to `--workers 2` under the new plan.
- Fixes for gh-619 and gh-620 — tracked separately, this PR only files the fragments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHxRyMD7ykhT6T3DeA2vFd)_