### PR TITLE
feat(web): simulation UI on /v2/review/stats

### DIFF
--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -116,6 +116,35 @@ The same `CATEGORY_ACTIONS` dict also drives the Reject-form dropdown in `unifie
 
 **Decisions on category-level recommendation cards are NOT persisted.** Category cards are render-only and do not participate in the `text_pattern_recommendation_decisions` accept/dismiss/defer flow — categories are run-scoped aggregations without a stable per-card `decision_key`.
 
+### Text-pattern simulation endpoints
+
+Powers the **Simulate Recommendations** card on `/v2/review/stats` (Summary tab) and the per-rec deltas overlay on the Patterns tab. Lets an admin preview the gold-standard R/P/F1 impact of every accepted-but-unshipped recommendation in one batch before a ship-to-PR PR is opened. Read-only: the script writes to two sim tables only and does not mutate `config/metric_keywords.yaml`, `text_pattern_recommendation_decisions`, or any extraction state.
+
+- `POST /api/v2/extraction/simulate-accepted` — kicks off `scripts/simulate_text_pattern_changes.py` as a detached subprocess via `_spawn_simulation_runner`. Returns `202 + {run_id, status: 'running'}`. Three server-side gates fire in this order (after a stale-row sweep flips `status='running' AND started_at < NOW() - INTERVAL '1 hour'` to `failed`):
+  - `_require_reviewer_id` → 403 `{error: "reviewer_name_required"}`.
+  - **Concurrency**: any `text_pattern_simulation_runs` row with `status='running'` → 409 `{error: "simulation_already_running", running_run_id}`.
+  - **Affected-recs**: zero rows with `decision='accepted' AND pr_number IS NULL` in `text_pattern_recommendation_decisions` → 409 `{error: "no_accepted_recs"}`.
+- `GET /api/v2/extraction/simulation-runs/<uuid:run_id>/status` — polled by `static/js/analytics.js` every 5s. Returns the `text_pattern_simulation_runs` row plus a `deltas` array (every `text_pattern_simulation_deltas` row for the run). Decimals are coerced to float and UUID/timestamp fields stringified at the boundary. Returns 404 on unknown id; the `<uuid:>` converter rejects non-UUID paths.
+
+**Schema** (timestamp migration `sql/202605121359_add_text_pattern_simulation_runs.sql`, PR #609):
+
+- `text_pattern_simulation_runs` — one row per click. `status IN ('running','succeeded','failed')`. Carries `tier1_presence_recall_baseline`/`_patched`, `tier2_presence_recall_baseline`/`_patched`, `tier1_regressed`, `runs_agree`, `config_snapshot_hash`, `num_recs_simulated`, `num_companies_validated`, `triggered_by`, `error`.
+- `text_pattern_simulation_deltas` — `(run_id, recommendation_decision_id, metric_id)` shape with `baseline_*` / `patched_*` recall/precision/f1 and `coverage_filings` / `coverage_facts`. `recommendation_decision_id` FK is `ON DELETE SET NULL`, so a rec that gets un-accepted post-run leaves dangling deltas — those are skipped at render time because there's no card to attach to.
+
+**Template kwargs passed by `stats()`** (all explicit-None when no run exists, because the project enables Jinja `StrictUndefined`):
+
+- `latest_simulation_run` — most recent `text_pattern_simulation_runs` row (any status); `None` until the first click.
+- `simulation_running`, `simulation_running_run_id` — concurrency probe results, drive the in-flight ⏳ marker on `#simulation-status` via `data-running-id`.
+- `accepted_unshipped_rec_count` — drives the disabled state on `#btn-simulate-accepted` and the "N accepted recommendations ready to simulate" body line.
+- `simulation_deltas_by_rec` — `dict[str, list[dict]]` keyed by `str(text_pattern_recommendation_decisions.id)`, populated only when the latest run has `status='succeeded'`. Empty `{}` otherwise. The template indexes via `r.decision.id | string` — only accepted recs have `r.decision`, and only accepted recs feed the simulation, so the lookup surface is exact.
+- `simulation_stale` — `True` when the latest succeeded run's `config_snapshot_hash` differs from current `compute_config_hash()` (run-scoped, not per-card; surfaces as one badge per `<details>` block on the Patterns tab).
+
+**Coverage badge thresholds**: `coverage_filings < 3` → red "thin", `3..10` → amber "medium", `> 10` → green "strong". Tier-1 regression is foreshadowed via a red `alert alert-danger` banner above the per-rec deltas table — the (future) Ship-to-PR button (Track C-2 / Track D) will be disabled when `tier1_regressed=True`.
+
+**No localStorage keys** — simulation state is fully server-rendered on every page load; the JS only writes `#simulation-status .innerHTML` while polling.
+
+Manual escape hatch for a stuck row (SIGKILL / OOM leaks past Python so terminal status never lands): the 1-hour sweep on the next click clears it, or `UPDATE text_pattern_simulation_runs SET status='failed', error='manual cleanup', completed_at=NOW() WHERE id = '<uuid>'`.
+
 ## Image-confirmation reviewer notes
 
 `v2_image_metric_confirmations` has a `reviewer_notes TEXT` column (nullable, Phase 4a). Free-text observation captured per-batch — one `#image-reviewer-notes` textarea on the image card, applied to every per-metric row submitted in the same POST. Validated at the API layer to ≤1000 chars; mirrors the text-side `v2_review_decisions.reviewer_notes` contract. JS clears the textarea after a successful submit. Bulk-reject and the "Reject all (no relevant metrics)" sentinel writes leave the column NULL — by design, no free-text capture for bulk actions. The deferred LLM "Top Reviewer Themes" panel (Phase 4b) will read this column for image-side themes.

