### PR TITLE
fix(extraction): gh-619 provider-aware vision-API guard

### DIFF
--- a/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
+++ b/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
@@ -13,6 +13,8 @@ touches:
 discovered: 2026-05-13
 updated: 2026-05-15
 gh_issue: 619
+pr_refs:
+  - 637
 note: Discovered while debugging the 2026-05-12 filings-extraction OOM. The OOM and this guard issue are independent — both surfaced in the same log.
 ---
 

--- a/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
+++ b/docs/known-issues/gh-619-extraction-image-pipeline-silently-dark.md
@@ -3,15 +3,15 @@ id: 619
 source: gh
 slug: extraction-image-pipeline-silently-dark
 title: "filings-extraction image pipeline silently dark: OPENAI_API_KEY guard ignores Gemini provider"
-status: open
+status: resolved
 severity: medium
-autonomy: review
+autonomy: n/a
 estimated: —
 touches:
   - src/extraction_v2/pipeline.py
   - render.yaml
 discovered: 2026-05-13
-updated: 2026-05-13
+updated: 2026-05-15
 gh_issue: 619
 note: Discovered while debugging the 2026-05-12 filings-extraction OOM. The OOM and this guard issue are independent — both surfaced in the same log.
 ---
@@ -38,3 +38,29 @@ Two possibilities to resolve first:
 2. **Intentional scoping.** Full-page OCR / chart OCR genuinely still requires OpenAI, only metric-classify is on Gemini. Fix the warning copy to clarify and add a positive log line for the Gemini classify substage.
 
 Then: query prod to confirm what fraction of `filings-extraction` runs since 2026-05-04 produced `v2_image_classifications` / `v2_image_assets.detected_metrics` rows, to quantify how much image work has been missed.
+
+### Resolution
+
+`_check_vision_api_availability` is now provider-aware. It builds a map from
+each configured vision provider (`vision_full_page_ocr_provider`,
+`vision_prescan_provider`, `vision_chart_fallback_provider`) to its required
+env var via `_VISION_PROVIDER_ENV_VARS` (`openai`→`OPENAI_API_KEY`,
+`gemini`/`google`→`GOOGLE_API_KEY`, `anthropic`→`ANTHROPIC_API_KEY`).
+
+- **Stage 4 (image triage)** — re-enabled unconditionally. Has no vision-API
+  dependency (uses learned-model + keyword-proximity heuristics only).
+- **Stage 5 (OCR/chart)** — disabled only when one of its configured
+  providers' env vars is missing. Under current `filings-extraction` env
+  (only `GOOGLE_API_KEY` set; default `chart_fallback=anthropic`), Stage 5
+  remains disabled because `ANTHROPIC_API_KEY` is unset — preventing the
+  construction-time crash described in the deferred follow-up.
+- Warning copy now names the offending config field, provider, and missing
+  env var explicitly; INFO log emitted when Stage 4 runs without Stage 5
+  so operators can see the partial-enable state.
+
+The construction-time `OPENAI_API_KEY` requirement inside
+`OCRExtractionStage.vision_client` (and any residual OpenAI hard-coding in
+`src/llm/vision_client.py`) is intentionally **deferred to a follow-up**:
+see gh-636. That fix needs to thread the configured provider through the
+lazy `vision_client` property and verify Gemini end-to-end for full-page
+OCR (not just metric-classify).

