### PR TITLE
fix(sweep-digest): stop emitting trailing blank line in render_digest

### DIFF
--- a/.claude/sweep-digests/2026-05-20.md
+++ b/.claude/sweep-digests/2026-05-20.md
@@ -11,4 +11,3 @@
 
 ## Abandoned (0)
 - _(none)_
-

--- a/scripts/write_sweep_digest.py
+++ b/scripts/write_sweep_digest.py
@@ -142,9 +142,7 @@ def render_digest(
         for o in opened:
             pr_num = o.get("pr_number", "?")
             pr_url = o.get("pr_url", "")
-            lines.append(
-                f"- #{o['issue']} — PR [#{pr_num}]({pr_url}) — open, CI pending"
-            )
+            lines.append(f"- #{o['issue']} — PR [#{pr_num}]({pr_url}) — open, CI pending")
             lines.append(f"  - Status: `gh pr checks {pr_num}`")
     lines.append("")
 
@@ -176,7 +174,6 @@ def render_digest(
         for o in abandoned:
             reason = o.get("reason", "unknown reason")
             lines.append(f"- #{o['issue']} — abandoned: {reason}")
-    lines.append("")
 
     return "\n".join(lines)
 

--- a/tests/unit/scripts/test_write_sweep_digest.py
+++ b/tests/unit/scripts/test_write_sweep_digest.py
@@ -36,6 +36,13 @@ class TestRenderDigest:
         assert "## Abandoned (0)" in out
         assert "_(none)_" in out
 
+    def test_render_digest_does_not_end_with_trailing_blank_line(self) -> None:
+        # The caller writes ``digest + "\n"`` to disk, so render_digest must not
+        # itself end with a newline — otherwise the file ends ``...\n\n`` and
+        # end-of-file-fixer (pre-commit) loops on every push.
+        out = render_digest([], "2026-04-22")
+        assert not out.endswith("\n"), "render_digest must not append trailing newline"
+
     def test_merged_outcome_renders_pr_link(self) -> None:
         out = render_digest(
             [


### PR DESCRIPTION
render_digest appended an empty string after the last section, so combined
with the caller's `digest + "\n"` the resulting file ended `...\n\n`. That
trailing blank line tripped pre-commit's end-of-file-fixer on every
force-push from a worktree, blocking rebases. Strip the trailing append and
fix the existing 2026-05-20 digest in place. Add a regression unit test.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
