### PR TITLE
fix(phase2-gate): C6 token-weighted cache rate + selected_* from post-dedup (gh-626)

### DIFF
--- a/docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md
+++ b/docs/operations/llm-presence-classifier-phase2-quantitative-eval-runbook.md
@@ -90,7 +90,7 @@ python3 scripts/run_phase2_quantitative_eval.py --gold-only --limit 1 --i-accept
 | C3 | At least one Tier-1 metric with kw recall < 0.95 has `clf_only_tp ≥ 3` AND `clf_only_precision ≥ 0.50` | metrics with headroom only | **Hard** |
 | C4 | No Tier-1 metric with classifier F1 < 0.40 (≥5-filing coverage) | all Tier-1 metrics | **Hard** |
 | C5 | Classifier error rate ≤ 0.5% of calls | hard cap | **Hard** |
-| C6 | Cache hit rate ≥ 85% | informational | No |
+| C6 | Token-weighted cache hit rate ≥ 85% (`cache_read / (cache_read + input_tokens)`) | informational | No |
 | C7 | Total cost ≤ `--cost-budget` USD (default $25) | informational | No |
 | C8 | Classifier-keyword agreement rate ≥ 85% across all (filing, metric) pairs | informational | No |
 | `C3_aggregate_recall_delta` | Aggregate Tier-1 classifier recall vs keyword recall (informational) | reported for triage | No |

--- a/scripts/run_phase2_quantitative_eval.py
+++ b/scripts/run_phase2_quantitative_eval.py
@@ -481,8 +481,22 @@ def evaluate_criteria(
     cache_reads: int,
     total_cost_usd: float,
     cost_budget_usd: float,
+    input_tokens: int = 0,
 ) -> list[CriterionResult]:
-    """Evaluate C1–C7 against the accumulated rows and cost metrics."""
+    """Evaluate C1–C8 against the accumulated rows and cost metrics.
+
+    ``cache_reads`` and ``input_tokens`` are token counts (cache-read tokens
+    and fresh input tokens respectively); C6 reports the token-weighted hit
+    rate ``cache_reads / (cache_reads + input_tokens)`` matching Anthropic's
+    per-call client logs. ``total_calls`` is the classify_segment call
+    count (used by C5).
+
+    gh-626: prior to this change, ``cache_reads`` was a call-equivalent
+    proxy and C6 divided it by ``total_calls``, producing meaningless
+    ratios. Callers may continue passing ``cache_reads`` alone (default
+    ``input_tokens=0`` keeps the old single-arg signature working in
+    tests that never asserted on the C6 value).
+    """
     tier1 = _get_tier1_metrics()
     prf = per_metric_prf(rows)
 
@@ -667,14 +681,18 @@ def evaluate_criteria(
     )
     results.append(c5)
 
-    # C6 — cache hit rate ≥ 85% (informational).
-    cache_rate = cache_reads / total_calls if total_calls > 0 else 0.0
+    # C6 — token-weighted cache hit rate ≥ 85% (informational).
+    # cache_reads and input_tokens are both token counts; the ratio
+    # cache_reads / (cache_reads + input_tokens) matches Anthropic's
+    # per-call client log (gh-626 fix).
+    total_input_tokens = cache_reads + input_tokens
+    cache_rate = cache_reads / total_input_tokens if total_input_tokens > 0 else 0.0
     c6 = CriterionResult(
         id="C6",
-        description="Cache hit rate ≥ 85% (informational)",
+        description="Token-weighted cache hit rate ≥ 85% (informational)",
         hard=False,
         passed=cache_rate >= 0.85,
-        detail=f"{cache_reads}/{total_calls} cached = {cache_rate:.1%}",
+        detail=(f"{cache_reads}/{total_input_tokens} cached tokens = {cache_rate:.1%}"),
         value=round(cache_rate, 4),
         threshold=0.85,
     )