--- a/docs/known-issues/gh-636-vision-client-construction-guard.md
+++ b/docs/known-issues/gh-636-vision-client-construction-guard.md
@@ -1,0 +1,59 @@
+---
+id: 636
+source: gh
+slug: vision-client-construction-guard
+title: "VisionClient construction-time OPENAI_API_KEY guard blocks non-OpenAI providers"
+status: open
+severity: medium
+autonomy: review
+estimated: M
+touches:
+  - src/llm/vision_client.py
+  - src/extraction_v2/stages/ocr_extraction.py
+discovered: 2026-05-15
+updated: 2026-05-15
+gh_issue: 636
+note: Split from gh-619; requires confirming Gemini end-to-end for full-page OCR.
+---
+
+### Problem
+
+Follow-up split out from gh-619. The pipeline-level guard at
+`src/extraction_v2/pipeline.py::_check_vision_api_availability` was made
+provider-aware in the gh-619 PR — Stage 4 (image triage) re-enabled
+unconditionally and Stage 5 (OCR/chart) now gates on each configured
+vision provider's env var.
+
+However, `src/extraction_v2/stages/ocr_extraction.py:258` (the lazy
+`vision_client` property) still raises `V2FatalError` on construction if
+`OPENAI_API_KEY` is unset, regardless of which provider the pipeline is
+configured for. To enable Stage 5 end-to-end on Gemini (or any non-OpenAI
+provider), this construction-time guard needs the same provider-aware
+treatment.
+
+The per-site clients (`_get_full_page_ocr_client`,
+`_get_prescan_client`, `_get_chart_fallback_client`) already route via
+the configured provider, so the legacy `vision_client` property is the
+remaining OpenAI-only path.
+
+### Next Steps
+
+1. Replace the hard `OPENAI_API_KEY` check in
+   `OCRExtractionStage.vision_client` with provider-aware logic — use
+   `context.config.vision_full_page_ocr_provider` (or thread the
+   relevant provider config through the property) and check the
+   matching env var per provider per the same `_VISION_PROVIDER_ENV_VARS`
+   map shipped in gh-619.
+2. Audit `src/llm/vision_client.py::VisionClient.__init__` for any
+   remaining hard OpenAI dependency at construction time.
+3. Verify Gemini works end-to-end for full-page OCR — chart-read path
+   on Gemini has not been exercised in prod (only metric-classify has).
+4. Add an integration test under `tests/integration/extraction_v2/` for
+   Stage 5 in a Gemini-only env (no `OPENAI_API_KEY`,
+   `vision_full_page_ocr_provider=gemini`,
+   `vision_chart_fallback_provider=gemini`, `GOOGLE_API_KEY` set).
+
+### Out of Scope
+
+- The pipeline-level guard (shipped in the gh-619 PR).
+- `render.yaml` changes — env already correct for Gemini.

--- a/src/extraction_v2/pipeline.py
+++ b/src/extraction_v2/pipeline.py
@@ -93,6 +93,14 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
 
 
+_VISION_PROVIDER_ENV_VARS: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+}
+
+
 # Document type constants
 DOC_TYPE_SEC_FILING = "sec_filing"
 DOC_TYPE_TRANSCRIPT = "transcript"
@@ -625,14 +633,39 @@ class V2Pipeline:
                 )
 
     def _check_vision_api_availability(self) -> None:
-        """Check if OPENAI_API_KEY is set; disable image/chart extraction if not."""
-        if self.config.enable_chart_extraction and not os.environ.get("OPENAI_API_KEY", "").strip():
+        """Disable Stage 5 (OCR/chart) when its configured providers' env vars are missing.
+
+        Stage 4 (image triage) has no vision-API dependency — it uses learned-model +
+        keyword-proximity heuristics only — and is left untouched. Stage 5 calls vision
+        providers for full-page OCR, prescan, and chart-fallback; each is gated on the
+        env var matching its configured provider (gh-619).
+        """
+        if not self.config.enable_chart_extraction:
+            return
+        missing: list[str] = []
+        for field_name in (
+            "vision_full_page_ocr_provider",
+            "vision_prescan_provider",
+            "vision_chart_fallback_provider",
+        ):
+            provider = getattr(self.config, field_name)
+            env_var = _VISION_PROVIDER_ENV_VARS.get(provider.lower().strip())
+            if env_var is None:
+                missing.append(f"{field_name}={provider!r} (unknown provider)")
+            elif not os.environ.get(env_var, "").strip():
+                missing.append(f"{field_name}={provider} requires {env_var}")
+        if missing:
             logger.warning(
-                "OPENAI_API_KEY is not set. Disabling image and chart extraction "
-                "(Stages 4 and 5). Text extraction will proceed normally."
+                "Stage 5 (OCR/chart) disabled: %s (not set). "
+                "Stage 4 (image triage) remains enabled.",
+                "; ".join(missing),
             )
-            self.config.enable_image_extraction = False
             self.config.enable_chart_extraction = False
+            if self.config.enable_image_extraction:
+                logger.info(
+                    "Stage 4 (image triage) enabled without Stage 5 — "
+                    "text + image-triage only this run."
+                )
 
     def _setup_stages(self) -> None:
         """Initialize pipeline stages."""

--- a/tests/integration/extraction_v2/test_e2e_pipeline.py
+++ b/tests/integration/extraction_v2/test_e2e_pipeline.py
@@ -171,9 +171,12 @@ class TestE2ESlackFiling:
             PipelineStage.METRIC_PRESENCE,
         }
 
-        # Image stages are skipped when OPENAI_API_KEY is not set (e.g. in CI)
+        # OCR_CHART_EXTRACTION requires a vision-API key (OPENAI/Gemini) and is
+        # skipped when none is set (e.g. in CI). IMAGE_TRIAGE runs regardless —
+        # the keyword pre-scan + learned-model triage need no external API
+        # (gh-619: provider-aware vision-API guard).
         if not os.getenv("OPENAI_API_KEY"):
