### PR TITLE
docs: close out LLM presence classifier rollout — Option A adopted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Metrics are classified into importance tiers based on analytical value. These ti
 - Extraction improvements (keywords, FP rules, value binding) should prioritize Tier 1 recall gaps first
 - Gold standard coverage expansion should target Tier 1 metrics with low coverage
 - Tier definitions live in `config/metric_keywords.yaml` (authoritative) and `src/gold_standard/v2_validator.py` (runtime)
-- **Phase-2 LLM presence classifier gate** (`scripts/run_phase2_quantitative_eval.py`) must pass (exit 0, go_no_go=GO) before flipping `presence_classifier_enabled` in production; run `python3 scripts/run_phase2_quantitative_eval.py --dry-run --gold-only` to validate corpus/label plumbing without API calls. See `docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md`.
+- **LLM presence classifier rollout: CLOSED for enrolled Tier-1 metrics (2026-05-15).** Phase-2 quantitative gate verdict was NO-GO on both live runs (2026-05-11 and 2026-05-14); the classifier catches zero positives the keyword path missed across all 10 enrolled Tier-1 metrics. `presence_classifier_enabled` stays at default `False` indefinitely. Code retained as dormant infrastructure. Option B carve-out (5 unenrolled Tier-1 metrics) is the only legitimate future activation path. Full record: `docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md`.
 
 ## Core Design Principles
 

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -96,10 +96,19 @@ Phase-2 quantitative gate v2 run (`run_id 20260514Trerun`) with C3 reframed (clf
 
 ---
 
+### llm-presence-classifier-rollout-closeout-20260515.md
+
+**Status**: Decision memo — Option A adopted
+**Date**: 2026-05-15
+
+Closeout for the LLM presence classifier rollout on the 10 enrolled Tier-1 metrics. Decision: Option A — rollout closed, `presence_classifier_enabled` stays at default `False` indefinitely, classifier code retained as dormant infrastructure. Option B carve-out (5 unenrolled Tier-1 metrics: `cm_balance_by_cohort`, `cm_customers_period_end_by_tenure`, `cm_gross_margin_by_cohort`, `cm_new_customers_acquired`, `cm_transactions_by_cohort`) is the only legitimate future activation path; tracking issue filed separately. Phase-1 and Phase-2 runbooks gain a "Status: CLOSED" banner. CLAUDE.md updated to reflect the closed status.
+
+---
+
 ## Archive
 
 Completed tasks, superseded reports, and research spikes are in `docs/archive/analysis/`. This includes all HRV-3 through HRV-6 validation docs, IMG-1-x completion summaries, GR-series validation reports, VIS-series chart extraction research, the beyond-SEC spike, and the 2025-12-26 comprehensive evaluation plan.
 
 ---
 
-**Last Updated**: 2026-05-14
+**Last Updated**: 2026-05-15

--- a/docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md
+++ b/docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md
@@ -1,0 +1,82 @@
+# LLM presence classifier — rollout closeout
+
+**Date**: 2026-05-15
+**Decision**: Option A adopted. Rollout closed for enrolled Tier-1 metrics.
+**Option B carve-out**: 5 unenrolled Tier-1 metrics remain open as a discrete future scope.
+
+## Decision
+
+The LLM presence classifier rollout for the 10 enrolled Tier-1 metrics is closed. The `presence_classifier_enabled` DB feature flag and the `ExtractionConfig.enable_llm_presence_classifier` config field both remain at their default of `False` indefinitely. The classifier code is retained in `src/llm/presence_classifier_client.py` and `src/extraction_v2/stages/llm_presence_classifier.py` as dormant, well-tested infrastructure.
+
+## Basis
+
+Two live Phase-2 quantitative gate runs evaluated the classifier against the corpus that mirrors production extraction:
+
+| Run | Date | Verdict | Key finding |
+|---|---|---|---|
+| `20260511T1416live` | 2026-05-11 | NO-GO (C3) | Aggregate classifier recall == keyword recall (0.988 / 0.988) across all 10 scoreable Tier-1 metrics. C3's +5pt threshold structurally unreachable. |
+| `20260514Trerun` | 2026-05-14 | NO-GO (C3 reframed) | Every enrolled Tier-1 metric has `clf_only_tp = 0`. Classifier catches zero positives keyword missed, even on the one metric with measurable headroom (cm_large_customers_period_end at 83.3% kw recall). |
+
+Full writeups: [`llm-presence-classifier-phase2-eval-results-20260511.md`](llm-presence-classifier-phase2-eval-results-20260511.md), [`llm-presence-classifier-phase2-eval-results-20260514.md`](llm-presence-classifier-phase2-eval-results-20260514.md).
+
+The 2026-05-14 run answered the question the 2026-05-11 run left unanswerable. Under a criterion that measures **net-new positives caught by the classifier and not by keyword**, the classifier produces zero contribution on every enrolled Tier-1 metric. The classifier also lowers precision on 6 of 10 metrics by predicting present on filings where ground truth is absent.
+
+The conclusion is robust:
+- Where keyword baseline is at ceiling (9 of 10 enrolled Tier-1 metrics at 100% recall), there is no headroom and the classifier matches but does not exceed.
+- Where keyword has measurable headroom (1 of 10 metrics at 83.3% recall), the classifier failed to fill that gap.
+- Classifier precision is lower than keyword on most metrics, costing accuracy without recovering anything in recall.
+
+There is no scoreable scenario where the classifier improves on the keyword path for the 10 enrolled Tier-1 metrics.
+
+## What stays
+
+- **Code**: `src/llm/presence_classifier_client.py`, `src/extraction_v2/stages/llm_presence_classifier.py`, the prompt YAMLs in `config/llm_classifier/prompts/`, the threshold YAML, recall_augmentation config, Phase-1 and Phase-2 eval scripts. All retained as dormant infrastructure.
+- **Tests**: All passing. Removing would orphan ~150 tests for no gain.
+- **Feature flag**: `presence_classifier_enabled` stays at default `False`. The flag exists in the DB schema as `feature_flags.presence_classifier_enabled`; no row needs creating, no row needs deleting.
+- **Runbooks**: `llm-presence-classifier-phase1-eval-runbook.md` and `llm-presence-classifier-phase2-quantitative-eval-runbook.md` are retained with a "Status: closed" banner. Useful both as a record of the gate design and as the entry point if Option B (below) is ever pursued.
+
+## What's NOT happening
+
+- **No flag flip.** The DB feature flag stays `False`.
+- **No rollout of the classifier to production extraction.** The V2 pipeline continues to use the keyword path as its sole presence signal.
+- **No re-runs of the Phase-2 gate on the current 10 enrolled metrics.** The verdict on this set is final.
+- **No staged-production shadowing** (Option C from the analysis docs). The 2026-05-14 run on real reviewed filings already provides the production-representative signal that shadowing was supposed to gather; running classifier in production without consuming its output would burn ongoing API spend for diminishing additional learning.
+
+## Option B carve-out
+
+The 5 unenrolled Tier-1 metrics were NOT measured by either Phase-2 run because no prompt YAML exists for them:
+
+- `cm_balance_by_cohort`
+- `cm_customers_period_end_by_tenure`
+- `cm_gross_margin_by_cohort`
+- `cm_new_customers_acquired`
+- `cm_transactions_by_cohort`
+
+These are precisely the metrics where the keyword baseline is presumed weakest (niche disclosure language with low keyword catchment). The 2026-05-14 verdict does NOT extend to them.
+
+Authoring prompts for these 5 metrics, mining few-shots, calibrating thresholds, and re-running Phase-2 against a targeted reviewed slice is the only remaining experiment worth running on this classifier infrastructure.
+
+A tracking issue is open at #N (file separately) for this scope. It is **not** being pursued by this closeout; it's recorded as the only legitimate future activation path for the dormant infrastructure.
+
+## What this enables
+
+- **Clarity for future contributors**: the classifier code in `src/llm/` and `src/extraction_v2/stages/llm_presence_classifier.py` is dormant, not work-in-progress. Future contributors don't need to wonder if it should be wired up.
+- **Bug-fix triage**: known-issues that block the classifier rollout (gh-626 reporting bugs, anything else that surfaces) are low-priority. They only matter if Option B is activated.
+- **Reclaimed scope**: future prompt-engineering effort on text-side metric detection should target keyword catchment improvements, not classifier prompts.
+
+## Open follow-ups
+
+- **gh-602** (dedup-by-filing-id): resolved by PR #627 logic; will close.
+- **gh-613** (cache counter not aggregated): resolved by PR #627 logic; will close.
+- **gh-626** (C6/C7 reporting bugs): stays open, low priority. Only matters if Option B reactivates the gate.
+- **New gh-N** (Option B tracking — see above): filed as a deliberately-open tracking item, not active scope.
+
+## Related artifacts (historical record)
+
+- 2026-05-11 results doc — first live Phase-2 run
+- 2026-05-14 results doc — Phase-2 v2 run with the reframed C3
+- Phase-1 smoke runbook
+- Phase-2 quantitative runbook (Run history table)
+- 10 prompt YAMLs in `config/llm_classifier/prompts/`
+- Recall augmentation config + threshold config (calibrated for the enrolled set)
+- ~150 tests covering classifier client, stage, and eval scripts

--- a/docs/archive/worker-prompts/PICK_gh612_section_classification_variant_gap.md
+++ b/docs/archive/worker-prompts/PICK_gh612_section_classification_variant_gap.md
@@ -1,0 +1,242 @@
+# Worker prompt — gh-612 section_classification variant gap
+
+## Context
+
+During Phase-2 gate run `20260511T1416live`, 6 of 55 filings
+returned **zero paraphrase segments** because `section_classification`
+detected no whitelisted sections (MDA, Business, Risk Factors). Each
+of these wrapped pipeline in 3–7 seconds vs. the typical 9–15
+minutes, confirming the paraphrase path was inert.
+
+The gh-574 fix (retain short paragraphs that carry an `<a name>` or
+`<a id>` anchor target) addressed the Datadog/Chewy heading shape —
+**but at least one other heading-markup variant slipped through**.
+This worker identifies the variant and extends the fix.
+
+Approximately **11% of the Phase-2 corpus** was affected, which
+silently biases gate measurements: filings with zero paraphrase
+segments cannot contribute classifier-only positives, so the
+classifier's actual contribution is under-measured.
+
+## The 6 affected filings
+
+| filing_id | R2 key | Size | Sections detected |
+|---|---|---|---|
+| 209382 | `filings/0001790625/0001213900-21-064292/primary.htm` | 12 MB | `{COVER: 0}` |
+| 215071 | `filings/0001840199/0001213900-22-059005/primary.htm` | 4.5 MB | `{COVER: 0, FINANCIALS: 1}` |
+| 833 | `filings/0001703956/0001437749-19-008842/primary.htm` | 6 MB | (zero whitelisted) |
+| 10273 | `filings/0001330421/0001330421-16-000057/primary.htm` | 2.5 MB | (zero whitelisted) |
+| 192171 | `filings/0001772757/0001104659-20-112736/primary.htm` | 7.7 MB | (zero whitelisted) |
+| 207445 | `filings/0001816581/0001193125-21-247997/primary.htm` | 4.7 MB | (zero whitelisted) |
+
+All 6 are reviewed-corpus filings with non-zero text-source review
+decisions in the DB — fetch via `_resolve_filing_html` from
+`scripts/run_phase1_eval.py` or directly from R2 with the keys above.
+
+## What to build
+
+### Step 1 — Investigate the heading markup (DO NOT GUESS)
+
+For each of the 6 filings:
+
+1. Fetch the HTML (R2 or filesystem).
+2. Search the raw HTML for the strings "MANAGEMENT'S DISCUSSION",
+   "Risk Factors", "Risk Factors Summary", "Description of Business",
+   "Item 1A", "Item 7", "ITEM 7", etc. — wherever these appear as
+   actual section headings (not just in-prose mentions or TOC entries).
+3. Record the surrounding HTML markup (5–10 lines of context around
+   each heading). Capture:
+   - The HTML tag (`<p>`, `<h1>`, `<h2>`, `<font>`, `<span>`, etc.)
+   - Any nested formatting (`<b>`, `<strong>`, `<center>`,
+     `<font size=...>`, inline CSS)
+   - Anchor markup (`<a name>`, `<a id>`, `id=...`)
+   - The exact text content and its character count
+4. Cross-reference what `IngestionStage._extract_paragraph_segments_with_elements`
+   does with that markup. Specifically: does the heading text survive
+   to a Segment, and if so, what does the Segment's `text` and
+   `segment_type` look like? If it gets dropped, what predicate drops
+   it?
+
+**Write up the findings before writing any code.** Add a "Root cause"
+section to the gh-612 fragment (`docs/known-issues/gh-612-...md`)
+with concrete line citations and HTML snippets. The fix must follow
+from the observed markup, not from a hypothesis.
+
+### Step 2 — Implement the fix
+
+Based on the findings:
+
+- **If the heading is dropped by an existing predicate**: extend the
+  retention logic (in `_extract_paragraph_segments_with_elements`,
+  alongside the gh-574 anchor-retention rule) to admit the variant.
+  Prefer surgical predicates that match the observed pattern, not
+  broad relaxations that risk pulling in TOC entries / footnotes /
+  page numbers.
+
+- **If the heading IS extracted as a Segment but `SECTION_PATTERNS`
+  doesn't match**: extend the regex set in
+  `src/extraction_v2/stages/section_classification.py::SECTION_PATTERNS`
+  with the observed pattern. Use anchored matching (`^...$`) and
+  case-sensitive flags consistent with existing patterns.
+
+- **If the heading is extracted but `_is_section_heading()` rejects
+  it** (e.g., text too long, fails uppercase predicate): relax the
+  predicate only as much as the observed evidence warrants. Add a
+  test that exercises the boundary.
+
+Whatever the fix shape, it must be **additive** — long, canonical
+headings (covered by current rules) must still work; the Datadog
+gh-574 case must still work.
+
+### Step 3 — Add an operator-visible diagnostic
+
+In `scripts/run_phase2_quantitative_eval.py` (or the Phase-1 helper
+that runs the pipeline, depending on where it fits cleanest), after
+section_classification runs, emit a warning to the log if a filing
+has:
+
+- `n_segments ≥ 1000`, AND
+- Zero whitelisted sections detected (MDA + Business + Risk Factors
+  all zero)
+
+Surface this in `summary.json` under
+`summary.section_classification_warnings` as a list of
+`{filing_id, filing_url, n_segments, detected_sections}` records.
+
+Operators reading the summary should be able to tell at a glance
+that filings X, Y, Z had inert paraphrase paths, so they can decide
+whether the gate result is trustworthy or biased by this gap.
+
+### Step 4 — Validate post-fix
+
+For each of the 6 affected filings, run a smoke check:
+
+```python
+from src.extraction_v2.pipeline import V2Pipeline, PipelineConfig
+from scripts import run_phase1_eval as p1
+# ... fetch HTML for the filing ...
+config = PipelineConfig(enable_llm_presence_classifier=False, retain_context=True)
+result = V2Pipeline(config=config).process(html_path=..., filing_id=..., ...)
+sections = result.context.section_counts  # or whatever surfaces it
+assert sections.get('MDA', 0) >= 1 or sections.get('BUSINESS', 0) >= 1 or sections.get('RISK_FACTORS', 0) >= 1, \
+    f"Filing {filing_id} still has no whitelisted sections"
+```
+
+Acceptance: all 6 filings detect at least one whitelisted section
+post-fix. If any still don't, the variant is more diverse than
+expected — flag and present findings rather than push a partial fix.
+
+### Step 5 — Test coverage
+
+- Unit test in `tests/unit/extraction_v2/test_ingestion.py` (or
+  `test_section_classification.py`, whichever the fix lives in) with
+  a minimized HTML snippet reproducing the variant heading markup
+  observed in one of the 6 filings. Assert the section is detected.
+- Regression test: a minimal Datadog-style HTML snippet (anchor-name
+  short paragraph) still produces an MDA detection.
+- Regression test: a minimal canonical heading (`<p>MANAGEMENT'S
+  DISCUSSION AND ANALYSIS</p>` long-form) still produces an MDA
+  detection.
+- Test for the operator diagnostic: a filing with 1500 segments and
+  zero whitelisted sections produces a `section_classification_warnings`
+  entry in the summary.
+
+### Step 6 — Update the fragment + close the issue
+
+Update `docs/known-issues/gh-612-...md`:
+
+- Add a "Root cause (verified <date>)" section with the HTML markup
+  findings.
+- Add a "Fix" section describing the additive predicate.
+- Add a "Verification" section listing the 6 filings + their
+  post-fix detected sections.
+
+On PR merge, the issue closes automatically via "Closes #612" in
+the PR body.
+
+## Constraints
+
+- **Investigation precedes code.** Do not write the fix until you
+  have written up the root cause with concrete HTML citations. The
+  Datadog gh-574 fragment is a good model — it shows specific line
+  numbers and snippets.
+
+- **Additive only.** Long canonical headings must still match. The
+  Datadog short-anchor-paragraph case (gh-574) must still match. Add
+  tests for both as regression guards.
+
+- **Tier-1 zero-tolerance gate must remain green.** Run
+  `python3 -m src.gold_standard.v2_validator --fail-on-regression`
+  before and after the fix. Both must exit 0. If the fix changes
+  segment extraction broadly, this is the canary.
+
+- **No edits to**: prompt YAMLs, threshold YAMLs, classifier client,
+  Phase-1 / Phase-2 eval scripts (except the diagnostic warning in
+  step 3). Stay in ingestion + section_classification + the tests.
+
+- **No worker confidence in untested HTML variants.** If a filing
+  uses a markup variant not seen in the 6 sample files, do not
+  hypothetically extend the fix to cover it. Mark it as out of scope.
+
+## Acceptance
+
+- All 6 affected filings detect at least one whitelisted section
+  (MDA, Business, or Risk Factors) post-fix.
+- `pytest -x -q` green, including the new unit tests.
+- Tier-1 zero-tolerance gate exits 0 before and after.
+- gh-612 fragment updated with root-cause + fix + verification.
+- Operator diagnostic surfaces the gap in `summary.json` (validated
+  by running `--dry-run --gold-only` and checking the output).
+
+## What NOT to do
+
+- Don't speculatively expand `SECTION_PATTERNS` with regexes for
+  markup variants you haven't observed in the 6 sample filings.
+- Don't relax `_is_section_heading()` predicates broadly — match the
+  evidence.
+- Don't touch the classifier, prompts, or gate criteria.
+- Don't widen the touched files beyond:
+  - `src/extraction_v2/stages/ingestion.py` OR
+    `src/extraction_v2/stages/section_classification.py` (whichever
+    the fix lives in)
+  - `tests/unit/extraction_v2/test_ingestion.py` OR
+    `tests/unit/extraction_v2/test_section_classification.py`
+  - `scripts/run_phase2_quantitative_eval.py` (just the diagnostic
+    warning + summary field)
+  - `docs/known-issues/gh-612-section-classification-variant-gap.md`
+    (update with root cause + fix)
+
+## Why this design
+
+- **Investigation-first protects against bad fixes.** The gh-574
+  fragment's "Root cause (verified)" section is the template — it
+  surfaces a real markup pattern with concrete citations, then fixes
+  exactly that. Anything looser risks dragging in TOC entries or
+  footnote numbers as fake "headings."
+
+- **The operator diagnostic is the highest long-term value.** Even
+  after this fix, the next variant we haven't seen will eventually
+  surface. Making it visible in `summary.json` means future
+  operators don't waste $14 on a gate run before noticing 11% of
+  their corpus had no paraphrase signal.
+
+- **Six samples is enough scope to find a pattern but small enough
+  to inspect manually.** Don't try to write a fix that covers every
+  conceivable SEC filing — fix the observed variant.
+
+## Parallel coordination
+
+This worker can run in parallel with the **Phase-2 gate v2 worker**
+(`PICK_phase2_gate_v2_c3_reframe_plus_fixes.md`). The two touch
+different files entirely:
+
+- Gate v2 → `scripts/run_phase2_quantitative_eval.py`
+- This worker → `src/extraction_v2/stages/ingestion.py` (or
+  section_classification) + tests + the warning hook in the eval
+  script
+
+If this worker lands before the gate v2 re-run, the v2 corpus picks
+up ~11% more paraphrase coverage and is more likely to surface
+classifier-only positives — strictly better signal. If it lands
+after, no harm; just file as a follow-up and the next gate run
+benefits.

--- a/docs/archive/worker-prompts/PICK_phase2_gate_v2_c3_reframe_plus_fixes.md
+++ b/docs/archive/worker-prompts/PICK_phase2_gate_v2_c3_reframe_plus_fixes.md
@@ -1,0 +1,263 @@
+# Worker prompt — Phase-2 gate v2: C3 reframe + #602 dedup + #613 cache counter
+
+## Context
+
+The first Phase-2 quantitative gate run (`20260511T1416live`) completed
+cleanly but returned **NO-GO** because of a gate-design problem, not a
+classifier problem. See the analysis doc:
+`docs/analysis/llm-presence-classifier-phase2-eval-results-20260511.md`.
+
+The headline:
+
+- Classifier recall == keyword recall to 3 decimals (0.988 / 0.988) on
+  all 10 scoreable Tier-1 metrics.
+- C3 ("aggregate Tier-1 classifier recall ≥ keyword recall + 5pt") is
+  mathematically unreachable when keyword baseline is 98.8% — maximum
+  possible delta is +1.2pt.
+- The classifier's actual contribution — finding net-new positives the
+  keyword path missed — is invisible under C3 because at the
+  (filing, metric) aggregation level the two paths converge on the same
+  set of positives.
+
+Three known infrastructure issues affect signal quality but don't
+flip the headline:
+
+- **gh-602**: dedup-by-URL misses same-filing-id duplicates. 5 of 55
+  filings were double-processed (Tenable within-gold; Datadog, Chewy,
+  Kingsoft Cloud, Maplebear across gold↔reviewed). Each duplicate is
+  weighted 2× in `compute_aggregates`.
+- **gh-613**: `summary.cost.cache_reads` and `total_calls` are always
+  zero; PR #600 hotfix captured `evaluate_filing_pipeline`'s
+  4-tuple's `token_totals` as `_fil_tokens` and discarded it. Real
+  cost and real cache hit rate are unknown; C6 reports a bogus FAIL.
+- **gh-612**: ~11% of corpus (6 filings) hit a section_classification
+  gap and ran with 0 paraphrase segments. **Out of scope for this
+  worker** — separate ingestion investigation, parallel track.
+
+## What to build
+
+Three changes in `scripts/run_phase2_quantitative_eval.py` and (for
+the dedup) `_select_reviewed_corpus_phase2`, plus a re-run of the
+gate against the existing corpus to validate.
+
+### 1. Fix gh-602: dedup by filing_id, not just URL
+
+In `_select_reviewed_corpus_phase2` (and the gold-selection path if
+applicable), add a second-pass dedup step that drops any filing whose
+`filing_id` already appears in the merged corpus. Keep the first
+occurrence (preserve deterministic ordering: gold before reviewed,
+within-corpus order unchanged).
+
+Constraint: URL-based dedup must remain — `filing_id` is sometimes
+unavailable for gold filings that aren't in the DB (the Phase-2 runner
+already handles this case with `paf.filing_id` being nullable). Treat
+`None` as "do not dedup against," not as a sentinel that matches all
+None values.
+
+### 2. Fix gh-613: aggregate token + cache stats from each filing
+
+Replace `_fil_tokens = ...` with a real running total. Carry:
+
+- `input_tokens`
+- `output_tokens`
+- `cache_read`
+- `cache_create`
+
+across all filings in `run_eval`. Compute `summary.cost.total_calls`
+as the sum of `(input_tokens + output_tokens)` calls (or whatever
+field `LLMPresenceClassifierStage` already uses for "calls" — confirm
+by reading `src/extraction_v2/stages/llm_presence_classifier.py`,
+don't guess).
+
+Compute `summary.cost.total_usd` from the token totals using Haiku
+4.5 pricing (input $1.00/M, output $5.00/M, cache reads at 10% of
+input rate per Anthropic prompt-cache docs — verify against
+`src/llm/presence_classifier_client.py` if it already computes cost).
+Replace the flat `n_filings × $0.25` estimate.
+
+C6 (`cache_read / total_calls`) should now report a meaningful value
+— expected 0.85+ based on per-segment logs from the 2026-05-11 run.
+
+### 3. C3 reframe: measure net-new positives, not aggregate-recall delta
+
+Replace C3 with a criterion that measures what the classifier
+*actually contributes* on top of the keyword baseline:
+
+**New C3**: For metrics where keyword recall < 0.95 (the metrics
+where there's headroom), the classifier must catch a non-trivial
+number of (filing, metric) positives the keyword baseline missed.
+
+Concretely:
+
+- For each Tier-1 metric with ≥`MIN_FILINGS_FOR_METRIC_GATE` of
+  coverage AND keyword recall < 0.95:
+  - Compute `clf_only_tp = TPs where classifier_present=True AND
+    keyword_present=False AND ground_truth=True`.
+  - Compute `clf_only_fp = FPs where classifier_present=True AND
+    keyword_present=False AND ground_truth=False`.
+  - Compute `clf_only_precision = clf_only_tp / (clf_only_tp +
+    clf_only_fp)`.
+- **Pass condition**: at least one Tier-1 metric satisfies BOTH
+  `clf_only_tp ≥ 3` (catches ≥3 new positives) AND
+  `clf_only_precision ≥ 0.50` (those new positives are more than
+  half real, controlling for the gold-negative bias).
+
+This rewards the classifier for catching real new positives without
+penalizing it on metrics where keyword is already perfect.
+
+**Important: keep the old aggregate-recall comparison as an
+informational metric** (rename to `C3_aggregate_recall_delta`,
+demoted to informational severity). It's still a useful diagnostic;
+just no longer the pass/fail gate.
+
+Add a new informational criterion **C8: classifier-vs-keyword
+agreement rate**: `(clf_present == kw_present) / total` across all
+(filing, metric) pairs. Target ≥ 0.85 (informational). High
+agreement + a few high-precision clf-only TPs is the GO signal under
+the new framing.
+
+### 4. Update the Phase-2 runbook
+
+`docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md`:
+
+- Update the pass/fail criteria table to reflect the new C3 + C8.
+- Add a note explaining the rationale: aggregate-recall delta is not
+  the right gate when the keyword baseline is near-ceiling; net-new
+  positive count + precision is.
+- Append a Run history entry for the v2 re-run once it completes (a
+  follow-up to this PR).
+
+### 5. Re-run the gate against the existing 2026-05-11 corpus
+
+After the code changes land, **re-run** Phase-2 against the same
+corpus to validate the new criteria report the right answer:
+
+```bash
+python3 scripts/run_phase2_quantitative_eval.py --cost-budget 25 \
+  --i-accept-cost --run-id 20260512Trerun
+```
+
+Expected outcome: the run uses the same Anthropic prompt-cache
+contents (deterministic prompts, deterministic corpus selection
+after dedup fix), so cost should be **much lower** than $13.75 if
+the cache is functioning. Cost estimate: ≤ $2 if cache hit rate ≥ 85%.
+
+Compare the v2 summary to the original run's summary
+(`data/eval/phase2_quantitative_20260511T1416live_summary.json`):
+
+- C3 (new framing): does it pass or fail?
+- `clf_only_tp` per metric: what does the classifier actually catch
+  that keyword misses?
+- `summary.cost.total_usd`: real cost vs. the $13.75 estimate
+- Dedup: corpus size should drop from 55 to 50 (5 dups removed)
+
+Write up the comparison as a follow-up section in
+`docs/analysis/llm-presence-classifier-phase2-eval-results-20260511.md`
+(or a sibling file dated 20260512). The follow-up answers: with the
+corrected gate, does the classifier ship or not?
+
+## Constraints
+
+- **No changes outside the listed files.** No edits to
+  `src/extraction_v2/`, `src/llm/`, prompt YAMLs, threshold YAMLs, or
+  the Phase-1 smoke eval. This is gate-design + counter aggregation
+  + dedup. If you find yourself wanting to change a prompt or
+  threshold, stop and flag it.
+
+- **Determinism preserved.** The dedup fix must produce the same
+  filing ordering on repeated runs. Token-total aggregation must be
+  identical across runs given the same classifier outputs.
+
+- **Test coverage.**
+  - Unit test for `compute_aggregates` confirming the new C3
+    calculation: construct a synthetic row set where one metric has
+    `clf_only_tp ≥ 3` and `clf_only_precision ≥ 0.50` and assert
+    PASS; another where `clf_only_precision < 0.50` and assert FAIL.
+  - Unit test for the dedup function with a corpus containing two
+    distinct URLs pointing at the same filing_id; assert one survives.
+  - Unit test for token-total aggregation: mock
+    `evaluate_filing_pipeline` to return varying token dicts; assert
+    the sum is correct and `summary.cost` matches.
+
+- **Don't change the Phase-1 smoke eval.** This worker only touches
+  Phase-2. Phase-1 `evaluate_filing_pipeline`'s 4-tuple signature is
+  load-bearing — don't refactor it.
+
+- **Don't flip `presence_classifier_enabled`.** This worker ships the
+  gate v2 + a re-run. The rollout decision is a separate operator
+  step that follows the v2 result.
+
+## Acceptance
+
+- `pytest -x -q` green, including new unit tests for the criterion
+  and dedup.
+- `python3 scripts/run_phase2_quantitative_eval.py --dry-run
+  --gold-only` exits 0 and writes CSV + summary.json.
+- Live re-run completes and produces a clear GO or NO-GO under the
+  new C3.
+- `summary.cost.total_usd` reports real spend from token totals (NOT
+  `n_filings × $0.25`).
+- `summary.cost.cache_reads / total_calls ≥ 0.85` (validating C6
+  counter).
+- Corpus size in the live re-run is 50 (after dedup), not 55.
+- Comparison writeup appended to or sibling-of the existing analysis
+  doc.
+
+## What NOT to do
+
+- Don't author new prompt YAMLs for the 5 unenrolled Tier-1 metrics.
+  That's a separate scope decision; this worker doesn't touch it.
+- Don't change Phase-1's `evaluate_filing_pipeline` signature.
+- Don't refactor the corpus selection into a new module — this is
+  surgical patching, not architecture.
+- Don't widen the touched files beyond:
+  - `scripts/run_phase2_quantitative_eval.py`
+  - `tests/unit/scripts/test_run_phase2_quantitative_eval.py`
+  - `tests/integration/test_run_phase2_quantitative_eval.py` (only if
+    a new integration test is needed — likely not)
+  - `docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md`
+  - `docs/analysis/llm-presence-classifier-phase2-eval-results-20260511.md`
+    (or a sibling file for the v2 results)
+  - `docs/analysis/README.md` (if a sibling file is added)
+
+## Why this design
+
+- **C3 reframe is the highest-leverage change.** Until the gate
+  asks the right question, no amount of corpus expansion or prompt
+  iteration can produce a meaningful answer. The 2026-05-11 run
+  proved this — clf == kw on every measured metric, but we don't
+  know if the classifier catches anything new at the segment level
+  the gate aggregates over.
+
+- **Dedup and cache-counter fixes are cheap and unblock signal
+  quality.** Without #613, operators can't see real cost or cache
+  rate. Without #602, 9% of the corpus is double-weighted. Neither
+  flips the headline, but both poison interpretation.
+
+- **Re-running on the existing corpus avoids new prompt-engineering
+  effort.** The 2026-05-11 corpus is fine as a measurement subject;
+  the question was always "is the gate measuring the right thing?"
+  not "is the corpus wrong?"
+
+- **The result of this v2 run determines the next decision**:
+  - GO → proceed with rollout (staging shakedown, then prod)
+  - NO-GO with classifier catching zero new positives → close out the
+    rollout, document classifier as non-additive on the enrolled set
+  - NO-GO with classifier catching new positives but
+    `clf_only_precision < 0.50` → prompts need targeted iteration on
+    the specific FP patterns surfaced
+
+## Parallel track (not in this worker)
+
+**gh-612** — section_classification heading-markup variant gap.
+6 filings (209382, 215071, 833, 10273, 192171, 207445) returned 0
+paraphrase segments because section_classification detected no
+whitelisted sections. The gh-574 fix caught the Datadog/Chewy
+heading shape; this is a different variant.
+
+That investigation is open-ended (inspect 6 HTMLs, identify the
+markup pattern, extend `SECTION_PATTERNS` or `_is_section_heading()`,
+add a test) and can run in parallel with this v2 gate worker. Its
+output doesn't block the v2 gate re-run, but if it lands first the
+re-run will have ~11% more paraphrase coverage and is more likely to
+surface clf-only TPs.

--- a/docs/known-issues/gh-631-option-b-unenrolled-tier1-classifier.md
+++ b/docs/known-issues/gh-631-option-b-unenrolled-tier1-classifier.md
@@ -1,0 +1,38 @@
+---
+id: 631
+source: gh
+slug: option-b-unenrolled-tier1-classifier
+title: "Option B carve-out: enroll 5 unenrolled Tier-1 metrics in LLM presence classifier (tracking only)"
+status: open
+severity: low
+autonomy: skip
+estimated: —
+touches:
+  - config/llm_classifier/prompts/
+  - config/llm_classifier/thresholds.yaml
+  - config/llm_classifier/recall_augmentation.yaml
+discovered: 2026-05-15
+updated: 2026-05-15
+gh_issue: 631
+note: "Tracking only — not active scope. 5 Tier-1 metrics (balance_by_cohort, customers_period_end_by_tenure, gross_margin_by_cohort, new_customers_acquired, transactions_by_cohort) skipped by Phase-2 runs because no prompt YAML; only legitimate future activation path for the dormant classifier infrastructure."
+---
+
+### Problem
+
+The Phase-2 quantitative gate (2026-05-11 and 2026-05-14 runs) determined that the LLM presence classifier provides zero net-new positives over keyword on the 10 currently-enrolled Tier-1 metrics. Rollout closed per Option A on 2026-05-15 (see `docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md`).
+
+5 additional Tier-1 metrics were skipped by both Phase-2 runs because no prompt YAML exists for them:
+
+- `cm_balance_by_cohort`
+- `cm_customers_period_end_by_tenure`
+- `cm_gross_margin_by_cohort`
+- `cm_new_customers_acquired`
+- `cm_transactions_by_cohort`
+
+These are presumed-weak keyword catchment metrics — the only remaining scenario where the classifier might add measurable value. This issue tracks the carve-out for activating the classifier on them specifically, if pursued.
+
+### Next Steps (activation path, not active scope)
+
+- Audit current keyword catchment on the 5 metrics against gold + reviewed corpora. If > 90%, close this scope.
+- Otherwise: author prompt YAMLs, mine few-shots, sweep thresholds, build a targeted reviewed-corpus selector that picks filings known to discuss these metrics, re-run Phase-2 v2 against the targeted slice.
+- A separate decision is needed about whether to enable the classifier for only these 5 metrics (would require metric-gated classifier flag — separate infra).

--- a/docs/operations/llm-presence-classifier-phase1-eval-runbook.md
+++ b/docs/operations/llm-presence-classifier-phase1-eval-runbook.md
@@ -1,5 +1,10 @@
 # LLM presence classifier — Phase-1 dual-corpus smoke eval
 
+> **Status (2026-05-15): CLOSED for enrolled Tier-1 metrics.** Phase-2 verdict
+> is final — see [`docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md`](../analysis/llm-presence-classifier-rollout-closeout-20260515.md).
+> This runbook is retained for reference and for the **Option B carve-out**
+> (author prompts for the 5 unenrolled Tier-1 metrics) if ever activated.
+
 `scripts/run_phase1_eval.py` is the qualitative pre-flight that runs
 *before* paying for the larger held-out + reviewed-corpus quantitative
 eval. It surfaces prompt failures, parse errors, and disagreement

--- a/docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md
+++ b/docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md
@@ -1,5 +1,13 @@
 # LLM presence classifier — Phase-2 held-out + reviewed-corpus quantitative eval
 
+> **Status (2026-05-15): CLOSED for enrolled Tier-1 metrics.** Rollout closed
+> per Option A. See [`docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md`](../analysis/llm-presence-classifier-rollout-closeout-20260515.md).
+> This runbook is retained as a record of the gate design and as the entry
+> point if the **Option B carve-out** (author prompts for the 5 unenrolled
+> Tier-1 metrics) is ever activated. The `presence_classifier_enabled` DB
+> flag stays at `False` indefinitely. Do NOT re-run this gate against the
+> currently enrolled set — its verdict is final.
+
 `scripts/run_phase2_quantitative_eval.py` is Gate 2 of 2 before flipping
 `presence_classifier_enabled` in production. Gate 1 (the qualitative smoke
 eval at `scripts/run_phase1_eval.py`) must pass first.


### PR DESCRIPTION
## Summary

Adopts **Option A** from the 2026-05-14 Phase-2 v2 analysis: rollout closed for the 10 enrolled Tier-1 metrics. The `presence_classifier_enabled` DB feature flag and `ExtractionConfig.enable_llm_presence_classifier` config stay at default `False` indefinitely. Classifier code in `src/llm/` and `src/extraction_v2/stages/llm_presence_classifier.py` is retained as dormant, well-tested infrastructure.

Closes #602, #613 (manually — PR #627 didn't use Closes syntax).

### Why Option A

Two live Phase-2 quantitative gate runs decisively answered the rollout question:

| Run | Verdict | Key finding |
|---|---|---|
| `20260511T1416live` | NO-GO (C3) | Aggregate classifier recall == keyword recall (0.988 / 0.988) across all 10 scoreable Tier-1 metrics. |
| `20260514Trerun` | NO-GO (C3 reframed) | Every enrolled Tier-1 metric has `clf_only_tp = 0` — classifier catches zero positives keyword missed, including on the one metric with measurable headroom. |

The classifier infrastructure works (0 errors in 520 calls; 95–99% real cache hit rate). It just doesn't add measurable value on the scored Tier-1 set.

### Changes

- **New**: `docs/analysis/llm-presence-classifier-rollout-closeout-20260515.md` — decision memo with full basis, what stays, what's not happening, Option B carve-out, open follow-ups
- **`CLAUDE.md`**: replace the pre-rollout gate expectation with the closed status + Option B carve-out note
- **Phase-1 + Phase-2 runbooks**: "Status: CLOSED" banner pointing at the closeout memo; retained as the entry point for Option B if activated
- **`docs/worker-prompts/` → `docs/archive/worker-prompts/`**: two completed worker prompts (gh-612 and Phase-2 v2) moved to archive
- **`docs/analysis/README.md`**: updated index

### Option B carve-out (tracked, not active)

5 Tier-1 metrics were skipped by both Phase-2 runs because no prompt YAML exists for them: `cm_balance_by_cohort`, `cm_customers_period_end_by_tenure`, `cm_gross_margin_by_cohort`, `cm_new_customers_acquired`, `cm_transactions_by_cohort`. These are presumed-weak keyword catchment metrics — the only remaining scenario where the classifier might add measurable value. Filed as #631 (tracking only, `autonomy: skip`, not blocked work).

## Test plan

- [x] No code changes — docs-only PR
- [x] Tier-1 zero-tolerance gate unaffected by docs
- [x] Verified CLAUDE.md, runbook banners, and analysis README cross-reference the closeout memo consistently
- [x] Worker prompts archived (docs/worker-prompts/ now empty)
- [x] Manual closure of #602 and #613 done

🤖 Generated with [Claude Code](https://claude.com/claude-code)