### PR TITLE
ci(unblock): EOF fix on sweep-digest 2026-05-19 + ignore joblib PYSEC-2024-277

### DIFF
--- a/.claude/sweep-digests/2026-05-19.md
+++ b/.claude/sweep-digests/2026-05-19.md
@@ -11,4 +11,3 @@
 
 ## Abandoned (0)
 - _(none)_
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,10 @@ jobs:
       - name: Audit dependencies
         # CVE-2026-3219 (pip 26.0.1) still has no upstream fix — ignore until
         # a patched pip is released. CVE-2026-6357 is resolved by the upgrade above.
-        run: uv run pip-audit --ignore-vuln CVE-2026-3219
+        # PYSEC-2024-277 (joblib): untrusted-load risk. N/A here — we only
+        # joblib.load() our own retrained model artifact stored in R2 via
+        # src/shared/image_features._load_model. No published fix version.
+        run: uv run pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln PYSEC-2024-277
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
Two small main-side fixes to unblock force-pushes and the Vulnerability Scan required check.

1. Strip trailing blank line on `.claude/sweep-digests/2026-05-19.md` — end-of-file-fixer was looping on every force-push from worktrees.
2. Add `--ignore-vuln PYSEC-2024-277` to the pip-audit step. The finding is joblib's untrusted-load risk; N/A here since we only `joblib.load()` our own retrained model artifact (R2 via `src/shared/image_features._load_model`). No published fix version.