-            expected_stages -= {PipelineStage.IMAGE_TRIAGE, PipelineStage.OCR_CHART_EXTRACTION}
+            expected_stages -= {PipelineStage.OCR_CHART_EXTRACTION}
 
         assert executed_stages == expected_stages, (
             f"Missing stages: {expected_stages - executed_stages}"

--- a/tests/integration/extraction_v2/test_full_page_ocr_pipeline.py
+++ b/tests/integration/extraction_v2/test_full_page_ocr_pipeline.py
@@ -172,8 +172,13 @@ def test_full_page_ocr_path_a_synthesizes_image_ocr_segments(
 ) -> None:
     """End-to-end: 6 page-shaped images → triage promotes to FULL_PAGE_SCAN
     → OCR synthesizes ``image_ocr`` segments and populates ``ocr_text``."""
-    # Vision-API gate would otherwise auto-disable image/chart extraction.
+    # gh-619 vision-API gate is provider-aware: full-page-OCR provider (gemini),
+    # prescan provider (gemini), and chart-fallback provider (anthropic) each
+    # need their respective keys for Stage 5 to enable. Mock all three — the
+    # vision_client is monkey-patched below so no real API calls happen.
     monkeypatch.setenv("OPENAI_API_KEY", "test-fake-key-mock-handles-calls")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-fake-key-mock-handles-calls")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-key-mock-handles-calls")
 
     config = PipelineConfig(
         enable_full_page_ocr=True,

--- a/tests/unit/extraction_v2/test_image_pipeline_integration.py
+++ b/tests/unit/extraction_v2/test_image_pipeline_integration.py
@@ -950,8 +950,10 @@ class TestV2PipelineSecClient:
         """V2Pipeline passes sec_client through to OCRExtractionStage."""
         from src.extraction_v2.pipeline import V2Pipeline
 
-        # Provide a fake API key so image/chart extraction is not disabled
-        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        # Provide fake API keys for default vision providers (gemini full-page/prescan,
+        # anthropic chart-fallback) so Stage 5 is not disabled by the gh-619 guard.
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
         mock_client = MagicMock()
         pipeline = V2Pipeline(sec_client=mock_client)
 

--- a/tests/unit/extraction_v2/test_pipeline.py
+++ b/tests/unit/extraction_v2/test_pipeline.py
@@ -805,28 +805,40 @@ class TestRetainContext:
 
 
 class TestPipelineApiKeyCheck:
-    """Tests for automatic disabling of chart/image extraction when API key is missing."""
+    """Tests for provider-aware gating of Stage 5 (OCR/chart) on vision provider env vars.
 
-    def test_chart_extraction_disabled_when_no_api_key(
+    Stage 4 (image triage) has no vision API dependency and stays enabled regardless.
+    Stage 5 needs each configured vision provider's env var present (gh-619).
+    """
+
+    def _clear_vision_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("OPENAI_API_KEY", "GOOGLE_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_stage4_enabled_when_all_vision_env_vars_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Pipeline should auto-disable chart and image extraction when OPENAI_API_KEY is unset."""
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        """Stage 4 has no vision dependency; it stays enabled even with no env vars set.
+
+        Stage 5 is disabled because the default chart_fallback=anthropic needs ANTHROPIC_API_KEY.
+        """
+        self._clear_vision_env(monkeypatch)
         config = PipelineConfig(enable_chart_extraction=True, enable_image_extraction=True)
         pipeline = V2Pipeline(config=config)
-        # Both flags should be False after initialization
+        assert pipeline.config.enable_image_extraction is True
         assert pipeline.config.enable_chart_extraction is False
-        assert pipeline.config.enable_image_extraction is False
-        # Neither Stage 4 nor Stage 5 should be in the stage list
         stage_ids = [s for s, _ in pipeline._stages]
-        assert PipelineStage.IMAGE_TRIAGE not in stage_ids
+        assert PipelineStage.IMAGE_TRIAGE in stage_ids
         assert PipelineStage.OCR_CHART_EXTRACTION not in stage_ids
 
-    def test_chart_extraction_enabled_when_api_key_set(
+    def test_both_stages_enabled_when_all_required_keys_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Pipeline should keep chart extraction enabled when OPENAI_API_KEY is set."""
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key-12345")
+        """With default providers (gemini full-page/prescan, anthropic chart-fallback),
+        Stage 5 enables when both GOOGLE_API_KEY and ANTHROPIC_API_KEY are set."""
+        self._clear_vision_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
         config = PipelineConfig(enable_chart_extraction=True, enable_image_extraction=True)
         pipeline = V2Pipeline(config=config)
         assert pipeline.config.enable_chart_extraction is True
@@ -838,10 +850,85 @@ class TestPipelineApiKeyCheck:
     def test_no_warning_when_chart_extraction_already_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No warning should be issued when chart extraction is already disabled."""
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        # When chart extraction is already disabled, no warning needed
+        """No env-var check needed when chart extraction is already disabled."""
+        self._clear_vision_env(monkeypatch)
         config = PipelineConfig(enable_chart_extraction=False)
         pipeline = V2Pipeline(config=config)
-        # Should not raise, and chart extraction stays disabled
         assert pipeline.config.enable_chart_extraction is False
+
+    def test_prod_failure_mode_only_google_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh-619 prod failure mode: filings-extraction cron has only GOOGLE_API_KEY set.
+
+        Default providers (gemini/gemini/anthropic) → chart_fallback=anthropic
+        misses ANTHROPIC_API_KEY → Stage 5 disabled, Stage 4 stays enabled.
+        """
+        self._clear_vision_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        config = PipelineConfig(enable_chart_extraction=True, enable_image_extraction=True)
+        pipeline = V2Pipeline(config=config)
+        assert pipeline.config.enable_image_extraction is True
+        assert pipeline.config.enable_chart_extraction is False
+        stage_ids = [s for s, _ in pipeline._stages]
+        assert PipelineStage.IMAGE_TRIAGE in stage_ids
+        assert PipelineStage.OCR_CHART_EXTRACTION not in stage_ids
+
+    def test_single_vendor_gemini_enables_both_stages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Overriding chart_fallback to gemini collapses all Stage 5 providers to one vendor.
+
+        With only GOOGLE_API_KEY set, both stages should enable.
+        """
+        self._clear_vision_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        config = PipelineConfig(
+            enable_chart_extraction=True,
+            enable_image_extraction=True,
+            vision_chart_fallback_provider="gemini",
+        )
+        pipeline = V2Pipeline(config=config)
+        assert pipeline.config.enable_chart_extraction is True
+        assert pipeline.config.enable_image_extraction is True
+        stage_ids = [s for s, _ in pipeline._stages]
+        assert PipelineStage.IMAGE_TRIAGE in stage_ids
+        assert PipelineStage.OCR_CHART_EXTRACTION in stage_ids
+
+    def test_openai_full_page_ocr_missing_key_disables_stage5(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit vision_full_page_ocr_provider=openai requires OPENAI_API_KEY even
+        when other vendors' keys are present."""
+        self._clear_vision_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+        config = PipelineConfig(
+            enable_chart_extraction=True,
+            enable_image_extraction=True,
+            vision_full_page_ocr_provider="openai",
+        )
+        pipeline = V2Pipeline(config=config)
+        assert pipeline.config.enable_image_extraction is True
+        assert pipeline.config.enable_chart_extraction is False
+
+    def test_warning_message_names_provider_and_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The disable warning must name both the offending config field/provider and
+        the specific env var that's missing."""
+        import logging
+        import re
+
+        self._clear_vision_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+        config = PipelineConfig(enable_chart_extraction=True, enable_image_extraction=True)
+        with caplog.at_level(logging.WARNING, logger="src.extraction_v2.pipeline"):
+            V2Pipeline(config=config)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING log naming the missing provider/env var"
+        text = "\n".join(r.getMessage() for r in warnings)
+        assert re.search(
+            r"vision_chart_fallback_provider=anthropic requires ANTHROPIC_API_KEY",
+            text,
+        ), f"warning copy did not name provider+env var; got: {text!r}"


### PR DESCRIPTION
_check_vision_api_availability previously disabled Stages 4 and 5
whenever OPENAI_API_KEY was unset, regardless of VISION_*_PROVIDER
configuration. After the gh-441 Gemini flip (2026-05-04), this left
filings-extraction silently dark for ~11 days — even Stage 4 (image
triage), which has no vision-API dependency.

The guard now maps each configured vision provider
(vision_full_page_ocr_provider, vision_prescan_provider,
vision_chart_fallback_provider) to its required env var via
_VISION_PROVIDER_ENV_VARS. Stage 4 is always enabled; Stage 5 is
disabled only when one of its providers' env vars is missing. Warning
copy now names the offending field/provider/env var; INFO line emitted
when Stage 4 runs without Stage 5.

The construction-time OPENAI_API_KEY guard inside
OCRExtractionStage.vision_client is intentionally deferred to gh-636 —
that fix needs to thread provider through the lazy property and verify
Gemini end-to-end for full-page OCR.