--- a/src/infra/db.py
+++ b/src/infra/db.py
@@ -3387,6 +3387,118 @@ class DatabaseAdapter:
             return False, None
         return True, str(rows[0]["id"])
 
+    def get_last_simulation_run(self) -> dict | None:
+        """Most recent text_pattern_simulation_runs row, any status.
+
+        Unlike the analysis surface (which gates on status='succeeded' so the
+        Patterns tab can render finding tables), the stats card surfaces
+        running, failed, and succeeded states alike — operator needs to see
+        whether the last click errored. Decimals and UUID/timestamps are
+        normalized at the boundary so the template can render directly.
+        """
+        rows = self.query(
+            """
+            SELECT id, status, started_at, completed_at,
+                   num_recs_simulated, num_companies_validated,
+                   tier1_presence_recall_baseline, tier1_presence_recall_patched,
+                   tier2_presence_recall_baseline, tier2_presence_recall_patched,
+                   tier1_regressed, runs_agree, config_snapshot_hash,
+                   triggered_by, error
+              FROM text_pattern_simulation_runs
+             ORDER BY started_at DESC
+             LIMIT 1
+            """
+        )
+        if not rows:
+            return None
+        row = dict(rows[0])
+        row["id"] = str(row["id"])
+        for num_field in (
+            "tier1_presence_recall_baseline",
+            "tier1_presence_recall_patched",
+            "tier2_presence_recall_baseline",
+            "tier2_presence_recall_patched",
+        ):
+            if row.get(num_field) is not None:
+                row[num_field] = float(row[num_field])
+        return row
+
+    def is_simulation_running(self) -> tuple[bool, str | None]:
+        """Concurrency probe mirroring is_text_analysis_running().
+
+        Returns (True, run_id) if any text_pattern_simulation_runs row is
+        currently in 'running' status, else (False, None).
+        """
+        rows = self.query(
+            """
+            SELECT id FROM text_pattern_simulation_runs
+             WHERE status = 'running'
+             LIMIT 1
+            """
+        )
+        if not rows:
+            return False, None
+        return True, str(rows[0]["id"])
+
+    def count_accepted_unshipped_recs(self) -> int:
+        """Recs eligible to feed the next simulation.
+
+        Mirrors the API gate in /api/v2/extraction/simulate-accepted — only
+        accepted decisions that have NOT been shipped to a PR (pr_number IS
+        NULL) are simulatable. Drives the Simulate card's disabled state and
+        the "N accepted recommendations ready to simulate" body line.
+        """
+        rows = self.query(
+            """
+            SELECT COUNT(*) AS n
+              FROM text_pattern_recommendation_decisions
+             WHERE decision = 'accepted'
+               AND pr_number IS NULL
+            """
+        )
+        return int(rows[0]["n"]) if rows else 0
+
+    def get_simulation_deltas_grouped(self, run_id: str) -> dict[str, list[dict]]:
+        """Per-recommendation deltas for the Patterns-tab overlay.
+
+        Returns a dict keyed by str(recommendation_decision_id) mapping to a
+        list of delta-row dicts (ordered by metric_id). Rows whose FK was
+        nulled out (rec was undone post-run; FK is ON DELETE SET NULL) are
+        skipped because they have no card to attach to. Decimals are coerced
+        to float at the boundary.
+        """
+        rows = self.query(
+            """
+            SELECT id, recommendation_decision_id, metric_id,
+                   baseline_recall, baseline_precision, baseline_f1,
+                   patched_recall, patched_precision, patched_f1,
+                   coverage_filings, coverage_facts
+              FROM text_pattern_simulation_deltas
+             WHERE run_id = %(run_id)s
+             ORDER BY metric_id
+            """,
+            {"run_id": run_id},
+        )
+        grouped: dict[str, list[dict]] = {}
+        for r in rows:
+            d = dict(r)
+            if d.get("recommendation_decision_id") is None:
+                continue
+            d["id"] = str(d["id"])
+            d["recommendation_decision_id"] = str(d["recommendation_decision_id"])
+            for num in (
+                "baseline_recall",
+                "baseline_precision",
+                "baseline_f1",
+                "patched_recall",
+                "patched_precision",
+                "patched_f1",
+            ):
+                if d.get(num) is not None:
+                    d[num] = float(d[num])
+            grouped.setdefault(d["recommendation_decision_id"], []).append(d)
+        return grouped
+
     def get_text_decision_metric_summary(self, run_id: str) -> list[dict]:
         """All text_decision_metric_summary rows for a given run, ordered by
         rejection volume DESC so the UI can render highest-pain metrics first.

--- a/src/web/routes/review_unified.py
+++ b/src/web/routes/review_unified.py
@@ -329,6 +329,25 @@ def stats():
     all_recommendations = [r for recs in text_recommendations.values() for r in recs]
     archived_count = sum(1 for r in all_recommendations if r.get("is_stale"))
 
+    # Simulation surface (Track C-1) — parallel to the text-analysis surface
+    # above. Drives the "Simulate Recommendations" card on the Summary tab and
+    # the per-rec deltas overlay on the Patterns tab. All five kwargs must be
+    # passed even when None because Jinja runs under StrictUndefined.
+    latest_simulation_run = db.get_last_simulation_run()
+    simulation_running, simulation_running_run_id = db.is_simulation_running()
+    accepted_unshipped_rec_count = db.count_accepted_unshipped_recs()
+    simulation_deltas_by_rec: dict[str, list[dict]] = {}
+    simulation_stale = False
+    if latest_simulation_run and latest_simulation_run.get("status") == "succeeded":
+        simulation_deltas_by_rec = db.get_simulation_deltas_grouped(
+            str(latest_simulation_run["id"])
+        )
+        sim_hash = latest_simulation_run.get("config_snapshot_hash")
+        if sim_hash:
+            from src.extraction_v2.config_hash import compute_config_hash
+
+            simulation_stale = sim_hash != compute_config_hash()
+
     category_rollup = compute_category_rollup(text_metric_summary)
     cross_metric_findings = compute_cross_metric_findings(text_phrase_findings)
     covered_phrases = {
@@ -390,6 +409,12 @@ def stats():
         covered_phrases=covered_phrases,
         interpretations=interpretations,
         image_add_findings=image_add_findings,
+        latest_simulation_run=latest_simulation_run,
+        simulation_running=simulation_running,
+        simulation_running_run_id=simulation_running_run_id,
+        simulation_deltas_by_rec=simulation_deltas_by_rec,
+        accepted_unshipped_rec_count=accepted_unshipped_rec_count,
+        simulation_stale=simulation_stale,
     )
 
 

--- a/src/web/static/js/analytics.js
+++ b/src/web/static/js/analytics.js
@@ -195,6 +195,98 @@
             });
     }
 
+    // ----------------------------------------------------------------
+    // Text-pattern simulation (Track C-1): parallel handler for the
+    // "Simulate Recommendations" button on the same page. Posts to
+    // /api/v2/extraction/simulate-accepted and polls
+    // /api/v2/extraction/simulation-runs/<uuid>/status. Reloads the page
+    // on success so the Patterns tab re-renders with the per-rec deltas.
+    // ----------------------------------------------------------------
+
+    function setSimulationStatusText(html) {
+        const el = $("#simulation-status");
+        if (el) el.innerHTML = html;
+    }
+
+    function pollSimulationStatus(runId) {
+        fetch(`/api/v2/extraction/simulation-runs/${runId}/status`, { credentials: "same-origin" })
+            .then((r) => {
+                if (!r.ok) throw new Error(`status HTTP ${r.status}`);
+                return r.json();
+            })
+            .then((row) => {
+                if (row.status === "running") {
+                    setSimulationStatusText('<span class="text-warning">⏳ Simulation in progress…</span>');
+                    setTimeout(() => pollSimulationStatus(runId), POLL_INTERVAL_MS);
+                } else if (row.status === "succeeded") {
+                    const n = row.num_recs_simulated || 0;
+                    const m = row.num_companies_validated || 0;
+                    setSimulationStatusText(
+                        `<span class="text-success">✓ Simulation complete (${n} recs across ${m} companies). Reloading…</span>`,
+                    );
+                    setTimeout(() => window.location.reload(), 1500);
+                } else if (row.status === "failed") {
+                    const err = row.error || "(no error message)";
+                    setSimulationStatusText(`<span class="text-danger">✗ Simulation failed: ${err}</span>`);
+                } else {
+                    setSimulationStatusText(
+                        `<span class="text-muted">Unknown status: ${row.status}</span>`,
+                    );
+                }
+            })
+            .catch((err) => {
+                setSimulationStatusText(
+                    `<span class="text-danger">Polling error: ${err.message}. Reload to recheck.</span>`,
+                );
+            });
+    }
+
+    function triggerSimulation() {
+        const reviewer = window.requireReviewerName ? window.requireReviewerName() : null;
+        if (!reviewer) return;
+
+        const btn = $("#btn-simulate-accepted");
+        if (btn) btn.disabled = true;
+        setSimulationStatusText('<span class="text-warning">Starting simulation…</span>');
+
+        fetch("/api/v2/extraction/simulate-accepted", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ reviewer_id: reviewer }),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}));
+                if (!r.ok) {
+                    if (body.error === "simulation_already_running") {
+                        setSimulationStatusText(
+                            `<span class="text-warning">A simulation is already running (id ${body.running_run_id}). Polling…</span>`,
+                        );
+                        pollSimulationStatus(body.running_run_id);
+                    } else if (body.error === "no_accepted_recs") {
+                        setSimulationStatusText(
+                            `<span class="text-warning">No accepted recommendations to simulate.</span>`,
+                        );
+                    } else if (body.error === "reviewer_name_required") {
+                        setSimulationStatusText(
+                            `<span class="text-danger">Reviewer name required. Reload and set your name.</span>`,
+                        );
+                    } else {
+                        setSimulationStatusText(
+                            `<span class="text-danger">Failed (HTTP ${r.status}): ${body.error || "unknown"}</span>`,
+                        );
+                    }
+                    return;
+                }
+                setSimulationStatusText('<span class="text-warning">⏳ Simulation queued — polling…</span>');
+                pollSimulationStatus(body.run_id);
+            })
+            .catch((err) => {
+                setSimulationStatusText(`<span class="text-danger">Network error: ${err.message}</span>`);
+                if (btn) btn.disabled = false;
+            });
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
         const btn = $("#btn-update-image-classifier");
         if (btn) btn.addEventListener("click", triggerRetrain);
@@ -213,6 +305,15 @@
         if (textStatusEl) {
             const runningId = textStatusEl.dataset.runningId;
             if (runningId) pollTextAnalysisStatus(runningId);
+        }
+
+        const simBtn = $("#btn-simulate-accepted");
+        if (simBtn) simBtn.addEventListener("click", triggerSimulation);
+
+        const simStatusEl = $("#simulation-status");
+        if (simStatusEl) {
+            const runningId = simStatusEl.dataset.runningId;
+            if (runningId) pollSimulationStatus(runningId);
         }
 
         // ----------------------------------------------------------------

--- a/src/web/templates/unified_stats.html
+++ b/src/web/templates/unified_stats.html
@@ -223,6 +223,97 @@
       </div>
     </div>
 
+    {# Simulate Recommendations card (Track C-1). Wires Track B's
+       POST /api/v2/extraction/simulate-accepted and the polling status endpoint
+       into a Summary-tab card mirroring the Text Pattern Analysis card above.
+       Per-rec deltas render under each accepted rec on the Patterns tab; this
+       card is the run trigger + last-run summary. #}
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card border-info">
+          <div class="card-body">
+            <div class="row align-items-center">
+              <div class="col-md-7">
+                <h5 class="card-title mb-2">Simulate Recommendations</h5>
+                <p class="mb-1 small">
+                  {% if latest_simulation_run %}
+                    <strong>Last simulation:</strong>
+                    {% if latest_simulation_run.completed_at %}
+                      {{ latest_simulation_run.completed_at.strftime('%Y-%m-%d %H:%M UTC') }}
+                    {% else %}
+                      {{ latest_simulation_run.started_at.strftime('%Y-%m-%d %H:%M UTC') }} (started)
+                    {% endif %}
+                    <span class="badge bg-{% if latest_simulation_run.status == 'succeeded' %}success{% elif latest_simulation_run.status == 'failed' %}danger{% else %}warning text-dark{% endif %} ms-1">
+                      {{ latest_simulation_run.status }}
+                    </span>
+                    {% if latest_simulation_run.triggered_by %}
+                    <span class="text-muted">(by {{ latest_simulation_run.triggered_by }})</span>
+                    {% endif %}
+                  {% else %}
+                    <strong>Last simulation:</strong>
+                    <span class="text-muted">never (no simulations recorded)</span>
+                  {% endif %}
+                </p>
+                {% if latest_simulation_run and latest_simulation_run.status == 'succeeded' %}
+                  {% set b = latest_simulation_run.tier1_presence_recall_baseline or 0 %}
+                  {% set p = latest_simulation_run.tier1_presence_recall_patched or 0 %}
+                  {% set d = p - b %}
+                  <p class="mb-0 small">
+                    <strong>Tier-1 presence recall:</strong>
+                    {{ '%.3f' | format(b) }} → {{ '%.3f' | format(p) }}
+                    <span class="{% if latest_simulation_run.tier1_regressed %}text-danger fw-bold{% elif d > 0 %}text-success{% else %}text-muted{% endif %}">
+                      ({{ '%+.3f' | format(d) }})
+                    </span>
+                    <span class="text-muted ms-2">runs_agree: {{ 'yes' if latest_simulation_run.runs_agree else 'no' }}</span>
+                  </p>
+                  <p class="mb-0 small text-muted">
+                    {{ latest_simulation_run.num_recs_simulated or 0 }} recs across
+                    {{ latest_simulation_run.num_companies_validated or 0 }} companies
+                  </p>
+                {% elif latest_simulation_run and latest_simulation_run.status == 'failed' and latest_simulation_run.error %}
+                  <p class="mb-0 small text-danger">
+                    <strong>Error:</strong> {{ latest_simulation_run.error }}
+                  </p>
+                {% endif %}
+                <p class="mb-0 small">
+                  <strong>Accepted recommendations ready to simulate:</strong>
+                  {{ accepted_unshipped_rec_count }}
+                </p>
+                <p class="mb-0 small text-muted">
+                  Runs <code>scripts/simulate_text_pattern_changes.py</code> over every accepted
+                  recommendation that has not yet shipped to a PR. Read-only — no config or
+                  extraction state is mutated; per-rec R/P/F1 deltas and gold-standard coverage
+                  appear on the Patterns tab when the run completes.
+                </p>
+                <div id="simulation-status" class="small mt-2"
+                     {% if simulation_running %}data-running-id="{{ simulation_running_run_id }}"{% endif %}>
+                  {% if simulation_running %}
+                  <span class="text-warning">⏳ Simulation in progress — polling for completion…</span>
+                  {% endif %}
+                </div>
+              </div>
+              <div class="col-md-5 text-md-end mt-3 mt-md-0">
+                <button id="btn-simulate-accepted"
+                        class="btn btn-primary"
+                        {% if simulation_running or accepted_unshipped_rec_count == 0 %}disabled{% endif %}>
+                  Simulate Recommendations
+                </button>
+                <div class="text-muted small mt-1">
+                  {% if simulation_running %}
+                    Simulation already running — waiting on it to finish.
+                  {% elif accepted_unshipped_rec_count == 0 %}
+                    Need at least 1 accepted recommendation.
+                  {% else %}
+                    Ready — clicking will start a simulation.
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     {# Side-by-side aggregate cards: text facts + image confirmations #}
     <div class="row mb-4">
       <div class="col-lg-6 mb-3">
@@ -1680,6 +1771,67 @@
                                       maxlength="1000" rows="2"
                                       placeholder="Optional note (≤1000 chars)"></textarea>
                           </div>
+                        {% endif %}
+                        {# Simulation impact overlay (Track C-1). Renders only
+                           when the rec has a persisted decision (decision-id is
+                           the FK target on text_pattern_simulation_deltas) and
+                           the latest simulation produced deltas for it. #}
+                        {% if r.decision and simulation_deltas_by_rec.get(r.decision.id|string) %}
+                        {% set deltas = simulation_deltas_by_rec[r.decision.id|string] %}
+                        <details class="mt-2 small">
+                          <summary class="text-muted" style="cursor:pointer;">
+                            Simulation impact ({{ deltas|length }} metric{{ '' if deltas|length == 1 else 's' }})
+                          </summary>
+                          <div class="mt-2">
+                            {% if latest_simulation_run and latest_simulation_run.tier1_regressed %}
+                            <div class="alert alert-danger small mb-2 py-1">
+                              Tier-1 presence-recall regressed — Ship-to-PR will be disabled when Track D ships.
+                            </div>
+                            {% endif %}
+                            {% if simulation_stale %}
+                            <span class="badge bg-warning text-dark mb-2">Sim is stale (config changed since)</span>
+                            {% endif %}
+                            <table class="table table-sm mb-0">
+                              <thead>
+                                <tr>
+                                  <th>Metric</th>
+                                  <th>Baseline R</th>
+                                  <th>Patched R</th>
+                                  <th>Δ R</th>
+                                  <th>Δ F1</th>
+                                  <th>Coverage</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {% for delta in deltas %}
+                                {% set dr = (delta.patched_recall or 0) - (delta.baseline_recall or 0) %}
+                                {% set df1 = (delta.patched_f1 or 0) - (delta.baseline_f1 or 0) %}
+                                <tr>
+                                  <td><code>{{ delta.metric_id }}</code></td>
+                                  <td>{{ '%.3f' | format(delta.baseline_recall or 0) }}</td>
+                                  <td>{{ '%.3f' | format(delta.patched_recall or 0) }}</td>
+                                  <td class="{% if dr < 0 %}text-danger{% elif dr > 0 %}text-success{% else %}text-muted{% endif %}">
+                                    {{ '%+.3f' | format(dr) }}
+                                  </td>
+                                  <td class="{% if df1 < 0 %}text-danger{% elif df1 > 0 %}text-success{% else %}text-muted{% endif %}">
+                                    {{ '%+.3f' | format(df1) }}
+                                  </td>
+                                  <td>
+                                    {% set cf = delta.coverage_filings or 0 %}
+                                    {% if cf < 3 %}
+                                      <span class="badge bg-danger">thin ({{ cf }} filings)</span>
+                                    {% elif cf <= 10 %}
+                                      <span class="badge bg-warning text-dark">medium ({{ cf }} filings)</span>
+                                    {% else %}
+                                      <span class="badge bg-success">strong ({{ cf }} filings)</span>
+                                    {% endif %}
+                                  </td>
+                                </tr>
+                                {% endfor %}
+                              </tbody>
+                            </table>
+                          </div>
+                        </details>
                         {% endif %}
                       </div>
                       {% endif %}

--- a/tests/unit/web/test_review_unified_stats.py
+++ b/tests/unit/web/test_review_unified_stats.py
@@ -121,6 +121,13 @@ def _stub_analytics_helpers(mock_db) -> None:
     # Per-metric image decisions rollup (Images tab). Default empty so the new
     # card renders the no-data fallback; populated-state tests override.
     mock_db.get_image_decisions_by_metric_v2.return_value = []
+    # Text-pattern simulation surface (Track C-1). Default "no run yet" so the
+    # Summary card shows "Last simulation: never" and the per-rec deltas
+    # overlay is hidden; populated-state tests override explicitly.
+    mock_db.get_last_simulation_run.return_value = None
+    mock_db.is_simulation_running.return_value = (False, None)
+    mock_db.count_accepted_unshipped_recs.return_value = 0
+    mock_db.get_simulation_deltas_grouped.return_value = {}
 
 
 def test_stats_renders_empty(client, mock_db):
@@ -389,6 +396,11 @@ def test_stats_summary_renders_review_activity(client, mock_db):
     mock_db.get_recommendation_decisions.return_value = []
     mock_db.get_rejection_reason_rollup.return_value = []
     mock_db.query.return_value = []
+    # Track C-1 simulation helpers (no run yet).
+    mock_db.get_last_simulation_run.return_value = None
+    mock_db.is_simulation_running.return_value = (False, None)
+    mock_db.count_accepted_unshipped_recs.return_value = 0
+    mock_db.get_simulation_deltas_grouped.return_value = {}
 
     resp = client.get("/v2/review/stats")
     assert resp.status_code == 200
@@ -1343,3 +1355,427 @@ def test_patterns_tab_image_add_panel_renders(client, mock_db):
     assert "quarterly growth" in body
     # Sample image link resolves to the review page.
     assert "/v2/review/101" in body
+
+
+# =============================================================================
+# Track C-1 — Simulate Recommendations card + per-rec deltas overlay
+# =============================================================================
+
+
+def _empty_image_stats(mock_db) -> None:
+    """Shared image-stats stub used by the sim tests below."""
+    mock_db.get_v2_review_stats.return_value = _empty_text_data()
+    mock_db.get_image_decision_overall_v2.return_value = {
+        "total_decisions": 0,
+        "relevant_count": 0,
+        "not_relevant_count": 0,
+        "relevant_pct": 0.0,
+        "not_relevant_pct": 0.0,
+    }
+    mock_db.get_image_review_progress_v2.return_value = {
+        "total_candidates": 0,
+        "pending_count": 0,
+        "reviewed_count": 0,
+        "skipped_count": 0,
+        "auto_rejected_count": 0,
+        "review_pct": 0.0,
+    }
+    mock_db.get_image_decisions_by_tier_v2.return_value = []
+    mock_db.get_image_rejection_reasons_by_tier_v2.return_value = []
+
+
+def test_stats_renders_when_no_simulation_has_run(client, mock_db):
+    """Empty-state: no sim has ever run. The Simulate card renders with the
+    "never" body text and the button is disabled (no accepted recs either)."""
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Simulate Recommendations" in body
+    assert "never (no simulations recorded)" in body
+    assert 'id="btn-simulate-accepted"' in body
+    # Button disabled when zero accepted recs.
+    assert "Need at least 1 accepted recommendation" in body
+
+
+def test_stats_renders_simulation_deltas_on_accepted_rec(client, mock_db):
+    """Succeeded run + delta tied to an accepted rec's decision_id renders
+    the Simulation impact <details> block under the rec card."""
+    import uuid as _uuid
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    ts = datetime(2026, 5, 14, 10, 0, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {"wrong_metric": 18, "wrong_value": 13},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "segment_text",
+            "occurrence_count": 14,
+            "pct_of_decisions": 45.20,
+            "examples": [],
+        }
+    ]
+    decision_id = _uuid.uuid4()
+    mock_db.get_recommendation_decisions.return_value = [
+        {
+            "id": decision_id,
+            "metric_id": "cm_new_customers_acquired",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "created_at": ts,
+            "updated_at": ts,
+        }
+    ]
+    sim_run_id = _uuid.uuid4()
+    mock_db.get_last_simulation_run.return_value = {
+        "id": str(sim_run_id),
+        "status": "succeeded",
+        "started_at": ts,
+        "completed_at": ts,
+        "num_recs_simulated": 1,
+        "num_companies_validated": 5,
+        "tier1_presence_recall_baseline": 0.80,
+        "tier1_presence_recall_patched": 0.82,
+        "tier2_presence_recall_baseline": 0.70,
+        "tier2_presence_recall_patched": 0.71,
+        "tier1_regressed": False,
+        "runs_agree": True,
+        "config_snapshot_hash": None,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.count_accepted_unshipped_recs.return_value = 1
+    mock_db.get_simulation_deltas_grouped.return_value = {
+        str(decision_id): [
+            {
+                "id": str(_uuid.uuid4()),
+                "recommendation_decision_id": str(decision_id),
+                "metric_id": "cm_new_customers_acquired",
+                "baseline_recall": 0.500,
+                "baseline_precision": 0.700,
+                "baseline_f1": 0.583,
+                "patched_recall": 0.600,
+                "patched_precision": 0.700,
+                "patched_f1": 0.646,
+                "coverage_filings": 5,
+                "coverage_facts": 12,
+            }
+        ]
+    }
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Simulation impact" in body
+    # Metric row + coverage badge for 5 filings (3..10 → amber medium).
+    assert "cm_new_customers_acquired" in body
+    assert "medium (5 filings)" in body
+    # Δ recall = +0.100 → text-success class on that cell.
+    assert "+0.100" in body
+    # Summary card shows the succeeded run summary.
+    assert "Tier-1 presence recall" in body
+    assert "runs_agree: yes" in body
+
+
+def test_stats_renders_tier1_regressed_banner(client, mock_db):
+    """When tier1_regressed=True, the Simulation impact block prefaces its
+    table with a red alert-danger banner referencing the Ship-to-PR future."""
+    import uuid as _uuid
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    ts = datetime(2026, 5, 14, 10, 0, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {"wrong_metric": 18, "wrong_value": 13},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "segment_text",
+            "occurrence_count": 14,
+            "pct_of_decisions": 45.20,
+            "examples": [],
+        }
+    ]
+    decision_id = _uuid.uuid4()
+    mock_db.get_recommendation_decisions.return_value = [
+        {
+            "id": decision_id,
+            "metric_id": "cm_new_customers_acquired",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "created_at": ts,
+            "updated_at": ts,
+        }
+    ]
+    sim_run_id = _uuid.uuid4()
+    mock_db.get_last_simulation_run.return_value = {
+        "id": str(sim_run_id),
+        "status": "succeeded",
+        "started_at": ts,
+        "completed_at": ts,
+        "num_recs_simulated": 1,
+        "num_companies_validated": 5,
+        "tier1_presence_recall_baseline": 0.80,
+        "tier1_presence_recall_patched": 0.75,
+        "tier2_presence_recall_baseline": 0.70,
+        "tier2_presence_recall_patched": 0.71,
+        "tier1_regressed": True,
+        "runs_agree": True,
+        "config_snapshot_hash": None,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.count_accepted_unshipped_recs.return_value = 1
+    mock_db.get_simulation_deltas_grouped.return_value = {
+        str(decision_id): [
+            {
+                "id": str(_uuid.uuid4()),
+                "recommendation_decision_id": str(decision_id),
+                "metric_id": "cm_new_customers_acquired",
+                "baseline_recall": 0.500,
+                "baseline_precision": 0.700,
+                "baseline_f1": 0.583,
+                "patched_recall": 0.400,
+                "patched_precision": 0.700,
+                "patched_f1": 0.508,
+                "coverage_filings": 2,
+                "coverage_facts": 3,
+            }
+        ]
+    }
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Tier-1 presence-recall regressed" in body
+    assert "Ship-to-PR will be disabled" in body
+    # Coverage_filings=2 → red "thin" badge.
+    assert "thin (2 filings)" in body
+
+
+def test_stats_renders_simulation_stale_badge(client, mock_db):
+    """When config_snapshot_hash differs from current compute_config_hash(),
+    the deltas overlay shows the 'Sim is stale' badge."""
+    import uuid as _uuid
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    ts = datetime(2026, 5, 14, 10, 0, tzinfo=UTC)
+    mock_db.get_last_text_analysis_run.return_value = {
+        "id": "abc",
+        "completed_at": ts,
+        "started_at": ts,
+        "status": "succeeded",
+        "num_decisions_analyzed": 31,
+        "num_metrics_analyzed": 1,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.get_text_decision_metric_summary.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "total_decisions": 50,
+            "accept_count": 5,
+            "reject_count": 31,
+            "correct_count": 14,
+            "rejection_categories": {"wrong_metric": 18, "wrong_value": 13},
+            "top_correction_targets": [],
+        }
+    ]
+    mock_db.get_text_decision_phrase_findings.return_value = [
+        {
+            "metric_id": "cm_new_customers_acquired",
+            "decision_type": "reject",
+            "phrase": "accounts receivable",
+            "phrase_ngram_size": 2,
+            "source_field": "segment_text",
+            "occurrence_count": 14,
+            "pct_of_decisions": 45.20,
+            "examples": [],
+        }
+    ]
+    decision_id = _uuid.uuid4()
+    mock_db.get_recommendation_decisions.return_value = [
+        {
+            "id": decision_id,
+            "metric_id": "cm_new_customers_acquired",
+            "rule": "exclusion_pattern",
+            "decision_key": "accounts receivable",
+            "decision": "accepted",
+            "reviewer_id": "RGM",
+            "reviewer_note": None,
+            "pr_number": None,
+            "pr_url": None,
+            "created_at": ts,
+            "updated_at": ts,
+        }
+    ]
+    sim_run_id = _uuid.uuid4()
+    mock_db.get_last_simulation_run.return_value = {
+        "id": str(sim_run_id),
+        "status": "succeeded",
+        "started_at": ts,
+        "completed_at": ts,
+        "num_recs_simulated": 1,
+        "num_companies_validated": 5,
+        "tier1_presence_recall_baseline": 0.80,
+        "tier1_presence_recall_patched": 0.82,
+        "tier2_presence_recall_baseline": 0.70,
+        "tier2_presence_recall_patched": 0.71,
+        "tier1_regressed": False,
+        "runs_agree": True,
+        "config_snapshot_hash": "stale-hash-value",
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.count_accepted_unshipped_recs.return_value = 1
+    mock_db.get_simulation_deltas_grouped.return_value = {
+        str(decision_id): [
+            {
+                "id": str(_uuid.uuid4()),
+                "recommendation_decision_id": str(decision_id),
+                "metric_id": "cm_new_customers_acquired",
+                "baseline_recall": 0.500,
+                "baseline_precision": 0.700,
+                "baseline_f1": 0.583,
+                "patched_recall": 0.600,
+                "patched_precision": 0.700,
+                "patched_f1": 0.646,
+                "coverage_filings": 15,
+                "coverage_facts": 30,
+            }
+        ]
+    }
+
+    with patch(
+        "src.extraction_v2.config_hash.compute_config_hash",
+        return_value="current-hash-value",
+    ):
+        resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Sim is stale" in body
+    # coverage_filings=15 → green "strong" badge.
+    assert "strong (15 filings)" in body
+
+
+def test_simulate_button_disabled_with_zero_accepted_recs(client, mock_db):
+    """Even with a succeeded sim history, zero accepted-unshipped recs
+    disables the button and surfaces the appropriate helper text."""
+    from datetime import datetime
+
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    ts = datetime(2026, 5, 14, 10, 0, tzinfo=UTC)
+    mock_db.get_last_simulation_run.return_value = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "succeeded",
+        "started_at": ts,
+        "completed_at": ts,
+        "num_recs_simulated": 1,
+        "num_companies_validated": 5,
+        "tier1_presence_recall_baseline": 0.80,
+        "tier1_presence_recall_patched": 0.82,
+        "tier2_presence_recall_baseline": 0.70,
+        "tier2_presence_recall_patched": 0.71,
+        "tier1_regressed": False,
+        "runs_agree": True,
+        "config_snapshot_hash": None,
+        "triggered_by": "RGM",
+        "error": None,
+    }
+    mock_db.count_accepted_unshipped_recs.return_value = 0
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Disabled attribute on the button.
+    assert 'id="btn-simulate-accepted"' in body
+    # Helper text confirms gating reason.
+    assert "Need at least 1 accepted recommendation" in body
+
+
+def test_simulate_button_data_running_id_set_when_running(client, mock_db):
+    """When a simulation is currently running, the status div carries the
+    data-running-id attribute so the JS resumes polling on page load."""
+    _stub_analytics_helpers(mock_db)
+    _empty_image_stats(mock_db)
+
+    running_id = "22222222-2222-2222-2222-222222222222"
+    mock_db.is_simulation_running.return_value = (True, running_id)
+    mock_db.count_accepted_unshipped_recs.return_value = 3
+
+    resp = client.get("/v2/review/stats")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'id="simulation-status"' in body
+    assert f'data-running-id="{running_id}"' in body
+    # In-flight first-paint marker.
+    assert "Simulation in progress" in body
+    # Button is disabled while a run is in flight.
+    assert "Simulation already running" in body


### PR DESCRIPTION
Wires PR #609's POST /api/v2/extraction/simulate-accepted and GET
.../simulation-runs/<id>/status into the Patterns tab so the admin can
run a simulation and read per-rec R/P/F1 deltas + coverage badges
without leaving the page.

A new "Simulate Recommendations" card on the Summary tab mirrors the
existing analyze card; per-rec deltas render under each accepted
recommendation with color-coded delta cells and coverage badges
(red/amber/green at 3/10 filings). Tier-1 regression surfaces as an
alert-danger banner so the operator knows the Ship-to-PR button
(Track D / Track C-2) will be disabled.

Out of scope: Ship-to-PR button (lands in Track C-2 after Track D
merges).

Foundation: PRs #607, #608, #609.
Plan: ~/.claude/plans/track-c1-stats-ui-simulate.md
