### PR TITLE
chore(deps): bump idna to 3.15 to clear CVE-2026-45409

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -80,7 +80,7 @@ fsspec==2026.2.0
     # via
     #   datasets
     #   huggingface-hub
-google-auth==2.52.0
+google-auth==2.53.0
     # via
     #   -r requirements.txt
     #   google-genai
@@ -101,8 +101,9 @@ httpx==0.28.1
     #   openai
 huggingface-hub==1.9.0
     # via datasets
-idna==3.11
+idna==3.15
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
@@ -142,7 +143,7 @@ multiprocess==0.70.19
     # via datasets
 nh3==0.3.4
     # via -r requirements.txt
-numpy==2.4.4
+numpy==2.4.6
     # via
     #   -r requirements.txt
     #   datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,4 +117,7 @@ nh3>=0.2.17
 # Image processing - parses pixel dimensions from cached image bytes for feature engineering
 Pillow>=12.2.0
 
+# Transitive constraint — pinned to clear CVE-2026-45409 (fixed in 3.15).
+idna>=3.15
+
 # Development and test dependencies are in requirements-dev.txt

--- a/uv.lock
+++ b/uv.lock
@@ -1128,11 +1128,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds idna>=3.15 as a transitive constraint in requirements.txt and refreshes
both lockfiles. The Vulnerability Scan check was failing on every open PR
because idna 3.11 is exposed to CVE-2026-45409 (fixed in 3.15).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
