### PR TITLE
worktree fix+ar fp exclusion

### DIFF
--- a/config/metric_keywords.yaml
+++ b/config/metric_keywords.yaml
@@ -588,8 +588,11 @@ cm_revenue_concentration:
     - '\bno\s+customer\b'
     - '\bdid\s+not\s+(?:exceed|comprise)\b'
     - '\bin\s+excess\s+of\b'
-    # FIX-FP: Exclude accounts receivable concentration (not revenue concentration)
-    - '\baccounts\s+receivable\b'
+    # FIX-FP: Exclude accounts receivable concentration (not revenue concentration).
+    # Covers plural ("receivables"), "receivable(s), net", and "trade receivable(s)".
+    - '\baccounts?\s+receivables?\b'
+    - '\breceivables?\s*,\s*net\b'
+    - '\btrade\s+receivables?\b'
 
 # =============================================================================
 # Revenue Predictability Metrics (DEPRECATED 2026-01-07)

--- a/docs/known-issues/gh-646-ar-revenue-cross-clause-disambiguation.md
+++ b/docs/known-issues/gh-646-ar-revenue-cross-clause-disambiguation.md
@@ -1,0 +1,31 @@
+---
+id: 646
+source: gh
+slug: ar-revenue-cross-clause-disambiguation
+title: AR-vs-revenue cross-clause disambiguation in cm_revenue_concentration
+status: open
+severity: medium
+autonomy: skip
+estimated: —
+touches:
+  - src/extraction_v2/stages/candidate_generation.py
+  - config/metric_keywords.yaml
+discovered: '2026-05-19'
+updated: '2026-05-19'
+gh_issue: 646
+note: 50-char exclusion window misses cross-clause AR mentions; naive full-segment scan regresses Tier-1 GS — needs narrower mitigation
+---
+
+### Problem
+
+The keyword-exclusion path for `cm_revenue_concentration` runs against a ±50 character window around the matched keyword (`src/extraction_v2/stages/candidate_generation.py::_is_excluded`). Two residual failure modes survive the parent fix that broadened the AR-exclusion regex:
+
+**(a) Cross-clause AR mentions outside the 50-char window.** Example: "Our largest customer's total balance, accumulated over the prior fiscal year, made up 82% of accounts receivable" — the AR phrase is the clear referent of the value but sits >50 chars from the trigger keyword, so the exclusion does not fire. A naive widening to full-segment scan was attempted in the parent session and reverted because it caused a Tier-1 gold-standard presence-recall regression on Datadog, Samsara, and Tenable (over-excluded legitimate revenue-concentration sentences that also mention AR elsewhere in the segment).
+
+**(b) Genuinely ambiguous "X% of revenue or accounts receivable" disclosures.** The value applies to both denominators by construction; treat as residual accepted-FP.
+
+### Next Steps
+
+- Pilot a narrower mitigation: forward-only window after the value, or 100–150 char window scoped to `cm_revenue_concentration` — verify against gold-standard before shipping.
+- If neither variant is GS-safe, consider a positive-context guard at the FP-filter layer (`_rule_accounts_receivable`) that uses surrounding phrase polarity to choose between AR and revenue interpretations.
+- Leave (b) as accepted residual unless it shows up in a future text-pattern analysis as a high-volume reject phrase.

--- a/tests/unit/extraction_v2/test_candidate_generation.py
+++ b/tests/unit/extraction_v2/test_candidate_generation.py
@@ -349,6 +349,31 @@ class TestFiltering:
         assert result.success
         assert len(mock_context.candidates) == 0
 
+    def test_excludes_plural_accounts_receivables_for_revenue_concentration(
+        self, stage: CandidateGenerationStage, mock_context: MockPipelineContext
+    ) -> None:
+        """AR exclusion catches the plural variant ("accounts receivables")."""
+        # The pre-fix regex \baccounts\s+receivable\b missed the trailing 's'.
+        segment = make_segment("Two customers accounted for 37% of our accounts receivables.")
+        mock_context.segments.append(segment)
+
+        stage.process(mock_context)
+
+        metric_ids = [c.metric_id for c in mock_context.candidates]
+        assert "cm_revenue_concentration" not in metric_ids
+
+    def test_excludes_receivables_net_for_revenue_concentration(
+        self, stage: CandidateGenerationStage, mock_context: MockPipelineContext
+    ) -> None:
+        """AR exclusion catches the "receivables, net" balance-sheet variant."""
+        segment = make_segment("Two customers accounted for 37% of our receivables, net.")
+        mock_context.segments.append(segment)
+
+        stage.process(mock_context)
+
+        metric_ids = [c.metric_id for c in mock_context.candidates]
+        assert "cm_revenue_concentration" not in metric_ids
+
 
 # =============================================================================
 # Confidence Scoring Tests


### PR DESCRIPTION
- **fix(extraction): broaden accounts-receivable exclusion in cm_revenue_concentration**
- **docs(known-issues): log issue #646 — AR/revenue cross-clause disambiguation**
