### PR TITLE
fix(sweep): fail-fast on expired GH_TOKEN with gh api user probe (gh-620)

### DIFF
--- a/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
+++ b/docs/known-issues/gh-620-sweeper-gh-token-401-fail-fast.md
@@ -3,7 +3,7 @@ id: 620
 source: gh
 slug: sweeper-gh-token-401-fail-fast
 title: "nightly-sweep: late-failing GH_TOKEN 401 — add gh api user probe to fail-fast"
-status: open
+status: resolved
 severity: low
 autonomy: safe
 estimated: XS

--- a/scripts/run_nightly_sweep.sh
+++ b/scripts/run_nightly_sweep.sh
@@ -103,6 +103,15 @@ fi
 # Idempotent; safe to run on every invocation.
 gh auth setup-git 2>/dev/null || { log "FATAL: gh auth setup-git failed (GH_TOKEN invalid?)"; exit 1; }
 
+# Probe the API immediately so an expired/revoked GH_TOKEN fails in one line
+# instead of scattering 401 symptoms across dozens of log lines mid-run.
+# One retry absorbs a transient network hiccup without masking a real token fault.
+_gh_probe() { gh api user --jq .login >/dev/null 2>&1; }
+if ! _gh_probe; then
+  sleep 3
+  _gh_probe || { log "FATAL: gh api user failed (GH_TOKEN expired/revoked? rotate in Render env group filings-claude-secrets)"; exit 1; }
+fi
+
 # Commit author identity is required downstream — the per-issue Claude session
 # runs /commit, which calls `git commit`, which aborts without user.email/name.
 git config --global user.email "${GIT_AUTHOR_EMAIL:-sweeper@users.noreply.github.com}"


### PR DESCRIPTION
Insert a `gh api user` probe (with one retry for transient network errors)
immediately after `gh auth setup-git` so a revoked/expired token surfaces in
one log line instead of scattering 401 symptoms across dozens of lines mid-run.
Also marks gh-620 fragment resolved.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