@@ -1132,24 +1150,10 @@ def run_eval(
 
     partial_fh.close()
 
-    # Compute cache_reads from token totals now that the loop is complete.
-    # cache_read_total is in tokens; we convert to a call-equivalent count
-    # by prorating against total_calls. A filing whose cache_read token count
-    # is > 0 "used the cache". We estimate the per-call fraction by assuming
-    # each call contributes equally. The true per-call count is not returned by
-    # evaluate_filing_pipeline, so we use: cache_reads ≈ total_calls if
-    # cache_read_total > 0 else 0 at the filing level. A more precise
-    # approximation: if cache_read_total / (input_tokens_total or 1) ≥ 0.5,
-    # we treat the filing-level bucket as "cached". We bucket at the filing
-    # level using the per-filing cache_read contribution tracked in the loop —
-    # but since we only have totals here, approximate as:
-    #   cache_reads = round(total_calls * cache_read_fraction)
-    # where cache_read_fraction = cache_read_total / max(input_tokens_total, 1).
-    if input_tokens_total > 0:
-        cache_read_fraction = cache_read_total / input_tokens_total
-        cache_reads = round(total_calls * cache_read_fraction)
-    else:
-        cache_reads = 0
+    # gh-626: cache_reads is now the raw cache-read token count;
+    # C6 computes the token-weighted hit rate from cache_read_total and
+    # input_tokens_total directly (no call-equivalent proxy).
+    cache_reads = cache_read_total
 
     run_finished_at = datetime.now(UTC).isoformat()
     for r in rows:
@@ -1210,6 +1214,7 @@ def run_eval(
         cache_reads=cache_reads,
         total_cost_usd=total_cost_usd,
         cost_budget_usd=cost_budget_usd,
+        input_tokens=input_tokens_total,
     )
 
     hard_failures = [c for c in criteria if c.hard and not c.passed]
@@ -1220,6 +1225,11 @@ def run_eval(
     prf_reviewed = per_metric_prf(rows, "reviewed")
     prf_merged = per_metric_prf(rows)
 
+    # gh-626: selected_* lists derive from the post-dedup enriched corpus
+    # so summary.json consumers see what actually ran (was inconsistent
+    # with per_metric.n which counted only deduped rows).
+    enriched_gold = [p.selection for p in enriched if p.selection.corpus == "gold"]
+    enriched_reviewed = [p.selection for p in enriched if p.selection.corpus == "reviewed"]
     summary = {
         "run_id": run_id,
         "run_started_at": run_started_at,
@@ -1228,10 +1238,10 @@ def run_eval(
         "go_no_go": go_no_go,
         "gold_only": gold_only,
         "limit": limit,
-        "selected_gold_filings": [f.filing_url for f in gold_filings],
+        "selected_gold_filings": [f.filing_url for f in enriched_gold],
         "selected_reviewed_filings": [
             {"filing_url": f.filing_url, "filing_id": f.filing_id, "company": f.company}
-            for f in reviewed_filings
+            for f in enriched_reviewed
         ],
         "metric_ids": metric_ids,
         "per_metric": {

--- a/tests/unit/scripts/test_run_phase2_quantitative_eval.py
+++ b/tests/unit/scripts/test_run_phase2_quantitative_eval.py
@@ -741,24 +741,26 @@ def test_dedup_by_filing_id_seen_ids_excludes_pre_existing(cli):
 
 
 def test_token_aggregation_cache_reads_computed(cli):
-    """cache_reads is proportional to cache_read / input_tokens ratio in summary cost."""
-    # The cache_reads field in the live path is computed from token totals
-    # after the loop. We test the formula by calling evaluate_criteria with
-    # a known cache_reads value — the live computation feeds it.
-    # Direct test: evaluate_criteria with explicit cache_reads reports correctly.
+    """C6 reports the token-weighted cache hit rate from cache_reads + input_tokens.
+
+    Updated for gh-626: C6 is now cache_reads / (cache_reads + input_tokens)
+    rather than the broken cache_reads / total_calls.
+    """
     rows = [_make_row(cli, filing_url=f"https://example.com/f{i}.htm") for i in range(6)]
-    # 9 out of 10 calls "cached" → 90% hit rate → C6 passes.
+    # 9 cached tokens out of 10 total inputs → 90% hit rate → C6 passes.
     criteria = cli.evaluate_criteria(
         rows,
         [],
         total_calls=10,
         cache_reads=9,
+        input_tokens=1,
         total_cost_usd=1.0,
         cost_budget_usd=25.0,
     )
     c6 = next(c for c in criteria if c.id == "C6")
     assert c6.passed is True
-    assert "90.0%" in c6.detail or "9/10" in c6.detail
+    assert c6.value == 0.9
+    assert "90.0%" in c6.detail
 
 
 def test_token_aggregation_zero_cache_reads_fails_c6(cli):
@@ -866,3 +868,92 @@ def test_c8_present_in_criteria_list(cli):
     ids = [c.id for c in criteria]
     assert "C8" in ids
     assert "C3_aggregate_recall_delta" in ids  # informational demoted criterion
+
+
+# ---------------------------------------------------------------------------
+# gh-626: C6 cache hit rate fix (token-weighted ratio)
+# ---------------------------------------------------------------------------
+
+
+def test_c6_cache_hit_rate_is_token_weighted(cli):
+    """C6 reports cache_reads / (cache_reads + input_tokens), bounded to [0, 1].
+
+    Regression guard for the prior bug where C6 divided cache-read *tokens*
+    by call *count*, producing ratios like 545,704% (or, in the proxy
+    formulation, unbounded values when cache_read_total exceeded
+    input_tokens_total — which is the common case with prompt caching).
+    """
+    rows = [_make_row(cli)]
+    criteria = cli.evaluate_criteria(
+        rows,
+        [],
+        total_calls=100,
+        cache_reads=850_000,  # cache-read tokens
+        input_tokens=150_000,  # fresh input tokens
+        total_cost_usd=1.0,
+        cost_budget_usd=25.0,
+    )
+    c6 = next(c for c in criteria if c.id == "C6")
+    # 850_000 / (850_000 + 150_000) = 0.85 — at threshold.
+    assert c6.value == 0.85
+    assert c6.passed is True
+    assert 0.0 <= c6.value <= 1.0
+
+
+def test_c6_below_threshold_fails(cli):
+    """C6 fails when cache hit rate falls below the 85% target."""
+    rows = [_make_row(cli)]
+    criteria = cli.evaluate_criteria(
+        rows,
+        [],
+        total_calls=100,
+        cache_reads=500_000,
+        input_tokens=500_000,  # 50% hit rate
+        total_cost_usd=1.0,
+        cost_budget_usd=25.0,
+    )
+    c6 = next(c for c in criteria if c.id == "C6")
+    assert c6.value == 0.5
+    assert c6.passed is False
+
+
+def test_c6_realistic_high_cache_ratio_bounds_below_one(cli):
+    """C6 stays in [0,1] even when cache_reads >> input_tokens.
+
+    Mirror of the real 2026-05-14 v2 run: 310M cache reads vs 9.6M
+    input tokens — the broken proxy gave 32.3 (3231%); the token-weighted
+    formula gives 0.97.
+    """
+    rows = [_make_row(cli)]
+    criteria = cli.evaluate_criteria(
+        rows,
+        [],
+        total_calls=56_905,
+        cache_reads=310_533_111,
+        input_tokens=9_630_602,
+        total_cost_usd=194.79,
+        cost_budget_usd=25.0,
+    )
+    c6 = next(c for c in criteria if c.id == "C6")
+    assert 0.96 <= c6.value <= 0.98
+    assert c6.passed is True
+
+
+def test_c6_default_input_tokens_falls_back_to_full_credit(cli):
+    """Callers that don't pass input_tokens (legacy tests) get a sane default.
+
+    When input_tokens defaults to 0 and cache_reads > 0, the ratio is 1.0
+    (100% of accounted tokens are cached). This preserves the contract for
+    existing tests that pass only cache_reads without asserting on c6.value.
+    """
+    rows = [_make_row(cli)]
+    criteria = cli.evaluate_criteria(
+        rows,
+        [],
+        total_calls=10,
+        cache_reads=9,
+        total_cost_usd=1.0,
+        cost_budget_usd=25.0,
+    )
+    c6 = next(c for c in criteria if c.id == "C6")
+    assert c6.value == 1.0


### PR DESCRIPTION
## Summary

Two of the three reporting bugs from #626:

- **C6 cache hit rate** was `cache_reads / total_calls` after `cache_reads` had been pre-multiplied into a call-equivalent proxy that didn't bound to [0, 1]. The 2026-05-14 v2 run reported a 3231% hit rate because cache_read tokens (310M) outnumbered fresh input tokens (9.6M) by ~32×. C6 now reports `cache_read / (cache_read + input_tokens)` matching the Anthropic per-call client log. Re-applying the formula to the 2026-05-14 v2 numbers gives 97.0%.
- **`summary.selected_gold_filings` / `selected_reviewed_filings`** were populated pre-dedup, leaving summary.json with internally inconsistent counts (selected lists showed 56, `per_metric.n` showed the deduped 52). Both lists now derive from the post-dedup `enriched` corpus.

The third gh-626 next-step (renaming `total_calls` / cost-per-filing planning estimate) is deferred — it's a more invasive schema-touching change and the 2026-05-14 v2 run already produced a decisive verdict, so the urgency is gone.

## Test plan

- [x] 4 new unit tests for C6 (token-weighted, below-threshold, real 2026-05-14 numbers stay in [0,1], default-input_tokens backward compat)
- [x] 1 existing test updated (`test_token_aggregation_cache_reads_computed`) for the new signature
- [x] All 35 phase2 unit tests + 4 phase2 integration tests pass
- [x] `--dry-run --gold-only` exits 0
- [x] Ruff clean
- [ ] CI green (Lint, Unit Tests, Vulnerability Scan, Integration Tests, UI E2E, Docker Build & Smoke)

Closes #626 partially (C6 + selected_* items); `total_calls` rename / cost-per-filing planning constant items remain open in that issue.